### PR TITLE
Pick 2.6.1 release notes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+phpmd-2.6.1 (2019/07/06)
+========================
+
+This is the first release of the new maintainer team of PHPMD. It is a 
+re-tag of 2.6.0 but with PHAR build on Travis-CI and deployment to 
+GitHub releases.
+
+- Implemented #616: Build the PHAR file on Travis-CI and publish it to 
+  GitHub releases Implemented in commit #135327d.
+
 phpmd-2.6.0 (2017/01/20)
 ========================
 

--- a/build.properties
+++ b/build.properties
@@ -1,7 +1,7 @@
 project.dir       =
 project.uri       = phpmd.org
 project.name      = phpmd
-project.version   = 2.6.0
+project.version   = 2.6.1
 project.stability = stable
 
 # Disable pear support

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -10,6 +10,13 @@
     </properties>
 
     <body>
+        <release version="2.6.1"
+                 date="2019/07/06"
+                 description="This is the first release of the new maintainer team of PHPMD. It is a re-tag of 2.6.0 but with PHAR build on Travis-CI and deployment to GitHub releases.">
+            <action date="135327d" dev="jakzal" type="update" system="github" issue="616">
+                Build the PHAR file on Travis-CI and publish it to GitHub releases
+            </action>
+        </release>
         <release version="2.6.0"
                  date="2017/01/20"
                  description="This release incorporates several pending PRs. Beside that we have rebased PHPMD on PDepend 2.5 which should complete support for PHP 7 language features.">


### PR DESCRIPTION
Since I tagged 2.6.1 upon 2.6.0, and didn't changed these in master, we have to post-merge them into master.