### PR TITLE
Display type correctly for constructors

### DIFF
--- a/src/main/php/PHPMD/Rule/Design/LongMethod.php
+++ b/src/main/php/PHPMD/Rule/Design/LongMethod.php
@@ -78,9 +78,14 @@ class LongMethod extends AbstractRule implements FunctionAware, MethodAware
             return;
         }
 
-        $type = explode('_', get_class($node));
-        $type = strtolower(array_pop($type));
-
-        $this->addViolation($node, array($type, $node->getName(), $loc, $threshold));
+        $this->addViolation(
+            $node,
+            array(
+                $node->getType(),
+                $node->getName(),
+                $loc,
+                $threshold
+            )
+        );
     }
 }


### PR DESCRIPTION
The old code displayed the type of __construct as "phpmd\node\methodnode" instead of the expected "method".