### PR TITLE
Correct documentaion about the --suffixes parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Command line options
     instead of the default output target ``STDOUT``.
 
   - ``--suffixes`` - Comma-separated string of valid source code filename
-    extensions.
+    extensions, e.g. php,phtml.
 
   - ``--exclude`` - Comma-separated string of patterns that are used to ignore
     directories.
@@ -96,7 +96,7 @@ Command line options
 
   An example command line: ::
 
-    phpmd PHP/Depend/DbusUI xml codesize --reportfile phpmd.xml --suffixes .php
+    phpmd PHP/Depend/DbusUI xml codesize --reportfile phpmd.xml --suffixes php,phtml
 
 Using multiple rule sets
 ````````````````````````

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -434,7 +434,7 @@ class CommandLineOptions
                '--reportfile: send report output to a file; default to STDOUT' .
                \PHP_EOL .
                '--suffixes: comma-separated string of valid source code ' .
-               'filename extensions' . \PHP_EOL .
+               'filename extensions, e.g. php,phtml' . \PHP_EOL .
                '--exclude: comma-separated string of patterns that are used to ' .
                'ignore directories' . \PHP_EOL .
                 '--strict: also report those nodes with a @SuppressWarnings ' .

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -47,7 +47,7 @@ Command line options
     instead of the default output target ``STDOUT``.
 
   - ``--suffixes`` - Comma-separated string of valid source code filename 
-    extensions.
+    extensions, e.g. php,phtml.
 
   - ``--exclude`` - Comma-separated string of patterns that are used to ignore 
     directories.
@@ -56,7 +56,7 @@ Command line options
 
   An example command line: ::
 
-    phpmd PHP/Depend/DbusUI xml codesize --reportfile phpmd.xml --suffixes .php
+    phpmd PHP/Depend/DbusUI xml codesize --reportfile phpmd.xml --suffixes php,phtml
 
 
 Using multiple rule sets


### PR DESCRIPTION
@manuelpichler either we fix the documenation or we change the way the CLI parses this parameter, so it would allow to give ``--suffixes .php,.phtml`` or even ``--suffixes=.php,.phtml``.

But personally I would prefer to only allow one correct way of input.
Otherwise it would open a can of worms, I guess.

Funny this didn't surface earlier, though.