### PR TITLE
Replace plus by a dot as concat operator in filename creation

### DIFF
--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -187,7 +187,7 @@ class RuleSetFactory
             if (file_exists($fileName) === true) {
                 return $fileName;
             }
-            $fileName = $includePath . '/' . $ruleSetOrFileName + ".xml";
+            $fileName = $includePath . '/' . $ruleSetOrFileName . ".xml";
             if (file_exists($fileName) === true) {
                 return $fileName;
             }


### PR DESCRIPTION
This bad concat operator transform filename into an int so rulset.xml can not be found.