### PR TITLE
Fix [Naming]: Trait can have method same as trait's name

### DIFF
--- a/src/main/php/PHP/PMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
+++ b/src/main/php/PHP/PMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
@@ -67,9 +67,8 @@ class PHP_PMD_Rule_Naming_ConstructorWithNameAsEnclosingClass
     implements PHP_PMD_Rule_IMethodAware
 {
     /**
-     * Extracts all variable and variable declarator nodes from the given node
-     * and checks the variable name length against the configured minimum
-     * length.
+     * Is method has the same name as the enclosing class
+     * (php4 style constructor).
      *
      * @param PHP_PMD_AbstractNode $node The context source code node.
      *
@@ -77,7 +76,9 @@ class PHP_PMD_Rule_Naming_ConstructorWithNameAsEnclosingClass
      */
     public function apply(PHP_PMD_AbstractNode $node)
     {
-        if (strcasecmp($node->getName(), $node->getParentName()) !== 0) {
+        if (strcasecmp($node->getName(), $node->getParentName()) !== 0
+            || $node->getNode()->getParent() instanceof PHP_Depend_Code_Trait
+        ) {
             return;
         }
         $this->addViolation($node);


### PR DESCRIPTION
```
trait TestTrait
{
    public function TestTrait()
    {
    }
}
```

I think this code is correct, but now get error 
"Classes should not have a constructor method with the same name as the class"
