### PR TITLE
Changed the OutOfBounds exceptions when getting a property

### DIFF
--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -361,7 +361,7 @@ abstract class AbstractRule implements Rule
         if (isset($this->properties[$name])) {
             return in_array($this->properties[$name], array('true', 'on', 1));
         }
-        throw new \OutOfBoundsException('Property $' . $name . ' does not exist.');
+        throw new \OutOfBoundsException('Property "' . $name . '" does not exist.');
     }
 
     /**
@@ -377,7 +377,7 @@ abstract class AbstractRule implements Rule
         if (isset($this->properties[$name])) {
             return (int) $this->properties[$name];
         }
-        throw new \OutOfBoundsException('Property $' . $name . ' does not exist.');
+        throw new \OutOfBoundsException('Property "' . $name . '" does not exist.');
     }
 
 
@@ -394,7 +394,7 @@ abstract class AbstractRule implements Rule
         if (isset($this->properties[$name])) {
             return $this->properties[$name];
         }
-        throw new \OutOfBoundsException('Property $' . $name . ' does not exist.');
+        throw new \OutOfBoundsException('Property "' . $name . '" does not exist.');
 
     }
 


### PR DESCRIPTION
They aren't variables but keys in the $properties array.
Thus the old error message was misleading.
