### PR TITLE
Trim exceptions for StaticAccess

### DIFF
--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -79,7 +79,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
             }
 
             $className = $methodCall->getChild(0)->getNode()->getImage();
-            if (in_array($className, $exceptions)) {
+            if (in_array(ltrim('\\', $className), $exceptions)) {
                 continue;
             }
 
@@ -120,7 +120,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
 
         $exceptionList = explode(',', $exceptions);
         foreach ($exceptionList as $key => $exception) {
-            $exceptionList[$key] = trim($exception);
+            $exceptionList[$key] = ltrim('\\', trim($exception));
         }
         return $exceptionList;
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -118,6 +118,10 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
             $exceptions = '';
         }
 
-        return explode(',', $exceptions);
+        $exceptionList = explode(',', $exceptions);
+        foreach ($exceptionList as $key => $exception) {
+            $exceptionList[$key] = trim($exception);
+        }
+        return $exceptionList;
     }
 }

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -79,7 +79,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
             }
 
             $className = $methodCall->getChild(0)->getNode()->getImage();
-            if (in_array(ltrim('\\', $className), $exceptions)) {
+            if (in_array($this->trimClassName($className), $exceptions)) {
                 continue;
             }
 
@@ -120,8 +120,18 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
 
         $exceptionList = explode(',', $exceptions);
         foreach ($exceptionList as $key => $exception) {
-            $exceptionList[$key] = ltrim('\\', trim($exception));
+            $exceptionList[$key] = $this->trimClassName($exception);
         }
         return $exceptionList;
+    }
+
+    /**
+     * Remove surrounding whitespace and preceding backslashes
+     * @param $className
+     * @return string
+     */
+    private function trimClassName($className)
+    {
+        return ltrim(trim($className), '\\');
     }
 }


### PR DESCRIPTION
Not sure how thrilled the xml purests will be however, it we trim the results of this list, we can split the exception string onto multiple lines. 

**Before:**
```xml
    <rule ref="rulesets/cleancode.xml/StaticAccess">
        <properties>
            <property name="exceptions" value="\Foundry\Masonry\Core\Notification,\Foundry\Masonry\Core\GlobalRegister,\Foundry\Masonry\ModuleRegister\ModuleRegister,\Symfony\Component\Yaml\Yaml"/>
        </properties>
    </rule>
```
**After:**
```xml
    <rule ref="rulesets/cleancode.xml/StaticAccess">
        <properties>
            <property name="exceptions" value="
                \Foundry\Masonry\Core\Notification,
                \Foundry\Masonry\Core\GlobalRegister,
                \Foundry\Masonry\ModuleRegister\ModuleRegister,
                \Symfony\Component\Yaml\Yaml
                "/>
        </properties>
    </rule>
```
A better solution from an xml point of view might be to have individual elements for each exception, however this at least makes the XML file readable