### PR TITLE
Support underscore in the beginning of parameter name.

### DIFF
--- a/src/main/php/PHP/PMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHP/PMD/Rule/Controversial/CamelCaseParameterName.php
@@ -78,7 +78,7 @@ class PHP_PMD_Rule_Controversial_CamelCaseParameterName
     public function apply(PHP_PMD_AbstractNode $node)
     {
         foreach ($node->getParameters() as $parameter) {
-            if (!preg_match('/^\$[a-z][a-zA-Z0-9]*$/', $parameter->getName())) {
+            if (!preg_match('/^\$(_)?[a-z][a-zA-Z0-9]*$/', $parameter->getName())) {
                 $this->addViolation(
                     $node,
                     array(


### PR DESCRIPTION
I believe, that both of names below are valid:
$_someVariable
$someVariable

I added this change to allow first type of variables, hope this will suite PHPMD.