### PR TITLE
Update StaticAccess.php

### DIFF
--- a/src/main/php/PHP/PMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHP/PMD/Rule/CleanCode/StaticAccess.php
@@ -23,6 +23,17 @@ class PHP_PMD_Rule_CleanCode_StaticAccess
             if ($this->isReferenceInParameter($reference)) {
                 continue;
             }
+            // references to self, parent and static are not considered static calls
+            switch ($reference->getImage()) {
+                case 'self':
+                case 'parent':
+                case 'static':
+                    continue 2;
+            }
+            // uses of "new" should be allowed
+            if ($reference->getParent()->getImage() == 'new') {
+                continue;
+            }
 
             $this->addViolation($reference, array($reference->getImage(), $node->getImage()));
         }


### PR DESCRIPTION
References to self::, parent:: and static:: aren't static unless the method itself is declared static.

Statements such as "new Exception()" should also be allowed.
