### PR TITLE
Fix a link to github help because the link is broken

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,5 +39,5 @@ Additional Resources
 
 * [Existing issues](https://github.com/phpmd/phpmd/issues/)
 * [General GitHub documentation](https://help.github.com/)
-* [GitHub pull request documentation](https://help.github.com/send-pull-requests/)
+* [GitHub pull request documentation](https://help.github.com/articles/creating-a-pull-request/)
 * [PHPMD IRC Channel on freenode.org](http://webchat.freenode.net/?channels=phpmd)


### PR DESCRIPTION
A link is broken in `CONTRIBUTING.md`.
![1480644731](https://cloud.githubusercontent.com/assets/4361134/20820667/4ff623c0-b880-11e6-8929-11ef6992b559.png)

![1480644709](https://cloud.githubusercontent.com/assets/4361134/20820654/324c64e2-b880-11e6-8174-60087a16634d.png)

I think the help have moved to https://help.github.com/articles/creating-a-pull-request .
So, I fixed the link.