### PR TITLE
Skip "unused formal parameter" checking when method signature has been annotated as inherited using @inheritdoc

### DIFF
--- a/src/main/php/PHP/PMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHP/PMD/Rule/UnusedFormalParameter.php
@@ -89,7 +89,7 @@ class PHP_PMD_Rule_UnusedFormalParameter
             return;
         }
         
-        if($this->isInheritedSignature($node)) {
+        if ($this->isInheritedSignature($node)) {
             return;
         }
 
@@ -130,9 +130,9 @@ class PHP_PMD_Rule_UnusedFormalParameter
      *
      * @return boolean
      */
-     private function isInheritedSignature(PHP_PMD_AbstractNode $node) {
-        
-        if($node instanceof PHP_PMD_Node_Method) {
+     private function isInheritedSignature(PHP_PMD_AbstractNode $node) 
+     {
+        if ($node instanceof PHP_PMD_Node_Method) {
             return preg_match('/\@inheritdoc/', $node->getDocComment());
         }
         


### PR DESCRIPTION
It's a little patch created to avoid false positives, when method signature has been annotated as inherited using @inheritdoc.
