### PR TITLE
[WIP] [GH-38] [GH-32] Implement undefined variable rule

### DIFF
--- a/src/main/php/PHP/PMD/Rule/UndefinedVariable.php
+++ b/src/main/php/PHP/PMD/Rule/UndefinedVariable.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * This file is part of PHP_PMD.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2012, Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category   PHP
+ * @package    PHP_PMD
+ * @subpackage Rule
+ * @author     Manuel Pichler <mapi@phpmd.org>
+ * @copyright  2008-2012 Manuel Pichler. All rights reserved.
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @version    SVN: $Id$
+ * @link       http://phpmd.org
+ */
+
+require_once 'PHP/PMD/Rule/AbstractLocalVariable.php';
+require_once 'PHP/PMD/Rule/IFunctionAware.php';
+require_once 'PHP/PMD/Rule/IMethodAware.php';
+
+/**
+ * This rule collects all local variable usages within a given function or method
+ * that are not defined previously by any code in the analyzed source artifact.
+ *
+ * @category   PHP
+ * @package    PHP_PMD
+ * @subpackage Rule
+ * @author     Manuel Pichler <mapi@phpmd.org>
+ * @author     Benjamin Eberlei <kontakt@beberlei.de>
+ * @copyright  2008-2012 Manuel Pichler. All rights reserved.
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @version    Release: @package_version@
+ * @link       http://phpmd.org
+ */
+class PHP_PMD_Rule_UndefinedVariable
+extends PHP_PMD_Rule_AbstractLocalVariable
+implements PHP_PMD_Rule_IFunctionAware,
+           PHP_PMD_Rule_IMethodAware
+{
+    /**
+     * Found variable assignment images within a single method or function.
+     *
+     * @var array(string)
+     */
+    private $images = array();
+
+    /**
+     * Computes the usage of undefined variables in the current scope.
+     *
+     * @param PHP_PMD_AbstractNode $node
+     * @return void
+     */
+    public function apply(PHP_PMD_AbstractNode $node)
+    {
+        $this->images = array();
+
+        $this->collectAssignments($node);
+        $this->collectParameters($node);
+
+        foreach ($node->findChildrenOfType('Variable') as $variable) {
+            if ( ! $this->checkVariableDefined($variable, $node)) {
+                $this->addViolation($variable, array($variable->getImage()));
+            }
+        }
+    }
+
+    /**
+     * Check if the given variable was defined in the current context before usage.
+     *
+     * @param PHP_PMD_AbstractNode $variable
+     * @param PHP_PMD_AbstractNode $parentNode
+     * @return bool
+     */
+    private function checkVariableDefined(PHP_PMD_AbstractNode $variable, PHP_PMD_AbstractNode $parentNode)
+    {
+        return isset($this->images[$variable->getImage()]) || $this->isNameAllowedInContext($parentNode);
+    }
+
+    /**
+     * Collect parameter names of method/function.
+     *
+     * @param PHP_PMD_Node_AbstractCallable $node
+     * @return void
+     */
+    private function collectParameters(PHP_PMD_Node_AbstractCallable $node)
+    {
+        // Get formal parameter container
+        $parameters = $node->getFirstChildOfType('FormalParameters');
+
+        // Now get all declarators in the formal parameters container
+        $declarators = $parameters->findChildrenOfType('VariableDeclarator');
+
+        foreach ($declarators as $declarator) {
+            $this->images[$declarator->getImage()] = $declarator;
+        }
+    }
+
+    /**
+     * Collect assignments of variables.
+     *
+     * @param PHP_PMD_Node_AbstractCallable $node
+     * @return void
+     */
+    private function collectAssignments(PHP_PMD_Node_AbstractCallable $node)
+    {
+        foreach ($node->findChildrenOfType('AssignmentExpression') as $assignment) {
+            $variable = $assignment->getChild(0);
+
+            if ( ! isset($definitions[$variable->getImage()])) {
+                $this->images[$variable->getImage()] = $variable;
+            }
+        }
+    }
+
+    /**
+     * Checks if a short name is acceptable in the current context.
+     *
+     * @param PHP_PMD_AbstractNode $node The context source code node.
+     *
+     * @return boolean
+     */
+    private function isNameAllowedInContext(PHP_PMD_AbstractNode $node)
+    {
+        return ($node instanceof PHP_PMD_Node_Method && $variable->getImage() === '$this');
+    }
+}

--- a/src/main/php/PHP/PMD/Rule/UndefinedVariable.php
+++ b/src/main/php/PHP/PMD/Rule/UndefinedVariable.php
@@ -91,10 +91,22 @@ implements PHP_PMD_Rule_IFunctionAware,
         $this->collectAssignments($node);
         $this->collectParameters($node);
         $this->collectExceptionCatches($node);
+        $this->collectGlobalStatements($node);
 
         foreach ($node->findChildrenOfType('Variable') as $variable) {
             if ( ! $this->checkVariableDefined($variable, $node)) {
                 $this->addViolation($variable, array($variable->getImage()));
+            }
+        }
+    }
+
+    private function collectGlobalStatements($node)
+    {
+        $globalStatements = $node->findChildrenOfType('GlobalStatement');
+
+        foreach ($globalStatements as $globalStatement) {
+            foreach ($globalStatement->getChildren() as $variable) {
+                $this->addVariableDefinition($variable);
             }
         }
     }

--- a/src/main/php/PHP/PMD/Rule/UndefinedVariable.php
+++ b/src/main/php/PHP/PMD/Rule/UndefinedVariable.php
@@ -196,7 +196,7 @@ implements PHP_PMD_Rule_IFunctionAware,
 
     private function addVariableDefinition($variable)
     {
-        if ( ! isset($definitions[$variable->getImage()])) {
+        if ( ! isset($this->images[$variable->getImage()])) {
             $this->images[$variable->getImage()] = $variable;
         }
     }
@@ -211,6 +211,10 @@ implements PHP_PMD_Rule_IFunctionAware,
      */
     private function isNameAllowedInContext(PHP_PMD_AbstractNode $node, PHP_PMD_AbstractNode $variable)
     {
-        return ($node instanceof PHP_PMD_Node_Method && $variable->getImage() === '$this');
+        return (
+            $node instanceof PHP_PMD_Node_Method &&
+            $variable->getImage() === '$this' &&
+            ($node->getModifiers() & PHP_Depend_ConstantsI::IS_STATIC) === 0
+        );
     }
 }

--- a/src/main/php/PHP/PMD/Rule/UndefinedVariable.php
+++ b/src/main/php/PHP/PMD/Rule/UndefinedVariable.php
@@ -105,7 +105,7 @@ implements PHP_PMD_Rule_IFunctionAware,
      */
     private function checkVariableDefined(PHP_PMD_AbstractNode $variable, PHP_PMD_AbstractNode $parentNode)
     {
-        return isset($this->images[$variable->getImage()]) || $this->isNameAllowedInContext($parentNode);
+        return isset($this->images[$variable->getImage()]) || $this->isNameAllowedInContext($parentNode, $variable);
     }
 
     /**
@@ -148,10 +148,11 @@ implements PHP_PMD_Rule_IFunctionAware,
      * Checks if a short name is acceptable in the current context.
      *
      * @param PHP_PMD_AbstractNode $node The context source code node.
+     * @param PHP_PMD_AbstractNode $variable The variable node.
      *
      * @return boolean
      */
-    private function isNameAllowedInContext(PHP_PMD_AbstractNode $node)
+    private function isNameAllowedInContext(PHP_PMD_AbstractNode $node, PHP_PMD_AbstractNode $variable)
     {
         return ($node instanceof PHP_PMD_Node_Method && $variable->getImage() === '$this');
     }

--- a/src/main/resources/rulesets/unusedcode.xml
+++ b/src/main/resources/rulesets/unusedcode.xml
@@ -82,14 +82,35 @@ class Something
         <description>
 Avoid passing parameters to methods or constructors and then not using those parameters.
         </description>
-        <priority>3</priority>
+    <priority>3</priority>
+    <example>
+<![CDATA[
+class Foo
+{
+private function bar($howdy)
+{
+    // $howdy is not used
+}
+}
+]]>
+    </example>
+    </rule>
+
+    <rule name="UndefinedVariable"
+          since="1.5"
+          message="Avoid using undefined variables such as '{0}' which will lead to PHP notices."
+          externalInfoUrl="">
+        <description>
+Detects when a variable is used that has not been defined before.
+        </description>
         <example>
 <![CDATA[
 class Foo
 {
-    private function bar($howdy)
+    private function bar()
     {
-        // $howdy is not used
+        // $message is undefined
+        echo $message;
     }
 }
 ]]>

--- a/src/main/resources/rulesets/unusedcode.xml
+++ b/src/main/resources/rulesets/unusedcode.xml
@@ -97,6 +97,7 @@ private function bar($howdy)
     </rule>
 
     <rule name="UndefinedVariable"
+          class="PHP_PMD_Rule_UndefinedVariable"
           since="1.5"
           message="Avoid using undefined variables such as '{0}' which will lead to PHP notices."
           externalInfoUrl="">


### PR DESCRIPTION
There is a class of bugs when you use a variable that is undefined. Some PHP functions allow this when the parameter is passed by reference, however it is still decouraged not define this variables beforehand for clarity.

This rule implements checking for undefined variables. This is done by first collecting all variable assignments, then all parameters of the method/function.

In the case of the following example, PHP_PMD will trigger two errors, unused local variable and undefined variable:

    function foo()
    {
        echo $bar;
    }

I therefore propose to work on this patch further by modifying the UnusedLocalVariable to only warn about variable assignments that are not used and keep the undefined variable rule to catch the error class shown above.

Possible Improvements:

* Check if the variable assignment is actually BEFORE the variable usage. Currently it only checks that there is an assignment, it could be after the usage though.
* Only run one loop, instead of one loop per construct.
* Add whitelist of common functions that create variables that are passed as references (preg_match, ...)