### PR TITLE
Remove the leading blank line from the TextRenderer

### DIFF
--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -65,7 +65,6 @@ class TextRenderer extends AbstractRenderer
     public function renderReport(Report $report)
     {
         $writer = $this->getWriter();
-        $writer->write(PHP_EOL);
 
         foreach ($report->getRuleViolations() as $violation) {
             $writer->write($violation->getFileName());

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -91,7 +91,6 @@ class TextRendererTest extends AbstractTest
         $renderer->end();
 
         $this->assertEquals(
-            PHP_EOL .
             "/bar.php:1\tTest description" . PHP_EOL .
             "/foo.php:2\tTest description" . PHP_EOL .
             "/foo.php:3\tTest description" . PHP_EOL,
@@ -131,7 +130,6 @@ class TextRendererTest extends AbstractTest
         $renderer->end();
 
         $this->assertEquals(
-            PHP_EOL .
             "/tmp/foo.php\t-\tFailed for file \"/tmp/foo.php\"." . PHP_EOL .
             "/tmp/bar.php\t-\tFailed for file \"/tmp/bar.php\"." . PHP_EOL .
             "/tmp/baz.php\t-\tFailed for file \"/tmp/baz.php\"." . PHP_EOL,


### PR DESCRIPTION
Currently, the 'text' report always starts with a blank line - even if there are no violations to report. This causes build tools such as Phing to show output, even if there is nothing to report. The other renderers seem to be unaffected.

This PR removes the blank line.