### PR TITLE
Factory for renderers

### DIFF
--- a/src/bin/phpmd
+++ b/src/bin/phpmd
@@ -31,6 +31,7 @@ class_alias('PHPMD\\AbstractRule', 'PHP_PMD_AbstractRule');
 class_alias('PHPMD\\Parser', 'PHP_PMD_Parser');
 class_alias('PHPMD\\ParserFactory', 'PHP_PMD_ParserFactory');
 class_alias('PHPMD\\ProcessingError', 'PHP_PMD_ProcessingError');
+class_alias('PHPMD\\RendererFactory', 'PHP_PMD_RendererFactory');
 class_alias('PHPMD\\Report', 'PHP_PMD_Report');
 class_alias('PHPMD\\Rule', 'PHP_PMD_Rule');
 class_alias('PHPMD\\RuleClassFileNotFoundException', 'PHP_PMD_RuleClassFileNotFoundException');

--- a/src/json.php
+++ b/src/json.php
@@ -1,4 +1,0 @@
-<?php
-class json {
-    
-}

--- a/src/json.php
+++ b/src/json.php
@@ -1,0 +1,4 @@
+<?php
+class json {
+    
+}

--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -82,7 +82,7 @@ abstract class AbstractRenderer
      *
      * @param \PHPMD\AbstractWriter $writer
      * @return void
-     * @deprecated 2.6.0 To delete in next major release
+     * @deprecated 2.6.0 To delete in next major release for ensuring contract on the class
      */
     public function setWriter(AbstractWriter $writer)
     {

--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -59,19 +59,34 @@ abstract class AbstractRenderer
      */
     private $writer = null;
 
-    public function __construct(AbstractWriter $writer)
+    public function __construct(AbstractWriter $writer = null)
     {
-        $this->writer = $writer;
+        if ($writer instanceof AbstractWriter) {
+            $this->setWriter($writer);
+        }
     }
 
     /**
      * Returns the associated output writer instance.
      *
      * @return \PHPMD\AbstractWriter
+     * @todo 2.6.0 : Change scope from public to protected in next major release
      */
-    protected function getWriter()
+    public function getWriter()
     {
         return $this->writer;
+    }
+
+    /**
+     * Sets the associated output writer instance.
+     *
+     * @param \PHPMD\AbstractWriter $writer
+     * @return void
+     * @deprecated 2.6.0 To delete in next major release
+     */
+    public function setWriter(AbstractWriter $writer)
+    {
+        $this->writer = $writer;
     }
 
     /**

--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -69,7 +69,7 @@ abstract class AbstractRenderer
      *
      * @return \PHPMD\AbstractWriter
      */
-    public function getWriter()
+    protected function getWriter()
     {
         return $this->writer;
     }

--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -41,6 +41,8 @@
 
 namespace PHPMD;
 
+use PHPMD\AbstractWriter;
+
 /**
  * Abstract base class for PHPMD rendering engines.
  *
@@ -57,6 +59,11 @@ abstract class AbstractRenderer
      */
     private $writer = null;
 
+    public function __construct(AbstractWriter $writer)
+    {
+        $this->writer = $writer;
+    }
+
     /**
      * Returns the associated output writer instance.
      *
@@ -65,17 +72,6 @@ abstract class AbstractRenderer
     public function getWriter()
     {
         return $this->writer;
-    }
-
-    /**
-     * Returns the associated output writer instance.
-     *
-     * @param \PHPMD\AbstractWriter $writer
-     * @return void
-     */
-    public function setWriter(AbstractWriter $writer)
-    {
-        $this->writer = $writer;
     }
 
     /**

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -75,7 +75,7 @@ class PHPMD
      * @var string
      */
     private $input;
-    
+
     /**
      * This property will be set to <b>true</b> when an error or a violation
      * was found in the processed source code.
@@ -225,7 +225,7 @@ class PHPMD
         foreach ($renderers as $renderer) {
             $renderer->start();
         }
-        
+
         foreach ($renderers as $renderer) {
             $renderer->renderReport($report);
         }

--- a/src/main/php/PHPMD/RendererFactory.php
+++ b/src/main/php/PHPMD/RendererFactory.php
@@ -59,11 +59,11 @@ abstract class RendererFactory
      * Creates a report renderer instance based on the user's command line
      * argument.
      *
-     * @param AbstractWriter $writer Associated output writer instance
      * @param string $reportFormat Format within xml, html, text or a custom one
+     * @param AbstractWriter $writer Associated output writer instance
      * @return \PHPMD\AbstractRenderer
      */
-    public static function createRenderer(AbstractWriter $writer, $reportFormat)
+    public static function createRenderer($reportFormat, AbstractWriter $writer = null)
     {
         switch ($reportFormat) {
             case 'xml':
@@ -80,12 +80,12 @@ abstract class RendererFactory
     /**
      * Create a custom renderer, for user's specific needs
      *
-     * @param AbstractWriter $writer Associated output writer instance
      * @param string $reportFormat A custom format, created by the user (for instance, json)
+     * @param AbstractWriter $writer Associated output writer instance
      * @return \PHPMD\AbstractRenderer
      * @throws \InvalidArgumentException When the format is empty
      */
-    private static function createCustomRenderer(AbstractWriter $writer, $reportFormat)
+    private static function createCustomRenderer($reportFormat, AbstractWriter $writer = null)
     {
         if ($reportFormat === '') {
             throw new \InvalidArgumentException(

--- a/src/main/php/PHPMD/RendererFactory.php
+++ b/src/main/php/PHPMD/RendererFactory.php
@@ -65,30 +65,32 @@ abstract class RendererFactory
      *   <li>text</li>
      * </ul>
      *
+     * @param AbstractWriter $writer Asociated output writer instance
      * @param string $reportFormat
      * @return \PHPMD\AbstractRenderer
      * @throws \InvalidArgumentException When the specified renderer does not exist.
      */
-    public static function createRenderer($reportFormat)
+    public static function createRenderer(AbstractWriter $writer, $reportFormat)
     {
         switch ($reportFormat) {
             case 'xml':
-                return new XMLRenderer();
+                return new XMLRenderer($writer);
             case 'html':
-                return new HTMLRenderer();
+                return new HTMLRenderer($writer);
             case 'text':
-                return new TextRenderer();
+                return new TextRenderer($writer);
             default:
-                return static::createCustomRenderer($reportFormat);
+                return static::createCustomRenderer($writer, $reportFormat);
         }
     }
 
     /**
+     * @param AbstractWriter $writer Asociated output writer instance
      * @param string $reportFormat
      * @return \PHPMD\AbstractRenderer
      * @throws \InvalidArgumentException
      */
-    private static function createCustomRenderer($reportFormat)
+    private static function createCustomRenderer(AbstractWriter $writer, $reportFormat)
     {
         if ('' === $reportFormat) {
             throw new \InvalidArgumentException(
@@ -97,7 +99,7 @@ abstract class RendererFactory
         }
 
         if (class_exists($reportFormat)) {
-            return new $reportFormat();
+            return new $reportFormat($writer);
         }
 
         // Try to load a custom renderer
@@ -116,6 +118,6 @@ abstract class RendererFactory
 
         include_once $fileName;
 
-        return new $reportFormat();
+        return new $reportFormat($writer);
     }
 }

--- a/src/main/php/PHPMD/RendererFactory.php
+++ b/src/main/php/PHPMD/RendererFactory.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) 2008-2017, Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PHPMD;
+
+/**
+ * Factory responsible for creating PHPMD rendering engines.
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+abstract class RendererFactory
+{
+    /**
+     * Creates a report renderer instance based on the user's command line
+     * argument.
+     *
+     * Valid renderers are:
+     * <ul>
+     *   <li>xml</li>
+     *   <li>html</li>
+     *   <li>text</li>
+     * </ul>
+     *
+     * @param string $reportFormat
+     * @return \PHPMD\AbstractRenderer
+     * @throws \InvalidArgumentException When the specified renderer does not exist.
+     */
+    public static function createRenderer()
+    {
+        $reportFormat = $reportFormat ?: $this->reportFormat;
+
+        switch ($reportFormat) {
+            case 'xml':
+                return $this->createXmlRenderer();
+            case 'html':
+                return $this->createHtmlRenderer();
+            case 'text':
+                return $this->createTextRenderer();
+            default:
+                return $this->createCustomRenderer();
+        }
+    }
+}

--- a/src/main/php/PHPMD/RendererFactory.php
+++ b/src/main/php/PHPMD/RendererFactory.php
@@ -73,7 +73,7 @@ abstract class RendererFactory
             case 'text':
                 return new TextRenderer($writer);
             default:
-                return static::createCustomRenderer($writer, $reportFormat);
+                return static::createCustomRenderer($reportFormat, $writer);
         }
     }
 

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -140,7 +140,7 @@ class Command
     }
 
     /**
-     * Returns renderers asked by user
+     * Returns renderers requested by user
      *
      * @param \PHPMD\TextUI\CommandLineOptions $opts
      * @return \PHPMD\AbstractRenderer[]

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -147,10 +147,8 @@ class Command
      */
     private function getRenderers(CommandLineOptions $opts)
     {
-        // Create a report stream
         $stream = $opts->getReportFile() ? fopen($opts->getReportFile(), 'wb') : STDOUT;
-
-        $renderers[] = $opts->createRenderer(new StreamWriter($stream));;
+        $renderers[] = $opts->createRenderer(new StreamWriter($stream));
 
         foreach ($opts->getReportFiles() as $reportFormat => $reportFile) {
             $renderers[] = $opts->createRenderer(

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -150,16 +150,13 @@ class Command
         // Create a report stream
         $stream = $opts->getReportFile() ? fopen($opts->getReportFile(), 'wb') : STDOUT;
 
-        $renderer = $opts->createRenderer();
-        $renderer->setWriter(new StreamWriter($stream));
-
-        $renderers = array($renderer);
+        $renderers[] = $opts->createRenderer(new StreamWriter($stream));;
 
         foreach ($opts->getReportFiles() as $reportFormat => $reportFile) {
-            $reportRenderer = $opts->createRenderer($reportFormat);
-            $reportRenderer->setWriter(new StreamWriter(fopen($reportFile, 'wb')));
-
-            $renderers[] = $reportRenderer;
+            $renderers[] = $opts->createRenderer(
+                new StreamWriter(fopen($reportFile, 'wb')),
+                $reportFormat
+            );
         }
 
         return $renderers;

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -84,22 +84,6 @@ class Command
             return self::EXIT_SUCCESS;
         }
 
-        // Create a report stream
-        $stream = $opts->getReportFile() ? fopen($opts->getReportFile(), 'wb') : STDOUT;
-
-        // Create renderer and configure output
-        $renderer = $opts->createRenderer();
-        $renderer->setWriter(new StreamWriter($stream));
-
-        $renderers = array($renderer);
-
-        foreach ($opts->getReportFiles() as $reportFormat => $reportFile) {
-            $reportRenderer = $opts->createRenderer($reportFormat);
-            $reportRenderer->setWriter(new StreamWriter(fopen($reportFile, 'wb')));
-
-            $renderers[] = $reportRenderer;
-        }
-
         // Configure a rule set factory
         $ruleSetFactory->setMinimumPriority($opts->getMinimumPriority());
         if ($opts->hasStrict()) {
@@ -128,7 +112,7 @@ class Command
         $phpmd->processFiles(
             $opts->getInputPath(),
             $opts->getRuleSets(),
-            $renderers,
+            $this->getRenderers($opts),
             $ruleSetFactory
         );
 
@@ -153,6 +137,32 @@ class Command
             $version = $data['project.version'];
         }
         return $version;
+    }
+
+    /**
+     * Returns renderers asked by user
+     *
+     * @param \PHPMD\TextUI\CommandLineOptions $opts
+     * @return \PHPMD\AbstractRenderer[]
+     */
+    private function getRenderers(CommandLineOptions $opts)
+    {
+        // Create a report stream
+        $stream = $opts->getReportFile() ? fopen($opts->getReportFile(), 'wb') : STDOUT;
+
+        $renderer = $opts->createRenderer();
+        $renderer->setWriter(new StreamWriter($stream));
+
+        $renderers = array($renderer);
+
+        foreach ($opts->getReportFiles() as $reportFormat => $reportFile) {
+            $reportRenderer = $opts->createRenderer($reportFormat);
+            $reportRenderer->setWriter(new StreamWriter(fopen($reportFile, 'wb')));
+
+            $renderers[] = $reportRenderer;
+        }
+
+        return $renderers;
     }
 
     /**

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -358,11 +358,11 @@ class CommandLineOptions
      * @return \PHPMD\AbstractRenderer
      * @throws \InvalidArgumentException When the specified renderer does not exist.
      */
-    public function createRenderer(AbstractWriter $writer, $reportFormat = null)
+    public function createRenderer(AbstractWriter $writer = null, $reportFormat = null)
     {
         try {
             $reportFormat = $reportFormat ?: $this->reportFormat;
-            return RendererFactory::createRenderer($writer, $reportFormat);
+            return RendererFactory::createRenderer($reportFormat, $writer);
         } catch (\InvalidArgumentException $e) {
             throw new \InvalidArgumentException(
                 $e->getMessage(),

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -41,9 +41,6 @@
 
 namespace PHPMD\TextUI;
 
-use PHPMD\Renderer\HTMLRenderer;
-use PHPMD\Renderer\TextRenderer;
-use PHPMD\Renderer\XMLRenderer;
 use PHPMD\RendererFactory;
 use PHPMD\Rule;
 
@@ -368,80 +365,15 @@ class CommandLineOptions
      */
     public function createRenderer($reportFormat = null)
     {
-        $renderer = RendererFactory::createRenderer();
-        $reportFormat = $reportFormat ?: $this->reportFormat;
-
-        switch ($reportFormat) {
-            case 'xml':
-                return $this->createXmlRenderer();
-            case 'html':
-                return $this->createHtmlRenderer();
-            case 'text':
-                return $this->createTextRenderer();
-            default:
-                return $this->createCustomRenderer();
-        }
-    }
-
-    /**
-     * @return \PHPMD\Renderer\XMLRenderer
-     */
-    protected function createXmlRenderer()
-    {
-        return new XMLRenderer();
-    }
-
-    /**
-     * @return \PHPMD\Renderer\XMLRenderer
-     */
-    protected function createTextRenderer()
-    {
-        return new TextRenderer();
-    }
-
-    /**
-     * @return \PHPMD\Renderer\HTMLRenderer
-     */
-    protected function createHtmlRenderer()
-    {
-        return new HTMLRenderer();
-    }
-
-    /**
-     * @return \PHPMD\AbstractRenderer
-     * @throws \InvalidArgumentException
-     */
-    protected function createCustomRenderer()
-    {
-        if ('' === $this->reportFormat) {
+        try {
+            $reportFormat = $reportFormat ?: $this->reportFormat;
+            return RendererFactory::createRenderer($reportFormat);
+        } catch (\InvalidArgumentException $e) {
             throw new \InvalidArgumentException(
-                'Can\'t create report with empty format.',
+                $e->getMessage(),
                 self::INPUT_ERROR
             );
         }
-
-        if (class_exists($this->reportFormat)) {
-            return new $this->reportFormat();
-        }
-
-        // Try to load a custom renderer
-        $fileName = strtr($this->reportFormat, '_\\', '//') . '.php';
-
-        $fileHandle = @fopen($fileName, 'r', true);
-        if (is_resource($fileHandle) === false) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Can\'t find the custom report class: %s',
-                    $this->reportFormat
-                ),
-                self::INPUT_ERROR
-            );
-        }
-        @fclose($fileHandle);
-
-        include_once $fileName;
-
-        return new $this->reportFormat();
     }
 
     /**

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -41,6 +41,7 @@
 
 namespace PHPMD\TextUI;
 
+use PHPMD\AbstractWriter;
 use PHPMD\RendererFactory;
 use PHPMD\Rule;
 
@@ -359,15 +360,16 @@ class CommandLineOptions
      *   <li>text</li>
      * </ul>
      *
+     * @param \PHPMD\AbstractWriter $writer Asociated output writer instance
      * @param string $reportFormat
      * @return \PHPMD\AbstractRenderer
      * @throws \InvalidArgumentException When the specified renderer does not exist.
      */
-    public function createRenderer($reportFormat = null)
+    public function createRenderer(AbstractWriter $writer, $reportFormat = null)
     {
         try {
             $reportFormat = $reportFormat ?: $this->reportFormat;
-            return RendererFactory::createRenderer($reportFormat);
+            return RendererFactory::createRenderer($writer, $reportFormat);
         } catch (\InvalidArgumentException $e) {
             throw new \InvalidArgumentException(
                 $e->getMessage(),

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -44,6 +44,7 @@ namespace PHPMD\TextUI;
 use PHPMD\Renderer\HTMLRenderer;
 use PHPMD\Renderer\TextRenderer;
 use PHPMD\Renderer\XMLRenderer;
+use PHPMD\RendererFactory;
 use PHPMD\Rule;
 
 /**
@@ -367,6 +368,7 @@ class CommandLineOptions
      */
     public function createRenderer($reportFormat = null)
     {
+        $renderer = RendererFactory::createRenderer();
         $reportFormat = $reportFormat ?: $this->reportFormat;
 
         switch ($reportFormat) {

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -353,13 +353,6 @@ class CommandLineOptions
      * Creates a report renderer instance based on the user's command line
      * argument.
      *
-     * Valid renderers are:
-     * <ul>
-     *   <li>xml</li>
-     *   <li>html</li>
-     *   <li>text</li>
-     * </ul>
-     *
      * @param \PHPMD\AbstractWriter $writer Asociated output writer instance
      * @param string $reportFormat
      * @return \PHPMD\AbstractRenderer

--- a/src/test/php/PHPMD/PMDTest.php
+++ b/src/test/php/PHPMD/PMDTest.php
@@ -68,8 +68,7 @@ class PHPMDTest extends AbstractTest
 
         $writer = new WriterStub();
 
-        $renderer = new XMLRenderer();
-        $renderer->setWriter($writer);
+        $renderer = new XMLRenderer($writer);
 
         $phpmd = new PHPMD();
 
@@ -94,8 +93,7 @@ class PHPMDTest extends AbstractTest
 
         $writer = new WriterStub();
 
-        $renderer = new XMLRenderer();
-        $renderer->setWriter($writer);
+        $renderer = new XMLRenderer($writer);
 
         $phpmd = new PHPMD();
         $phpmd->processFiles(
@@ -119,8 +117,7 @@ class PHPMDTest extends AbstractTest
 
         $writer = new WriterStub();
 
-        $renderer = new XMLRenderer();
-        $renderer->setWriter($writer);
+        $renderer = new XMLRenderer($writer);
 
         $phpmd = new PHPMD();
         $phpmd->processFiles(
@@ -140,7 +137,7 @@ class PHPMDTest extends AbstractTest
      */
     public function testHasViolationsReturnsFalseByDefault()
     {
-        $phpmd = new PHPMD();
+        $phpmd = new PHPMD(new WriterStub());
         $this->assertFalse($phpmd->hasViolations());
     }
 
@@ -153,8 +150,7 @@ class PHPMDTest extends AbstractTest
     {
         self::changeWorkingDirectory();
 
-        $renderer = new XMLRenderer();
-        $renderer->setWriter(new WriterStub());
+        $renderer = new XMLRenderer(new WriterStub());
 
         $phpmd = new PHPMD();
         $phpmd->processFiles(
@@ -176,8 +172,7 @@ class PHPMDTest extends AbstractTest
     {
         self::changeWorkingDirectory();
 
-        $renderer = new XMLRenderer();
-        $renderer->setWriter(new WriterStub());
+        $renderer = new XMLRenderer(new WriterStub());
 
         $phpmd = new PHPMD();
         $phpmd->processFiles(

--- a/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
+++ b/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
@@ -68,8 +68,7 @@ class AcceptsFilesAndDirectoriesAsInputTicket001Test extends AbstractTest
     {
         self::changeWorkingDirectory();
 
-        $renderer = new XMLRenderer();
-        $renderer->setWriter(new WriterStub());
+        $renderer = new XMLRenderer(new WriterStub());
 
         $phpmd = new PHPMD();
         $phpmd->processFiles(
@@ -89,8 +88,7 @@ class AcceptsFilesAndDirectoriesAsInputTicket001Test extends AbstractTest
     {
         self::changeWorkingDirectory();
 
-        $renderer = new XMLRenderer();
-        $renderer->setWriter(new WriterStub());
+        $renderer = new XMLRenderer(new WriterStub());
 
         $phpmd = new PHPMD();
         $phpmd->processFiles(

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
@@ -73,8 +73,9 @@ class MaximumNestingLevelTicket24975295Test extends AbstractTest
      */
     public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported()
     {
-        $renderer = new TextRenderer();
-        $renderer->setWriter(new StreamWriter(self::createTempFileUri()));
+        $renderer = new TextRenderer(
+            new StreamWriter(self::createTempFileUri())
+        );
 
         $inputs   = self::createCodeResourceUriForTest();
         $rules    = 'unusedcode';

--- a/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -81,7 +81,6 @@ class HTMLRendererTest extends AbstractTest
             ->method('getErrors')
             ->will($this->returnValue(new \ArrayIterator(array())));
 
-        // Create a writer instance.
         $writer = new WriterStub();
         $renderer = new HTMLRenderer($writer);
 
@@ -121,7 +120,6 @@ class HTMLRendererTest extends AbstractTest
             ->method('getErrors')
             ->will($this->returnValue(new \ArrayIterator($errors)));
 
-        // Create a writer instance.
         $writer = new WriterStub();
         $renderer = new HTMLRenderer($writer);
 

--- a/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -66,8 +66,6 @@ class HTMLRendererTest extends AbstractTest
      */
     public function testRendererCreatesExpectedHtmlTableRow()
     {
-        // Create a writer instance.
-        $writer = new WriterStub();
 
         $violations = array(
             $this->getRuleViolationMock('/bar.php', 1),
@@ -83,8 +81,9 @@ class HTMLRendererTest extends AbstractTest
             ->method('getErrors')
             ->will($this->returnValue(new \ArrayIterator(array())));
 
-        $renderer = new HTMLRenderer();
-        $renderer->setWriter($writer);
+        // Create a writer instance.
+        $writer = new WriterStub();
+        $renderer = new HTMLRenderer($writer);
 
         $renderer->start();
         $renderer->renderReport($report);
@@ -108,9 +107,6 @@ class HTMLRendererTest extends AbstractTest
      */
     public function testRendererAddsProcessingErrorsToHtmlReport()
     {
-        // Create a writer instance.
-        $writer = new WriterStub();
-
         $errors = array(
             new ProcessingError('Failed for file "/tmp/foo.php".'),
             new ProcessingError('Failed for file "/tmp/bar.php".'),
@@ -125,8 +121,9 @@ class HTMLRendererTest extends AbstractTest
             ->method('getErrors')
             ->will($this->returnValue(new \ArrayIterator($errors)));
 
-        $renderer = new HTMLRenderer();
-        $renderer->setWriter($writer);
+        // Create a writer instance.
+        $writer = new WriterStub();
+        $renderer = new HTMLRenderer($writer);
 
         $renderer->start();
         $renderer->renderReport($report);

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -66,9 +66,6 @@ class TextRendererTest extends AbstractTest
      */
     public function testRendererCreatesExpectedNumberOfTextEntries()
     {
-        // Create a writer instance.
-        $writer = new WriterStub();
-
         $violations = array(
             $this->getRuleViolationMock('/bar.php', 1),
             $this->getRuleViolationMock('/foo.php', 2),
@@ -83,8 +80,9 @@ class TextRendererTest extends AbstractTest
             ->method('getErrors')
             ->will($this->returnValue(new \ArrayIterator(array())));
 
-        $renderer = new TextRenderer();
-        $renderer->setWriter($writer);
+        // Create a writer instance.
+        $writer = new WriterStub();
+        $renderer = new TextRenderer($writer);
 
         $renderer->start();
         $renderer->renderReport($report);
@@ -105,9 +103,6 @@ class TextRendererTest extends AbstractTest
      */
     public function testRendererAddsProcessingErrorsToTextReport()
     {
-        // Create a writer instance.
-        $writer = new WriterStub();
-
         $errors = array(
             new ProcessingError('Failed for file "/tmp/foo.php".'),
             new ProcessingError('Failed for file "/tmp/bar.php".'),
@@ -122,8 +117,9 @@ class TextRendererTest extends AbstractTest
             ->method('getErrors')
             ->will($this->returnValue(new \ArrayIterator($errors)));
 
-        $renderer = new TextRenderer();
-        $renderer->setWriter($writer);
+        // Create a writer instance.
+        $writer = new WriterStub();
+        $renderer = new TextRenderer($writer);
 
         $renderer->start();
         $renderer->renderReport($report);

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -80,7 +80,6 @@ class TextRendererTest extends AbstractTest
             ->method('getErrors')
             ->will($this->returnValue(new \ArrayIterator(array())));
 
-        // Create a writer instance.
         $writer = new WriterStub();
         $renderer = new TextRenderer($writer);
 
@@ -117,7 +116,6 @@ class TextRendererTest extends AbstractTest
             ->method('getErrors')
             ->will($this->returnValue(new \ArrayIterator($errors)));
 
-        // Create a writer instance.
         $writer = new WriterStub();
         $renderer = new TextRenderer($writer);
 

--- a/src/test/php/PHPMD/Renderer/XMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/XMLRendererTest.php
@@ -80,7 +80,6 @@ class XMLRendererTest extends AbstractTest
             ->method('getErrors')
             ->will($this->returnValue(new \ArrayIterator(array())));
 
-        // Create a writer instance.
         $writer = new WriterStub();
         $renderer = new XMLRenderer($writer);
 
@@ -116,7 +115,6 @@ class XMLRendererTest extends AbstractTest
             ->method('getErrors')
             ->will($this->returnValue(new \ArrayIterator($processingErrors)));
 
-        // Create a writer instance.
         $writer = new WriterStub();
         $renderer = new XMLRenderer($writer);
 

--- a/src/test/php/PHPMD/Renderer/XMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/XMLRendererTest.php
@@ -66,9 +66,6 @@ class XMLRendererTest extends AbstractTest
      */
     public function testRendererCreatesExpectedNumberOfXmlElements()
     {
-        // Create a writer instance.
-        $writer = new WriterStub();
-        
         $violations = array(
             $this->getRuleViolationMock('/bar.php'),
             $this->getRuleViolationMock('/foo.php'),
@@ -83,8 +80,9 @@ class XMLRendererTest extends AbstractTest
             ->method('getErrors')
             ->will($this->returnValue(new \ArrayIterator(array())));
 
-        $renderer = new XMLRenderer();
-        $renderer->setWriter($writer);
+        // Create a writer instance.
+        $writer = new WriterStub();
+        $renderer = new XMLRenderer($writer);
 
         $renderer->start();
         $renderer->renderReport($report);
@@ -104,9 +102,6 @@ class XMLRendererTest extends AbstractTest
      */
     public function testRendererAddsProcessingErrorsToXmlReport()
     {
-        // Create a writer instance.
-        $writer = new WriterStub();
-
         $processingErrors = array(
             new ProcessingError('Failed for file "/tmp/foo.php".'),
             new ProcessingError('Failed for file "/tmp/bar.php".'),
@@ -121,8 +116,9 @@ class XMLRendererTest extends AbstractTest
             ->method('getErrors')
             ->will($this->returnValue(new \ArrayIterator($processingErrors)));
 
-        $renderer = new XMLRenderer();
-        $renderer->setWriter($writer);
+        // Create a writer instance.
+        $writer = new WriterStub();
+        $renderer = new XMLRenderer($writer);
 
         $renderer->start();
         $renderer->renderReport($report);

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -392,7 +392,7 @@ class CommandLineOptionsTest extends AbstractTest
     {
         $args = array(__FILE__, __FILE__, $reportFormat, 'codesize');
         $opts = new CommandLineOptions($args);
-        $opts->createRenderer();
+        $opts->createRenderer(new WriterStub());
     }
 
     /**

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -43,6 +43,7 @@ namespace PHPMD\TextUI;
 
 use PHPMD\AbstractTest;
 use PHPMD\Rule;
+use PHPMD\Stubs\WriterStub;
 
 /**
  * Test case for the {@link \PHPMD\TextUI\CommandLineOptions} class.
@@ -361,7 +362,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, $reportFormat, 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertInstanceOf($expectedClass, $opts->createRenderer($reportFormat));
+        $this->assertInstanceOf($expectedClass, $opts->createRenderer(new WriterStub(), $reportFormat));
     }
 
     /**


### PR DESCRIPTION
In order to contribute (add rules, correct bugs, …) in the future, I need to be more comfortable with your code, methods and practices. So I studied `Command` and `CommandLineOptions` and I decided to make some improvements to follow SRP in them. I also noted these classes might be agnostics of all renderers because at these steps, « renderable » notion isn't useful ; thus I created a `RendererFactory` to get a single entry point and display a common facade for consumers.

## Factory
I follow « Abstract Factory » design pattern in `RendererFactory`. I would also like to completely forbid constructions of `*Renderer` classes outside of `RendererFactory` entry point but I'm not sure it will stick to your coding convention so let me know your point of view about that.
I didn't test `RendererFactory` yet, I need to know if my way corresponds to yours methods and designs before.

  
I also enhance contract on `*Renderer` classes by making them immutables (*a render **need** a writer to work*).

PS : forgive my english, I'm rusted :yum: 