### PR TITLE
Fix error when using entire ruleset "Naming" 

### DIFF
--- a/src/main/php/PHP/PMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHP/PMD/Rule/Naming/ShortVariable.php
@@ -165,8 +165,13 @@ class PHP_PMD_Rule_Naming_ShortVariable
      */
     private function getExceptionsList()
     {
+        try {
+            $exceptions = $this->getStringProperty('exceptions');
+        } catch (OutOfBoundsException $e) {
+            $exceptions = '';
+        }
 
-        return explode(',',$this->getStringProperty('exceptions'));
+        return explode(',', $exceptions);
     }
 
     /**


### PR DESCRIPTION
When using entire ruleset "Naming", "Property $exceptions does not exist." error occurs.
