### PR TITLE
Fixed error message for StaticAccess

### DIFF
--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -83,7 +83,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
                 continue;
             }
 
-            $this->addViolation($methodCall, array($methodCall->getImage(), $methodCall->getImage()));
+            $this->addViolation($methodCall, array($className, $node->getName()));
         }
     }
 


### PR DESCRIPTION
This fixes #169.

Example code:

``` php
<?php
class Baz {
    public static function qux()
    {

    }
}

class Foo {
    public function bar()
    {
        Baz::qux();
    }
}

$foo = new Foo;
$foo->bar();
```

Instead of `Avoid using static access to class '::' in method '::'.` it now outputs `Avoid using static access to class 'Baz' in method 'bar'.`
