### PR TITLE
Three new features about references, includes and include-paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .abc
 .idea
 .sonar
+.project
+.buildpath
+.settings
 composer.phar
 vendor

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -375,7 +375,7 @@ class RuleSetFactory
         }
 
         if (!is_readable($fileName)) {
-            $fileName = str_replace(['\\', '_'], '/', $className) . '.php';
+            $fileName = str_replace(array('\\', '_'), '/', $className) . '.php';
         }
         
         if (class_exists($className) === false) {

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -182,6 +182,17 @@ class RuleSetFactory
             return $fileName;
         }
 
+        foreach(explode(PATH_SEPARATOR, get_include_path()) as $includePath) {
+            $fileName = $includePath . '/' . $ruleSetOrFileName;
+            if(file_exists($fileName) === true) {
+                return $fileName;
+            }
+            $fileName = $includePath . '/' . $ruleSetOrFileName + ".xml";
+            if(file_exists($fileName) === true) {
+                return $fileName;
+            }
+        }
+        
         throw new RuleSetNotFoundException($ruleSetOrFileName);
     }
 
@@ -233,6 +244,20 @@ class RuleSetFactory
             $ruleSet->setStrict();
         }
 
+        foreach ($xml->children() as $node) {
+            if ($node->getName() === 'php-includepath') {
+                $includePath = (string) $node;
+                
+                if(is_dir(dirname($fileName) . DIRECTORY_SEPARATOR . $includePath)) {
+                    $includePath = dirname($fileName) . DIRECTORY_SEPARATOR . $includePath;
+                    $includePath = realpath($includePath);
+                }
+                
+                $includePath = get_include_path() . PATH_SEPARATOR . $includePath;
+                set_include_path($includePath);
+            }
+        }
+        
         foreach ($xml->children() as $node) {
             if ($node->getName() === 'description') {
                 $ruleSet->setDescription((string) $node);
@@ -328,9 +353,31 @@ class RuleSetFactory
      */
     private function parseSingleRuleNode(RuleSet $ruleSet, \SimpleXMLElement $ruleNode)
     {
-        $className = (string) $ruleNode['class'];
-        $fileName  = strtr($className, '\\', '/') . '.php';
+        $fileName = "";
+        
+        $ruleSetFilePath   = $ruleSet->getFileName();
+        $ruleSetFolderPath = dirname($ruleSetFilePath);
+        
+        if (isset($ruleNode['file'])) {
+            
+            if (is_readable((string) $ruleNode['file'])){
+                $fileName = (string) $ruleNode['file'];
+                
+            } elseif (is_readable($ruleSetFolderPath . DIRECTORY_SEPARATOR . (string) $ruleNode['file'])) {
+                $fileName       = $ruleSetFolderPath . DIRECTORY_SEPARATOR . (string) $ruleNode['file'];
+            }
+        }
 
+        $className = (string) $ruleNode['class'];
+        
+        if (!is_readable($fileName)) {
+            $fileName = strtr($className, '\\', '/') . '.php';
+        }
+
+        if (!is_readable($fileName)) {
+            $fileName = str_replace(['\\', '_'], '/', $className) . '.php';
+        }
+        
         if (class_exists($className) === false) {
             $handle = @fopen($fileName, 'r', true);
             if ($handle === false) {

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -647,7 +647,7 @@ class RuleSetFactoryTest extends AbstractTest
         
         try{
             $factory = new RuleSetFactory();
-            $ruleSets = $factory->createRuleSets($fileName);
+            $factory->createRuleSets($fileName);
             
             $expectedIncludePath  = "/foo/bar/baz";
             $actualIncludePaths   = explode(PATH_SEPARATOR, get_include_path());

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -616,7 +616,7 @@ class RuleSetFactoryTest extends AbstractTest
 
     /**
      * testCreateRuleSetsActivatesStrictModeOnRuleSet
-     * 
+     *
      * @return void
      */
     public function testCreateRuleSetsActivatesStrictModeOnRuleSet()
@@ -629,6 +629,41 @@ class RuleSetFactoryTest extends AbstractTest
         $ruleSets = $factory->createRuleSets($fileName);
 
         $this->assertAttributeEquals(true, 'strict', $ruleSets[0]);
+    }
+    
+    /**
+     * Tests that adding an include-path via ruleset works.
+     * Also implicitly tests (by parsing the ruleset) that
+     * reference-by-includepath and explicit-classfile-declaration works.
+     *
+     * @return void
+     */
+    public function testAddPHPIncludePath()
+    {
+        $includePathBefore = get_include_path();
+        
+        $rulesetFilepath = 'rulesets/ruleset-refs.xml';
+        $fileName = self::createFileUri($rulesetFilepath);
+        
+        try{
+            $factory = new RuleSetFactory();
+            $ruleSets = $factory->createRuleSets($fileName);
+            
+            $expectedIncludePath  = "/foo/bar/baz";
+            $actualIncludePaths   = explode(PATH_SEPARATOR, get_include_path());
+            $isIncludePathPresent = in_array($expectedIncludePath, $actualIncludePaths);
+        
+        }catch(\Exception $exception){
+            set_include_path($includePathBefore);
+            throw $exception;
+        }
+        
+        set_include_path($includePathBefore);
+        
+        $this->assertTrue(
+            $isIncludePathPresent,
+            "The include-path from '{$rulesetFilepath}' was not set!"
+        );
     }
 
     /**

--- a/src/test/resources/files/classes/does_not_follow_psr0.class.php
+++ b/src/test/resources/files/classes/does_not_follow_psr0.class.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @author Gerrit Addiks <gerrit.addiks@brille24.de>
+ * @author Gerrit Addiks <gerrit@addiks.de>
  */
 
 /**

--- a/src/test/resources/files/classes/does_not_follow_psr0.class.php
+++ b/src/test/resources/files/classes/does_not_follow_psr0.class.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @author Gerrit Addiks <gerrit.addiks@brille24.de>
+ */
+
+/**
+ * Some class that stands as an example for classes not following PSR-0.
+ */
+class some_class_that_does_not_follow_psr0 extends \PHPMD\AbstractRule{
+    
+    /**
+     * A method that returnes foo, bar and baz.
+     *
+     * @return string
+     */
+    public function getFooBarBaz(){
+        return array('foo', 'bar', 'baz');
+    }
+    
+    public function apply(\PHPMD\AbstractNode $node){
+        
+    }
+    
+}

--- a/src/test/resources/files/rulesets/ruleset-refs.xml
+++ b/src/test/resources/files/rulesets/ruleset-refs.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset 
+    name="phpmd-phpincludepath-test" 
+    xmlns="http://www.addiks.net/xmlns/pmd" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="http://www.addiks.net/xmlns/pmd http://files.addiks.de/xmlns/phpmd.xsd" 
+    xsi:noNamespaceSchemaLocation=" http://files.addiks.de/xmlns/phpmd.xsd"> 
+    <description>First description...</description>
+    
+    <php-includepath>/foo/bar/baz</php-includepath>
+    
+    <!-- this ref's set1.xml using the include-path '.../src/test/php'
+         It will cause an error if that feature does not work properly. -->
+    <rule ref="../resources/files/rulesets/set1.xml" />
+    
+    <!-- This includes a certain file not following PSR-0 using an explicit filepath.
+         If including a rule with explicit filename does not work, this will fail. 
+         Also, the file is referenced relative from this rule-file. -->
+    <rule name="SomeTestRule" 
+          message="The method is missing a valid @return annotation!"
+          class="some_class_that_does_not_follow_psr0" 
+          file="../classes/does_not_follow_psr0.class.php"> 
+        <priority>1</priority> 
+    </rule>
+    
+</ruleset>


### PR DESCRIPTION
Hello,

i have added three little new features in my fork of phpmd and would like to see them in the real repository:
 - Define PHP include-path's in ruleset-xml files.
 - Reference other rulesets relative to the defined include-path's.
 - Define an explicit filepath to a rule beside it's classname.

I think these features will make it easier to write project-specific rules (and be able to use them in the project's rulesets).

For an better understanding of how these features work, see the test-ruleset below.
**src/test/resources/rulesets/ruleset-refs.xml** :
```xml
<?xml version="1.0" encoding="UTF-8"?>
<ruleset 
    name="phpmd-phpincludepath-test" 
    xmlns="http://www.addiks.net/xmlns/pmd" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
    xsi:schemaLocation="http://www.addiks.net/xmlns/pmd http://files.addiks.de/xmlns/phpmd.xsd" 
    xsi:noNamespaceSchemaLocation=" http://files.addiks.de/xmlns/phpmd.xsd"> 
    <description>First description...</description>
    
    <php-includepath>/foo/bar/baz</php-includepath>
    
    <!-- this ref's set1.xml using the include-path '.../src/test/php'
         It will cause an error if that feature does not work properly. -->
    <rule ref="../resources/files/rulesets/set1.xml" />
    
    <!-- This includes a certain file not following PSR-0 using an explicit filepath.
         If including a rule with explicit filename does not work, this will fail. 
         Also, the file is referenced relative from this rule-file. -->
    <rule name="SomeTestRule" 
          message="The method is missing a valid @return annotation!"
          class="some_class_that_does_not_follow_psr0" 
          file="../classes/does_not_follow_psr0.class.php"> 
        <priority>1</priority> 
    </rule>
    
</ruleset>
```

**Why i need these features:** I want to sell magento-modules. And because i want to guarantee high-quality code, i want to also ship a central module defining phpmd-rules for my modules (besides other things). I want my customers (or other developers) be able to also test my (and their) code with the rulesets and rules i provide. Also, i want to test the doccomment-descriptions and annotations which is currently not possible with plain phpmd, so i have written my own rules testing the doccomments. I also need to ship these new rules together with the magento-module. In magento, modules are placed in "app/code/[core|community|local]/[VendorName]/[ModuleName]" with app/code/app/code/[core|community|local] as three include-paths. Absolute filepath's are a no-go here as i do not know where in the filesystem the customer has installed his magento-instance. For my rules to be loadable by phpmd i need to add these three folders as include-paths to the phpmd-runtime. 
Also i want to have a seperate ruleset for doccomment-checks to be reusable later, which means i need to reference that doccomment-ruleset from the actual used ruleset, both of wich are shipped and placed inside the module. So i need to be able to reference other rulesets relative from one of the include-path's i defined.
As for the third feature (be able to define an explicit filepath for rule-classes beside the classname), that was my first approach to solve this problem which i later replaced by using include-paths because that seams to be the better solution. I did not want to throw away the already implemented feature which might someone else need someday, so i decided to leave it in there.

Of cource i have written a test to cover these three new features and made sure that the tests all run fine.

I'm still very new to contributing to other projects (not only) on github, so please tell me if i did something wrong. :)