### PR TITLE
Ignore isser-, hasser-, wither-method for TooManyMethods

### DIFF
--- a/src/main/resources/rulesets/codesize.xml
+++ b/src/main/resources/rulesets/codesize.xml
@@ -351,7 +351,7 @@ The default was changed from 10 to 25 in PHPMD 2.3.
         <priority>3</priority>
         <properties>
             <property name="maxmethods" description="The method count reporting threshold" value="25"/>
-            <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get))i"/>
+            <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get|is|has))i"/>
         </properties>
     </rule>
 
@@ -371,7 +371,7 @@ By default it ignores methods starting with 'get' or 'set'.
         <priority>3</priority>
         <properties>
             <property name="maxmethods" description="The method count reporting threshold" value="10"/>
-            <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get))i"/>
+            <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get|is|has))i"/>
         </properties>
     </rule>
 

--- a/src/main/resources/rulesets/codesize.xml
+++ b/src/main/resources/rulesets/codesize.xml
@@ -351,7 +351,7 @@ The default was changed from 10 to 25 in PHPMD 2.3.
         <priority>3</priority>
         <properties>
             <property name="maxmethods" description="The method count reporting threshold" value="25"/>
-            <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get|is|has))i"/>
+            <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get|is|has|with))i"/>
         </properties>
     </rule>
 
@@ -371,7 +371,7 @@ By default it ignores methods starting with 'get' or 'set'.
         <priority>3</priority>
         <properties>
             <property name="maxmethods" description="The method count reporting threshold" value="10"/>
-            <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get|is|has))i"/>
+            <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get|is|has|with))i"/>
         </properties>
     </rule>
 

--- a/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -157,6 +157,42 @@ class TooManyMethodsTest extends AbstractTest
     }
 
     /**
+     * @return void
+     */
+    public function testRuleIgnoresHassers()
+    {
+        $rule = new TooManyMethods();
+        $rule->setReport($this->getReportMock(0));
+        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
+        $rule->apply($this->createClassMock(2, array('invoke', 'hasClass')));
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleIgnoresIssers()
+    {
+        $rule = new TooManyMethods();
+        $rule->setReport($this->getReportMock(0));
+        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
+        $rule->apply($this->createClassMock(2, array('invoke', 'isClass')));
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleIgnoresWithers()
+    {
+        $rule = new TooManyMethods();
+        $rule->setReport($this->getReportMock(0));
+        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
+        $rule->apply($this->createClassMock(2, array('invoke', 'withClass')));
+    }
+
+    /**
      * Creates a prepared class node mock
      *
      * @param integer $numberOfMethods

--- a/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -158,6 +158,42 @@ class TooManyPublicMethodsTest extends AbstractTest
     }
 
     /**
+     * @return void
+     */
+    public function testRuleIgnoresHassers()
+    {
+        $rule = new TooManyPublicMethods();
+        $rule->setReport($this->getReportMock(0));
+        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
+        $rule->apply($this->createClassMock(2, array('invoke', 'hasClass')));
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleIgnoresIssers()
+    {
+        $rule = new TooManyPublicMethods();
+        $rule->setReport($this->getReportMock(0));
+        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
+        $rule->apply($this->createClassMock(2, array('invoke', 'isClass')));
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleIgnoresWithers()
+    {
+        $rule = new TooManyPublicMethods();
+        $rule->setReport($this->getReportMock(0));
+        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
+        $rule->apply($this->createClassMock(2, array('invoke', 'withClass')));
+    }
+
+    /**
      * Creates a prepared class node mock
      *
      * @param integer $numberOfMethods


### PR DESCRIPTION
Widely used methods, but still getters and setters

https://symfony.com/doc/current/components/property_access/introduction.html#using-hassers-issers

Please consider to skip them too
