### PR TITLE
Add support for setting a maximum priority

### DIFF
--- a/src/main/php/PHPMD/Rule.php
+++ b/src/main/php/PHPMD/Rule.php
@@ -32,6 +32,11 @@ interface Rule
     const LOWEST_PRIORITY = 5;
 
     /**
+     * The default highest rule priority.
+     */
+    const HIGHEST_PRIORITY = 1;
+
+    /**
      * Returns the name for this rule instance.
      *
      * @return string

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -431,7 +431,7 @@ class RuleSetFactory
             }
         }
 
-	if ($rule->getPriority() <= $this->minimumPriority && $rule->getPriority() >= $this->maximumPriority) {
+        if ($rule->getPriority() <= $this->minimumPriority && $rule->getPriority() >= $this->maximumPriority) {
             $ruleSet->addRule($rule);
         }
     }

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -47,6 +47,13 @@ class RuleSetFactory
     private $minimumPriority = Rule::LOWEST_PRIORITY;
 
     /**
+     * The maximum priority for rules to load.
+     *
+     * @var integer
+     */
+    private $maximumPriority = Rule::HIGHEST_PRIORITY;
+
+    /**
      * Constructs a new default rule-set factory instance.
      */
     public function __construct()
@@ -79,6 +86,17 @@ class RuleSetFactory
     public function setMinimumPriority($minimumPriority)
     {
         $this->minimumPriority = $minimumPriority;
+    }
+
+    /**
+     * Sets the maximum priority that a rule must have.
+     *
+     * @param integer $maximumPriority The maximum priority value.
+     * @return void
+     */
+    public function setMaximumPriority($maximumPriority)
+    {
+        $this->maximumPriority = $maximumPriority;
     }
 
     /**
@@ -266,6 +284,7 @@ class RuleSetFactory
     {
         $ruleSetFactory = new RuleSetFactory();
         $ruleSetFactory->setMinimumPriority($this->minimumPriority);
+        $ruleSetFactory->setMaximumPriority($this->maximumPriority);
 
         return $ruleSetFactory->createSingleRuleSet((string) $ruleSetNode['ref']);
     }
@@ -362,7 +381,7 @@ class RuleSetFactory
             }
         }
 
-        if ($rule->getPriority() <= $this->minimumPriority) {
+        if ($rule->getPriority() <= $this->minimumPriority && $rule->getPriority() >= $this->maximumPriority) {
             $ruleSet->addRule($rule);
         }
     }

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -431,7 +431,7 @@ class RuleSetFactory
             }
         }
 
-        if ($rule->getPriority() <= $this->minimumPriority) {
+	if ($rule->getPriority() <= $this->minimumPriority && $rule->getPriority() >= $this->maximumPriority) {
             $ruleSet->addRule($rule);
         }
     }

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -74,6 +74,7 @@ class Command
 
         // Configure a rule set factory
         $ruleSetFactory->setMinimumPriority($opts->getMinimumPriority());
+        $ruleSetFactory->setMaximumPriority($opts->getMaximumPriority());
         if ($opts->hasStrict()) {
             $ruleSetFactory->setStrict();
         }

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -41,6 +41,13 @@ class CommandLineOptions
     protected $minimumPriority = Rule::LOWEST_PRIORITY;
 
     /**
+     * The maximum rule priority.
+     *
+     * @var integer
+     */
+    protected $maximumPriority = Rule::HIGHEST_PRIORITY;
+
+    /**
      * A php source code filename or directory.
      *
      * @var string
@@ -146,6 +153,11 @@ class CommandLineOptions
                 case '--minimum-priority':
                 case '--minimumpriority':
                     $this->minimumPriority = (int)array_shift($args);
+                    break;
+                case '--max-priority':
+                case '--maximum-priority':
+                case '--maximumpriority':
+                    $this->maximumPriority = (int)array_shift($args);
                     break;
                 case '--report-file':
                 case '--reportfile':
@@ -268,6 +280,16 @@ class CommandLineOptions
     public function getMinimumPriority()
     {
         return $this->minimumPriority;
+    }
+
+    /**
+     * Returns the maximum rule priority.
+     *
+     * @return integer
+     */
+    public function getMaximumPriority()
+    {
+        return $this->maximumPriority;
     }
 
     /**

--- a/src/site/rst/documentation/ant-task.rst
+++ b/src/site/rst/documentation/ant-task.rst
@@ -65,6 +65,7 @@ The following attributes can be defined on the PHPMD task xml-element.
  failonerror           Whether or not to fail the build if any errors occur while processing the files                                           No
  failOnRuleViolation   Whether or not to fail the build if PHPMD finds any problems                                                              No
  minimumPriority       The rule priority threshold; rules with lower priority than they will not be used                                         No
+ maximumPriority       The rule priority threshold; rules with higher priority than this will not be used                                         No
 ===================== ========================================================================================================================= ================================================
 
 Nested xml elements

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -43,6 +43,9 @@ Command line options
   - ``--minimumpriority`` ``--min-priority`` ``--minimum-priority`` - The rule priority threshold; rules with lower
     priority than they will not be used.
 
+  - ``--maximumpriority`` ``--max-priority`` ``--maximum-priority`` - The rule priority threshold; rules with higher
+    priority than this will not be used.
+
   - ``--reportfile`` ``--report-file`` - Sends the report output to the specified file,
     instead of the default output target ``STDOUT``.
 

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -370,7 +370,7 @@ class RuleSetFactoryTest extends AbstractTest
         $ruleSets = $factory->createRuleSets('refset3');
 
         $rule = $ruleSets[0]->getRules()->current();
-        $this->assertSame(-42, $rule->getPriority());
+        $this->assertSame(4, $rule->getPriority());
     }
 
     /**

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -290,11 +290,11 @@ class RuleSetFactoryTest extends AbstractTest
     }
 
     /**
-     * Tests that the rule-set factory applies a set priority filter correct.
+     * Tests that the rule-set factory applies a set minimum priority filter correct.
      *
      * @return void
      */
-    public function testCreateRuleSetWithSpecifiedPriorityOnlyContainsMatchingRules()
+    public function testCreateRuleSetWithSpecifiedMinimumPriorityOnlyContainsMatchingRules()
     {
         self::changeWorkingDirectory();
 
@@ -303,6 +303,39 @@ class RuleSetFactoryTest extends AbstractTest
 
         $ruleSet = $factory->createSingleRuleSet('set1');
         $this->assertSame(1, iterator_count($ruleSet->getRules()));
+    }
+
+    /**
+     * Tests that the rule-set factory applies a set maximum priority filter correct.
+     *
+     * @return void
+     */
+    public function testCreateRuleSetWithSpecifiedMaximumPriorityOnlyContainsMatchingRules()
+    {
+        self::changeWorkingDirectory();
+
+        $factory = new RuleSetFactory();
+        $factory->setMaximumPriority(2);
+
+        $ruleSet = $factory->createSingleRuleSet('set1');
+        $this->assertSame(1, iterator_count($ruleSet->getRules()));
+    }
+
+    /**
+     * Tests that the rule-set factory applies a set maximum priority filter correct.
+     *
+     * @return void
+     */
+    public function testCreateRuleSetWithSpecifiedPrioritiesOnlyContainsMatchingRules()
+    {
+        self::changeWorkingDirectory();
+
+        $factory = new RuleSetFactory();
+        $factory->setMinimumPriority(2);
+        $factory->setMaximumPriority(2);
+
+        $ruleSet = $factory->createSingleRuleSet('set1');
+        $this->assertCount(0, $ruleSet->getRules());
     }
 
     /**

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -294,6 +294,17 @@ class CommandLineOptionsTest extends AbstractTest
     /**
      * @return void
      */
+    public function testCliOptionsAcceptsMaximumpriorityArgument()
+    {
+        $args = array(__FILE__, '--maximumpriority', 42, __FILE__, 'text', 'codesize');
+        $opts = new CommandLineOptions($args);
+
+        $this->assertEquals(42, $opts->getMaximumPriority());
+    }
+
+    /**
+     * @return void
+     */
     public function testGetMinimumPriorityReturnsLowestValueByDefault()
     {
         $args = array(__FILE__, __FILE__, 'text', 'codesize');

--- a/src/test/resources/files/rulesets/refset3.xml
+++ b/src/test/resources/files/rulesets/refset3.xml
@@ -9,7 +9,7 @@
     <description>First description...</description>
 
     <rule ref="rulesets/set1.xml/RuleTwoInFirstRuleSet">
-        <priority>-42</priority>
+        <priority>4</priority>
         <description>description 42</description>
         <properties>
             <property name="foo" value="42" />


### PR DESCRIPTION
This adds support for setting a maximum priority next to the existing minimum priority.

As PHP mess detector doesn't really differentiate between errors and warnings - but does support priorities -, setting a maximum priority can be useful to differentiate in CI environments as it allows you to run once with the priorities confined to e.g. 1 and treat that as a CI failure whilst running a second time with the priorities confined to 2 and treat that as warnings that don't cause the CI to fail.

In this same scenario, where you run multiple times using different priorities for different severities, only being able to specify a minimum priority for the second run causes the messages of the first to be included a second time, as it is not possible to set a higher bound for the priority.