### PR TITLE
Custom command line options for custom renderer

### DIFF
--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -126,6 +126,13 @@ class CommandLineOptions
     protected $availableRuleSets = array();
 
     /**
+     * List of custom options for custom renderer
+     *
+     * @var array
+     */
+    protected $customOptions = array();
+
+    /**
      * Constructs a new command line options instance.
      *
      * @param array $args
@@ -194,7 +201,12 @@ class CommandLineOptions
                     $this->reportFiles[$match[1]] = array_shift($args);
                     break;
                 default:
-                    $arguments[] = $arg;
+                    $customPrefix = '--custom-';
+                    if (strpos($arg, $customPrefix) !== false) {
+                        $this->customOptions[substr($arg, strlen($customPrefix))] = array_shift($args);
+                    } else {
+                        $arguments[] = $arg;
+                    }
                     break;
             }
         }
@@ -403,7 +415,7 @@ class CommandLineOptions
         }
 
         if (class_exists($this->reportFormat)) {
-            return new $this->reportFormat();
+            return new $this->reportFormat($this->customOptions);
         }
 
         // Try to load a custom renderer
@@ -423,7 +435,7 @@ class CommandLineOptions
 
         include_once $fileName;
 
-        return new $this->reportFormat();
+        return new $this->reportFormat($this->customOptions);
     }
 
     /**
@@ -466,12 +478,12 @@ class CommandLineOptions
      */
     protected function getListOfAvailableRenderers()
     {
-        $renderersDirPathName=__DIR__.'/../Renderer';
+        $renderersDirPathName = __DIR__ . '/../Renderer';
         $renderers = array();
 
         foreach (scandir($renderersDirPathName) as $rendererFileName) {
             if (preg_match('/^(\w+)Renderer.php$/i', $rendererFileName, $rendererName)) {
-                $renderers[] =  strtolower($rendererName[1]);
+                $renderers[] = strtolower($rendererName[1]);
             }
         }
 


### PR DESCRIPTION
adds the ability to transmit custom command line options for custom renderer

For example:
`phpmd --custom-pretty-json 1 path-to-source JsonRenderer codesize,unusedcode,naming`

Then in custom renderer we can get these options in costructor and then use them in renderReport function, for example:
```php
class JsonRenderer extends AbstractRenderer
{
    /**
     * Custom command line options
     *
     * @var array
     */
    protected $options = [];

    public function __construct($options)
    {
        $this->options = $options;
    }

    /**
     * This method will be called when the engine has finished the source analysis
     * phase.
     *
     * @param \PHPMD\Report $report
     * @return void
     */
    public function renderReport(Report $report)
    {
        ...
        $options = 0;
        if (isset($this->options['pretty-json']) && (int)$this->options['pretty-json'] === 1) {
            $options = JSON_PRETTY_PRINT;
        }
        ...
    }
}
```
Full example can see [here](https://github.com/dnolbon/phpmd-renderer)

