### PR TITLE
Updating composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "phpmd/phpmd",
     "description": "Official version of PHPMD handled with Composer.",
     "license": "BSD-3-Clause",
-    "version": "2.1.2",
 
     "minimum-stability" : "stable",
 
@@ -18,15 +17,8 @@
     "autoload": {
         "psr-0": {
             "PHPMD\\": "src/main/php",
-            "PDepend\\": "vendor/pdepend/pdepend/src/main/php/"
         }
     },
 
-    "include-path": [
-        "../../pdepend/pdepend/src/main/php",
-        "src/main/php"
-    ],
-
     "bin": ["src/bin/phpmd"]
 }
-


### PR DESCRIPTION
- Yanking out hard-coded "version" key. This will cause a lot of problems/issues. Latest composer will also warn about this when you do "composer validate".
- updating psr-0 block and yanking out the stuff we shouldn't be registering. pdepend should register it's own autoload stuff.
- include-path seems conflicting to the autoload and probably unnecessary.
