### PR TITLE
Bump minimal PHP version to 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 matrix:
   include:
-      env: DEPENDENCIES=low
     - php: 5.4
       env: DEPENDENCIES=low
     - php: 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 5.3
       env: DEPENDENCIES=low
     - php: 5.4
       env: DEPENDENCIES=low

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
   },
   "minimum-stability": "stable",
   "require": {
-    "php": ">=5.3.9",
+    "php": ">=5.4.0",
     "pdepend/pdepend": "^2.5",
     "ext-xml": "*"
   },

--- a/src/site/rst/download/index.rst
+++ b/src/site/rst/download/index.rst
@@ -62,7 +62,7 @@ PHPMD itself is considered as an early development version at its
 current state. It relies on the following software products:
 
 - `PHP_Depend >= 2.0.0`__
-- `PHP >= 5.3.0`__
+- `PHP >= 5.4.0`__
 
 __ https://github.com/phpmd/phpmd
 __ http://getcomposer.org/composer.phar


### PR DESCRIPTION
Since Travis does not support PHP versions below 5.4 anymore.