### PR TITLE
Use PHP 7.1 in AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - SET PATH=C:\Program Files\OpenSSL;%PATH%
   - sc config wuauserv start= auto
   - net start wuauserv
-  - cinst -y php
+  - cinst -y php -version 7.1.14
   - cd c:\tools\php71
   - copy php.ini-production php.ini
   - echo date.timezone="UTC" >> php.ini


### PR DESCRIPTION
AppVeyor builds are currently failing, because chocolatey started to install PHP 7.2 as default.

Besides the wrong path, the PHPUnit tests are not yet ready for PHP 7.2 (they require non-namespaced version of PHPUnit, however there isn't one for PHP 7.2 - the minimal version of PHPUnit running on PHP 7.2 is PHPUnit 6, which uses namespaces) - this is why the build isn't just upgraded to PHP 7.2 and rather forced to use PHP 7.1.