### PR TITLE
disable reporting of unused local variables inside catch statements

### DIFF
--- a/src/main/php/PHP/PMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHP/PMD/Rule/UnusedLocalVariable.php
@@ -92,7 +92,7 @@ class PHP_PMD_Rule_UnusedLocalVariable
 
         foreach ($this->_images as $image => $nodes) {
             if (count($nodes) === 1) {
-                $this->addViolation(reset($nodes), array($image));
+                $this->doCheckNodeImage($nodes[0]);
             }
         }
     }
@@ -156,4 +156,52 @@ class PHP_PMD_Rule_UnusedLocalVariable
         }
         $this->_images[$node->getImage()][] = $node;
     }
+
+    /**
+     * Template method that performs the real node image check.
+     *
+     * @param PHP_PMD_AbstractNode $node The context source code node.
+     *
+     * @return void
+     */
+    protected function doCheckNodeImage(PHP_PMD_AbstractNode $node)
+    {
+        if ($this->_isNameAllowedInContext($node)) {
+            return;
+        }
+        $this->addViolation($node, array($node->getImage()));
+    }
+
+    /**
+     * Checks if a short name is acceptable in the current context. For the
+     * moment these contexts are the init section of a for-loop and short
+     * variable names in catch-statements.
+     *
+     * @param PHP_PMD_AbstractNode $node The context source code node.
+     *
+     * @return boolean
+     */
+    private function _isNameAllowedInContext(PHP_PMD_AbstractNode $node)
+    {
+        return $this->_isChildOf($node, 'CatchStatement');
+    }
+
+    /**
+     * Checks if the given node is a direct or indirect child of a node with
+     * the given type.
+     *
+     * @param PHP_PMD_AbstractNode $node The context source code node.
+     * @param string               $type Possible parent type.
+     *
+     * @return boolean
+     */
+    private function _isChildOf(PHP_PMD_AbstractNode $node, $type)
+    {
+        $parent = $node->getParent();
+        if ($parent->isInstanceOf($type)) {
+            return true;
+        }
+        return false;
+    }
 }
+?>

--- a/src/test/php/PHP/PMD/Rule/UnusedLocalVariableTest.php
+++ b/src/test/php/PHP/PMD/Rule/UnusedLocalVariableTest.php
@@ -599,4 +599,31 @@ class PHP_PMD_Rule_UnusedLocalVariableTest extends PHP_PMD_AbstractTest
         $rule->setReport($this->getReportMock(0));
         $rule->apply($this->getMethod());
     }
+
+    /**
+     * testRuleDoesNotApplyToCatchStatement
+     *
+     * <code>
+     * class Foo {
+     *     public function bar() {
+     *         try {
+     *         } catch (Exception $e) {
+     *         }
+     *     }
+     * }
+     * </code>
+     *
+     * @return void
+     * @covers PHP_PMD_Rule_UnusedLocalVariable
+     * @covers PHP_PMD_Rule_AbstractLocalVariable
+     * @group phpmd
+     * @group phpmd::rule
+     * @group unittest
+     */
+    public function testRuleDoesNotApplyToCatchStatement()
+    {
+        $rule = new PHP_PMD_Rule_UnusedLocalVariable();
+        $rule->setReport($this->getReportMock(0));
+        $rule->apply($this->getMethod());
+    }
 }

--- a/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToCatchStatement.php
+++ b/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToCatchStatement.php
@@ -1,0 +1,11 @@
+<?php
+class testRuleDoesNotApplyToCatchStatement
+{
+    public function testRuleDoesNotApplyToCatchStatement()
+    {
+        try {
+        } catch (Exception $e) {
+        }
+    }
+}
+?>


### PR DESCRIPTION
I hope you'll find this useful. My reasoning is that you don't use a caught exception every time, and I don't consider it a bad practice.
