### PR TITLE
Add .mailmap file to fix git shortlog

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Manuel Pichler <mapi@manuel-pichler.de> <github@manuel-pichler.de>
+Stefan Zerkalica <zerkalica@gmail.com>
+Daniel Mason <daniel@danielmason.com> <daniel.mason@thefoundry.co.uk>
+Ilia Shakitko <shakitko@gmail.com> <i.shakitko@leaseweb.com>


### PR DESCRIPTION
When executing ``git shortlog -sne`` it show, for example:

``````
655	Manuel Pichler <mapi@manuel-pichler.de>
195	Manuel Pichler <github@manuel-pichler.de>
``````

With this file, it becomes:

``````
850	Manuel Pichler <mapi@manuel-pichler.de>
``````

https://git-scm.com/docs/git-shortlog#_mapping_authors
https://stacktoheap.com/blog/2013/01/06/using-mailmap-to-fix-authors-list-in-git/
https://shane.io/2011/10/07/git-shortlog-and-mailmap.html