### PR TITLE
Replace --ignore with --exclude

### DIFF
--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -49,8 +49,8 @@ Command line options
   - ``--extensions`` - Comma separated string of valid PHP source file
     extensions.
 
-  - ``--ignore`` - Comma separated string of files or directories that
-    will be ignored during the parsing process.
+  - ``--exclude`` - Comma separated string of files or directories that
+    will be excluded from the parsing process.
 
 Using multiple rule sets
 ````````````````````````


### PR DESCRIPTION
Calling `phpmd` with `--ignore` is deprecated:

```
The --ignore option is deprecated, please use --exclude instead.
```

Update website documentation to match command.
