### PR TITLE
Fix: PHP Fatal error:  Call to a member function isInstanceOf() on a non-object in /usr/share/pear/PHP/PMD/Rule/UnusedPrivateField.php on line 200

### DIFF
--- a/src/main/php/PHP/PMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHP/PMD/Rule/UnusedPrivateField.php
@@ -202,6 +202,9 @@ class PHP_PMD_Rule_UnusedPrivateField
                 return false;
             }
             $parent = $parent->getParent();
+            if (is_null($parent)) {
+                   return false;
+            }
         }
         return true;
     }


### PR DESCRIPTION
Here is the stack trace I was getting:-

PHP Fatal error:  Call to a member function isInstanceOf() on a non-object in /usr/share/pear/PHP/PMD/Rule/UnusedPrivateField.php on line 200
PHP Stack trace:
PHP   1. {main}() /usr/bin/phpmd:0
PHP   2. PHP_PMD_TextUI_Command::main() /usr/bin/phpmd:48
PHP   3. PHP_PMD_TextUI_Command->run() /usr/share/pear/PHP/PMD/TextUI/Command.php:151
PHP   4. PHP_PMD->processFiles() /usr/share/pear/PHP/PMD/TextUI/Command.php:129
PHP   5. PHP_PMD_Parser->parse() /usr/share/pear/PHP/PMD.php:203
PHP   6. PHP_Depend->analyze() /usr/share/pear/PHP/PMD/Parser.php:128
PHP   7. PHP_PMD_Parser->close() /usr/share/pear/PHP/Depend.php:328
PHP   8. PHP_Depend_Code_Package->accept() /usr/share/pear/PHP/PMD/Parser.php:184
PHP   9. PHP_Depend_Visitor_AbstractVisitor->visitPackage() /usr/share/pear/PHP/Depend/Code/Package.php:338
PHP  10. PHP_Depend_Code_Class->accept() /usr/share/pear/PHP/Depend/Visitor/AbstractVisitor.php:227
PHP  11. PHP_PMD_Parser->visitClass() /usr/share/pear/PHP/Depend/Code/Class.php:212
PHP  12. PHP_PMD_Parser->apply() /usr/share/pear/PHP/PMD/Parser.php:213
PHP  13. PHP_PMD_RuleSet->apply() /usr/share/pear/PHP/PMD/Parser.php:293
PHP  14. PHP_PMD_Rule_UnusedPrivateField->apply() /usr/share/pear/PHP/PMD/RuleSet.php:296
PHP  15. PHP_PMD_Rule_UnusedPrivateField->collectUnusedPrivateFields() /usr/share/pear/PHP/PMD/Rule/UnusedPrivateField.php:87
PHP  16. PHP_PMD_Rule_UnusedPrivateField->removeUsedFields() /usr/share/pear/PHP/PMD/Rule/UnusedPrivateField.php:105
PHP  17. PHP_PMD_Rule_UnusedPrivateField->removeUsedField() /usr/share/pear/PHP/PMD/Rule/UnusedPrivateField.php:156
PHP  18. PHP_PMD_Rule_UnusedPrivateField->isValidPropertyNode() /usr/share/pear/PHP/PMD/Rule/UnusedPrivateField.php:180

Unfortunately I can't provide my code files and since phpmd gives me no clue which file it errors on I can't isolate the issue without taking up a lot of time, but there is probably something seriously wrong with one of my code files. Either way though, it shouldn't cause PHPMD to fatal.

I have wrapped $parent in a check for is_null() since it is possible for the call to $parent->getParent() on line 204 to return null, thus setting $parent to null on the same line. Henceforth, when we call functions on it in subsequent iterations of the loop on line 200, we get 'Call to a member function isInstanceOf() on a non-object in /usr/share/pear/PHP/PMD/Rule/UnusedPrivateField.php on line 200'

Hope this helps someone,

All the best,

Tim.
