### PR TITLE
Enable Windows Update service on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ branches:
 install:
   - cinst -y OpenSSL.Light
   - SET PATH=C:\Program Files\OpenSSL;%PATH%
+  - sc config wuauserv start= auto
+  - net start wuauserv
   - cinst -y php
   - cd c:\tools\php
   - copy php.ini-production php.ini


### PR DESCRIPTION
The `php` Chocolatey package depends on `KB2919442` which isn't installed on AppVeyor, and thus attempts to install it. This was failing as it requires the Windows Update process to be running properly. This forces that to be enabled.

Fixes #417.