### PR TITLE
Complete fix for #77 (timezone warning)

### DIFF
--- a/src/bin/phpmd
+++ b/src/bin/phpmd
@@ -21,7 +21,7 @@ if (file_exists(__DIR__ . '/../../../../autoload.php')) {
     }
 }
 
-if (!ini_get('date.timezone') && !date_default_timezone_get()) {
+if (!ini_get('date.timezone')) {
     date_default_timezone_set('UTC');
 }
 


### PR DESCRIPTION
The #77 bug involves this warning being raised when PHPMD is executed:

> Warning: **date()**: It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function.

In [v2.0.0](https://github.com/phpmd/phpmd/releases/tag/2.0.0) and earlier, the warning was caused by calling `date()` without first setting the timezone, in [this line in `XMLRenderer::renderReport()`](https://github.com/phpmd/phpmd/blob/2.0.0/src/main/php/PHPMD/Renderer/XMLRenderer.php#L92):

```php
$writer->write('timestamp="' . date('c') . '">');
```

93b5835 attempted to fix the bug by adding this code to `src/bin/phpmd`:

```php
if (!ini_get('date.timezone') && !date_default_timezone_get()) {
    date_default_timezone_set('UTC');
}
```

:warning: Although this fixed the warning from the `date()` call in `XMLRenderer::renderReport()`, it introduced a new bug. The new call to `date_default_timezone_get()` raises this warning:

> Warning: **date_default_timezone_get()**: It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function.

See @hbandura's [comment](https://github.com/phpmd/phpmd/issues/77#issuecomment-61386700) on #77.

From the [docs](http://php.net/date_default_timezone_get) for `date_default_timezone_get()`:

> In order of preference, this function returns the default timezone by:
> * Reading the timezone set using the `date_default_timezone_set()` function (if any)
> * Reading the value of the `date.timezone` ini option (if set)

There's no need to call `date_default_timezone_get()`, because:

* We know `date_default_timezone_set()` hasn't been called. (Look at [the top of `src/bin/phpmd`](https://github.com/phpmd/phpmd/blob/2.2.3/src/bin/phpmd#L1-L22). Only Composer's `autoload.php` is executed, and `date_default_timezone_set()` is not called there.)
* We've just tested the value of the `date.timezone` ini option by calling `ini_get('date.timezone')`.

So the call to `date_default_timezone_get()` can safely be removed, and this will completely fix the issue of the timezone warning.
