### PR TITLE
Fix #303, change if condition order

### DIFF
--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -121,12 +121,14 @@ class MethodNode extends AbstractCallableNode
     {
         $parentNode = $this->getNode()->getParent();
 
-        if ($parentNode instanceof ASTClass) {
-            return new ClassNode($parentNode);
-        }
         if ($parentNode instanceof ASTTrait) {
             return new TraitNode($parentNode);
         }
+
+        if ($parentNode instanceof ASTClass) {
+            return new ClassNode($parentNode);
+        }
+        
         return new InterfaceNode($parentNode);
     }
 


### PR DESCRIPTION
If I switch the if conditions, then ```getParentType``` returns a ```TraitNode```. When the parent node is a class I get a ```ClassNode```. So this works too.