### PR TITLE
Fix package type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "mess detection",
     "mess detector"
   ],
-  "type": "project",
+  "type": "library",
   "license": "BSD-3-Clause",
   "homepage": "https://phpmd.org/",
   "authors": [


### PR DESCRIPTION
Packagist.org displays `composer create-project phpmd/phpmd`
It should display `composer require phpmd/phpmd` as you more commonly require phpmd