### PR TITLE
Test against lowest possible dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ php:
 sudo: false
 
 env:
-  - TEST_CONFIG="phpunit.xml.dist"
+  - TEST_CONFIG="phpunit.xml.dist" COMPOSER_OPTS="install"
+  - TEST_CONFIG="phpunit.xml.dist" COMPOSER_OPTS="update --prefer-lowest"
 
 before_script:
-  - composer install
+  - composer $COMPOSER_OPTS
 
 script: phpunit --configuration $TEST_CONFIG --colors --coverage-text
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "minimum-stability" : "stable",
     "require": {
         "php": ">=5.3.9",
-        "pdepend/pdepend": "^2.0.4"
+        "pdepend/pdepend": "^2.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0",


### PR DESCRIPTION
The current minimum required version `^2.0.4` of `pdepend/pdepend` is a lie and the tests don't pass with this version installed. I bumped it to the lowest I could get all tests to pass with and took the liberty to make sure Travis runs the tests against the lowest possible versions as well as against what's in the lock file.