### PR TITLE
Assignment within conditional rule

### DIFF
--- a/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) 2008-2017, Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PHPMD\Rule\CleanCode;
+
+use PHPMD\AbstractNode;
+use PHPMD\AbstractRule;
+use PHPMD\Node\ASTNode;
+use PHPMD\Rule\FunctionAware;
+use PHPMD\Rule\MethodAware;
+
+/**
+ * @author    Kamil Szymanski <kamilszymanski@gmail.com>
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ */
+class IfStatementAssignment extends AbstractRule implements MethodAware, FunctionAware
+{
+    /**
+     * This method checks if method/function has any if statement that uses assignment instead of comparison.
+     *
+     * @param \PHPMD\AbstractNode $node
+     * @return void
+     */
+    public function apply(AbstractNode $node)
+    {
+        $statements = $this->getStatements($node);
+        $expressions = $this->getExpressions($statements);
+        $assignments = $this->getAssignments($expressions);
+        $this->addViolations($node, $assignments);
+    }
+
+    /**
+     * @param AbstractNode $node
+     * @return array
+     */
+    private function getStatements(AbstractNode $node)
+    {
+        $ifStatements = $node->findChildrenOfType('IfStatement');
+        $elseIfStatements = $node->findChildrenOfType('ElseIfStatement');
+
+        return array_merge($ifStatements, $elseIfStatements);
+    }
+
+    /**
+     * @param array $scopes
+     * @return array
+     */
+    private function getExpressions(array $scopes)
+    {
+        $expressions = array();
+        /** @var ASTNode $scope */
+        foreach ($scopes as $scope) {
+            $expressions = array_merge($expressions, $scope->findChildrenOfType('Expression'));
+        }
+
+        return $expressions;
+    }
+
+    /**
+     * @param array $expressions
+     * @return array
+     */
+    private function getAssignments(array $expressions)
+    {
+        $assignments = array();
+        /** @var ASTNode $expression */
+        foreach ($expressions as $expression) {
+            $assignments = array_merge($assignments, $expression->findChildrenOfType('AssignmentExpression'));
+        }
+
+        return $assignments;
+    }
+
+    /**
+     * @param AbstractNode $node
+     * @param array $assignments
+     */
+    private function addViolations(AbstractNode $node, array $assignments)
+    {
+        $processesViolations = array();
+        /** @var \PDepend\Source\AST\AbstractASTNode $assignment */
+        foreach ($assignments as $assignment) {
+            if (null === $assignment || $assignment->getImage() !== '=') {
+                continue;
+            }
+            $uniqueHash = $assignment->getStartColumn() . ':' . $assignment->getStartLine();
+            if (!in_array($uniqueHash, $processesViolations)) {
+                $processesViolations[] = $uniqueHash;
+                $this->addViolation($node, array($assignment->getStartColumn(), $assignment->getStartLine()));
+            }
+        }
+    }
+}

--- a/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
@@ -48,6 +48,8 @@ use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
 
 /**
+ * If Statement Assignment Rule
+ *
  * This rule covers the following cases:
  * - single assignment in an if clause
  * - multiple assignments in same if clause

--- a/src/main/resources/rulesets/cleancode.xml
+++ b/src/main/resources/rulesets/cleancode.xml
@@ -70,15 +70,16 @@ class Foo
 
     <rule name="IfStatementAssignment"
           since="2.7.0"
-          message="Avoid assigning values to variables in if statement (line '{0}', column '{1}')."
+          message="Avoid assigning values to variables in if clauses and the like (line '{0}', column '{1}')."
           class="PHPMD\Rule\CleanCode\IfStatementAssignment"
-          externalInfoUrl="http://phpmd.org/rules/cleancode.html#elseexpression">
+          externalInfoUrl="http://phpmd.org/rules/cleancode.html#ifstatementassignment">
         <description>
             <![CDATA[
-If assignments are considered an anti-pattern. Assignments in PHP return
-right operand as a result. In many cases it's an expected behavior, but
-in reality may be a source of many bugs, especially when right operand
-may result in 0, null or empty string.
+Assignments in if clauses the like are considered a code smell.
+Assignments in PHP return the right operand as their result.
+In many cases, this is an expected behavior, but can lead
+to many difficult to spot bugs, especially when the right
+operand could result in zero, null or an empty string.
             ]]>
         </description>
         <priority>1</priority>
@@ -89,11 +90,11 @@ class Foo
 {
     public function bar($flag)
     {
-        if ($foo = 'bar') {
-            // possible typo
+        if ($foo = 'bar') { // possible typo
+            // ...
         }
-        if ($baz = 0) {
-            // always false
+        if ($baz = 0) { // always false
+            // ...
         }
     }
 }

--- a/src/main/resources/rulesets/cleancode.xml
+++ b/src/main/resources/rulesets/cleancode.xml
@@ -68,6 +68,39 @@ class Foo
         </example>
     </rule>
 
+    <rule name="IfStatementAssignment"
+          since="2.7.0"
+          message="Avoid assigning values to variables in if statement (line '{0}', column '{1}')."
+          class="PHPMD\Rule\CleanCode\IfStatementAssignment"
+          externalInfoUrl="http://phpmd.org/rules/cleancode.html#elseexpression">
+        <description>
+            <![CDATA[
+If assignments are considered an anti-pattern. Assignments in PHP return
+right operand as a result. In many cases it's an expected behavior, but
+in reality may be a source of many bugs, especially when right operand
+may result in 0, null or empty string.
+            ]]>
+        </description>
+        <priority>1</priority>
+        <properties></properties>
+        <example>
+            <![CDATA[
+class Foo
+{
+    public function bar($flag)
+    {
+        if ($foo = 'bar') {
+            // possible typo
+        }
+        if ($baz = 0) {
+            // always false
+        }
+    }
+}
+            ]]>
+        </example>
+    </rule>
+
     <rule name="StaticAccess"
           since="1.4.0"
           message="Avoid using static access to class '{0}' in method '{1}'."

--- a/src/main/resources/rulesets/cleancode.xml
+++ b/src/main/resources/rulesets/cleancode.xml
@@ -75,11 +75,11 @@ class Foo
           externalInfoUrl="http://phpmd.org/rules/cleancode.html#ifstatementassignment">
         <description>
             <![CDATA[
-Assignments in if clauses the like are considered a code smell.
+Assignments in if clauses and the like are considered a code smell.
 Assignments in PHP return the right operand as their result.
 In many cases, this is an expected behavior, but can lead
 to many difficult to spot bugs, especially when the right
-operand could result in zero, null or an empty string.
+operand could result in zero, null or an empty string and the like.
             ]]>
         </description>
         <priority>1</priority>

--- a/src/site/rst/rules/cleancode.rst
+++ b/src/site/rst/rules/cleancode.rst
@@ -67,6 +67,29 @@ This rule has the following properties:
  exceptions                                          Comma-separated class name list of exceptions 
 =================================== =============== ===============================================
 
+IfStatementAssignment
+=============
+
+Since: PHPMD 2.7.0
+
+Assignments in if clauses and the like are considered a code smell. Assignments in PHP return the right operand as their result. In many cases, this is an expected behavior, but can lead to many difficult to spot bugs, especially when the right operand could result in zero, null or an empty string.
+
+
+Example: ::
+
+  class Foo
+  {
+      public function bar($flag)
+      {
+          if ($foo = 'bar') { // possible typo
+              // ...
+          }
+          if ($baz = 0) { // always false
+              // ...
+          }
+      }
+  }
+
 
 Remark
 ======

--- a/src/site/rst/rules/design.rst
+++ b/src/site/rst/rules/design.rst
@@ -184,28 +184,6 @@ This rule has the following properties:
  unwanted-functions                  var_dump,print_r,debug_zval_dump,debug_print_backtrace  Comma separated list of suspect function images. 
 =================================== =============== ==================================================
 
-IfStatementAssignment
-=============
-
-Since: PHPMD 2.7.0
-
-Assignments in if clauses the like are considered a code smell. Assignments in PHP return the right operand as their result. In many cases, this is an expected behavior, but can lead to many difficult to spot bugs, especially when the right operand could result in zero, null or an empty string
-
-
-Example: ::
-
-  class Foo
-  {
-      public function bar($flag)
-      {
-          if ($foo = 'bar') { // possible typo
-              // ...
-          }
-          if ($baz = 0) { // always false
-              // ...
-          }
-      }
-  }
 
 Remark
 ======

--- a/src/site/rst/rules/design.rst
+++ b/src/site/rst/rules/design.rst
@@ -184,6 +184,28 @@ This rule has the following properties:
  unwanted-functions                  var_dump,print_r,debug_zval_dump,debug_print_backtrace  Comma separated list of suspect function images. 
 =================================== =============== ==================================================
 
+IfStatementAssignment
+=============
+
+Since: PHPMD 2.7.0
+
+Assignments in if clauses the like are considered a code smell. Assignments in PHP return the right operand as their result. In many cases, this is an expected behavior, but can lead to many difficult to spot bugs, especially when the right operand could result in zero, null or an empty string
+
+
+Example: ::
+
+  class Foo
+  {
+      public function bar($flag)
+      {
+          if ($foo = 'bar') { // possible typo
+              // ...
+          }
+          if ($baz = 0) { // always false
+              // ...
+          }
+      }
+  }
 
 Remark
 ======

--- a/src/site/rst/rules/index.rst
+++ b/src/site/rst/rules/index.rst
@@ -81,7 +81,7 @@ Design Rules
 - `DepthOfInheritance`__: A class with many parents is an indicator for an unbalanced and wrong class hierarchy. You should consider to refactor this class hierarchy.
 - `CouplingBetweenObjects`__: A class with too many dependencies has negative impacts on several quality aspects of a class. This includes quality criteria like stability, maintainability and understandability
 - `DevelopmentCodeFragment`__: Functions like var_dump(), print_r() etc. are normally only used during development and therefore such calls in production code are a good indicator that they were just forgotten.
-- `IfStatementAssignment`__: Assignments in if clauses the like are considered a code smell. Assignments in PHP return the right operand as their result. In many cases, this is an expected behavior, but can lead to many difficult to spot bugs, especially when the right operand could result in zero, null or an empty string.
+- `IfStatementAssignment`__: Assignments in if clauses and the like are considered a code smell. Assignments in PHP return the right operand as their result. In many cases, this is an expected behavior, but can lead to many difficult to spot bugs, especially when the right operand could result in zero, null or an empty string.
 
 __ design.html#exitexpression
 __ design.html#evalexpression

--- a/src/site/rst/rules/index.rst
+++ b/src/site/rst/rules/index.rst
@@ -81,6 +81,7 @@ Design Rules
 - `DepthOfInheritance`__: A class with many parents is an indicator for an unbalanced and wrong class hierarchy. You should consider to refactor this class hierarchy.
 - `CouplingBetweenObjects`__: A class with too many dependencies has negative impacts on several quality aspects of a class. This includes quality criteria like stability, maintainability and understandability
 - `DevelopmentCodeFragment`__: Functions like var_dump(), print_r() etc. are normally only used during development and therefore such calls in production code are a good indicator that they were just forgotten.
+- `IfStatementAssignment`__: Assignments in if clauses the like are considered a code smell. Assignments in PHP return the right operand as their result. In many cases, this is an expected behavior, but can lead to many difficult to spot bugs, especially when the right operand could result in zero, null or an empty string.
 
 __ design.html#exitexpression
 __ design.html#evalexpression
@@ -89,6 +90,7 @@ __ design.html#numberofchildren
 __ design.html#depthofinheritance
 __ design.html#couplingbetweenobjects
 __ design.html#developmentcodefragment
+__ design.html#ifstatementassignment
 
 Naming Rules
 ============

--- a/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace PHPMD\Rule\CleanCode;
+
+use PHPMD\AbstractTest;
+
+class IfStatementAssignmentTest extends AbstractTest
+{
+    public function testRuleNotAppliesToIfsWithoutAssignment()
+    {
+        $rule = new IfStatementAssignment();
+        $rule->setReport($this->getReportMock(0));
+        $rule->apply($this->getMethod());
+    }
+
+    public function testRuleNotAppliesToIfsWithConditionsOnly()
+    {
+        $rule = new IfStatementAssignment();
+        $rule->setReport($this->getReportMock(0));
+        $rule->apply($this->getMethod());
+    }
+
+    public function testRuleNotAppliesToLogicalOperators()
+    {
+        $rule = new IfStatementAssignment();
+        $rule->setReport($this->getReportMock(0));
+        $rule->apply($this->getMethod());
+    }
+
+    public function testRuleWorksCorrectlyWhenExpressionContainsMath()
+    {
+        $rule = new IfStatementAssignment();
+        $rule->setReport($this->getReportMock(3));
+        $rule->apply($this->getMethod());
+    }
+
+    public function testRuleAppliesToFunctions()
+    {
+        $rule = new IfStatementAssignment();
+        $rule->setReport($this->getReportMock(1));
+        $rule->apply($this->getFunction());
+    }
+
+    public function testRuleAppliesMultipleIfConditions()
+    {
+        $rule = new IfStatementAssignment();
+        $rule->setReport($this->getReportMock(1));
+        $rule->apply($this->getFunction());
+    }
+
+    public function testRuleAppliesToMultilevelIfConditions()
+    {
+        $rule = new IfStatementAssignment();
+        $rule->setReport($this->getReportMock(6));
+        $rule->apply($this->getFunction());
+    }
+
+    public function testRuleAppliesMultipleTimesInOneIfCondition()
+    {
+        $rule = new IfStatementAssignment();
+        $rule->setReport($this->getReportMock(3));
+        $rule->apply($this->getFunction());
+    }
+}

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesMultipleIfConditions.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesMultipleIfConditions.php
@@ -2,10 +2,10 @@
 
 function testRuleAppliesMultipleIfConditions()
 {
-    if (1 || 0) {
-        // not applied
+    if (1 || 0) { // not applied
+        // ...
     }
-    if (1 == 1 || 1 && 0 and 4 % 2 || ($foo = 1) xor 5 * 4 * 3 * 2 * 1) {
-        // applied
+    if (1 == 1 || 1 && 0 and 4 % 2 || ($foo = 1) xor 5 * 4 * 3 * 2 * 1) { // applied
+        // ...
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesMultipleIfConditions.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesMultipleIfConditions.php
@@ -1,0 +1,11 @@
+<?php
+
+function testRuleAppliesMultipleIfConditions()
+{
+    if (1 || 0) {
+        // not applied
+    }
+    if (1 == 1 || 1 && 0 and 4 % 2 || ($foo = 1) xor 5 * 4 * 3 * 2 * 1) {
+        // applied
+    }
+}

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesMultipleTimesInOneIfCondition.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesMultipleTimesInOneIfCondition.php
@@ -6,8 +6,6 @@ function testRuleAppliesMultipleTimesInOneIfCondition()
         // not applied
     }
     if ($foo = 'bar' && $bar = 'baz' || $baz = 'foo') {
-        // applied
-        // applied
-        // applied
+        // applied 3 times
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesMultipleTimesInOneIfCondition.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesMultipleTimesInOneIfCondition.php
@@ -1,0 +1,13 @@
+<?php
+
+function testRuleAppliesMultipleTimesInOneIfCondition()
+{
+    if (1 || 0) {
+        // not applied
+    }
+    if ($foo = 'bar' && $bar = 'baz' || $baz = 'foo') {
+        // applied
+        // applied
+        // applied
+    }
+}

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesMultipleTimesInOneIfCondition.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesMultipleTimesInOneIfCondition.php
@@ -2,10 +2,10 @@
 
 function testRuleAppliesMultipleTimesInOneIfCondition()
 {
-    if (1 || 0) {
-        // not applied
+    if (1 || 0) { // not applied
+        // ...
     }
-    if ($foo = 'bar' && $bar = 'baz' || $baz = 'foo') {
-        // applied 3 times
+    if ($foo = 'bar' && $bar = 'baz' || $baz = 'foo') { // applied 3 times
+        // ...
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesToFunctions.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesToFunctions.php
@@ -2,10 +2,10 @@
 
 function testRuleAppliesToFunctions()
 {
-    if ('foo' || 'bar') {
-        // not applied
+    if ('foo' || 'bar') { // not applied
+        // ...
     }
-    if ($foo = 'baz') {
-        // applied
+    if ($foo = 'baz') { // applied
+        // ...
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesToFunctions.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesToFunctions.php
@@ -1,0 +1,11 @@
+<?php
+
+function testRuleAppliesToFunctions()
+{
+    if (1 || 0) {
+        // not applied
+    }
+    if (1 == 1 || 1 && 0 and 4 % 2 || ($foo = 1) xor 5 * 4 * 3 * 2 * 1) {
+        // applied
+    }
+}

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesToFunctions.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesToFunctions.php
@@ -2,10 +2,10 @@
 
 function testRuleAppliesToFunctions()
 {
-    if (1 || 0) {
+    if ('foo' || 'bar') {
         // not applied
     }
-    if (1 == 1 || 1 && 0 and 4 % 2 || ($foo = 1) xor 5 * 4 * 3 * 2 * 1) {
+    if ($foo = 'baz') {
         // applied
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesToMultilevelIfConditions.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesToMultilevelIfConditions.php
@@ -5,7 +5,7 @@ function testRuleAppliesToMultilevelIfConditions()
     if (1 || 0) {
         if (1 == 1 || $foo = 'baz') {
             // applied
-        } elseif (1 != [] && 'foo' != 'baz' && $bar = 'baz') {
+        } elseif (1 != array() && 'foo' != 'baz' && $bar = 'baz') {
             // applied
         } elseif (1 % 2 !== !false && $baz = 1 + 1 + 1 - 3) {
             // applied
@@ -16,7 +16,7 @@ function testRuleAppliesToMultilevelIfConditions()
                     if (true) {
                         // not applied
                         if (1) {
-                            // applied
+                            // not applied
                         } elseif ($foo = 1) {
                             // applied
                         } elseif ($foo = 2) {

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesToMultilevelIfConditions.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesToMultilevelIfConditions.php
@@ -1,0 +1,35 @@
+<?php
+
+function testRuleAppliesToMultilevelIfConditions()
+{
+    if (1 || 0) {
+        if (1 == 1 || $foo = 'baz') {
+            // applied
+        } elseif (1 != [] && 'foo' != 'baz' && $bar = 'baz') {
+            // applied
+        } elseif (1 % 2 !== !false && $baz = 1 + 1 + 1 - 3) {
+            // applied
+            if ($foo == 'baz') {
+                // not applied
+                if (3 - 2 == 3) {
+                    // not applied
+                    if (true) {
+                        // not applied
+                        if (1) {
+                            // applied
+                        } elseif ($foo = 1) {
+                            // applied
+                        } elseif ($foo = 2) {
+                            // applied
+                        } elseif (5 % 5 == 0) {
+                            // not applied
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if (1 == 1 || 1 && 0 and 4 % 2 || ($foo = 1) xor 5 * 4 * 3 * 2 * 1) {
+        // applied
+    }
+}

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesToMultilevelIfConditions.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleAppliesToMultilevelIfConditions.php
@@ -2,34 +2,34 @@
 
 function testRuleAppliesToMultilevelIfConditions()
 {
-    if (1 || 0) {
-        if (1 == 1 || $foo = 'baz') {
-            // applied
-        } elseif (1 != array() && 'foo' != 'baz' && $bar = 'baz') {
-            // applied
-        } elseif (1 % 2 !== !false && $baz = 1 + 1 + 1 - 3) {
-            // applied
-            if ($foo == 'baz') {
-                // not applied
-                if (3 - 2 == 3) {
-                    // not applied
-                    if (true) {
-                        // not applied
-                        if (1) {
-                            // not applied
-                        } elseif ($foo = 1) {
-                            // applied
-                        } elseif ($foo = 2) {
-                            // applied
-                        } elseif (5 % 5 == 0) {
-                            // not applied
+    if (1 || 0) { // not applied
+        if (1 == 1 || $foo = 'baz') { // applied
+            // ...
+        } elseif (1 != array() && 'foo' != 'baz' && $bar = 'baz') { // applied
+            // ...
+        } elseif (1 % 2 !== !false && $baz = 1 + 1 + 1 - 3) { // applied
+            // ...
+            if ($foo == 'baz') { // not applied
+                // ...
+                if (3 - 2 == 3) { // not applied
+                    // ...
+                    if (true) { // not applied
+                        // ...
+                        if (1) { // not applied
+                            // ...
+                        } elseif ($foo = 1) { // applied
+                            // ...
+                        } elseif ($foo = 2) { // applied
+                            // ...
+                        } elseif (5 % 5 == 0) { // not applied
+                            // ...
                         }
                     }
                 }
             }
         }
     }
-    if (1 == 1 || 1 && 0 and 4 % 2 || ($foo = 1) xor 5 * 4 * 3 * 2 * 1) {
-        // applied
+    if (1 == 1 || 1 && 0 and 4 % 2 || ($foo = 1) xor 5 * 4 * 3 * 2 * 1) { // applied
+        // ...
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleNotAppliesToIfsWithConditionsOnly.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleNotAppliesToIfsWithConditionsOnly.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace PHPMDTest;
+
+class Foo
+{
+
+    public function testRuleNotAppliesToIfsWithConditionsOnly()
+    {
+        $foo = 'bar';
+
+        if ($foo == 'bar') {
+            // not applied
+        }
+        if ($foo === 'bar') {
+            // not applied
+        }
+        if ($foo != 'bar') {
+            // not applied
+        }
+        if ($foo !== 'bar') {
+            // not applied
+        }
+        if ($foo > 1) {
+            // not applied
+        }
+        if ($foo >= 1) {
+            // not applied
+        }
+        if ($foo < 1) {
+            // not applied
+        }
+        if ($foo <= 1) {
+            // not applied
+        }
+    }
+}

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleNotAppliesToIfsWithConditionsOnly.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleNotAppliesToIfsWithConditionsOnly.php
@@ -9,29 +9,29 @@ class Foo
     {
         $foo = 'bar';
 
-        if ($foo == 'bar') {
-            // not applied
+        if ($foo == 'bar') { // not applied
+            // ...
         }
-        if ($foo === 'bar') {
-            // not applied
+        if ($foo === 'bar') { // not applied
+            // ...
         }
-        if ($foo != 'bar') {
-            // not applied
+        if ($foo != 'bar') { // not applied
+            // ...
         }
-        if ($foo !== 'bar') {
-            // not applied
+        if ($foo !== 'bar') { // not applied
+            // ...
         }
-        if ($foo > 1) {
-            // not applied
+        if ($foo > 1) { // not applied
+            // ...
         }
-        if ($foo >= 1) {
-            // not applied
+        if ($foo >= 1) { // not applied
+            // ...
         }
-        if ($foo < 1) {
-            // not applied
+        if ($foo < 1) { // not applied
+            // ...
         }
-        if ($foo <= 1) {
-            // not applied
+        if ($foo <= 1) { // not applied
+            // ...
         }
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleNotAppliesToIfsWithoutAssignment.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleNotAppliesToIfsWithoutAssignment.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace PHPMDTest;
+
+class Foo
+{
+
+    public function testRuleNotAppliesToIfsWithoutAssignment()
+    {
+        $foo = 'bar';
+
+        if (true) {
+            // not applied
+        } else {
+            // not applied
+        }
+        if (null) {
+            // not applied
+        }
+        if (rand()) {
+            // not applied
+        }
+        if ($foo) {
+            // not applied
+        }
+    }
+}

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleNotAppliesToIfsWithoutAssignment.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleNotAppliesToIfsWithoutAssignment.php
@@ -9,19 +9,19 @@ class Foo
     {
         $foo = 'bar';
 
-        if (true) {
-            // not applied
-        } else {
-            // not applied
+        if (true) { // not applied
+            // ...
+        } else { // not applied
+            // ...
         }
-        if (null) {
-            // not applied
+        if (null) { // not applied
+            // ...
         }
-        if (rand()) {
-            // not applied
+        if (rand()) { // not applied
+            // ...
         }
-        if ($foo) {
-            // not applied
+        if ($foo) { // not applied
+            // ...
         }
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleNotAppliesToLogicalOperators.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleNotAppliesToLogicalOperators.php
@@ -7,29 +7,29 @@ class Foo
 
     public function testRuleNotAppliesToLogicalOperators()
     {
-        if (1 || 0) {
-            // not applied
+        if (1 || 0) { // not applied
+            // ...
         }
-        if (1 && 1) {
-            // not applied
+        if (1 && 1) { // not applied
+            // ...
         }
-        if (1 or 0) {
-            // not applied
+        if (1 or 0) { // not applied
+            // ...
         }
-        if (1 and 1) {
-            // not applied
+        if (1 and 1) { // not applied
+            // ...
         }
-        if (1 xor 1) {
-            // not applied
+        if (1 xor 1) { // not applied
+            // ...
         }
-        if (1 % 1) {
-            // not applied
+        if (1 % 1) { // not applied
+            // ...
         }
-        if (1 || !1) {
-            // not applied
+        if (1 || !1) { // not applied
+            // ...
         }
-        if (!1 % !1) {
-            // not applied
+        if (!1 % !1) { // not applied
+            // ...
         }
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleNotAppliesToLogicalOperators.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleNotAppliesToLogicalOperators.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PHPMDTest;
+
+class Foo
+{
+
+    public function testRuleNotAppliesToLogicalOperators()
+    {
+        if (1 || 0) {
+            // not applied
+        }
+        if (1 && 1) {
+            // not applied
+        }
+        if (1 or 0) {
+            // not applied
+        }
+        if (1 and 1) {
+            // not applied
+        }
+        if (1 xor 1) {
+            // not applied
+        }
+        if (1 % 1) {
+            // not applied
+        }
+        if (1 || !1) {
+            // not applied
+        }
+        if (!1 % !1) {
+            // not applied
+        }
+    }
+}

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleWorksCorrectlyWhenExpressionContainsMath.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleWorksCorrectlyWhenExpressionContainsMath.php
@@ -8,29 +8,29 @@ class Foo
     public function testRuleWorksCorrectlyWhenExpressionContainsMath()
     {
         $foo = 0;
-        if ($foo == 1 * 1) {
-            // not applied
+        if ($foo == 1 * 1) { // not applied
+            // ...
         }
-        if ($foo == 1 % 2) {
-            // not applied
+        if ($foo == 1 % 2) { // not applied
+            // ...
         }
-        if ($foo == 1 + 2 + 2 / 1) {
-            // not applied
+        if ($foo == 1 + 2 + 2 / 1) { // not applied
+            // ...
         }
-        if ($foo == 'foo' . 'bar') {
-            // not applied
+        if ($foo == 'foo' . 'bar') { // not applied
+            // ...
         }
-        if ($foo == ('' . '')) {
-            // not applied
+        if ($foo == ('' . '')) { // not applied
+            // ...
         }
-        if ($foo = 1 * 1) {
-            // applied
+        if ($foo = 1 * 1) { // applied
+            // ...
         }
-        if ($foo = '' . 1) {
-            // applied
+        if ($foo = '' . 1) { // applied
+            // ...
         }
-        if ($foo = (int)1.0 + (float)false % (string)1) {
-            // applied
+        if ($foo = (int)1.0 + (float)false % (string)1) { // applied
+            // ...
         }
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleWorksCorrectlyWhenExpressionContainsMath.php
+++ b/src/test/resources/files/Rule/CleanCode/IfStatementAssignment/testRuleWorksCorrectlyWhenExpressionContainsMath.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PHPMDTest;
+
+class Foo
+{
+
+    public function testRuleWorksCorrectlyWhenExpressionContainsMath()
+    {
+        $foo = 0;
+        if ($foo == 1 * 1) {
+            // not applied
+        }
+        if ($foo == 1 % 2) {
+            // not applied
+        }
+        if ($foo == 1 + 2 + 2 / 1) {
+            // not applied
+        }
+        if ($foo == 'foo' . 'bar') {
+            // not applied
+        }
+        if ($foo == ('' . '')) {
+            // not applied
+        }
+        if ($foo = 1 * 1) {
+            // applied
+        }
+        if ($foo = '' . 1) {
+            // applied
+        }
+        if ($foo = (int)1.0 + (float)false % (string)1) {
+            // applied
+        }
+    }
+}


### PR DESCRIPTION
Closes phpmd/phpmd#393

Covers:
- multiple assignments in same *if*
- nested *ifs*
- *elseifs*
- duplicated assignments (multiple conditions before and after *=* sign)
- empty *ifs* are skipped