### PR TITLE
Added __debugInfo to list of ignored methods

### DIFF
--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -71,6 +71,7 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
         '__invoke',
         '__set_state',
         '__clone',
+        '__debugInfo',
     );
 
     /**


### PR DESCRIPTION
Starting with PHP 5.6, __debugInfo is also an available PHP magic method.

Reference: http://php.net/manual/en/language.oop5.magic.php#object.debuginfo