### PR TITLE
Upgrade to PHP 7.2 and PHPUnit 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,12 @@ language: php
 
 matrix:
   include:
-    - php: 5.4
-    - php: 5.4
-      env: DEPENDENCIES=low
-    - php: 5.5
-    - php: 5.5
-      env: DEPENDENCIES=low
-    - php: 5.6
-    - php: 5.6
-      env: DEPENDENCIES=low
-    - php: 7.0
-    - php: 7.0
-      env: DEPENDENCIES=low
-    - php: 7.1
-    - php: 7.1
-      env: DEPENDENCIES=low
     - php: 7.2
-    # Could be enabled when we'll upgrade PHPUnit
-    # - php: 7.2
-    #   env: DEPENDENCIES=low
+    - php: 7.2
+      env: DEPENDENCIES=low
     - php: 7.3
-    # Could be enabled when we'll upgrade PHPUnit
-    # - php: 7.3
-    #   env: DEPENDENCIES=low
+    - php: 7.3
+      env: DEPENDENCIES=low
     - php: 5.4
       env: BUILD_PHAR=true
     - php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: DEPENDENCIES=low
-    - php: 5.4
+    - php: 7.2
       env: BUILD_PHAR=true
     - php: 7.3
       env: WEBSITE=true
@@ -17,8 +17,8 @@ matrix:
 sudo: false
 
 env:
-    global:
-        TEST_CONFIG="phpunit.xml.dist"
+  global:
+    TEST_CONFIG="phpunit.xml.dist"
 
 before_script:
   - composer self-update
@@ -41,23 +41,23 @@ notifications:
     on_start: never
 
 deploy:
-- provider: pages
-  skip_cleanup: true
-  github_token: $GITHUB_TOKEN
-  local_dir: dist/website
-  on:
-    branch: master
-    condition: $WEBSITE
-- provider: releases
-  api_key: $GITHUB_TOKEN
-  file: phpmd.phar
-  skip_cleanup: true
-  on:
-    tags: true
-    repo: phpmd/phpmd
-    condition: "$BUILD_PHAR"
+  - provider: pages
+    skip_cleanup: true
+    github_token: $GITHUB_TOKEN
+    local_dir: dist/website
+    on:
+      branch: master
+      condition: $WEBSITE
+  - provider: releases
+    api_key: $GITHUB_TOKEN
+    file: phpmd.phar
+    skip_cleanup: true
+    on:
+      tags: true
+      repo: phpmd/phpmd
+      condition: "$BUILD_PHAR"
 
 addons:
   snaps:
-  - name: ant
-    classic: true
+    - name: ant
+      classic: true

--- a/build.properties
+++ b/build.properties
@@ -19,4 +19,4 @@ project.scm.uri = github.com/${project.name}/${project.name}/commit
 # Execute the following command for pdepend profiling
 profile.command = ${basedir}/src/bin/phpmd '/opt/Sources/PHP/Flow3/Packages/Framework' xml naming,codesize,unusedcode,design --reportfile pmd.xml
 
-phpunit.package.name = phpunit-4.8.28
+phpunit.package.name = phpunit-8.2.4

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   "minimum-stability": "stable",
   "require": {
     "php": "^7.2",
-    "pdepend/pdepend": "^2.5",
+    "pdepend/pdepend": "^2.5.2",
     "ext-xml": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -35,13 +35,13 @@
   },
   "minimum-stability": "stable",
   "require": {
-    "php": ">=5.4.0",
+    "php": "^7.2",
     "pdepend/pdepend": "^2.5",
     "ext-xml": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.36 || ^5.7.27",
-    "squizlabs/php_codesniffer": "^2.0",
+    "phpunit/phpunit": "^8.2",
+    "squizlabs/php_codesniffer": "^3.4",
     "mikey179/vfsstream": "^1.6.4",
     "gregwar/rst": "^1.0"
   },

--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -112,7 +112,7 @@ class ParserFactory
      */
     private function initIgnores(Engine $pdepend, PHPMD $phpmd)
     {
-        if (count($phpmd->getIgnorePattern()) > 0) {
+        if (count($phpmd->getIgnorePattern() ?: []) > 0) {
             $pdepend->addFileFilter(
                 new ExcludePathFilter($phpmd->getIgnorePattern())
             );
@@ -128,7 +128,7 @@ class ParserFactory
      */
     private function initExtensions(Engine $pdepend, PHPMD $phpmd)
     {
-        if (count($phpmd->getFileExtensions()) > 0) {
+        if (count($phpmd->getFileExtensions() ?: []) > 0) {
             $pdepend->addFileFilter(
                 new ExtensionFilter($phpmd->getFileExtensions())
             );
@@ -145,7 +145,7 @@ class ParserFactory
     private function initOptions(Engine $pdepend, PHPMD $phpmd)
     {
         $options = array();
-        foreach (array_filter($phpmd->getOptions()) as $name => $value) {
+        foreach (array_filter($phpmd->getOptions() ?: []) as $name => $value) {
             if (isset($this->phpmd2pdepend[$name])) {
                 $options[$this->phpmd2pdepend[$name]] = $value;
             }

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -27,11 +27,12 @@ use PHPMD\Node\InterfaceNode;
 use PHPMD\Node\MethodNode;
 use PHPMD\Node\TraitNode;
 use PHPMD\Stubs\RuleStub;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Abstract base class for PHPMD test cases.
  */
-abstract class AbstractTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractTest extends TestCase
 {
     /**
      * Directory with test files.
@@ -59,7 +60,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (self::$originalWorkingDirectory !== null) {
             chdir(self::$originalWorkingDirectory);
@@ -271,7 +272,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     protected function getClassMock($metric = null, $value = null)
     {
-        $class = $this->getMock(
+        $class = $this->createMock(
             'PHPMD\\Node\\ClassNode',
             array(),
             array(null),
@@ -285,6 +286,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
                 ->with($this->equalTo($metric))
                 ->will($this->returnValue($value));
         }
+
         return $class;
     }
 
@@ -298,7 +300,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
     protected function getMethodMock($metric = null, $value = null)
     {
         return $this->initFunctionOrMethod(
-            $this->getMock('PHPMD\\Node\\MethodNode', array(), array(null), '', false),
+            $this->createMock('PHPMD\\Node\\MethodNode'),
             $metric,
             $value
         );
@@ -314,7 +316,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
     protected function createFunctionMock($metric = null, $value = null)
     {
         return $this->initFunctionOrMethod(
-            $this->getMock('PHPMD\\Node\\FunctionNode', array(), array(null), '', false),
+            $this->createMock('PHPMD\\Node\\FunctionNode', array(), array(null), '', false),
             $metric,
             $value
         );
@@ -360,7 +362,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
             $expects = $this->exactly($expectedInvokes);
         }
 
-        $report = $this->getMock('PHPMD\\Report');
+        $report = $this->getMockBuilder('PHPMD\\Report')->getMock();
         $report->expects($expects)
             ->method('addRuleViolation');
 
@@ -386,7 +388,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     protected function getRuleSetMock($expectedClass = null, $count = '*')
     {
-        $ruleSet = $this->getMock('PHPMD\RuleSet');
+        $ruleSet = $this->createMock('PHPMD\RuleSet');
         if ($expectedClass === null) {
             $ruleSet->expects($this->never())->method('apply');
         } else {
@@ -416,7 +418,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
         $rule = null,
         $description = null
     ) {
-        $ruleViolation = $this->getMock(
+        $ruleViolation = $this->createMock(
             'PHPMD\\RuleViolation',
             array(),
             array(null, null, null),
@@ -525,7 +527,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$filesDirectory = realpath(__DIR__ . '/../../resources/files');
 

--- a/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
+++ b/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
@@ -35,7 +35,7 @@ class CommandLineInputFileOptionTest extends AbstractTest
      */
     public function testReportContainsExpectedRuleViolationWarning()
     {
-        self::assertContains(
+        self::assertStringContainsString(
             "Avoid unused local variables such as '\$foo'.",
             self::runCommandLine()
         );
@@ -49,7 +49,7 @@ class CommandLineInputFileOptionTest extends AbstractTest
      */
     public function testReportNotContainsRuleViolationWarningForFileNotInList()
     {
-        self::assertNotContains(
+        self::assertStringNotContainsString(
             "Avoid unused local variables such as '\$bar'.",
             self::runCommandLine()
         );

--- a/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
@@ -48,7 +48,7 @@ class CouplingBetweenObjectsIntegrationTest extends AbstractTest
             )
         );
 
-        self::assertContains(
+        self::assertStringContainsString(
             'has a coupling between objects value of 14. ' .
             'Consider to reduce the number of dependencies under 13.',
             file_get_contents($file)

--- a/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
@@ -48,6 +48,6 @@ class GotoStatementIntegrationTest extends AbstractTest
             )
         );
 
-        self::assertContains('utilizes a goto statement.', file_get_contents($file));
+        self::assertStringContainsString('utilizes a goto statement.', file_get_contents($file));
     }
 }

--- a/src/test/php/PHPMD/Node/ASTNodeTest.php
+++ b/src/test/php/PHPMD/Node/ASTNodeTest.php
@@ -33,7 +33,7 @@ class ASTNodeTest extends AbstractTest
      */
     public function testGetImageDelegatesToGetImageMethodOfWrappedNode()
     {
-        $mock = $this->getMock('PDepend\Source\AST\ASTNode');
+        $mock = $this->createMock('PDepend\Source\AST\ASTNode');
         $mock->expects($this->once())
             ->method('getImage');
 
@@ -48,7 +48,7 @@ class ASTNodeTest extends AbstractTest
      */
     public function testGetNameDelegatesToGetImageMethodOfWrappedNode()
     {
-        $mock = $this->getMock('PDepend\Source\AST\ASTNode');
+        $mock = $this->createMock('PDepend\Source\AST\ASTNode');
         $mock->expects($this->once())
             ->method('getImage');
 
@@ -63,7 +63,7 @@ class ASTNodeTest extends AbstractTest
      */
     public function testHasSuppressWarningsAnnotationForAlwaysReturnsFalse()
     {
-        $mock = $this->getMock('PDepend\Source\AST\ASTNode');
+        $mock = $this->createMock('PDepend\Source\AST\ASTNode');
 
         $node = new ASTNode($mock, __FILE__);
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
@@ -78,7 +78,7 @@ class ASTNodeTest extends AbstractTest
      */
     public function testGetParentNameReturnsNull()
     {
-        $mock = $this->getMock('PDepend\Source\AST\ASTNode');
+        $mock = $this->createMock('PDepend\Source\AST\ASTNode');
         $node = new ASTNode($mock, __FILE__);
 
         $this->assertNull($node->getParentName());
@@ -91,7 +91,7 @@ class ASTNodeTest extends AbstractTest
      */
     public function testGetNamespaceNameReturnsNull()
     {
-        $mock = $this->getMock('PDepend\Source\AST\ASTNode');
+        $mock = $this->createMock('PDepend\Source\AST\ASTNode');
         $node = new ASTNode($mock, __FILE__);
 
         $this->assertNull($node->getNamespaceName());
@@ -104,7 +104,7 @@ class ASTNodeTest extends AbstractTest
      */
     public function testGetFullQualifiedNameReturnsNull()
     {
-        $mock = $this->getMock('PDepend\Source\AST\ASTNode');
+        $mock = $this->createMock('PDepend\Source\AST\ASTNode');
         $node = new ASTNode($mock, __FILE__);
 
         $this->assertNull($node->getFullQualifiedName());

--- a/src/test/php/PHPMD/Node/ClassNodeTest.php
+++ b/src/test/php/PHPMD/Node/ClassNodeTest.php
@@ -55,7 +55,7 @@ class ClassNodeTest extends AbstractTest
         $class = new ASTClass(null);
         $class->setComment('/** @SuppressWarnings("PMD") */');
 
-        $rule = $this->getMock('PHPMD\\AbstractRule');
+        $rule = $this->createMock('PHPMD\\AbstractRule');
 
         $node = new ClassNode($class);
 

--- a/src/test/php/PHPMD/Node/FunctionTest.php
+++ b/src/test/php/PHPMD/Node/FunctionTest.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Node;
 
+use BadMethodCallException;
 use PDepend\Source\AST\ASTFunction;
 use PHPMD\AbstractTest;
 
@@ -35,7 +36,7 @@ class FunctionNodeTest extends AbstractTest
      */
     public function testMagicCallDelegatesToWrappedPHPDependFunction()
     {
-        $function = $this->getMock('PDepend\\Source\\AST\\ASTFunction', array(), array(null));
+        $function = $this->createMock('PDepend\\Source\\AST\\ASTFunction', array(), array(null));
         $function->expects($this->once())
             ->method('getStartLine');
 
@@ -47,10 +48,10 @@ class FunctionNodeTest extends AbstractTest
      * testMagicCallThrowsExceptionWhenNoMatchingMethodExists
      *
      * @return void
-     * @expectedException BadMethodCallException
      */
     public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists()
     {
+        $this->expectException(BadMethodCallException::class);
         $node = new FunctionNode(new ASTFunction(null));
         $node->getFooBar();
     }

--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Node;
 
+use BadMethodCallException;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
@@ -37,7 +38,7 @@ class MethodNodeTest extends AbstractTest
      */
     public function testMagicCallDelegatesToWrappedPHPDependMethod()
     {
-        $method = $this->getMock('PDepend\\Source\\AST\\ASTMethod', array(), array(null));
+        $method = $this->createMock('PDepend\\Source\\AST\\ASTMethod', array(), array(null));
         $method->expects($this->once())
             ->method('getStartLine');
 
@@ -49,10 +50,10 @@ class MethodNodeTest extends AbstractTest
      * testMagicCallThrowsExceptionWhenNoMatchingMethodExists
      *
      * @return void
-     * @expectedException \BadMethodCallException
      */
     public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists()
     {
+        $this->expectException(BadMethodCallException::class);
         $node = new MethodNode(new ASTMethod(null));
         $node->getFooBar();
     }

--- a/src/test/php/PHPMD/ParserFactoryTest.php
+++ b/src/test/php/PHPMD/ParserFactoryTest.php
@@ -35,7 +35,7 @@ class ParserFactoryTest extends AbstractTest
 
         $uri = $this->createFileUri('ParserFactory/Directory');
 
-        $phpmd = $this->getMock('PHPMD\\PHPMD', array('getInput'));
+        $phpmd = $this->createMock('PHPMD\\PHPMD', array('getInput'));
         $phpmd->expects($this->once())
             ->method('getInput')
             ->will($this->returnValue($uri));
@@ -58,7 +58,7 @@ class ParserFactoryTest extends AbstractTest
 
         $uri = $this->createFileUri('ParserFactory/File/Test.php');
 
-        $phpmd = $this->getMock('PHPMD\\PHPMD', array('getInput'));
+        $phpmd = $this->createMock('PHPMD\\PHPMD', array('getInput'));
         $phpmd->expects($this->once())
             ->method('getInput')
             ->will($this->returnValue($uri));
@@ -82,7 +82,7 @@ class ParserFactoryTest extends AbstractTest
         $uri1 = $this->createFileUri('ParserFactory/File');
         $uri2 = $this->createFileUri('ParserFactory/Directory');
 
-        $phpmd = $this->getMock('PHPMD\\PHPMD', array('getInput'));
+        $phpmd = $this->createMock('PHPMD\\PHPMD', array('getInput'));
         $phpmd->expects($this->once())
             ->method('getInput')
             ->will($this->returnValue($uri1 . ',' . $uri2));
@@ -106,7 +106,7 @@ class ParserFactoryTest extends AbstractTest
         $uri1 = $this->createFileUri('ParserFactory/File/Test.php');
         $uri2 = $this->createFileUri('ParserFactory/Directory');
 
-        $phpmd = $this->getMock('PHPMD\\PHPMD', array('getInput'));
+        $phpmd = $this->createMock('PHPMD\\PHPMD', array('getInput'));
         $phpmd->expects($this->once())
             ->method('getInput')
             ->will($this->returnValue($uri1 . ',' . $uri2));
@@ -129,7 +129,7 @@ class ParserFactoryTest extends AbstractTest
 
         $uri = $this->createFileUri('ParserFactory/File/Test.php');
 
-        $phpmd = $this->getMock('PHPMD\\PHPMD', array('getIgnorePattern', 'getInput'));
+        $phpmd = $this->createMock('PHPMD\\PHPMD', array('getIgnorePattern', 'getInput'));
         $phpmd->expects($this->exactly(2))
             ->method('getIgnorePattern')
             ->will($this->returnValue(array('Test')));
@@ -151,7 +151,7 @@ class ParserFactoryTest extends AbstractTest
 
         $uri = $this->createFileUri('ParserFactory/File/Test.php');
 
-        $phpmd = $this->getMock('PHPMD\\PHPMD', array('getFileExtensions', 'getInput'));
+        $phpmd = $this->createMock('PHPMD\\PHPMD', array('getFileExtensions', 'getInput'));
         $phpmd->expects($this->exactly(2))
             ->method('getFileExtensions')
             ->will($this->returnValue(array('.php')));

--- a/src/test/php/PHPMD/ParserTest.php
+++ b/src/test/php/PHPMD/ParserTest.php
@@ -147,7 +147,7 @@ class ParserTest extends AbstractTest
      */
     private function getPHPDependMock()
     {
-        return $this->getMock('PDepend\Engine', array(), array(null), '', false);
+        return $this->createMock('PDepend\Engine', array(), array(null), '', false);
     }
 
     /**
@@ -157,7 +157,7 @@ class ParserTest extends AbstractTest
      */
     protected function getPHPDependClassMock()
     {
-        $class = $this->getMock('PDepend\\Source\\AST\\ASTClass', array(), array(null));
+        $class = $this->createMock('PDepend\\Source\\AST\\ASTClass', array(), array(null));
         $class->expects($this->any())
             ->method('getCompilationUnit')
             ->will($this->returnValue($this->getPHPDependFileMock('foo.php')));
@@ -182,7 +182,7 @@ class ParserTest extends AbstractTest
      */
     protected function getPHPDependFunctionMock($fileName = '/foo/bar.php')
     {
-        $function = $this->getMock('PDepend\Source\AST\ASTFunction', array(), array(null));
+        $function = $this->createMock('PDepend\Source\AST\ASTFunction', array(), array(null));
         $function->expects($this->atLeastOnce())
             ->method('getCompilationUnit')
             ->will($this->returnValue($this->getPHPDependFileMock($fileName)));
@@ -198,7 +198,7 @@ class ParserTest extends AbstractTest
      */
     protected function getPHPDependMethodMock($fileName = '/foo/bar.php')
     {
-        $method = $this->getMock('PDepend\Source\AST\ASTMethod', array(), array(null));
+        $method = $this->createMock('PDepend\Source\AST\ASTMethod', array(), array(null));
         $method->expects($this->atLeastOnce())
             ->method('getCompilationUnit')
             ->will($this->returnValue($this->getPHPDependFileMock($fileName)));
@@ -214,7 +214,7 @@ class ParserTest extends AbstractTest
      */
     protected function getPHPDependFileMock($fileName)
     {
-        $file = $this->getMock('PDepend\Source\AST\ASTCompilationUnit', array(), array(null));
+        $file = $this->createMock('PDepend\Source\AST\ASTCompilationUnit', array(), array(null));
         $file->expects($this->any())
             ->method('getFileName')
             ->will($this->returnValue($fileName));

--- a/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
+++ b/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
@@ -43,11 +43,13 @@ class AcceptsFilesAndDirectoriesAsInputTicket001Test extends AbstractTest
 
         $phpmd = new PHPMD();
         $phpmd->processFiles(
-            self::createFileUri('source'),
+            ($uri = self::createFileUri('source')),
             'pmd-refset1',
             array($renderer),
             new RuleSetFactory()
         );
+
+        $this->assertSame($uri, $phpmd->getInput());
     }
 
     /**
@@ -64,10 +66,12 @@ class AcceptsFilesAndDirectoriesAsInputTicket001Test extends AbstractTest
 
         $phpmd = new PHPMD();
         $phpmd->processFiles(
-            self::createFileUri('source/FooBar.php'),
+            ($uri = self::createFileUri('source/FooBar.php')),
             'pmd-refset1',
             array($renderer),
             new RuleSetFactory()
         );
+
+        $this->assertSame($uri, $phpmd->getInput());
     }
 }

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
@@ -41,7 +41,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
     /**
      * Sets up the renderer mock
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->renderer = $this->getMockBuilder('PHPMD\Renderer\TextRenderer')
             ->disableOriginalConstructor()

--- a/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007Test.php
+++ b/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007Test.php
@@ -37,6 +37,8 @@ class InvalidUnusedLocalVariableAndFormalParameterTicket007Test extends Abstract
         $rule = new UnusedLocalVariable();
         $rule->setReport($this->getReportMock(0));
         $rule->apply($this->getMethod());
+
+        $this->assertSame('', $rule->getMessage());
     }
 
     /**
@@ -49,5 +51,7 @@ class InvalidUnusedLocalVariableAndFormalParameterTicket007Test extends Abstract
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportMock(0));
         $rule->apply($this->getMethod());
+
+        $this->assertSame('', $rule->getMessage());
     }
 }

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
@@ -50,5 +50,11 @@ class MaximumNestingLevelTicket24975295Test extends AbstractTest
 
         $phpmd = new PHPMD();
         $phpmd->processFiles($inputs, $rules, $renderes, $factory);
+
+        $this->assertSame(
+            realpath(__DIR__.'/../../../resources/files/Regression/24975295/'.
+                'testLocalVariableUsedInDoubleQuoteStringGetsNotReported.php'),
+            realpath($phpmd->getInput())
+        );
     }
 }

--- a/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -59,7 +59,7 @@ class HTMLRendererTest extends AbstractTest
         $renderer->renderReport($report);
         $renderer->end();
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<tr>' . PHP_EOL .
             '<td align="center">2</td>' . PHP_EOL .
             '<td>/foo.php</td>' . PHP_EOL .
@@ -101,7 +101,7 @@ class HTMLRendererTest extends AbstractTest
         $renderer->renderReport($report);
         $renderer->end();
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<tr>' .
             '<td>/tmp/bar.php</td>' .
             '<td>Failed for file &quot;/tmp/bar.php&quot;.</td>' .

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -18,6 +18,8 @@
 namespace PHPMD;
 
 use org\bovigo\vfs\vfsStream;
+use ReflectionProperty;
+use RuntimeException;
 
 /**
  * Test case for the rule set factory class.
@@ -43,7 +45,7 @@ class RuleSetFactoryTest extends AbstractTest
         $factory = new RuleSetFactory();
         $ruleSet = $factory->createSingleRuleSet('codesize');
 
-        $this->assertContains('The Code Size Ruleset', $ruleSet->getDescription());
+        $this->assertStringContainsString('The Code Size Ruleset', $ruleSet->getDescription());
     }
 
     /**
@@ -69,7 +71,7 @@ class RuleSetFactoryTest extends AbstractTest
     public function testCreateRuleSetsReturnsArray()
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
-        $this->assertInternalType('array', $ruleSets);
+        $this->assertIsArray($ruleSets);
     }
 
     /**
@@ -185,7 +187,7 @@ class RuleSetFactoryTest extends AbstractTest
         self::changeWorkingDirectory();
 
         $ruleSets = $this->createRuleSetsFromFiles('rulesets/set1.xml');
-        $this->assertInternalType('array', $ruleSets);
+        $this->assertIsArray($ruleSets);
     }
 
     /**
@@ -562,8 +564,8 @@ class RuleSetFactoryTest extends AbstractTest
     {
         $factory = new RuleSetFactory();
 
-        $this->setExpectedException(
-            'PHPMD\\RuleSetNotFoundException',
+        $this->expectException('PHPMD\\RuleSetNotFoundException');
+        $this->expectExceptionMessage(
             'Cannot find specified rule-set "foo-bar-ruleset-23".'
         );
 
@@ -582,8 +584,10 @@ class RuleSetFactoryTest extends AbstractTest
         $fileName = self::createFileUri('rulesets/set-class-file-not-found.xml');
         $factory  = new RuleSetFactory();
 
-        $this->setExpectedException(
-            'PHPMD\\RuleClassFileNotFoundException',
+        $this->expectException(
+            'PHPMD\\RuleClassFileNotFoundException'
+        );
+        $this->expectExceptionMessage(
             'Cannot load source file for class: PHPMD\\Stubs\\ClassFileNotFoundRule'
         );
 
@@ -602,8 +606,10 @@ class RuleSetFactoryTest extends AbstractTest
         $fileName = self::createFileUri('rulesets/set-class-not-found.xml');
         $factory  = new RuleSetFactory();
 
-        $this->setExpectedException(
-            'PHPMD\\RuleClassNotFoundException',
+        $this->expectException(
+            'PHPMD\\RuleClassNotFoundException'
+        );
+        $this->expectExceptionMessage(
             'Cannot find rule class: PHPMD\\Stubs\\ClassNotFoundRule'
         );
 
@@ -616,10 +622,10 @@ class RuleSetFactoryTest extends AbstractTest
      *
      * @return void
      * @covers \PHPMD\RuleClassNotFoundException
-     * @expectedException \RuntimeException
      */
     public function testCreateRuleSetsThrowsExpectedExceptionForInvalidXmlFile()
     {
+        $this->expectException(RuntimeException::class);
         $fileName = self::createFileUri('rulesets/set-invalid-xml.xml');
 
         $factory = new RuleSetFactory();
@@ -640,7 +646,12 @@ class RuleSetFactoryTest extends AbstractTest
 
         $ruleSets = $factory->createRuleSets($fileName);
 
-        $this->assertAttributeEquals(true, 'strict', $ruleSets[0]);
+        $this->assertInstanceOf(RuleSet::class, $ruleSets[0]);
+
+        $property = new ReflectionProperty($ruleSets[0], 'strict');
+        $property->setAccessible(true);
+
+        $this->assertTrue($property->getValue($ruleSets[0]));
     }
 
     /**
@@ -699,7 +710,7 @@ class RuleSetFactoryTest extends AbstractTest
                 );
             } catch (RuleSetNotFoundException $e) {
                 $ruleSetNotFoundExceptionCount++;
-            } catch (\RuntimeException $e) {
+            } catch (RuntimeException $e) {
                 $runtimeExceptionCount++;
             }
         }

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -17,6 +17,8 @@
 
 namespace PHPMD;
 
+use OutOfBoundsException;
+
 /**
  * Test case for the {@link \PHPMD\AbstractRule} class.
  *
@@ -93,10 +95,10 @@ class RuleTest extends AbstractTest
      * testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
-     * @expectedException \OutOfBoundsException
      */
     public function testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
+        $this->expectException(OutOfBoundsException::class);
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->getIntProperty(__FUNCTION__);
     }
@@ -105,10 +107,10 @@ class RuleTest extends AbstractTest
      * testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
-     * @expectedException \OutOfBoundsException
      */
     public function testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
+        $this->expectException(OutOfBoundsException::class);
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->getBooleanProperty(__FUNCTION__);
     }
@@ -117,10 +119,10 @@ class RuleTest extends AbstractTest
      * testStringPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
-     * @expectedException \OutOfBoundsException
      */
     public function testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
+        $this->expectException(OutOfBoundsException::class);
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->getStringProperty(__FUNCTION__);
     }

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\TextUI;
 
+use InvalidArgumentException;
 use PHPMD\AbstractTest;
 use PHPMD\Rule;
 
@@ -35,7 +36,7 @@ class CommandLineOptionsTest extends AbstractTest
     /**
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (is_resource($this->stderrStreamFilter)) {
             stream_filter_remove($this->stderrStreamFilter);
@@ -92,10 +93,10 @@ class CommandLineOptionsTest extends AbstractTest
      *
      * @return void
      * @since 1.1.0
-     * @expectedException \InvalidArgumentException
      */
     public function testThrowsExpectedExceptionWhenRequiredArgumentsNotSet()
     {
+        $this->expectException(InvalidArgumentException::class);
         $args = array(__FILE__, 'text', 'design');
         new CommandLineOptions($args);
     }
@@ -153,10 +154,10 @@ class CommandLineOptionsTest extends AbstractTest
      *
      * @return void
      * @since 1.1.0
-     * @expectedException \InvalidArgumentException
      */
     public function testThrowsExpectedExceptionWhenInputFileNotExists()
     {
+        $this->expectException(InvalidArgumentException::class);
         $args = array('foo.php', 'text', 'design', '--inputfile', 'inputfail.txt');
         new CommandLineOptions($args);
     }
@@ -223,7 +224,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertContains('--ignore-violations-on-exit:', $opts->usage());
+        $this->assertStringContainsString('--ignore-violations-on-exit:', $opts->usage());
     }
 
     /**
@@ -236,7 +237,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertContains('Available formats: html, json, text, xml.', $opts->usage());
+        $this->assertStringContainsString('Available formats: html, json, text, xml.', $opts->usage());
     }
 
     /**
@@ -249,7 +250,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertContains('--strict:', $opts->usage());
+        $this->assertStringContainsString('--strict:', $opts->usage());
     }
 
     /**
@@ -376,12 +377,12 @@ class CommandLineOptionsTest extends AbstractTest
     /**
      * @param string $reportFormat
      * @return void
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp (^Can\'t )
      * @dataProvider dataProviderCreateRendererThrowsException
      */
     public function testCreateRendererThrowsException($reportFormat)
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp("/^Can't/");
         $args = array(__FILE__, __FILE__, $reportFormat, 'codesize');
         $opts = new CommandLineOptions($args);
         $opts->createRenderer();
@@ -412,7 +413,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize', sprintf('--%s', $deprecatedName), 42);
         new CommandLineOptions($args);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             sprintf(
                 'The --%s option is deprecated, please use --%s instead.',
                 $deprecatedName,

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -34,7 +34,7 @@ class CommandTest extends AbstractTest
     /**
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (is_resource($this->stderrStreamFilter)) {
             stream_filter_remove($this->stderrStreamFilter);
@@ -184,7 +184,7 @@ class CommandTest extends AbstractTest
             )
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Can\'t find the custom report class: ',
             StreamFilter::$streamHandle
         );


### PR DESCRIPTION
Before any other development on 3.x, we should upgrade composer settings, PHPUnit and Travis, so we'll get accurate build status on other 3.x PRs.