### PR TITLE
UnusedLocalVariable fix for compact handling in Symfony2

### DIFF
--- a/src/main/php/PHP/PMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHP/PMD/Rule/UnusedLocalVariable.php
@@ -141,7 +141,7 @@ class PHP_PMD_Rule_UnusedLocalVariable
             $this->collectVariable($variable);
         }
         foreach ($node->findChildrenOfType('FunctionPostfix') as $func) {
-            if(strpos($func->getImage(),'compact')) {
+            if(substr($func->getName(), 1 + (strrpos($func->getName(), "\\") ?: -1)) === "compact") {
                 foreach ($func->findChildrenOfType('Literal') as $literal) {
                     $this->collectLiteral($literal);
                 }


### PR DESCRIPTION
This is a fix for my issue: https://github.com/phpmd/phpmd/issues/60

Here is a little bug. In Symfony 2.1 $func->getImage() returns a string like "Acme/SomethingBundle/compact"

So current code can't handle it. Because this string is not equals to 'compact'.
