### PR TITLE
Skip DuplicatedArrayKey rule check, if there is no array key...

### DIFF
--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -93,8 +93,13 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      */
     private function normalizeKey(AbstractASTNode $node, $index)
     {
+        $childCount = count($node->getChildren());
+        // Skip, if there is no array key, just an array value
+        if ($childCount === 1) {
+            return null;
+        }
         // non-associative - key name equals to its index
-        if (count($node->getChildren()) === 0) {
+        if ($childCount === 0) {
             $node->setImage((string) $index);
             return $node;
         }

--- a/src/test/resources/files/Rule/CleanCode/DuplicatedArrayKey/testRuleNotAppliesToFunctionWithNonAssotiativeArrayDefinition.php
+++ b/src/test/resources/files/Rule/CleanCode/DuplicatedArrayKey/testRuleNotAppliesToFunctionWithNonAssotiativeArrayDefinition.php
@@ -20,5 +20,6 @@ function testRuleNotAppliesToFunctionWithNonAssotiativeArrayDefinition()
     return array(
         42,
         43,
+        43,
     );
 }


### PR DESCRIPTION
... but just an array value

Extend test example to cover this case.