### PR TITLE
Added 'is' to ignore regexp filter.

### DIFF
--- a/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
@@ -61,7 +61,7 @@ class TooManyMethods extends AbstractRule implements ClassAware
      *
      * @var string
      */
-    const DEFAULT_IGNORE_REGEXP = '(^(set|get))i';
+    const DEFAULT_IGNORE_REGEXP = '(^(set|get|is))i';
 
     /**
      * Regular expression that filter all methods that are ignored by this rule.


### PR DESCRIPTION
'is' added to ignore regexp for filtering methods.