### PR TITLE
Replace Travis build notification from IRC to the new Gitter core channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,12 @@ script:
   - if [[ $WEBSITE != 'true' && $TRAVIS_PHP_VERSION  = 7.1 ]]; then vendor/phpunit/phpunit/phpunit --configuration $TEST_CONFIG --colors --coverage-text; fi
 
 notifications:
-  irc: "irc.freenode.org#phpmd"
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/5a993c0b870b2fa9141e
+    on_success: change
+    on_failure: always
+    on_start: never
 
 deploy:
   provider: pages


### PR DESCRIPTION
The documentation for the integration read:

````
Instructions

You need to configure your Travis job to send Webhook notifications [https://docs.travis-ci.com/user/notifications].

Add the following to your .travis.yml configuration:

notifications:
  webhooks:
    urls:
      - YOUR_WEBHOOK_URL
    on_success: change  # options: [always|never|change] default: always
    on_failure: always  # options: [always|never|change] default: always
    on_start: never     # options: [always|never|change] default: always

Your unique webhook url for this service:

https://webhooks.gitter.im/e/5a993c0b870b2fa9141e
````
