### PR TITLE
Fix url to "How to create a custom rule set" documentation page

### DIFF
--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -86,7 +86,7 @@ You can also mix custom `rule set files`__ with build-in rule sets: ::
 
   ~ $ phpmd /path/to/source text codesize,/my/rules.xml
 
-__ /documentation/creating-a-ruleset.html
+__ creating-a-ruleset.html
 
 That's it. With this behavior you can specify you own combination of rule sets
 that will check the source code.


### PR DESCRIPTION
Just url fix for documenation