### PR TITLE
LongParameterList: added option to ignore constructors

### DIFF
--- a/src/main/php/PHPMD/Rule/Design/LongParameterList.php
+++ b/src/main/php/PHPMD/Rule/Design/LongParameterList.php
@@ -41,6 +41,9 @@ class LongParameterList extends AbstractRule implements FunctionAware, MethodAwa
         if ($count < $threshold) {
             return;
         }
+        if ($node->getName() === '__construct' && $this->getBooleanProperty('ignoreConstructors')) {
+            return;
+        }
 
         $this->addViolation(
             $node,

--- a/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
@@ -27,6 +27,29 @@ use PHPMD\AbstractTest;
 class LongParameterListTest extends AbstractTest
 {
     /**
+     * testApplyIgnoresConstructorsWithMoreParametersThanMinimum
+     *
+     * @return void
+     */
+    public function testApplyIgnoresConstructorsWithMoreParametersThanMinimum()
+    {
+        $node = $this->getMock('PHPMD\\Node\\MethodNode', array(), array(null), '', false);
+        $node->expects($this->once())
+            ->method('getParameterCount')
+            ->willReturn(3);
+
+        $node->expects($this->once())
+            ->method('getName')
+            ->willReturn('__construct');
+
+        $rule = new LongParameterList();
+        $rule->setReport($this->getReportMock(0));
+        $rule->addProperty('minimum', '0');
+        $rule->addProperty('ignoreConstructors', 'true');
+        $rule->apply($node);
+    }
+
+    /**
      * testApplyIgnoresMethodsWithLessParametersThanMinimum
      *
      * @return void


### PR DESCRIPTION
Due to many dependencies injected via constructors I had to disable the rule in multiple projects.
But the rule is very useful, hence a new setting `ignoreConstructors` being introduced.