### PR TITLE
Allow any future minor version of Symfony2 2.5 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         "php": ">=5.3.0",
         "pdepend/pdepend": "2.0.*",
 
-        "symfony/dependency-injection": "2.5.*",
-        "symfony/filesystem": "2.5.*",
-        "symfony/config": "2.5.*"
+        "symfony/dependency-injection": "~2.5",
+        "symfony/filesystem": "~2.5",
+        "symfony/config": "~2.5"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b29e100f49e4f43e14d93896656f4a1e",
+    "hash": "9caa4d02f341dfadf2cacdab420a87b0",
     "packages": [
         {
             "name": "pdepend/pdepend",


### PR DESCRIPTION
Addresses #196. I've tested PHPMD with 2.6@dev as well, so I don't expect any BC breaks (and there shouldn't be any).

While one could still install PHPMD globally, I use it in projects on a regular basis.
