### PR TITLE
Add: New parameter 'ignore-whitespace' to LongClass and LongMethod rules

### DIFF
--- a/src/main/php/PHP/PMD/Rule/Design/LongClass.php
+++ b/src/main/php/PHP/PMD/Rule/Design/LongClass.php
@@ -76,7 +76,14 @@ class PHP_PMD_Rule_Design_LongClass
     public function apply(PHP_PMD_AbstractNode $node)
     {
         $threshold = $this->getIntProperty('minimum');
-        $loc = $node->getMetric('loc');
+        $ignoreWhitespace = $this->getBooleanProperty('ignore-whitespace');
+
+        if ($ignoreWhitespace) {
+            $loc = $node->getMetric('eloc');
+        } else {
+            $loc = $node->getMetric('loc');
+        }
+
         if ($loc < $threshold) {
             return;
         }

--- a/src/main/php/PHP/PMD/Rule/Design/LongMethod.php
+++ b/src/main/php/PHP/PMD/Rule/Design/LongMethod.php
@@ -79,7 +79,14 @@ class PHP_PMD_Rule_Design_LongMethod
     public function apply(PHP_PMD_AbstractNode $node)
     {
         $threshold = $this->getIntProperty('minimum');
-        $loc = $node->getMetric('loc');
+        $ignoreWhitespace = $this->getBooleanProperty('ignore-whitespace');
+
+        if ($ignoreWhitespace) {
+            $loc = $node->getMetric('eloc');
+        } else {
+            $loc = $node->getMetric('loc');
+        }
+
         if ($loc < $threshold) {
             return;
         }

--- a/src/main/resources/rulesets/codesize.xml
+++ b/src/main/resources/rulesets/codesize.xml
@@ -9,7 +9,7 @@
     <description>
 The Code Size Ruleset contains a collection of rules that find code size related problems.
     </description>
-  
+
     <rule name="CyclomaticComplexity"
           since="0.1"
           message = "The {0} {1}() has a Cyclomatic Complexity of {2}. The configured cyclomatic complexity threshold is {3}."
@@ -114,6 +114,7 @@ too much.  Try to reduce the method size by creating helper methods and removing
         <priority>3</priority>
         <properties>
             <property name="minimum" description="The method size reporting threshold" value="100"/>
+            <property name="ignore-whitespace" description="Count whitespace in reporting threshold" value="false"/>
         </properties>
         <example>
             <![CDATA[
@@ -141,6 +142,7 @@ manageable.
         <priority>3</priority>
         <properties>
             <property name="minimum" description="The class size reporting threshold"  value="1000"/>
+            <property name="ignore-whitespace" description="Count whitespace in reporting threshold" value="false"/>
         </properties>
         <example>
             <![CDATA[

--- a/src/test/php/PHP/PMD/Rule/Design/LongClassTest.php
+++ b/src/test/php/PHP/PMD/Rule/Design/LongClassTest.php
@@ -84,6 +84,7 @@ class PHP_PMD_Rule_Design_LongClassTest extends PHP_PMD_AbstractTest
         $rule = new PHP_PMD_Rule_Design_LongClass();
         $rule->setReport($report);
         $rule->addProperty('minimum', '41');
+        $rule->addProperty('ignore-whitespace', false);
         $rule->apply($class);
     }
 
@@ -101,6 +102,7 @@ class PHP_PMD_Rule_Design_LongClassTest extends PHP_PMD_AbstractTest
         $rule = new PHP_PMD_Rule_Design_LongClass();
         $rule->setReport($report);
         $rule->addProperty('minimum', '42');
+        $rule->addProperty('ignore-whitespace', false);
         $rule->apply($class);
     }
 
@@ -118,6 +120,24 @@ class PHP_PMD_Rule_Design_LongClassTest extends PHP_PMD_AbstractTest
         $rule = new PHP_PMD_Rule_Design_LongClass();
         $rule->setReport($report);
         $rule->addProperty('minimum', '23');
+        $rule->addProperty('ignore-whitespace', false);
+        $rule->apply($class);
+    }
+
+    /**
+     * Tests that the rule uses eloc when ignore whitespace is set
+     *
+     * @return void
+     */
+    public function testRuleUsesElocWhenIgnoreWhitespaceSet()
+    {
+        $class  = $this->getClassMock('eloc', 22);
+        $report = $this->getReportMock(0);
+
+        $rule = new PHP_PMD_Rule_Design_LongClass();
+        $rule->setReport($report);
+        $rule->addProperty('minimum', '23');
+        $rule->addProperty('ignore-whitespace', true);
         $rule->apply($class);
     }
 }

--- a/src/test/php/PHP/PMD/Rule/Design/LongMethodTest.php
+++ b/src/test/php/PHP/PMD/Rule/Design/LongMethodTest.php
@@ -84,6 +84,7 @@ class PHP_PMD_Rule_Design_LongMethodTest extends PHP_PMD_AbstractTest
         $rule = new PHP_PMD_Rule_Design_LongMethod();
         $rule->setReport($report);
         $rule->addProperty('minimum', '41');
+        $rule->addProperty('ignore-whitespace', false);
         $rule->apply($method);
     }
 
@@ -101,6 +102,7 @@ class PHP_PMD_Rule_Design_LongMethodTest extends PHP_PMD_AbstractTest
         $rule = new PHP_PMD_Rule_Design_LongMethod();
         $rule->setReport($report);
         $rule->addProperty('minimum', '42');
+        $rule->addProperty('ignore-whitespace', false);
         $rule->apply($method);
     }
 
@@ -118,6 +120,24 @@ class PHP_PMD_Rule_Design_LongMethodTest extends PHP_PMD_AbstractTest
         $rule = new PHP_PMD_Rule_Design_LongMethod();
         $rule->setReport($report);
         $rule->addProperty('minimum', '23');
+        $rule->addProperty('ignore-whitespace', false);
         $rule->apply($method);
+    }
+
+    /**
+     * Tests that the rule uses eloc when ignore whitespace is set
+     *
+     * @return void
+     */
+    public function testRuleUsesElocWhenIgnoreWhitespaceSet()
+    {
+        $class  = $this->getClassMock('eloc', 22);
+        $report = $this->getReportMock(0);
+
+        $rule = new PHP_PMD_Rule_Design_LongMethod();
+        $rule->setReport($report);
+        $rule->addProperty('minimum', '23');
+        $rule->addProperty('ignore-whitespace', true);
+        $rule->apply($class);
     }
 }


### PR DESCRIPTION
Quite often you don't care about Comment Lines of Code nor whitespace when
counting the lines of code in a method.  The ignore-whitespace option allows you
to set these rules to ignore whitespace and only count the executable lines of
code.

This parameter defaults to `false` to avoid changing default behavior.
