### PR TITLE
Modified version constraint for pdepend/pdepend

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 
     "require": {
         "php": ">=5.3.0",
-        "pdepend/pdepend": ">=1.1.1"
+        "pdepend/pdepend": "~1.1.1"
     },
 
     "include-path": [

--- a/composer.lock
+++ b/composer.lock
@@ -1,39 +1,51 @@
 {
-    "hash": "fae9e6c8fac23d0272b04d32d39c662c",
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "04a208835d0f0c4dcae3d6f09a16ffb6",
     "packages": [
         {
             "name": "pdepend/pdepend",
-            "version": "1.1.0",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
-                "url": "git://github.com/pdepend/pdepend.git",
-                "reference": "1.1.0"
+                "url": "https://github.com/pdepend/pdepend.git",
+                "reference": "1537f19d62d7b30c13ac173270106df7c6b9c459"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/pdepend/pdepend/zipball/1.1.0",
-                "reference": "1.1.0",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/1537f19d62d7b30c13ac173270106df7c6b9c459",
+                "reference": "1537f19d62d7b30c13ac173270106df7c6b9c459",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.2.3"
             },
-            "time": "2012-09-12 04:09:19",
             "bin": [
                 "src/bin/pdepend"
             ],
             "type": "library",
-            "installation-source": "dist",
+            "autoload": {
+                "psr-0": {
+                    "PHP_": "src/main/php/"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
-            "description": "Official version of pdepend to be handled with Composer"
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Official version of pdepend to be handled with Composer",
+            "time": "2013-12-04 17:46:00"
         }
     ],
-    "packages-dev": null,
-    "aliases": [
-
-    ],
+    "packages-dev": [],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ]
+    "stability-flags": [],
+    "platform": {
+        "php": ">=5.3.0"
+    },
+    "platform-dev": []
 }


### PR DESCRIPTION
Switched to the tilde comparison operator to make sure composer will not
grab the 2.x (or higher even) incompatible release from pdepend/pdepend.
