### PR TITLE
CountInLoop Rule initial implementation

### DIFF
--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -81,8 +81,8 @@ class CountInLoopExpression extends AbstractRule implements ClassAware
     }
 
     /**
-     * Scans for expressions and count() or sizeof() functions inside.
-     * If found, triggers violation
+     * Scans for expressions and count() or sizeof() functions inside,
+     * if found, triggers a violation
      *
      * @param AbstractNode $loop Loop statement to look against
      */

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Rule\Design;
+
+use PDepend\Source\AST\AbstractASTNode;
+use PHPMD\AbstractNode;
+use PHPMD\AbstractRule;
+use PHPMD\Node\ASTNode;
+use PHPMD\Rule\ClassAware;
+
+/**
+ * Count In Loop Expression Rule
+ *
+ * Performs a scan to check if loops use
+ * count() or sizeof() in expressions.
+ * Works with:
+ * - for() loops
+ * - while() loops
+ * - do-while() loops
+ *
+ * @author Kamil Szymanski <kamilszymanski@gmail.com>
+ */
+class CountInLoopExpression extends AbstractRule implements ClassAware
+{
+    /**
+     * List of functions to search against
+     *
+     * @var array
+     */
+    private $violatingFunctions = array('count', 'sizeof');
+
+    /**
+     * List of already processed functions
+     *
+     * @var array
+     */
+    private $processedFunctions = array();
+
+    /**
+     * Functions in classes tends to be name-spaced
+     *
+     * @var string
+     */
+    private $namespaceName = '';
+
+    /**
+     * Gets a list of loops in node and iterates over them
+     *
+     * @param AbstractNode $node
+     * @return void
+     */
+    public function apply(AbstractNode $node)
+    {
+        $this->namespaceName = $node->getNamespaceName() . '\\';
+        $loops = array_merge(
+            $node->findChildrenOfType('ForStatement'),
+            $node->findChildrenOfType('WhileStatement'),
+            $node->findChildrenOfType('DoWhileStatement')
+        );
+
+        /** @var AbstractNode $loop */
+        foreach ($loops as $loop) {
+            $this->findPossibleViolations($loop);
+        }
+    }
+
+    /**
+     * Scans for expressions and count() or sizeof() functions inside.
+     * If found, triggers violation
+     *
+     * @param AbstractNode $loop Loop statement to look against
+     */
+    private function findPossibleViolations(AbstractNode $loop)
+    {
+        foreach ($loop->findChildrenOfType('Expression') as $expression) {
+            if ($this->isDirectChild($loop, $expression)) {
+                continue;
+            }
+
+            foreach ($expression->findChildrenOfType('FunctionPostfix') as $function) {
+                if (!$this->isViolatingRule($function)) {
+                    continue;
+                }
+
+                $hash = $this->getHash($function->getNode());
+                if (isset($this->processedFunctions[$hash])) {
+                    continue;
+                }
+
+                $this->addViolation($loop, array($function->getImage(), $loop->getImage()));
+                $this->processedFunctions[$hash] = true;
+            }
+        }
+    }
+
+    /**
+     * Checks if expression node in a direct child of loop
+     *
+     * @param AbstractNode $loop
+     * @param ASTNode $expression
+     * @return bool
+     */
+    private function isDirectChild(AbstractNode $loop, ASTNode $expression)
+    {
+        return $this->getHash($expression->getParent()->getNode()) !== $this->getHash($loop->getNode());
+    }
+
+    /**
+     * Generates unique hash for given node
+     *
+     * @param AbstractASTNode $node
+     * @return string
+     */
+    private function getHash(AbstractASTNode $node)
+    {
+        return sprintf(
+            '%s:%s:%s:%s:%s',
+            $node->getStartLine(),
+            $node->getEndLine(),
+            $node->getStartColumn(),
+            $node->getEndColumn(),
+            $node->getImage()
+        );
+    }
+
+    /**
+     * Checks if given function exists in violations array
+     *
+     * @param ASTNode $function
+     * @return bool
+     */
+    private function isViolatingRule(ASTNode $function)
+    {
+        $functionName = str_replace($this->namespaceName, '', $function->getImage());
+
+        return in_array($functionName, $this->violatingFunctions);
+    }
+}

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -125,8 +125,8 @@ class CountInLoopExpression extends AbstractRule implements ClassAware
      * Generates an unique hash for a given node
      *
      * PDepend method getChildrenOfType() iterates trough all children of a node.
-     * As the result one function may be found more than once, we use hash (which
-     * in reality is a clone of node's metadata) to check, if given node hasn't
+     * As one function may be found more than once, we use a hash (which in reality
+     * is a clone of the node's metadata) to check, if a given node hasn't
      * already been processed.
      *
      * Example hash:

--- a/src/main/resources/rulesets/design.xml
+++ b/src/main/resources/rulesets/design.xml
@@ -263,8 +263,8 @@ class Foo {
           externalInfoUrl="https://phpmd.org/rules/design.html#countinloopexpression">
         <description>
             <![CDATA[
-Using count/sizeof in loops expressions is considered bad practice and is a source of
-many bugs, especially when loop manipulates an array, as count happens on each iteration.
+Using count/sizeof in loops expressions is considered bad practice and is a potential source of
+many bugs, especially when the loop manipulates an array, as count happens on each iteration.
             ]]>
         </description>
         <priority>2</priority>

--- a/src/main/resources/rulesets/design.xml
+++ b/src/main/resources/rulesets/design.xml
@@ -275,9 +275,9 @@ class Foo {
 
   public function bar()
   {
-    $arr = array();
+    $array = array();
 
-    for ($i = 0; count($arr); $i++) {
+    for ($i = 0; count($array); $i++) {
       // ...
     }
   }

--- a/src/main/resources/rulesets/design.xml
+++ b/src/main/resources/rulesets/design.xml
@@ -255,4 +255,34 @@ class Foo {
             ]]>
         </example>
     </rule>
+
+    <rule name="CountInLoopExpression"
+          since="2.7.0"
+          message="Avoid using {0}() function in {1} loops."
+          class="PHPMD\Rule\Design\CountInLoopExpression"
+          externalInfoUrl="https://phpmd.org/rules/design.html#countinloopexpression">
+        <description>
+            <![CDATA[
+Using count/sizeof in loops expressions is considered bad practice and is a source of
+many bugs, especially when loop manipulates an array, as count happens on each iteration.
+            ]]>
+        </description>
+        <priority>2</priority>
+        <properties />
+        <example>
+            <![CDATA[
+class Foo {
+
+  public function bar()
+  {
+    $arr = array();
+
+    for ($i = 0; count($arr); $i++) {
+      // ...
+    }
+  }
+}
+            ]]>
+        </example>
+    </rule>
 </ruleset>

--- a/src/site/rst/rules/design.rst
+++ b/src/site/rst/rules/design.rst
@@ -194,6 +194,28 @@ Example: ::
       }
   }
 
+CountInLoopExpression
+=====================
+
+Since: PHPMD 2.7.0
+
+Using count/sizeof in loops expressions is considered bad practice and is a source of many bugs, especially when loop manipulates an array, as count happens on each iteration.
+
+
+Example: ::
+
+  class Foo {
+
+    public function bar()
+    {
+      $arr = array();
+
+      for ($i = 0; count($arr); $i++) {
+        // ...
+      }
+    }
+  }
+
 Remark
 ======
 

--- a/src/site/rst/rules/design.rst
+++ b/src/site/rst/rules/design.rst
@@ -199,7 +199,8 @@ CountInLoopExpression
 
 Since: PHPMD 2.7.0
 
-Using count/sizeof in loops expressions is considered bad practice and is a source of many bugs, especially when loop manipulates an array, as count happens on each iteration.
+Using count/sizeof in loops expressions is considered bad practice and is a potential source of
+many bugs, especially when the loop manipulates an array, as count happens on each iteration.
 
 
 Example: ::

--- a/src/site/rst/rules/design.rst
+++ b/src/site/rst/rules/design.rst
@@ -202,7 +202,6 @@ Since: PHPMD 2.7.0
 Using count/sizeof in loops expressions is considered bad practice and is a potential source of
 many bugs, especially when the loop manipulates an array, as count happens on each iteration.
 
-
 Example: ::
 
   class Foo {

--- a/src/site/rst/rules/index.rst
+++ b/src/site/rst/rules/index.rst
@@ -85,7 +85,8 @@ Design Rules
 - `DevelopmentCodeFragment`__: Functions like var_dump(), print_r() etc. are normally only used during development and therefore such calls in production code are a good indicator that they were just forgotten.
 - `IfStatementAssignment`__: Assignments in if clauses and the like are considered a code smell. Assignments in PHP return the right operand as their result. In many cases, this is an expected behavior, but can lead to many difficult to spot bugs, especially when the right operand could result in zero, null or an empty string.
 - `EmptyCatchBlock`__: Usually empty try-catch is a bad idea because you are silently swallowing an error condition and then continuing execution. Occasionally this may be the right thing to do, but often it's a sign that a developer saw an exception, didn't know what to do about it, and so used an empty catch to silence the problem.
-- `CountInLoopExpression`__: Using count/sizeof in loops expressions is considered bad practice and is a source of many bugs, especially when loop manipulates an array, as count happens on each iteration.
+- `CountInLoopExpression`__: Using count/sizeof in loops expressions is considered bad practice and is a potential source of
+many bugs, especially when the loop manipulates an array, as count happens on each iteration.
 
 __ design.html#exitexpression
 __ design.html#evalexpression

--- a/src/site/rst/rules/index.rst
+++ b/src/site/rst/rules/index.rst
@@ -85,6 +85,7 @@ Design Rules
 - `DevelopmentCodeFragment`__: Functions like var_dump(), print_r() etc. are normally only used during development and therefore such calls in production code are a good indicator that they were just forgotten.
 - `IfStatementAssignment`__: Assignments in if clauses and the like are considered a code smell. Assignments in PHP return the right operand as their result. In many cases, this is an expected behavior, but can lead to many difficult to spot bugs, especially when the right operand could result in zero, null or an empty string.
 - `EmptyCatchBlock`__: Usually empty try-catch is a bad idea because you are silently swallowing an error condition and then continuing execution. Occasionally this may be the right thing to do, but often it's a sign that a developer saw an exception, didn't know what to do about it, and so used an empty catch to silence the problem.
+- `CountInLoopExpression`__: Using count/sizeof in loops expressions is considered bad practice and is a source of many bugs, especially when loop manipulates an array, as count happens on each iteration.
 
 __ design.html#exitexpression
 __ design.html#evalexpression
@@ -95,6 +96,7 @@ __ design.html#couplingbetweenobjects
 __ design.html#developmentcodefragment
 __ design.html#ifstatementassignment
 __ design.html#emptycatchblock
+__ design.html#countinloopexpression
 
 Naming Rules
 ============

--- a/src/test/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Rule\Design;
+
+use PHPMD\AbstractTest;
+
+/**
+ * Count In Loop Expression Test
+ *
+ * @author Kamil Szymanski <kamilszymanski@gmail.com>
+ */
+class CountInLoopExpressionTest extends AbstractTest
+{
+    /**
+     * testRuleAppliesToAllTypesOfLoops
+     *
+     * @return void
+     */
+    public function testRuleAppliesToAllTypesOfLoops()
+    {
+        $rule = new CountInLoopExpression();
+        $rule->setReport($this->getReportMock(3));
+        $rule->apply($this->getMethod());
+    }
+    /**
+     * testRuleNotApplyToExpressionElsewhere
+     *
+     * @return void
+     */
+    public function testRuleNotApplyToExpressionElsewhere()
+    {
+        $rule = new CountInLoopExpression();
+        $rule->setReport($this->getReportMock(0));
+        $rule->apply($this->getMethod());
+    }
+    /**
+     * testRuleApplyToNestedLoops
+     *
+     * @return void
+     */
+    public function testRuleApplyToNestedLoops()
+    {
+        $rule = new CountInLoopExpression();
+        $rule->setReport($this->getReportMock(8));
+        $rule->apply($this->getFunction());
+    }
+}

--- a/src/test/resources/files/Rule/Design/CountInLoopExpression/testRuleAppliesToAllTypesOfLoops.php
+++ b/src/test/resources/files/Rule/Design/CountInLoopExpression/testRuleAppliesToAllTypesOfLoops.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMDTest;
+
+class testRuleAppliesToAllTypesOfLoops
+{
+    public function testRuleAppliesToAllTypesOfLoops()
+    {
+        $arr = array(0, 1, 2, 3, 4, 5);
+        for ($i = 0; count($arr) < 0; $i++) {
+            $foo = $arr[0] % 0;
+        }
+
+        while (count($arr) || $foo === 'baz') {
+            $foo = 0 < $arr[0];
+        }
+
+        do {
+            $foo = end($arr);
+        } while (count($arr));
+
+        return $foo;
+    }
+}

--- a/src/test/resources/files/Rule/Design/CountInLoopExpression/testRuleApplyToNestedLoops.php
+++ b/src/test/resources/files/Rule/Design/CountInLoopExpression/testRuleApplyToNestedLoops.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+function testRuleApplyToNestedLoops()
+{
+    $foo = 'foo';
+
+    for ($i = 0; sizeof($i) < 5 || $i < 5; $i++) {
+        while ($i !== 'baz' && count($foo) || $i < 5) {
+            $foo .= $i;
+            do {
+                $i += 2;
+            } while (5 - 0 < sizeof($foo) && 3 < $foo . 'bar');
+            while (count($foo) < 5 && sizeof($foo) < 5 && count($foo) < 5) {
+                while (count($_GET) > -1 && 0) {
+                    for ($j = 0; $j < count($_GET); $j++) {
+                        $i += $j * 2;
+                    }
+                }
+            }
+        }
+    }
+
+    return $foo;
+}

--- a/src/test/resources/files/Rule/Design/CountInLoopExpression/testRuleNotApplyToExpressionElsewhere.php
+++ b/src/test/resources/files/Rule/Design/CountInLoopExpression/testRuleNotApplyToExpressionElsewhere.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMDTest;
+
+class testRuleNotApplyToExpressionElsewhere
+{
+    public function testRuleNotApplyToExpressionElsewhere()
+    {
+        $foo = 'foo';
+        $bar = 'bar';
+
+        for ($i = 0; $i < 5; $i++) {
+            $foo .= $i;
+        }
+
+        if (sizeof($foo) < 5) {
+            $bar = $foo;
+        }
+
+        for ($j = 0; $j < 1; $j++) {
+            if (count($bar)) {
+                return $foo;
+            } elseif (sizeof($foo)) {
+                return $bar;
+            }
+        }
+
+        return $bar;
+    }
+}


### PR DESCRIPTION
Rule applies whenever in loop (for/while/do) we use count() or sizeof() functions.
```
for ($i = 0; count($_GET); $i++) {
  // ...
}
```
