### PR TITLE
Remove section about commercial support

### DIFF
--- a/src/site/rst/support/index.rst
+++ b/src/site/rst/support/index.rst
@@ -5,28 +5,16 @@ Support & Contact
 Support Channel
 ===============
 
-If you have trouble using PHPMD, you may find help in our 
+If you have trouble using PHPMD, you may find help in our
 `Gitter channel <https://gitter.im/phpmd/community>`_.
 
 Issue-Tracker
 =============
 
-You can file an issue in PHPMD's 
+You can file an issue in PHPMD's
 `issue tracker <https://github.com/phpmd/phpmd/issues>`_ when
 you think you found a bug or you have a feature request for future
 versions of PHPMD.
 If you can even provide a fix for a bug or provide a new feature,
 please open a `pull request <https://github.com/phpmd/phpmd/pulls>`_.
 
-Commercial support
-==================
-
-There are also companies providing commercial support for PHPMD:
-
-- `Qafoo GmbH - passion for software quality`__
-
-  Founded by me, the lead developer of PHPMD, and two friends, Qafoo
-  provides support for PHPMD and general consulting and training on
-  software quality tools and processes.
-
-__ http://qafoo.com


### PR DESCRIPTION
Manuel told me that Qafoo doesn't do any commercial support for PHPMD, anymore.