### PR TITLE
Add ExceptionList property for LongParameterList

### DIFF
--- a/src/main/php/PHPMD/Rule/Design/LongParameterList.php
+++ b/src/main/php/PHPMD/Rule/Design/LongParameterList.php
@@ -42,6 +42,12 @@ class LongParameterList extends AbstractRule implements FunctionAware, MethodAwa
             return;
         }
 
+        $exceptions = $this->getExceptionsList();
+
+        if (in_array($node->getName(), $exceptions)) {
+            return;
+        }
+
         $this->addViolation(
             $node,
             array(
@@ -51,5 +57,21 @@ class LongParameterList extends AbstractRule implements FunctionAware, MethodAwa
                 $threshold
             )
         );
+    }
+
+    /**
+     * Gets array of exceptions from property
+     *
+     * @return array
+     */
+    private function getExceptionsList()
+    {
+        try {
+            $exceptions = $this->getStringProperty('exceptions');
+        } catch (\OutOfBoundsException $e) {
+            $exceptions = '';
+        }
+
+        return explode(',', $exceptions);
     }
 }

--- a/src/main/php/PHPMD/Rule/Design/LongParameterList.php
+++ b/src/main/php/PHPMD/Rule/Design/LongParameterList.php
@@ -43,7 +43,6 @@ class LongParameterList extends AbstractRule implements FunctionAware, MethodAwa
         }
 
         $exceptions = $this->getExceptionsList();
-
         if (in_array($node->getName(), $exceptions)) {
             return;
         }


### PR DESCRIPTION
I took inspiration/code from the [ShortVariable](https://github.com/phpmd/phpmd/blob/master/src/main/php/PHPMD/Rule/Naming/ShortVariable.php#L122) rule which already had an exception list property and added it to the LongParameterList rule.

