### PR TITLE
Check for false positives during static access detection

### DIFF
--- a/src/main/php/PHP/PMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHP/PMD/Rule/CleanCode/StaticAccess.php
@@ -23,6 +23,9 @@ class PHP_PMD_Rule_CleanCode_StaticAccess
             if ($this->isReferenceInParameter($reference)) {
                 continue;
             }
+            if ($this->isReferenceInternalTo($reference, $node)) {
+                continue;
+            }
 
             $this->addViolation($reference, array($reference->getImage(), $node->getImage()));
         }
@@ -31,5 +34,16 @@ class PHP_PMD_Rule_CleanCode_StaticAccess
     private function isReferenceInParameter($reference)
     {
         return $reference->getParent()->getNode() instanceof PHP_Depend_Code_ASTFormalParameter;
+    }
+
+    private function isReferenceInternalTo($reference, $node) {
+        $referenceName = $reference->getName();
+        switch ($referenceName) {
+            case 'self':
+            case 'parent':
+                return true;
+            default:
+                return $node->getType() === 'method' && $node->getParentName() === $referenceName;
+        }
     }
 }


### PR DESCRIPTION
Self/parent access should not be reported as static access violations imo, because doing so makes it impossible to call parent methods and to use class constants.

I'm not saying the issue should be handled my way (I just checked phpmd source for the first time), but it seems to work.
