### PR TITLE
test for PHPMD or PMD on SuppressWarnings

### DIFF
--- a/src/main/php/PHPMD/Node/Annotation.php
+++ b/src/main/php/PHPMD/Node/Annotation.php
@@ -107,7 +107,7 @@ class Annotation
     {
         if (in_array($this->value, array('PHPMD', 'PMD'))) {
             return true;
-        } elseif (strpos($this->value, 'PMD.' . $rule->getName()) !== false) {
+        } elseif (preg_match('/^(PH)?PMD\.' . $rule->getName() . '/', $this->value)) {
             return true;
         }
         return (stripos($rule->getName(), $this->value) !== false);


### PR DESCRIPTION
Testing for #409 I spotted that `SuppressWarnings` annotation rule selection allows weird formatting, any of the following is considered valid and should not:

```php
/**
 * @SuppressWarnings(PH_PMD.UnusedPrivateMethod)
 * @SuppressWarnings(HohohoPMD.ExitExpression)
 * @SuppressWarnings(what? PHPMD.Superglobals)
 */
```