### PR TITLE
Tweak with CamelCase matching inheritDoc

### DIFF
--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -120,7 +120,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
     private function isInheritedSignature(AbstractNode $node)
     {
         if ($node instanceof MethodNode) {
-            return preg_match('/\@inheritdoc/', $node->getDocComment());
+            return preg_match('/\@inheritdoc/i', $node->getDocComment());
         }
         return false;
     }

--- a/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -386,6 +386,16 @@ class UnusedFormalParameterTest extends AbstractTest
     }
 
     /**
+     * testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase
+     */
+    public function testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase()
+    {
+        $rule = new UnusedFormalParameter();
+        $rule->setReport($this->getReportMock(0));
+        $rule->apply($this->getMethod());
+    }
+
+    /**
      * @test
      * @return void
      * @since 2.0.0

--- a/src/test/resources/files/Rule/UnusedFormalParameter/testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase.php
+++ b/src/test/resources/files/Rule/UnusedFormalParameter/testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase.php
@@ -1,0 +1,11 @@
+<?php
+class testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase
+{
+    /**
+     * @inheritDoc
+     */
+    public function testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase($foo, $bar, $baz)
+    {
+
+    }
+}


### PR DESCRIPTION
Tweak with CamelCase in @inheritDoc. Added test.

In the official documentation:
http://phpdoc.org/docs/latest/guides/inheritance.html

The issues in Scrutinizer are same reason of this PR.
