### PR TITLE
Fix a bug in the renderer autodiscovery

### DIFF
--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -481,7 +481,7 @@ class CommandLineOptions
             return implode(', ', $renderers);
         }
 
-        return array_pop($list);
+        return array_pop($renderers);
     }
 
     /**


### PR DESCRIPTION
PHPMD has reported the following problem with its own source code:

```
/opt/src/PHPMD/TextUI/CommandLineOptions.php:484        Avoid unused local variables such as '$list'.
```

This pull request will fix it.