### PR TITLE
(tiny) documentation typo fix

### DIFF
--- a/src/site/rst/documentation/suppress-warnings.rst
+++ b/src/site/rst/documentation/suppress-warnings.rst
@@ -1,6 +1,6 @@
-=========================
-PHPMD Supressing Warnings
-=========================
+==========================
+PHPMD Suppressing Warnings
+==========================
 
 You can use doc comment annotations to exclude methods or classes 
 from PHPMD or to suppress special rules for some software artifacts. ::


### PR DESCRIPTION
supressing -> suppressing

There are three more instances of this typo in the changelogs, but I assume you don't want to change them after the fact.

```
$ grep -Rin 'supress' *
CHANGELOG:50:- Fixed #36: @SupressWarnings annotation does not work for 
src/site/docx/changes.xml:213:                @SupressWarnings annotation does not work for
src/conf/package.xml:537:- Fixed #36: @SupressWarnings annotation does not work for
```
