### PR TITLE
SuppressWarnings for ExcessivePublicCount #409

### DIFF
--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
@@ -64,14 +64,15 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
     {
         self::changeWorkingDirectory();
         $phpmd = new PHPMD();
+        $self = $this;
         $this->renderer->expects($this->once())
             ->method('renderReport')
             ->will(
                 $this->returnCallback(
-                    function (Report $report) {
+                    function (Report $report) use ($self) {
                         $isViolating = false;
                         foreach ($report->getRuleViolations() as $ruleViolation) {
-                            if (strpos($ruleViolation->getDescription(), self::VIOLATION_MESSAGE) === 0) {
+                            if (strpos($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE) === 0) {
                                 $isViolating = true;
                                 break;
                             }
@@ -103,14 +104,15 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
     {
         self::changeWorkingDirectory();
         $phpmd = new PHPMD();
+        $self = $this;
         $this->renderer->expects($this->once())
             ->method('renderReport')
             ->will(
                 $this->returnCallback(
-                    function (Report $report) {
+                    function (Report $report) use ($self) {
                         $isViolating = false;
                         foreach ($report->getRuleViolations() as $ruleViolation) {
-                            if (strpos($ruleViolation->getDescription(), self::VIOLATION_MESSAGE) === 0) {
+                            if (strpos($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE) === 0) {
                                 $isViolating = true;
                                 break;
                             }

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
@@ -66,18 +66,20 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
         $phpmd = new PHPMD();
         $this->renderer->expects($this->once())
             ->method('renderReport')
-            ->will($this->returnCallback(
-                function (Report $report) {
-                    $isViolating = false;
-                    foreach ($report->getRuleViolations() as $ruleViolation) {
-                        if (strpos($ruleViolation->getDescription(), self::VIOLATION_MESSAGE) === 0) {
-                            $isViolating = true;
-                            break;
+            ->will(
+                $this->returnCallback(
+                    function (Report $report) {
+                        $isViolating = false;
+                        foreach ($report->getRuleViolations() as $ruleViolation) {
+                            if (strpos($ruleViolation->getDescription(), self::VIOLATION_MESSAGE) === 0) {
+                                $isViolating = true;
+                                break;
+                            }
                         }
+                        $this->assertTrue($isViolating);
+                        $this->assertEquals(4, count($report->getRuleViolations()));
                     }
-                    $this->assertTrue($isViolating);
-                    $this->assertEquals(4, count($report->getRuleViolations()));
-                })
+                )
             );
         $phpmd->processFiles(
             __DIR__ . '/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php',
@@ -103,18 +105,20 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
         $phpmd = new PHPMD();
         $this->renderer->expects($this->once())
             ->method('renderReport')
-            ->will($this->returnCallback(
-                function (Report $report) {
-                    $isViolating = false;
-                    foreach ($report->getRuleViolations() as $ruleViolation) {
-                        if (strpos($ruleViolation->getDescription(), self::VIOLATION_MESSAGE) === 0) {
-                            $isViolating = true;
-                            break;
+            ->will(
+                $this->returnCallback(
+                    function (Report $report) {
+                        $isViolating = false;
+                        foreach ($report->getRuleViolations() as $ruleViolation) {
+                            if (strpos($ruleViolation->getDescription(), self::VIOLATION_MESSAGE) === 0) {
+                                $isViolating = true;
+                                break;
+                            }
                         }
+                        $this->assertFalse($isViolating);
+                        $this->assertEquals(3, count($report->getRuleViolations()));
                     }
-                    $this->assertFalse($isViolating);
-                    $this->assertEquals(3, count($report->getRuleViolations()));
-                })
+                )
             );
         $phpmd->processFiles(
             __DIR__ . '/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php',

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
@@ -67,7 +67,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
         $this->renderer->expects($this->once())
             ->method('renderReport')
             ->will($this->returnCallback(
-                function(Report $report) {
+                function (Report $report) {
                     $isViolating = false;
                     foreach ($report->getRuleViolations() as $ruleViolation) {
                         if (strpos($ruleViolation->getDescription(), self::VIOLATION_MESSAGE) === 0) {
@@ -104,7 +104,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
         $this->renderer->expects($this->once())
             ->method('renderReport')
             ->will($this->returnCallback(
-                function(Report $report) {
+                function (Report $report) {
                     $isViolating = false;
                     foreach ($report->getRuleViolations() as $ruleViolation) {
                         if (strpos($ruleViolation->getDescription(), self::VIOLATION_MESSAGE) === 0) {

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
@@ -45,7 +45,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
     {
         $this->renderer = $this->getMockBuilder('PHPMD\Renderer\TextRenderer')
             ->disableOriginalConstructor()
-            ->setMethods(['renderReport', 'start', 'end'])
+            ->setMethods(array('renderReport', 'start', 'end'))
             ->getMock();
     }
 
@@ -84,7 +84,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
         $phpmd->processFiles(
             __DIR__ . '/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php',
             'codesize',
-            [$this->renderer],
+            array($this->renderer),
             new RuleSetFactory()
         );
     }
@@ -123,7 +123,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
         $phpmd->processFiles(
             __DIR__ . '/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php',
             'codesize',
-            [$this->renderer],
+            array($this->renderer),
             new RuleSetFactory()
         );
     }

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
@@ -77,8 +77,8 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
                                 break;
                             }
                         }
-                        $this->assertTrue($isViolating);
-                        $this->assertEquals(4, count($report->getRuleViolations()));
+                        $self->assertTrue($isViolating);
+                        $self->assertEquals(4, count($report->getRuleViolations()));
                     }
                 )
             );
@@ -117,8 +117,8 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
                                 break;
                             }
                         }
-                        $this->assertFalse($isViolating);
-                        $this->assertEquals(3, count($report->getRuleViolations()));
+                        $self->assertFalse($isViolating);
+                        $self->assertEquals(3, count($report->getRuleViolations()));
                     }
                 )
             );

--- a/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
+++ b/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Regression\Sources;
+
+/**
+ * @SuppressWarnings(PHPMD.ExcessivePublicCount)
+ */
+class ExcessivePublicCountSuppressionWorksForPublicStaticMethods
+{
+    public static function aMethod() {}
+    public static function bMethod() {}
+    public static function cMethod() {}
+    public static function dMethod() {}
+    public static function eMethod() {}
+    public static function fMethod() {}
+    public static function gMethod() {}
+    public static function hMethod() {}
+    public static function iMethod() {}
+    public static function jMethod() {}
+    public static function kMethod() {}
+    public static function lMethod() {}
+    public static function mMethod() {}
+    public static function nMethod() {}
+    public static function oMethod() {}
+    public static function pMethod() {}
+    public static function rMethod() {}
+    public static function sMethod() {}
+    public static function tMethod() {}
+    public static function uMethod() {}
+    public static function wMethod() {}
+    public static function xMethod() {}
+    public static function yMethod() {}
+    public static function zMethod() {}
+    public static function aaMethod() {}
+    public static function abMethod() {}
+    public static function acMethod() {}
+    public static function adMethod() {}
+    public static function aeMethod() {}
+    public static function afMethod() {}
+    public static function agMethod() {}
+    public static function ahMethod() {}
+    public static function ajMethod() {}
+    public static function akMethod() {}
+    public static function alMethod() {}
+    public static function amMethod() {}
+    public static function anMethod() {}
+    public static function aoMethod() {}
+    public static function apMethod() {}
+    public static function arMethod() {}
+    public static function asMethod() {}
+    public static function atMethod() {}
+    public static function auMethod() {}
+    public static function awMethod() {}
+    public static function axMethod() {}
+    public static function ayMethod() {}
+    public static function azMethod() {}
+    public static function baMethod() {}
+    public static function bbMethod() {}
+    public static function bcMethod() {}
+    public static function bdMethod() {}
+    public static function beMethod() {}
+    public static function bfMethod() {}
+    public static function bgMethod() {}
+    public static function bhMethod() {}
+    public static function biMethod() {}
+    public static function bjMethod() {}
+    public static function bkMethod() {}
+    public static function blmethod() {}
+    public static function bmmethod() {}
+    public static function bnMethod() {}
+    public static function boMethod() {}
+    public static function bpMethod() {}
+    public static function brMethod() {}
+    public static function bsMethod() {}
+    public static function btMethod() {}
+    public static function buMethod() {}
+    public static function bwMethod() {}
+    public static function bxMethod() {}
+    public static function byMethod() {}
+    public static function bzMethod() {}
+}

--- a/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
+++ b/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
@@ -22,75 +22,287 @@ namespace PHPMD\Regression\Sources;
  */
 class ExcessivePublicCountSuppressionWorksForPublicStaticMethods
 {
-    public static function aMethod() {}
-    public static function bMethod() {}
-    public static function cMethod() {}
-    public static function dMethod() {}
-    public static function eMethod() {}
-    public static function fMethod() {}
-    public static function gMethod() {}
-    public static function hMethod() {}
-    public static function iMethod() {}
-    public static function jMethod() {}
-    public static function kMethod() {}
-    public static function lMethod() {}
-    public static function mMethod() {}
-    public static function nMethod() {}
-    public static function oMethod() {}
-    public static function pMethod() {}
-    public static function rMethod() {}
-    public static function sMethod() {}
-    public static function tMethod() {}
-    public static function uMethod() {}
-    public static function wMethod() {}
-    public static function xMethod() {}
-    public static function yMethod() {}
-    public static function zMethod() {}
-    public static function aaMethod() {}
-    public static function abMethod() {}
-    public static function acMethod() {}
-    public static function adMethod() {}
-    public static function aeMethod() {}
-    public static function afMethod() {}
-    public static function agMethod() {}
-    public static function ahMethod() {}
-    public static function ajMethod() {}
-    public static function akMethod() {}
-    public static function alMethod() {}
-    public static function amMethod() {}
-    public static function anMethod() {}
-    public static function aoMethod() {}
-    public static function apMethod() {}
-    public static function arMethod() {}
-    public static function asMethod() {}
-    public static function atMethod() {}
-    public static function auMethod() {}
-    public static function awMethod() {}
-    public static function axMethod() {}
-    public static function ayMethod() {}
-    public static function azMethod() {}
-    public static function baMethod() {}
-    public static function bbMethod() {}
-    public static function bcMethod() {}
-    public static function bdMethod() {}
-    public static function beMethod() {}
-    public static function bfMethod() {}
-    public static function bgMethod() {}
-    public static function bhMethod() {}
-    public static function biMethod() {}
-    public static function bjMethod() {}
-    public static function bkMethod() {}
-    public static function blmethod() {}
-    public static function bmmethod() {}
-    public static function bnMethod() {}
-    public static function boMethod() {}
-    public static function bpMethod() {}
-    public static function brMethod() {}
-    public static function bsMethod() {}
-    public static function btMethod() {}
-    public static function buMethod() {}
-    public static function bwMethod() {}
-    public static function bxMethod() {}
-    public static function byMethod() {}
-    public static function bzMethod() {}
+    public static function aMethod()
+    {
+    }
+
+    public static function bMethod()
+    {
+    }
+
+    public static function cMethod()
+    {
+    }
+
+    public static function dMethod()
+    {
+    }
+
+    public static function eMethod()
+    {
+    }
+
+    public static function fMethod()
+    {
+    }
+
+    public static function gMethod()
+    {
+    }
+
+    public static function hMethod()
+    {
+    }
+
+    public static function iMethod()
+    {
+    }
+
+    public static function jMethod()
+    {
+    }
+
+    public static function kMethod()
+    {
+    }
+
+    public static function lMethod()
+    {
+    }
+
+    public static function mMethod()
+    {
+    }
+
+    public static function nMethod()
+    {
+    }
+
+    public static function oMethod()
+    {
+    }
+
+    public static function pMethod()
+    {
+    }
+
+    public static function rMethod()
+    {
+    }
+
+    public static function sMethod()
+    {
+    }
+
+    public static function tMethod()
+    {
+    }
+
+    public static function uMethod()
+    {
+    }
+
+    public static function wMethod()
+    {
+    }
+
+    public static function xMethod()
+    {
+    }
+
+    public static function yMethod()
+    {
+    }
+
+    public static function zMethod()
+    {
+    }
+
+    public static function aaMethod()
+    {
+    }
+
+    public static function abMethod()
+    {
+    }
+
+    public static function acMethod()
+    {
+    }
+
+    public static function adMethod()
+    {
+    }
+
+    public static function aeMethod()
+    {
+    }
+
+    public static function afMethod()
+    {
+    }
+
+    public static function agMethod()
+    {
+    }
+
+    public static function ahMethod()
+    {
+    }
+
+    public static function ajMethod()
+    {
+    }
+
+    public static function akMethod()
+    {
+    }
+
+    public static function alMethod()
+    {
+    }
+
+    public static function amMethod()
+    {
+    }
+
+    public static function anMethod()
+    {
+    }
+
+    public static function aoMethod()
+    {
+    }
+
+    public static function apMethod()
+    {
+    }
+
+    public static function arMethod()
+    {
+    }
+
+    public static function asMethod()
+    {
+    }
+
+    public static function atMethod()
+    {
+    }
+
+    public static function auMethod()
+    {
+    }
+
+    public static function awMethod()
+    {
+    }
+
+    public static function axMethod()
+    {
+    }
+
+    public static function ayMethod()
+    {
+    }
+
+    public static function azMethod()
+    {
+    }
+
+    public static function baMethod()
+    {
+    }
+
+    public static function bbMethod()
+    {
+    }
+
+    public static function bcMethod()
+    {
+    }
+
+    public static function bdMethod()
+    {
+    }
+
+    public static function beMethod()
+    {
+    }
+
+    public static function bfMethod()
+    {
+    }
+
+    public static function bgMethod()
+    {
+    }
+
+    public static function bhMethod()
+    {
+    }
+
+    public static function biMethod()
+    {
+    }
+
+    public static function bjMethod()
+    {
+    }
+
+    public static function bkMethod()
+    {
+    }
+
+    public static function blmethod()
+    {
+    }
+
+    public static function bmmethod()
+    {
+    }
+
+    public static function bnMethod()
+    {
+    }
+
+    public static function boMethod()
+    {
+    }
+
+    public static function bpMethod()
+    {
+    }
+
+    public static function brMethod()
+    {
+    }
+
+    public static function bsMethod()
+    {
+    }
+
+    public static function btMethod()
+    {
+    }
+
+    public static function buMethod()
+    {
+    }
+
+    public static function bwMethod()
+    {
+    }
+
+    public static function bxMethod()
+    {
+    }
+
+    public static function byMethod()
+    {
+    }
+
+    public static function bzMethod()
+    {
+    }
 }

--- a/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php
+++ b/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php
@@ -19,75 +19,287 @@ namespace PHPMD\Regression\Sources;
 
 class ExcessivePublicCountWorksForPublicStaticMethods
 {
-    public static function aMethod() {}
-    public static function bMethod() {}
-    public static function cMethod() {}
-    public static function dMethod() {}
-    public static function eMethod() {}
-    public static function fMethod() {}
-    public static function gMethod() {}
-    public static function hMethod() {}
-    public static function iMethod() {}
-    public static function jMethod() {}
-    public static function kMethod() {}
-    public static function lMethod() {}
-    public static function mMethod() {}
-    public static function nMethod() {}
-    public static function oMethod() {}
-    public static function pMethod() {}
-    public static function rMethod() {}
-    public static function sMethod() {}
-    public static function tMethod() {}
-    public static function uMethod() {}
-    public static function wMethod() {}
-    public static function xMethod() {}
-    public static function yMethod() {}
-    public static function zMethod() {}
-    public static function aaMethod() {}
-    public static function abMethod() {}
-    public static function acMethod() {}
-    public static function adMethod() {}
-    public static function aeMethod() {}
-    public static function afMethod() {}
-    public static function agMethod() {}
-    public static function ahMethod() {}
-    public static function ajMethod() {}
-    public static function akMethod() {}
-    public static function alMethod() {}
-    public static function amMethod() {}
-    public static function anMethod() {}
-    public static function aoMethod() {}
-    public static function apMethod() {}
-    public static function arMethod() {}
-    public static function asMethod() {}
-    public static function atMethod() {}
-    public static function auMethod() {}
-    public static function awMethod() {}
-    public static function axMethod() {}
-    public static function ayMethod() {}
-    public static function azMethod() {}
-    public static function baMethod() {}
-    public static function bbMethod() {}
-    public static function bcMethod() {}
-    public static function bdMethod() {}
-    public static function beMethod() {}
-    public static function bfMethod() {}
-    public static function bgMethod() {}
-    public static function bhMethod() {}
-    public static function biMethod() {}
-    public static function bjMethod() {}
-    public static function bkMethod() {}
-    public static function blmethod() {}
-    public static function bmmethod() {}
-    public static function bnMethod() {}
-    public static function boMethod() {}
-    public static function bpMethod() {}
-    public static function brMethod() {}
-    public static function bsMethod() {}
-    public static function btMethod() {}
-    public static function buMethod() {}
-    public static function bwMethod() {}
-    public static function bxMethod() {}
-    public static function byMethod() {}
-    public static function bzMethod() {}
+    public static function aMethod()
+    {
+    }
+
+    public static function bMethod()
+    {
+    }
+
+    public static function cMethod()
+    {
+    }
+
+    public static function dMethod()
+    {
+    }
+
+    public static function eMethod()
+    {
+    }
+
+    public static function fMethod()
+    {
+    }
+
+    public static function gMethod()
+    {
+    }
+
+    public static function hMethod()
+    {
+    }
+
+    public static function iMethod()
+    {
+    }
+
+    public static function jMethod()
+    {
+    }
+
+    public static function kMethod()
+    {
+    }
+
+    public static function lMethod()
+    {
+    }
+
+    public static function mMethod()
+    {
+    }
+
+    public static function nMethod()
+    {
+    }
+
+    public static function oMethod()
+    {
+    }
+
+    public static function pMethod()
+    {
+    }
+
+    public static function rMethod()
+    {
+    }
+
+    public static function sMethod()
+    {
+    }
+
+    public static function tMethod()
+    {
+    }
+
+    public static function uMethod()
+    {
+    }
+
+    public static function wMethod()
+    {
+    }
+
+    public static function xMethod()
+    {
+    }
+
+    public static function yMethod()
+    {
+    }
+
+    public static function zMethod()
+    {
+    }
+
+    public static function aaMethod()
+    {
+    }
+
+    public static function abMethod()
+    {
+    }
+
+    public static function acMethod()
+    {
+    }
+
+    public static function adMethod()
+    {
+    }
+
+    public static function aeMethod()
+    {
+    }
+
+    public static function afMethod()
+    {
+    }
+
+    public static function agMethod()
+    {
+    }
+
+    public static function ahMethod()
+    {
+    }
+
+    public static function ajMethod()
+    {
+    }
+
+    public static function akMethod()
+    {
+    }
+
+    public static function alMethod()
+    {
+    }
+
+    public static function amMethod()
+    {
+    }
+
+    public static function anMethod()
+    {
+    }
+
+    public static function aoMethod()
+    {
+    }
+
+    public static function apMethod()
+    {
+    }
+
+    public static function arMethod()
+    {
+    }
+
+    public static function asMethod()
+    {
+    }
+
+    public static function atMethod()
+    {
+    }
+
+    public static function auMethod()
+    {
+    }
+
+    public static function awMethod()
+    {
+    }
+
+    public static function axMethod()
+    {
+    }
+
+    public static function ayMethod()
+    {
+    }
+
+    public static function azMethod()
+    {
+    }
+
+    public static function baMethod()
+    {
+    }
+
+    public static function bbMethod()
+    {
+    }
+
+    public static function bcMethod()
+    {
+    }
+
+    public static function bdMethod()
+    {
+    }
+
+    public static function beMethod()
+    {
+    }
+
+    public static function bfMethod()
+    {
+    }
+
+    public static function bgMethod()
+    {
+    }
+
+    public static function bhMethod()
+    {
+    }
+
+    public static function biMethod()
+    {
+    }
+
+    public static function bjMethod()
+    {
+    }
+
+    public static function bkMethod()
+    {
+    }
+
+    public static function blmethod()
+    {
+    }
+
+    public static function bmmethod()
+    {
+    }
+
+    public static function bnMethod()
+    {
+    }
+
+    public static function boMethod()
+    {
+    }
+
+    public static function bpMethod()
+    {
+    }
+
+    public static function brMethod()
+    {
+    }
+
+    public static function bsMethod()
+    {
+    }
+
+    public static function btMethod()
+    {
+    }
+
+    public static function buMethod()
+    {
+    }
+
+    public static function bwMethod()
+    {
+    }
+
+    public static function bxMethod()
+    {
+    }
+
+    public static function byMethod()
+    {
+    }
+
+    public static function bzMethod()
+    {
+    }
 }

--- a/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php
+++ b/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Regression\Sources;
+
+class ExcessivePublicCountWorksForPublicStaticMethods
+{
+    public static function aMethod() {}
+    public static function bMethod() {}
+    public static function cMethod() {}
+    public static function dMethod() {}
+    public static function eMethod() {}
+    public static function fMethod() {}
+    public static function gMethod() {}
+    public static function hMethod() {}
+    public static function iMethod() {}
+    public static function jMethod() {}
+    public static function kMethod() {}
+    public static function lMethod() {}
+    public static function mMethod() {}
+    public static function nMethod() {}
+    public static function oMethod() {}
+    public static function pMethod() {}
+    public static function rMethod() {}
+    public static function sMethod() {}
+    public static function tMethod() {}
+    public static function uMethod() {}
+    public static function wMethod() {}
+    public static function xMethod() {}
+    public static function yMethod() {}
+    public static function zMethod() {}
+    public static function aaMethod() {}
+    public static function abMethod() {}
+    public static function acMethod() {}
+    public static function adMethod() {}
+    public static function aeMethod() {}
+    public static function afMethod() {}
+    public static function agMethod() {}
+    public static function ahMethod() {}
+    public static function ajMethod() {}
+    public static function akMethod() {}
+    public static function alMethod() {}
+    public static function amMethod() {}
+    public static function anMethod() {}
+    public static function aoMethod() {}
+    public static function apMethod() {}
+    public static function arMethod() {}
+    public static function asMethod() {}
+    public static function atMethod() {}
+    public static function auMethod() {}
+    public static function awMethod() {}
+    public static function axMethod() {}
+    public static function ayMethod() {}
+    public static function azMethod() {}
+    public static function baMethod() {}
+    public static function bbMethod() {}
+    public static function bcMethod() {}
+    public static function bdMethod() {}
+    public static function beMethod() {}
+    public static function bfMethod() {}
+    public static function bgMethod() {}
+    public static function bhMethod() {}
+    public static function biMethod() {}
+    public static function bjMethod() {}
+    public static function bkMethod() {}
+    public static function blmethod() {}
+    public static function bmmethod() {}
+    public static function bnMethod() {}
+    public static function boMethod() {}
+    public static function bpMethod() {}
+    public static function brMethod() {}
+    public static function bsMethod() {}
+    public static function btMethod() {}
+    public static function buMethod() {}
+    public static function bwMethod() {}
+    public static function bxMethod() {}
+    public static function byMethod() {}
+    public static function bzMethod() {}
+}


### PR DESCRIPTION
I've checked if phpmd/phpmd#409 is still valid and it looks it's not. I've covered it with tests to prove it. Issue may be closed.
Closes phpmd/phpmd#409