### PR TITLE
Removed all @version annotations

### DIFF
--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -53,7 +52,6 @@ use PHPMD\Node\ASTNode;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 abstract class AbstractNode
 {

--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -50,7 +49,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 abstract class AbstractRenderer
 {

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -50,7 +49,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @SuppressWarnings(PHPMD)
  */

--- a/src/main/php/PHPMD/AbstractWriter.php
+++ b/src/main/php/PHPMD/AbstractWriter.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -50,7 +49,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 abstract class AbstractWriter
 {

--- a/src/main/php/PHPMD/Node/ASTNode.php
+++ b/src/main/php/PHPMD/Node/ASTNode.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PHPMD\Rule;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class ASTNode extends \PHPMD\AbstractNode
 {

--- a/src/main/php/PHPMD/Node/AbstractCallableNode.php
+++ b/src/main/php/PHPMD/Node/AbstractCallableNode.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PDepend\Source\AST\AbstractASTCallable;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 abstract class AbstractCallableNode extends AbstractNode
 {

--- a/src/main/php/PHPMD/Node/AbstractNode.php
+++ b/src/main/php/PHPMD/Node/AbstractNode.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PHPMD\Rule;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 abstract class AbstractNode extends \PHPMD\AbstractNode
 {

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PDepend\Source\AST\AbstractASTClassOrInterface;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 abstract class AbstractTypeNode extends AbstractNode
 {

--- a/src/main/php/PHPMD/Node/Annotation.php
+++ b/src/main/php/PHPMD/Node/Annotation.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PHPMD\Rule;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class Annotation
 {

--- a/src/main/php/PHPMD/Node/Annotations.php
+++ b/src/main/php/PHPMD/Node/Annotations.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PHPMD\Rule;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class Annotations
 {

--- a/src/main/php/PHPMD/Node/ClassNode.php
+++ b/src/main/php/PHPMD/Node/ClassNode.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PDepend\Source\AST\ASTClass;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class ClassNode extends AbstractTypeNode
 {

--- a/src/main/php/PHPMD/Node/FunctionNode.php
+++ b/src/main/php/PHPMD/Node/FunctionNode.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PDepend\Source\AST\ASTFunction;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class FunctionNode extends AbstractCallableNode
 {

--- a/src/main/php/PHPMD/Node/InterfaceNode.php
+++ b/src/main/php/PHPMD/Node/InterfaceNode.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PDepend\Source\AST\ASTInterface;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class InterfaceNode extends AbstractTypeNode
 {

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -55,7 +54,6 @@ use PHPMD\Rule;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class MethodNode extends AbstractCallableNode
 {

--- a/src/main/php/PHPMD/Node/TraitNode.php
+++ b/src/main/php/PHPMD/Node/TraitNode.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PDepend\Source\AST\ASTTrait;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   Release: 1.3.3
  */
 class TraitNode extends AbstractTypeNode
 {

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -50,7 +49,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class PHPMD
 {

--- a/src/main/php/PHPMD/Parser.php
+++ b/src/main/php/PHPMD/Parser.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -64,7 +63,6 @@ use PHPMD\Node\MethodNode;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class Parser extends AbstractASTVisitor implements CodeAwareGenerator
 {

--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -55,7 +54,6 @@ use PDepend\Input\ExtensionFilter;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class ParserFactory
 {

--- a/src/main/php/PHPMD/ProcessingError.php
+++ b/src/main/php/PHPMD/ProcessingError.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since     1.2.1
  */
 
@@ -51,7 +50,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since     1.2.1
  */
 class ProcessingError

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Renderer;
@@ -54,7 +53,6 @@ use PHPMD\Report;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class HTMLRenderer extends AbstractRenderer
 {

--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Renderer;
@@ -54,7 +53,6 @@ use PHPMD\Report;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class TextRenderer extends AbstractRenderer
 {

--- a/src/main/php/PHPMD/Renderer/XMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/XMLRenderer.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Renderer;
@@ -54,7 +53,6 @@ use PHPMD\Report;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class XMLRenderer extends AbstractRenderer
 {

--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -51,7 +50,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class Report
 {

--- a/src/main/php/PHPMD/Rule.php
+++ b/src/main/php/PHPMD/Rule.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -50,7 +49,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since     1.1.0
  */
 interface Rule

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      0.2.6
  */
 
@@ -55,7 +54,6 @@ use PHPMD\Node\ASTNode;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since     0.2.6
  */
 abstract class AbstractLocalVariable extends AbstractRule

--- a/src/main/php/PHPMD/Rule/ClassAware.php
+++ b/src/main/php/PHPMD/Rule/ClassAware.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -50,7 +49,6 @@ namespace PHPMD\Rule;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 interface ClassAware
 {

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\CleanCode;
@@ -58,7 +57,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Benjamin Eberlei <benjamin@qafoo.com>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionAware
 {

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\CleanCode;
@@ -59,7 +58,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Benjamin Eberlei <benjamin@qafoo.com>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
 {

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\CleanCode;
@@ -62,7 +61,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Benjamin Eberlei <benjamin@qafoo.com>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
 {

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseClassName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseClassName.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 
@@ -56,7 +55,6 @@ use PHPMD\Rule\InterfaceAware;
  * @author     Francis Besset <francis.besset@gmail.com>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 class CamelCaseClassName extends AbstractRule implements ClassAware, InterfaceAware

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 
@@ -55,7 +54,6 @@ use PHPMD\Rule\MethodAware;
  * @author     Francis Besset <francis.besset@gmail.com>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 class CamelCaseMethodName extends AbstractRule implements MethodAware

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 
@@ -56,7 +55,6 @@ use PHPMD\Rule\MethodAware;
  * @author     Francis Besset <francis.besset@gmail.com>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 class CamelCaseParameterName extends AbstractRule implements MethodAware, FunctionAware

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 
@@ -55,7 +54,6 @@ use PHPMD\Rule\ClassAware;
  * @author     Francis Besset <francis.besset@gmail.com>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 class CamelCasePropertyName extends AbstractRule implements ClassAware

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 
@@ -56,7 +55,6 @@ use PHPMD\Rule\MethodAware;
  * @author     Francis Besset <francis.besset@gmail.com>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 class CamelCaseVariableName extends AbstractRule implements MethodAware, FunctionAware

--- a/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
+++ b/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 
@@ -56,7 +55,6 @@ use PHPMD\Rule\MethodAware;
  * @author     Francis Besset <francis.besset@gmail.com>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 class Superglobals extends AbstractRule implements MethodAware, FunctionAware

--- a/src/main/php/PHPMD/Rule/CyclomaticComplexity.php
+++ b/src/main/php/PHPMD/Rule/CyclomaticComplexity.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -54,7 +53,6 @@ use PHPMD\AbstractRule;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class CyclomaticComplexity extends AbstractRule implements FunctionAware, MethodAware
 {

--- a/src/main/php/PHPMD/Rule/Design/CouplingBetweenObjects.php
+++ b/src/main/php/PHPMD/Rule/Design/CouplingBetweenObjects.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 
@@ -55,7 +54,6 @@ use PHPMD\Rule\ClassAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 class CouplingBetweenObjects extends AbstractRule implements ClassAware

--- a/src/main/php/PHPMD/Rule/Design/DepthOfInheritance.php
+++ b/src/main/php/PHPMD/Rule/Design/DepthOfInheritance.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -54,7 +53,6 @@ use PHPMD\Rule\ClassAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class DepthOfInheritance extends AbstractRule implements ClassAware
 {

--- a/src/main/php/PHPMD/Rule/Design/EvalExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/EvalExpression.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -55,7 +54,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class EvalExpression extends AbstractRule implements MethodAware, FunctionAware
 {

--- a/src/main/php/PHPMD/Rule/Design/ExitExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/ExitExpression.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -55,7 +54,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class ExitExpression extends AbstractRule implements MethodAware, FunctionAware
 {

--- a/src/main/php/PHPMD/Rule/Design/GotoStatement.php
+++ b/src/main/php/PHPMD/Rule/Design/GotoStatement.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 
@@ -56,7 +55,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 class GotoStatement extends AbstractRule implements MethodAware, FunctionAware

--- a/src/main/php/PHPMD/Rule/Design/LongClass.php
+++ b/src/main/php/PHPMD/Rule/Design/LongClass.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -54,7 +53,6 @@ use PHPMD\Rule\ClassAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class LongClass extends AbstractRule implements ClassAware
 {

--- a/src/main/php/PHPMD/Rule/Design/LongMethod.php
+++ b/src/main/php/PHPMD/Rule/Design/LongMethod.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -56,7 +55,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class LongMethod extends AbstractRule implements FunctionAware, MethodAware
 {

--- a/src/main/php/PHPMD/Rule/Design/LongParameterList.php
+++ b/src/main/php/PHPMD/Rule/Design/LongParameterList.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -55,7 +54,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class LongParameterList extends AbstractRule implements FunctionAware, MethodAware
 {

--- a/src/main/php/PHPMD/Rule/Design/NpathComplexity.php
+++ b/src/main/php/PHPMD/Rule/Design/NpathComplexity.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -56,7 +55,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class NpathComplexity extends AbstractRule implements FunctionAware, MethodAware
 {

--- a/src/main/php/PHPMD/Rule/Design/NumberOfChildren.php
+++ b/src/main/php/PHPMD/Rule/Design/NumberOfChildren.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -54,7 +53,6 @@ use PHPMD\Rule\ClassAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class NumberOfChildren extends AbstractRule implements ClassAware
 {

--- a/src/main/php/PHPMD/Rule/Design/TooManyFields.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyFields.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -54,7 +53,6 @@ use PHPMD\Rule\ClassAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class TooManyFields extends AbstractRule implements ClassAware
 {

--- a/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -55,7 +54,6 @@ use PHPMD\Rule\ClassAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class TooManyMethods extends AbstractRule implements ClassAware
 {

--- a/src/main/php/PHPMD/Rule/Design/WeightedMethodCount.php
+++ b/src/main/php/PHPMD/Rule/Design/WeightedMethodCount.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      0.2.5
  */
 
@@ -56,7 +55,6 @@ use PHPMD\Rule\ClassAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      0.2.5
  */
 class WeightedMethodCount extends AbstractRule implements ClassAware

--- a/src/main/php/PHPMD/Rule/ExcessivePublicCount.php
+++ b/src/main/php/PHPMD/Rule/ExcessivePublicCount.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -54,7 +53,6 @@ use PHPMD\AbstractRule;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class ExcessivePublicCount extends AbstractRule implements ClassAware
 {

--- a/src/main/php/PHPMD/Rule/FunctionAware.php
+++ b/src/main/php/PHPMD/Rule/FunctionAware.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -50,7 +49,6 @@ namespace PHPMD\Rule;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 interface FunctionAware
 {

--- a/src/main/php/PHPMD/Rule/InterfaceAware.php
+++ b/src/main/php/PHPMD/Rule/InterfaceAware.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -50,7 +49,6 @@ namespace PHPMD\Rule;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 interface InterfaceAware
 {

--- a/src/main/php/PHPMD/Rule/MethodAware.php
+++ b/src/main/php/PHPMD/Rule/MethodAware.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -50,7 +49,6 @@ namespace PHPMD\Rule;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 interface MethodAware
 {

--- a/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license    http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Naming;
@@ -56,7 +55,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license    http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class BooleanGetMethodName extends AbstractRule implements MethodAware
 {

--- a/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license    http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Naming;
@@ -56,7 +55,6 @@ use PHPMD\Rule\InterfaceAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class ConstantNamingConventions extends AbstractRule implements ClassAware, InterfaceAware
 {

--- a/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license    http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Naming;
@@ -56,7 +55,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class ConstructorWithNameAsEnclosingClass extends AbstractRule implements MethodAware
 {

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Naming;
@@ -57,7 +56,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class LongVariable extends AbstractRule implements ClassAware, MethodAware, FunctionAware
 {

--- a/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Naming;
@@ -55,7 +54,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class ShortMethodName extends AbstractRule implements MethodAware, FunctionAware
 {

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Naming;
@@ -57,7 +56,6 @@ use PHPMD\Rule\MethodAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class ShortVariable extends AbstractRule implements ClassAware, MethodAware, FunctionAware
 {

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -54,7 +53,6 @@ use PHPMD\Node\MethodNode;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAware, MethodAware
 {

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -55,7 +54,6 @@ use PHPMD\Node\ASTNode;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware, MethodAware
 {

--- a/src/main/php/PHPMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateField.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -56,7 +55,6 @@ use PHPMD\Node\ClassNode;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class UnusedPrivateField extends AbstractRule implements ClassAware
 {

--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -57,7 +56,6 @@ use PHPMD\Node\MethodNode;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class UnusedPrivateMethod extends AbstractRule implements ClassAware
 {

--- a/src/main/php/PHPMD/RuleClassFileNotFoundException.php
+++ b/src/main/php/PHPMD/RuleClassFileNotFoundException.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -51,7 +50,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class RuleClassFileNotFoundException extends \RuntimeException
 {

--- a/src/main/php/PHPMD/RuleClassNotFoundException.php
+++ b/src/main/php/PHPMD/RuleClassNotFoundException.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -50,7 +49,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class RuleClassNotFoundException extends \RuntimeException
 {

--- a/src/main/php/PHPMD/RuleSet.php
+++ b/src/main/php/PHPMD/RuleSet.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -50,7 +49,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class RuleSet implements \IteratorAggregate
 {

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -51,7 +50,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class RuleSetFactory
 {

--- a/src/main/php/PHPMD/RuleSetNotFoundException.php
+++ b/src/main/php/PHPMD/RuleSetNotFoundException.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -50,7 +49,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class RuleSetNotFoundException extends \RuntimeException
 {

--- a/src/main/php/PHPMD/RuleViolation.php
+++ b/src/main/php/PHPMD/RuleViolation.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -56,7 +55,6 @@ use PHPMD\Node\MethodNode;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class RuleViolation
 {

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\TextUI;
@@ -54,7 +53,6 @@ use PHPMD\Writer\StreamWriter;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class Command
 {

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\TextUI;
@@ -56,7 +55,6 @@ use PHPMD\Rule;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class CommandLineOptions
 {

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Writer;
@@ -52,7 +51,6 @@ use PHPMD\AbstractWriter;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class StreamWriter extends AbstractWriter
 {

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -56,7 +55,6 @@ use PHPMD\Stubs\RuleStub;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
+++ b/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 
@@ -54,7 +53,6 @@ use PHPMD\TextUI\Command;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  *
  * @group phpmd

--- a/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 
@@ -54,7 +53,6 @@ use PHPMD\TextUI\Command;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  *
  * @group phpmd

--- a/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  */
 
@@ -54,7 +53,6 @@ use PHPMD\TextUI\Command;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      1.1.0
  *
  * @group phpmd

--- a/src/test/php/PHPMD/Node/ASTNodeTest.php
+++ b/src/test/php/PHPMD/Node/ASTNodeTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Node\ASTNode
  * @group phpmd

--- a/src/test/php/PHPMD/Node/AnnotationTest.php
+++ b/src/test/php/PHPMD/Node/AnnotationTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Node\Annotation
  * @group phpmd

--- a/src/test/php/PHPMD/Node/AnnotationsTest.php
+++ b/src/test/php/PHPMD/Node/AnnotationsTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Node\Annotations
  * @group phpmd

--- a/src/test/php/PHPMD/Node/ClassNodeTest.php
+++ b/src/test/php/PHPMD/Node/ClassNodeTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Node\ClassNode
  * @covers \PHPMD\Node\AbstractTypeNode

--- a/src/test/php/PHPMD/Node/FunctionTest.php
+++ b/src/test/php/PHPMD/Node/FunctionTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -53,7 +52,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Node\FunctionNode
  * @covers \PHPMD\Node\AbstractCallableNode

--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Node;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Node\MethodNode
  * @covers \PHPMD\Node\AbstractCallableNode

--- a/src/test/php/PHPMD/PMDTest.php
+++ b/src/test/php/PHPMD/PMDTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -53,7 +52,6 @@ use PHPMD\Stubs\WriterStub;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\PHPMD
  * @group phpmd

--- a/src/test/php/PHPMD/ParserFactoryTest.php
+++ b/src/test/php/PHPMD/ParserFactoryTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -50,7 +49,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2009 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\ParserFactory
  * @group phpmd

--- a/src/test/php/PHPMD/ParserTest.php
+++ b/src/test/php/PHPMD/ParserTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -50,7 +49,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Parser
  * @group phpmd

--- a/src/test/php/PHPMD/ProcessingErrorTest.php
+++ b/src/test/php/PHPMD/ProcessingErrorTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since     1.2.1
  */
 
@@ -51,7 +50,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since     1.2.1
  *
  * @covers \PHPMD\ProcessingError

--- a/src/test/php/PHPMD/Regression/AbstractTest.php
+++ b/src/test/php/PHPMD/Regression/AbstractTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Regression;
@@ -50,7 +49,6 @@ namespace PHPMD\Regression;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 abstract class AbstractTest extends \PHPMD\AbstractTest
 {

--- a/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
+++ b/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Regression;
@@ -55,7 +54,6 @@ use PHPMD\Stubs\WriterStub;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \stdClass
  * @group phpmd

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015Test.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015Test.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Regression;
@@ -53,7 +52,6 @@ use PHPMD\RuleSet;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers stdClass
  * @group phpmd

--- a/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007Test.php
+++ b/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007Test.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Regression;
@@ -53,7 +52,6 @@ use PHPMD\Rule\UnusedLocalVariable;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers stdClass
  * @group phpmd

--- a/src/test/php/PHPMD/Regression/LongVariablePrivatePropertiesTicket010096717Test.php
+++ b/src/test/php/PHPMD/Regression/LongVariablePrivatePropertiesTicket010096717Test.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @link       https://www.pivotaltracker.com/story/show/10096717
  */
 
@@ -53,7 +52,6 @@ use PHPMD\Rule\Naming\LongVariable;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @link       https://www.pivotaltracker.com/story/show/10096717
  * @since      1.1.0
  *

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @link       https://www.pivotaltracker.com/story/show/24975295
  * @since      1.3.1
  */
@@ -57,7 +56,6 @@ use PHPMD\Writer\StreamWriter;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @link       https://www.pivotaltracker.com/story/show/24975295
  * @since      1.3.1
  *

--- a/src/test/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020Test.php
+++ b/src/test/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020Test.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Regression;
@@ -52,7 +51,6 @@ use PHPMD\Rule\UnusedLocalVariable;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \stdClass
  * @group phpmd

--- a/src/test/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019Test.php
+++ b/src/test/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019Test.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Regression;
@@ -52,7 +51,6 @@ use PHPMD\Rule\UnusedLocalVariable;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \stdClass
  * @group phpmd

--- a/src/test/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036Test.php
+++ b/src/test/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036Test.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Regression;
@@ -53,7 +52,6 @@ use PHPMD\RuleSet;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers stdClass
  * @group phpmd

--- a/src/test/php/PHPMD/Regression/UnusedParameterArgvTicket14990109Test.php
+++ b/src/test/php/PHPMD/Regression/UnusedParameterArgvTicket14990109Test.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @link       https://www.pivotaltracker.com/story/show/14990109
  */
 
@@ -54,7 +53,6 @@ use PHPMD\RuleSet;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @link       https://www.pivotaltracker.com/story/show/14990109
  * @since      1.1.0
  *

--- a/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Renderer;
@@ -54,7 +53,6 @@ use PHPMD\Stubs\WriterStub;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Renderer\HTMLRenderer
  * @group phpmd

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Renderer;
@@ -54,7 +53,6 @@ use PHPMD\Stubs\WriterStub;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Renderer\TextRenderer
  * @group phpmd

--- a/src/test/php/PHPMD/Renderer/XMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/XMLRendererTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Renderer;
@@ -54,7 +53,6 @@ use PHPMD\Stubs\WriterStub;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Renderer\XMLRenderer
  * @group phpmd

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -50,7 +49,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Report
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Controversial;
@@ -53,7 +52,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\Controversial\CamelCaseMethodName
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\CyclomaticComplexity
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @ticket 10474987
  * @covers \PHPMD\Rule\Design\CouplingBetweenObjects

--- a/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\Design\DepthOfInheritance
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -52,8 +51,7 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
- * 
+ *
  * @covers \PHPMD\Rule\Design\EvalExpression
  * @group phpmd
  * @group phpmd::rule

--- a/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\Design\ExitExpression
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
+++ b/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @link       https://www.pivotaltracker.com/story/show/10474873
  * @ticket     10474873
  */
@@ -54,7 +53,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @link       https://www.pivotaltracker.com/story/show/10474873
  * @ticket     10474873
  *

--- a/src/test/php/PHPMD/Rule/Design/LongClassTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongClassTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\Design\LongClass
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\Design\LongMethod
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\Design\LongParameterList
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\Design\NpathComplexity
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\Design\NumberOfChildren
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\Design\TooManyFields
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Design;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\Design\TooManyMethods
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
+++ b/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      0.2.5
  */
 
@@ -53,7 +52,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since      0.2.5
  *
  * @covers \PHPMD\Rule\Design\WeightedMethodCount

--- a/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
+++ b/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\ExcessivePublicCount
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Naming;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers PHPMD\Rule\Naming\BooleanGetMethodName
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Naming;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers PHPMD\Rule\Naming\ConstantNamingConventions
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Naming;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers PHPMD\Rule\Naming\ConstructorWithNameAsEnclosingClass
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Naming;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers PHPMD\Rule\Naming\LongVariable
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Naming;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers PHPMD\Rule\Naming\ShortMethodName
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule\Naming;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers PHPMD\Rule\Naming\ShortVariable
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\UnusedFormalParameter
  * @covers \PHPMD\Rule\AbstractLocalVariable

--- a/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\UnusedLocalVariable
  * @covers \PHPMD\Rule\AbstractLocalVariable

--- a/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\UnusedPrivateField
  * @group phpmd

--- a/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Rule;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\Rule\UnusedPrivateMethod
  * @group phpmd

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -50,7 +49,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\RuleSetFactory
  * @group phpmd

--- a/src/test/php/PHPMD/RuleSetTest.php
+++ b/src/test/php/PHPMD/RuleSetTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -52,7 +51,6 @@ use PHPMD\Stubs\RuleStub;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\RuleSet
  * @group phpmd

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD;
@@ -50,7 +49,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\AbstractRule
  * @group phpmd

--- a/src/test/php/PHPMD/RuleViolationTest.php
+++ b/src/test/php/PHPMD/RuleViolationTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since     0.2.5
  */
 
@@ -51,7 +50,6 @@ namespace PHPMD;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  * @since     0.2.5
  *
  * @covers \PHPMD\RuleViolation

--- a/src/test/php/PHPMD/Stubs/RuleStub.php
+++ b/src/test/php/PHPMD/Stubs/RuleStub.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Stubs;
@@ -54,7 +53,6 @@ use PHPMD\Rule\ClassAware;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class RuleStub extends AbstractRule implements ClassAware
 {

--- a/src/test/php/PHPMD/Stubs/WriterStub.php
+++ b/src/test/php/PHPMD/Stubs/WriterStub.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\Stubs;
@@ -52,7 +51,6 @@ use PHPMD\AbstractWriter;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class WriterStub extends AbstractWriter
 {

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\TextUI;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  *
  * @covers \PHPMD\TextUI\CommandLineOptions
  * @group phpmd

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 namespace PHPMD\TextUI;
@@ -52,7 +51,6 @@ use PHPMD\AbstractTest;
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 class CommandTest extends AbstractTest
 {

--- a/src/test/php/bootstrap.php
+++ b/src/test/php/bootstrap.php
@@ -39,7 +39,6 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
- * @version   @project.version@
  */
 
 require_once __DIR__ . '/../../../vendor/autoload.php';


### PR DESCRIPTION
They make no sense as they use VCS variables, which aren't processed when fetching phpmd through Composer
