### PR TITLE
Perform case insensitive matching to inheritDoc annotation.

### DIFF
--- a/src/main/php/PHP/PMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHP/PMD/Rule/UnusedFormalParameter.php
@@ -133,7 +133,7 @@ class PHP_PMD_Rule_UnusedFormalParameter
      private function isInheritedSignature(PHP_PMD_AbstractNode $node)
      {
         if ($node instanceof PHP_PMD_Node_Method) {
-            return preg_match('/\@inheritdoc/', $node->getDocComment());
+            return preg_match('/\@inheritdoc/i', $node->getDocComment());
         }
         return false;
     }


### PR DESCRIPTION
The inheritDoc annotation is sometimes written as @inheritdoc and sometimes as @inheritDoc. PHPMD should match both cases, imo.
