### PR TITLE
UnusedPrivateMethod chained method calls

### DIFF
--- a/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
@@ -257,4 +257,16 @@ class UnusedPrivateMethodTest extends AbstractTest
         $rule->setReport($this->getReportMock(0));
         $rule->apply($this->getClass());
     }
+
+    /**
+     * testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo
+     *
+     * @return void
+     */
+    public function testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo()
+    {
+        $rule = new UnusedPrivateMethod();
+        $rule->setReport($this->getReportMock(0));
+        $rule->apply($this->getClass());
+    }
 }

--- a/src/test/resources/files/Rule/UnusedPrivateMethod/testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo.php
+++ b/src/test/resources/files/Rule/UnusedPrivateMethod/testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace PHPMDTest;
+
+/**
+ * @see https://github.com/phpmd/phpmd/issues/110
+ */
+class testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo
+{
+
+    public function foo()
+    {
+        $this
+            ->bar()
+            ->baz()
+            ->baw();
+    }
+
+    public function abc()
+    {
+        $this
+            ->bar()
+            ->baz();
+        $this->baw();
+    }
+
+    public function xyz()
+    {
+        $this
+            ->bar()
+            ->baz()
+            ->baw()
+            ->bar()
+            ->baz()
+            ->baw()
+            ->bar()
+            ->baz()
+            ->baw();
+    }
+
+    /**
+     * @return $this
+     */
+    private function bar()
+    {
+        // Do some stuff ...
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    private function baz()
+    {
+        // Do some stuff ...
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    private function baw()
+    {
+        // Do some stuff ...
+        return $this;
+    }
+}


### PR DESCRIPTION
Closes phpmd/phpmd#151 phpmd/phpmd#110

I've just went trough Issues and I've noticed those two. I've checked locally and I couldn't reproduce it, so I decided to write test to prove these are not relevant anymore.