### PR TITLE
Release 2.7.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,167 @@
+phpmd-2.7.0 (2019/07/29)
+========================
+
+This is the first minor release of the new PHPMD maintainer team. It 
+contains all the new features, improvements and fixes from two and a 
+half years since 2.6.0.
+
+- Fixed #449: Code style improvements Fixed in commit #67cdab2.
+- Fixed #447: Code style improvements Fixed in commit #3ef4ba8.
+- Fixed #450: Code style improvements Fixed in commit #9525da7.
+- Fixed #378: Fix warning/error when trying to export to a 
+  non-existing path Fixed in commit #67bd7c6.
+- Fix invalid "array of strings" type hints Fixed in commit #16e4eda.
+- Fixed #480: Start tag expected, '<' not found Fixed in commit 
+  #3e2e058.
+- Fixed #482: Rename minimum property to maximum in 
+  CouplingBetweenObjects Fixed in commit #9210116.
+- Fixed #494: Fix UnusedPrivateField false positive Fixed in commit 
+  #99f3ba9.
+- Fixed #567: Minor fix to Clean Code Rules documentation Fixed in 
+  commit #175b08f.
+- Fixed #582: Fixed a typo in Clean Code Rules documentation Fixed in 
+  commit #85e48ad.
+- Fixed #583: Apply LongNaming rule to private fields Fixed in commit 
+  #42bf8ad.
+- Fixed #598: Fix a bug in the renderer autodiscovery Fixed in commit 
+  #cc06bfd.
+- Fixed #599: Fix Composer package type Fixed in commit #0ca4eff.
+- Fixed #604: Rename mikey179/vfsStream to mikey179/vfsstream to 
+  prevent Composer error Fixed in commit #f66247f.
+- Fixed #609: Fix main logo link in website build script Fixed in 
+  commit #f3b68be.
+- Fixed #572: Allow different letter casing for @suppressWarnings 
+  annotation Fixed in commit #bb2cfe9.
+- Fixed #575: Fix UnusedFormalParameter false positive in string 
+  compound variable Fixed in commit #8790cbb.
+- Fixed #599: Fix Composer package type Fixed in commit #0ca4eff.
+- Fixed #626: Convert special chars in violation description for XML 
+  output Fixed in commit #5305f5b.
+- Fixed #631: Fix url to "How to create a custom rule set" 
+  documentation page Fixed in commit #3c5b534.
+- Fixed #632: Use local PHPUnit in Scrutinizer Fixed in commit 
+  #dfaa509.
+- Fixed #633: Fix AppVeyor build Fixed in commit #40189f3.
+- Implemented #443: Support for compound variables in 
+  UnusedLocalVariable Implemented in commit #c7009d5.
+- Implemented #448: Use HTTPS instead of HTTP Implemented in commit 
+  #51eb887.
+- Implemented #454: Use HTTPS instead of HTTP for test files 
+  Implemented in commit #f1c1426.
+- Implemented #451: Use HTTPS instead of HTTP for main files 
+  Implemented in commit #9a77c48.
+- Implemented #455: Use HTTPS instead of HTTP for resource files 
+  Implemented in commit #b073ad2.
+- Implemented #381: Add annotations to allow IDE to reference correct 
+  classes Implemented in commit #2dbae11.
+- Implemented #458: Updated PHPCS dev dependency from 2.3.4 to 2.8.1 
+  Implemented in commit #f2ae09f.
+- Implemented #459: Integrate Stickler CI Implemented in commit 
+  #d106330.
+- Implemented #458: Update PHPCS & add Composer scripts Implemented in 
+  commit #24ff5a9.
+- Implemented #460: Add ApiGen config file Implemented in commit 
+  #4514235.
+- Implemented #469: Update to Coding Standard command Implemented in 
+  commit #9962dae.
+- Implemented #470: Changed HTTP to HTTPS Implemented in commit 
+  #1ca30d0.
+- Implemented #471: Modified default PHP installation directory to 
+  match Chocolatey package in AppVeyor config Implemented in commit 
+  #2b55442.
+- Implemented #472: Add assignment within conditional rule Implemented 
+  in commit #716ecf5.
+- Implemented #474: Put down Support for HHVM Implemented in commit 
+  #9f7b4d2.
+- Implemented #469: Improvement to contributing guide for Linux / OS X 
+  users Implemented in commit #63ff5bf.
+- Implemented #476: Add empty catch block rule Implemented in commit 
+  #4bc19bd.
+- Implemented #475: Support for chained methods (fluent interfaces) 
+  for UnusedPrivateMethod rule Implemented in commit #d5c1372.
+- Implemented #477: Some random fixes for issues found through 
+  PhpStorms code inspection Implemented in commit #3c6b69b.
+- Implemented #383: Slightly improve the ElseExpression description 
+  Implemented in commit #3c6b69b.
+- Implemented #478: Implemented renderer autodiscovery Implemented in 
+  commit #91c4ca8.
+- Implemented #479: Replace all file header doc blocks with uniform 
+  one Implemented in commit #fff046c.
+- Implemented #329: Allowing one to whitelist variables in the 
+  UnusedLocalVariable rule Implemented in commit #55ca654.
+- Implemented #481: Doc block cleanups Implemented in commit #08a38d4.
+- Implemented #483: Remove broken link to Web Content Viewer 
+  Implemented in commit #eeea9ee.
+- Implemented #484: Duplicated array key rule Implemented in commit 
+  #a295850.
+- Implemented #489: Added new predefined variables to 
+  AbstractLocalVariable rule Implemented in commit #63047d9.
+- Implemented #489: Added new predefined variables to 
+  AbstractLocalVariable rule Implemented in commit #63047d9.
+- Implemented #491: Some Cleanup Implemented in commit #dcdd61a.
+- Implemented #492: Adjust Stickler-CI config for ignoring test 
+  resource files Implemented in commit #9b18153.
+- Implemented #490: Add CountInLoop rule Implemented in commit 
+  #0e30d82.
+- Implemented #495: Add test for SuppressWarnings for 
+  ExcessivePublicCount Implemented in commit #b1c15f8.
+- Implemented #382: Ignore isser-, hasser-, wither-method for 
+  TooManyMethods Implemented in commit #609c6bb.
+- Implemented #528: Bump minimal PHP version to 5.4 since Travis-CI 
+  does not support anything below, anymore Implemented in commit 
+  #0a69edf.
+- Implemented #525: Added new options to CLI Implemented in commit 
+  #71b52be.
+- Implemented #524: Use HTTPS instead of HTTP in resource file 
+  Implemented in commit #409b276.
+- Implemented #548: Update PDepend to 2.5.2 Implemented in commit 
+  #f1c145e.
+- Implemented #552: Use PHP 7.1 in AppVeyor builds Implemented in 
+  commit #252b178.
+- Implemented #566: Add CLI usage example Implemented in commit 
+  #e12e59c.
+- Implemented #605: Build the website as static files using pure PHP 
+  Implemented in commit #6f56a8f.
+- Implemented #606: Use BSD 3-clause license template Implemented in 
+  commit #e850660.
+- Implemented #608: Handle anchor links and use direct links whenever 
+  possible in website build script Implemented in commit #6cf7a2d.
+- Implemented #565: Add example for modifying properties in a rule set 
+  Implemented in commit #59551fc.
+- Implemented #611: Remove section about commercial support 
+  Implemented in commit #671760a.
+- Implemented #612: Remove IRC, add Gitter & reword Support & Contact 
+  section Implemented in commit #671760a.
+- Implemented #612: Remove IRC, add Gitter & reword Support & Contact 
+  section Implemented in commit #3e94d6b.
+- Implemented #579: Add support for setting a maximum priority 
+  Implemented in commit #45de3be.
+- Implemented #614: Remove API docs that do not exist anymore 
+  Implemented in commit #7c8d9bc.
+- Implemented #615: Added Gitter badge Implemented in commit #7c8d9bc.
+- Implemented #617: Replace Travis build notification from IRC to the 
+  new Gitter core channel Implemented in commit #8e1e9e8.
+- Implemented #618: Add badges for the monthly and total downloads 
+  Implemented in commit #1e86639.
+- Implemented #620: Add PHPMD Gitter Community Channel notifications 
+  Implemented in commit #f1c05bf.
+- Implemented #621: Updated wording about PHPMD Implemented in commit 
+  #c116054.
+- Implemented #405: Add JSON Renderer for Report #405 Implemented in 
+  commit #7552089.
+- Implemented #623: Extend test matrix & do only one job per build on 
+  Travis Implemented in commit #a2c64bf.
+- Implemented #625: Skip DuplicatedArrayKey rule check, if there is no 
+  array key... Implemented in commit #43d4ed0.
+- Implemented #627: Remove composer.lock Implemented in commit 
+  #981c78f.
+- Implemented #636: Add missing import rule Implemented in commit 
+  #3a82eab.
+- Implemented #639: Use standard type syntax for arrays Implemented in 
+  commit #858c9fd.
+- Implemented #640: Add type hint annotations Implemented in commit 
+  #d68e511.
+
 phpmd-2.6.1 (2019/07/06)
 ========================
 
@@ -67,7 +231,7 @@ Maintenance release with new PDepend version bundled
 phpmd-2.4.2 (2016/03/10)
 ========================
 
-- Fixed #261: Prove Issue 261 and added tests for 
+- Fixed #261: Prove Issue 261 and added tests for
   CamelCaseVariableName Fixed in commit #319b398.
 - Fixed #328: Cannot create new nodes, when internal state is frozen. 
   Fixed in commit #2fd479b.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,166 +1,171 @@
-phpmd-2.7.0 (2019/07/29)
+phpmd-2.7.0 (2019/07/30)
 ========================
 
 This is the first minor release of the new PHPMD maintainer team. It 
 contains all the new features, improvements and fixes from two and a 
-half years since 2.6.0.
+half years since 2.6.0. Please take note of a backwards incompatible 
+property renaming in the CouplingBetweenObjects rule.
 
-- Fixed #449: Code style improvements Fixed in commit #67cdab2.
-- Fixed #447: Code style improvements Fixed in commit #3ef4ba8.
-- Fixed #450: Code style improvements Fixed in commit #9525da7.
-- Fixed #378: Fix warning/error when trying to export to a 
+- Fixed #482: Renamed minimum property to maximum in 
+  CouplingBetweenObjects rule (backwards incompatible) Fixed in commit 
+  #9210116.
+- Fixed #626: Fixed special characters escaping in violation 
+  description for XML output Fixed in commit #5305f5b.
+- Fixed #378: Fixed warning/error when trying to export to a 
   non-existing path Fixed in commit #67bd7c6.
-- Fix invalid "array of strings" type hints Fixed in commit #16e4eda.
-- Fixed #480: Start tag expected, '<' not found Fixed in commit 
-  #3e2e058.
-- Fixed #482: Rename minimum property to maximum in 
-  CouplingBetweenObjects Fixed in commit #9210116.
-- Fixed #494: Fix UnusedPrivateField false positive Fixed in commit 
+- Fixed #575: Fixed UnusedFormalParameter false positive in string 
+  compound variable Fixed in commit #8790cbb.
+- Fixed #480: Fixed "Start tag expected, '<' not found" error Fixed in 
+  commit #3e2e058.
+- Fixed #494: Fixed UnusedPrivateField false positive Fixed in commit 
   #99f3ba9.
-- Fixed #567: Minor fix to Clean Code Rules documentation Fixed in 
-  commit #175b08f.
+- Fixed #583: Changed LongNaming rule to apply on private fields too 
+  Fixed in commit #42bf8ad.
+- Fixed #598: Fixed a bug in the renderer auto-discovery Fixed in 
+  commit #cc06bfd.
+- Fixed #572: Added support for both @SuppressWarnings and 
+  @suppressWarnings annotation cases Fixed in commit #bb2cfe9.
+- Fixed invalid "array of strings" type hints Fixed in commit 
+  #16e4eda.
+- Fixed #599: Fixed Composer package type Fixed in commit #0ca4eff.
+- Fixed #604: Renamed mikey179/vfsStream to mikey179/vfsstream to 
+  prevent Composer error Fixed in commit #f66247f.
+- Fixed #632: Changed Scrutinizer CI settings to use local PHPUnit 
+  Fixed in commit #dfaa509.
+- Fixed #633: Fixed AppVeyor CI build Fixed in commit #40189f3.
+- Fixed #609: Fixed main logo link in website build script Fixed in 
+  commit #f3b68be.
+- Fixed #631: Fixed URL to "How to create a custom rule set" 
+  documentation page on website Fixed in commit #3c5b534.
+- Fixed #449: Improved code style Fixed in commit #67cdab2.
+- Fixed #447: Improved code style Fixed in commit #3ef4ba8.
+- Fixed #450: Improved code style Fixed in commit #9525da7.
 - Fixed #582: Fixed a typo in Clean Code Rules documentation Fixed in 
   commit #85e48ad.
-- Fixed #583: Apply LongNaming rule to private fields Fixed in commit 
-  #42bf8ad.
-- Fixed #598: Fix a bug in the renderer autodiscovery Fixed in commit 
-  #cc06bfd.
-- Fixed #599: Fix Composer package type Fixed in commit #0ca4eff.
-- Fixed #604: Rename mikey179/vfsStream to mikey179/vfsstream to 
-  prevent Composer error Fixed in commit #f66247f.
-- Fixed #609: Fix main logo link in website build script Fixed in 
-  commit #f3b68be.
-- Fixed #572: Allow different letter casing for @suppressWarnings 
-  annotation Fixed in commit #bb2cfe9.
-- Fixed #575: Fix UnusedFormalParameter false positive in string 
-  compound variable Fixed in commit #8790cbb.
-- Fixed #599: Fix Composer package type Fixed in commit #0ca4eff.
-- Fixed #626: Convert special chars in violation description for XML 
-  output Fixed in commit #5305f5b.
-- Fixed #631: Fix url to "How to create a custom rule set" 
-  documentation page Fixed in commit #3c5b534.
-- Fixed #632: Use local PHPUnit in Scrutinizer Fixed in commit 
-  #dfaa509.
-- Fixed #633: Fix AppVeyor build Fixed in commit #40189f3.
-- Implemented #443: Support for compound variables in 
-  UnusedLocalVariable Implemented in commit #c7009d5.
-- Implemented #448: Use HTTPS instead of HTTP Implemented in commit 
-  #51eb887.
-- Implemented #454: Use HTTPS instead of HTTP for test files 
-  Implemented in commit #f1c1426.
-- Implemented #451: Use HTTPS instead of HTTP for main files 
-  Implemented in commit #9a77c48.
-- Implemented #455: Use HTTPS instead of HTTP for resource files 
-  Implemented in commit #b073ad2.
-- Implemented #381: Add annotations to allow IDE to reference correct 
-  classes Implemented in commit #2dbae11.
+- Fixed #567: Fixed a typo in Clean Code Rules documentation Fixed in 
+  commit #175b08f.
+- Implemented #472: Added rule for assignment within conditional 
+  (IfStatementAssignment) Implemented in commit #716ecf5.
+- Implemented #490: Added rule for count in loop (CountInLoop) 
+  Implemented in commit #0e30d82.
+- Implemented #484: Added rule for duplicated array key 
+  (DuplicatedArrayKey) Implemented in commit #a295850.
+- Implemented #476: Added rule for empty catch block (EmptyCatchBlock) 
+  Implemented in commit #4bc19bd.
+- Implemented #636: Added rule for missing import (MissingImport) 
+  Implemented in commit #3a82eab.
+- Implemented #443: Added support for compound variables in 
+  UnusedLocalVariable rule Implemented in commit #c7009d5.
+- Implemented #329: Added support to whitelist variables in the 
+  UnusedLocalVariable rule Implemented in commit #55ca654.
+- Implemented #478: Implemented renderer auto-discovery Implemented in 
+  commit #91c4ca8.
+- Implemented #405: Added JSON output format Implemented in commit 
+  #7552089.
+- Implemented #525: Added new options to CLI (min-priority, 
+  minimum-priority, report-file, input-file, not-strict) Implemented 
+  in commit #71b52be.
+- Implemented #579: Added support for setting the maximum execution 
+  priority through CLI (max-priority, maximum-priority, 
+  maximumpriority) Implemented in commit #45de3be.
+- Implemented #489: Added new predefined variables to 
+  AbstractLocalVariable rule Implemented in commit #63047d9.
+- Implemented #382: Changed TooManyMethods rule to ignore isser-, 
+  hasser-, wither-methods Implemented in commit #609c6bb.
+- Implemented #625: Fixed DuplicatedArrayKey rule to check only arrays 
+  with keys Implemented in commit #43d4ed0.
+- Implemented #528: Fixed Travis-CI build by temporarily removing PHP 
+  5.3 Implemented in commit #0a69edf.
+- Implemented #643: Fixed Travis-CI build to run PHP 5.3 and fixed 5.3 
+  compatibility Implemented in commit #4a8a567.
+- Implemented #475: Added tests that show support for chained methods 
+  (fluent interfaces) for UnusedPrivateMethod rule Implemented in 
+  commit #d5c1372.
+- Implemented #495: Added test for SuppressWarnings for 
+  ExcessivePublicCount Implemented in commit #b1c15f8.
+- Implemented #381: Added annotations to allow IDEs to reference 
+  correct classes Implemented in commit #2dbae11.
+- Implemented #639: Fixed arrays types to use standard type syntax 
+  Implemented in commit #858c9fd.
+- Implemented #640: Added type hint annotations Implemented in commit 
+  #d68e511.
+- Implemented #481: Cleaned boc block comments Implemented in commit 
+  #08a38d4.
+- Implemented #491: Cleaned whitespaces Implemented in commit 
+  #dcdd61a.
+- Implemented #477: Fixed code formatting Implemented in commit 
+  #3c6b69b.
+- Implemented #548: Updated PDepend to 2.5.2 Implemented in commit 
+  #f1c145e.
+- Implemented #474: Dropped HHVM support Implemented in commit 
+  #9f7b4d2.
 - Implemented #458: Updated PHPCS dev dependency from 2.3.4 to 2.8.1 
   Implemented in commit #f2ae09f.
-- Implemented #459: Integrate Stickler CI Implemented in commit 
-  #d106330.
-- Implemented #458: Update PHPCS & add Composer scripts Implemented in 
-  commit #24ff5a9.
-- Implemented #460: Add ApiGen config file Implemented in commit 
-  #4514235.
-- Implemented #469: Update to Coding Standard command Implemented in 
+- Implemented #458: Updated PHPCS & added Composer scripts Implemented 
+  in commit #24ff5a9.
+- Implemented #469: Updated Coding Standard command Implemented in 
   commit #9962dae.
-- Implemented #470: Changed HTTP to HTTPS Implemented in commit 
-  #1ca30d0.
-- Implemented #471: Modified default PHP installation directory to 
-  match Chocolatey package in AppVeyor config Implemented in commit 
-  #2b55442.
-- Implemented #472: Add assignment within conditional rule Implemented 
-  in commit #716ecf5.
-- Implemented #474: Put down Support for HHVM Implemented in commit 
-  #9f7b4d2.
-- Implemented #469: Improvement to contributing guide for Linux / OS X 
-  users Implemented in commit #63ff5bf.
-- Implemented #476: Add empty catch block rule Implemented in commit 
-  #4bc19bd.
-- Implemented #475: Support for chained methods (fluent interfaces) 
-  for UnusedPrivateMethod rule Implemented in commit #d5c1372.
-- Implemented #477: Some random fixes for issues found through 
-  PhpStorms code inspection Implemented in commit #3c6b69b.
-- Implemented #383: Slightly improve the ElseExpression description 
-  Implemented in commit #3c6b69b.
-- Implemented #478: Implemented renderer autodiscovery Implemented in 
-  commit #91c4ca8.
-- Implemented #479: Replace all file header doc blocks with uniform 
-  one Implemented in commit #fff046c.
-- Implemented #329: Allowing one to whitelist variables in the 
-  UnusedLocalVariable rule Implemented in commit #55ca654.
-- Implemented #481: Doc block cleanups Implemented in commit #08a38d4.
-- Implemented #483: Remove broken link to Web Content Viewer 
-  Implemented in commit #eeea9ee.
-- Implemented #484: Duplicated array key rule Implemented in commit 
-  #a295850.
-- Implemented #489: Added new predefined variables to 
-  AbstractLocalVariable rule Implemented in commit #63047d9.
-- Implemented #489: Added new predefined variables to 
-  AbstractLocalVariable rule Implemented in commit #63047d9.
-- Implemented #491: Some Cleanup Implemented in commit #dcdd61a.
-- Implemented #492: Adjust Stickler-CI config for ignoring test 
+- Implemented #627: Removed composer.lock Implemented in commit 
+  #981c78f.
+- Implemented #623: Extended test matrix & do only one job per build 
+  on Travis-CI Implemented in commit #a2c64bf.
+- Implemented #617: Replaced Travis-CI build notification from IRC to 
+  the new Gitter core channel Implemented in commit #e1a4cd7.
+- Implemented #620: Added PHPMD Gitter Community Channel notifications 
+  for Travis-CI Implemented in commit #f1c05bf.
+- Implemented #459: Integrated Stickler CI Implemented in commit 
+  #d106330.
+- Implemented #492: Adjusted Stickler-CI config for ignoring test 
   resource files Implemented in commit #9b18153.
-- Implemented #490: Add CountInLoop rule Implemented in commit 
-  #0e30d82.
-- Implemented #495: Add test for SuppressWarnings for 
-  ExcessivePublicCount Implemented in commit #b1c15f8.
-- Implemented #382: Ignore isser-, hasser-, wither-method for 
-  TooManyMethods Implemented in commit #609c6bb.
-- Implemented #528: Bump minimal PHP version to 5.4 since Travis-CI 
-  does not support anything below, anymore Implemented in commit 
-  #0a69edf.
-- Implemented #525: Added new options to CLI Implemented in commit 
-  #71b52be.
-- Implemented #524: Use HTTPS instead of HTTP in resource file 
+- Implemented #460: Added ApiGen config file Implemented in commit 
+  #4514235.
+- Implemented #471: Modified default PHP installation directory to 
+  match Chocolatey package in AppVeyor CI config Implemented in commit 
+  #2b55442.
+- Implemented #552: Updated PHP in AppVeyor CI builds to 7.1 
+  Implemented in commit #252b178.
+- Implemented #605: Added a pure PHP build script to generate the 
+  website as static files Implemented in commit #6f56a8f.
+- Implemented #608: Updated the website build script to handle anchor 
+  links and to use direct links whenever possible Implemented in 
+  commit #6cf7a2d.
+- Implemented #483: Removed broken link to Web Content Viewer from 
+  website Implemented in commit #eeea9ee.
+- Implemented #611: Removed section about commercial support from 
+  website Implemented in commit #671760a.
+- Implemented #612: Removed IRC, add Gitter & reword Support & Contact 
+  section from/on website Implemented in commit #3e94d6b.
+- Implemented #479: Replaced all file header doc blocks with uniform 
+  one Implemented in commit #fff046c.
+- Implemented #470: Changed HTTP to HTTPS in some files Implemented in 
+  commit #1ca30d0.
+- Implemented #448: Switched from HTTP to HTTPS in some files 
+  Implemented in commit #51eb887.
+- Implemented #524: Switched from HTTP to HTTPS in resource file 
   Implemented in commit #409b276.
-- Implemented #548: Update PDepend to 2.5.2 Implemented in commit 
-  #f1c145e.
-- Implemented #552: Use PHP 7.1 in AppVeyor builds Implemented in 
-  commit #252b178.
-- Implemented #566: Add CLI usage example Implemented in commit 
+- Implemented #454: Switched from HTTP to HTTPS for test files 
+  Implemented in commit #f1c1426.
+- Implemented #451: Switched from HTTP to HTTPS for main files 
+  Implemented in commit #9a77c48.
+- Implemented #455: Switched from HTTP to HTTPS for resource files 
+  Implemented in commit #b073ad2.
+- Implemented #566: Added CLI usage example Implemented in commit 
   #e12e59c.
-- Implemented #605: Build the website as static files using pure PHP 
-  Implemented in commit #6f56a8f.
-- Implemented #606: Use BSD 3-clause license template Implemented in 
-  commit #e850660.
-- Implemented #608: Handle anchor links and use direct links whenever 
-  possible in website build script Implemented in commit #6cf7a2d.
-- Implemented #565: Add example for modifying properties in a rule set 
-  Implemented in commit #59551fc.
-- Implemented #611: Remove section about commercial support 
-  Implemented in commit #671760a.
-- Implemented #612: Remove IRC, add Gitter & reword Support & Contact 
-  section Implemented in commit #671760a.
-- Implemented #612: Remove IRC, add Gitter & reword Support & Contact 
-  section Implemented in commit #3e94d6b.
-- Implemented #579: Add support for setting a maximum priority 
-  Implemented in commit #45de3be.
-- Implemented #614: Remove API docs that do not exist anymore 
-  Implemented in commit #7c8d9bc.
-- Implemented #615: Added Gitter badge Implemented in commit #7c8d9bc.
-- Implemented #617: Replace Travis build notification from IRC to the 
-  new Gitter core channel Implemented in commit #8e1e9e8.
-- Implemented #618: Add badges for the monthly and total downloads 
-  Implemented in commit #1e86639.
-- Implemented #620: Add PHPMD Gitter Community Channel notifications 
-  Implemented in commit #f1c05bf.
 - Implemented #621: Updated wording about PHPMD Implemented in commit 
   #c116054.
-- Implemented #405: Add JSON Renderer for Report #405 Implemented in 
-  commit #7552089.
-- Implemented #623: Extend test matrix & do only one job per build on 
-  Travis Implemented in commit #a2c64bf.
-- Implemented #625: Skip DuplicatedArrayKey rule check, if there is no 
-  array key... Implemented in commit #43d4ed0.
-- Implemented #627: Remove composer.lock Implemented in commit 
-  #981c78f.
-- Implemented #636: Add missing import rule Implemented in commit 
-  #3a82eab.
-- Implemented #639: Use standard type syntax for arrays Implemented in 
-  commit #858c9fd.
-- Implemented #640: Add type hint annotations Implemented in commit 
-  #d68e511.
+- Implemented #606: Updated license according to BSD 3-clause template 
+  Implemented in commit #e850660.
+- Implemented #469: Improved contributing guide for Linux / OS X users 
+  Implemented in commit #63ff5bf.
+- Implemented #383: Improved the ElseExpression description 
+  Implemented in commit #6f02406.
+- Implemented #565: Added example for modifying properties in a rule 
+  set Implemented in commit #59551fc.
+- Implemented #614: Removed API docs that do not exist anymore 
+  Implemented in commit #7c8d9bc.
+- Implemented #615: Added Gitter badge Implemented in commit #8e1e9e8.
+- Implemented #618: Added badges for the monthly and total downloads 
+  Implemented in commit #1e86639.
 
 phpmd-2.6.1 (2019/07/06)
 ========================
@@ -231,7 +236,9 @@ Maintenance release with new PDepend version bundled
 phpmd-2.4.2 (2016/03/10)
 ========================
 
-- Fixed #261: Prove Issue 261 and added tests for
+
+
+- Fixed #261: Prove Issue 261 and added tests for 
   CamelCaseVariableName Fixed in commit #319b398.
 - Fixed #328: Cannot create new nodes, when internal state is frozen. 
   Fixed in commit #2fd479b.
@@ -439,6 +446,8 @@ outstanding pull requests.
 
 phpmd-2.1.1 (2014/09/09)
 ========================
+
+
 
 - Fixed #181: 404 error on your website release area
 - Fixed #168: --version argument doesn't return version Fixed in 

--- a/build.properties
+++ b/build.properties
@@ -1,7 +1,7 @@
 project.dir       =
 project.uri       = phpmd.org
 project.name      = phpmd
-project.version   = 2.6.1
+project.version   = 2.7.0
 project.stability = stable
 
 # Disable pear support

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -157,7 +157,7 @@
                 Adjusted Stickler-CI config for ignoring test resource files
             </action>
             <action date="dfaa509" dev="kylekatarnls" type="fix" system="github" issue="632">
-                Changed Scrutinizer settings to use local PHPUnit
+                Changed Scrutinizer CI settings to use local PHPUnit
             </action>
             <action date="4514235" dev="ravage84" type="add" system="github" issue="460">
                 Added ApiGen config file

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -163,13 +163,13 @@
                 Added ApiGen config file
             </action>
             <action date="2b55442" dev="eeree" type="update" system="github" issue="471">
-                Modified default PHP installation directory to match Chocolatey package in AppVeyor config
+                Modified default PHP installation directory to match Chocolatey package in AppVeyor CI config
             </action>
             <action date="252b178" dev="OndraM" type="update" system="github" issue="552">
-                Updated PHP in AppVeyor builds to 7.1
+                Updated PHP in AppVeyor CI builds to 7.1
             </action>
             <action date="40189f3" dev="kylekatarnls" type="fix" system="github" issue="633">
-                Fixed AppVeyor build
+                Fixed AppVeyor CI build
             </action>
             <action date="6f56a8f" dev="kylekatarnls" due-to="edhgoose" type="add" system="github" issue="605">
                 Added a pure PHP build script to generate the website as static files

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -142,7 +142,7 @@
             <action date="a2c64bf" dev="kylekatarnls" type="update" system="github" issue="623">
                 Extended test matrix &amp; do only one job per build on Travis
             </action>
-            <action date="8e1e9e8" dev="ravage84" type="update" system="github" issue="617">
+            <action date="e1a4cd7" dev="ravage84" type="update" system="github" issue="617">
                 Replaced Travis build notification from IRC to the new Gitter core channel
             </action>
             <action date="f1c05bf" dev="ravage84" type="add" system="github" issue="620">
@@ -247,7 +247,7 @@
             <action date="7c8d9bc" dev="ravage84" type="update" system="github" issue="614">
                 Removed API docs that do not exist anymore
             </action>
-            <action date="7c8d9bc" dev="MarkVaughn" type="add" system="github" issue="615">
+            <action date="8e1e9e8" dev="MarkVaughn" type="add" system="github" issue="615">
                 Added Gitter badge
             </action>
             <action date="1e86639" dev="tvbeek" type="add" system="github" issue="618">

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -11,7 +11,7 @@
 
     <body>
         <release version="2.7.0"
-                 date="2019/07/31"
+                 date="2019/07/30"
                  description="This is the first minor release of the new PHPMD maintainer team.
                  It contains all the new features, improvements and fixes from two and a half years since 2.6.0.
                  Please take note of a backwards compatibility breaking property renaming in the CouplingBetweenObjects rule.">

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -49,7 +49,7 @@
             <action date="45de3be" dev="tominventisbe" type="add" system="github" issue="579">
                 Added support for setting a maximum execution priority through CLI (max-priority, maximum-priority, maximumpriority)
             </action>
-            <action date="63047d9" dev="eeree" due-to="schinkel" type="update" system="github" issue="489">
+            <action date="63047d9" dev="eeree" due-to="schinkel" type="add" system="github" issue="489">
                 Added new predefined variables to AbstractLocalVariable rule
             </action>
             <action date="609c6bb" dev="dxops" type="update" system="github" issue="382">
@@ -98,9 +98,9 @@
                 Added annotations to allow IDEs to reference correct classes
             </action>
             <action date="858c9fd" dev="JeroenDeDauw" type="update" system="github" issue="639">
-                Use standard type syntax for arrays
+                Used standard type syntax for arrays
             </action>
-            <action date="d68e511" dev="kylekatarnls" type="update" system="github" issue="640">
+            <action date="d68e511" dev="kylekatarnls" type="add" system="github" issue="640">
                 Added type hint annotations
             </action>
             <action date="08a38d4" dev="ravage84" type="update" system="github" issue="481">
@@ -220,7 +220,7 @@
             <action date="b073ad2" dev="RyDroid" type="update" system="github" issue="455">
                 Used HTTPS instead of HTTP for resource files
             </action>
-            <action date="e12e59c" dev="Marius786" type="update" system="github" issue="566">
+            <action date="e12e59c" dev="Marius786" type="add" system="github" issue="566">
                 Added CLI usage example
             </action>
             <action date="c116054" dev="ravage84" type="update" system="github" issue="621">
@@ -250,7 +250,7 @@
             <action date="7c8d9bc" dev="MarkVaughn" type="add" system="github" issue="615">
                 Added Gitter badge
             </action>
-            <action date="1e86639" dev="tvbeek" type="update" system="github" issue="618">
+            <action date="1e86639" dev="tvbeek" type="add" system="github" issue="618">
                 Added badges for the monthly and total downloads
             </action>
         </release>

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -187,10 +187,10 @@
                 Removed section about commercial support from website
             </action>
             <action date="3e94d6b" dev="ravage84" type="update" system="github" issue="612">
-                Removed IRC, add Gitter &amp; reword Support &amp; Contact section from website
+                Removed IRC, add Gitter &amp; reword Support &amp; Contact section from/on website
             </action>
             <action date="3c5b534" dev="DmitryNaum" type="fix" system="github" issue="631">
-                Fixed URL to "How to create a custom rule set" documentation page from website
+                Fixed URL to "How to create a custom rule set" documentation page on website
             </action>
             <action date="67cdab2" dev="RyDroid" type="fix" system="github" issue="449">
                 Improved code style

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -10,6 +10,256 @@
     </properties>
 
     <body>
+        <release version="2.7.0"
+                 date="2019/07/29"
+                 description="This is the first minor release of the new PHPMD maintainer team. It contains all the new features, improvements and fixes from two and a half years since 2.6.0.">
+            <action date="c7009d5" dev="john-whitley" type="add" system="github" issue="443">
+                Support for compound variables in UnusedLocalVariable
+            </action>
+            <action date="67cdab2" dev="RyDroid" type="fix" system="github" issue="449">
+                Code style improvements
+            </action>
+            <action date="3ef4ba8" dev="RyDroid" type="fix" system="github" issue="447">
+                Code style improvements
+            </action>
+            <action date="9525da7" dev="RyDroid" type="fix" system="github" issue="450">
+                Code style improvements
+            </action>
+            <action date="51eb887" dev="RyDroid" type="update" system="github" issue="448">
+                Use HTTPS instead of HTTP
+            </action>
+            <action date="f1c1426" dev="RyDroid" type="update" system="github" issue="454">
+                Use HTTPS instead of HTTP for test files
+            </action>
+            <action date="9a77c48" dev="RyDroid" type="update" system="github" issue="451">
+                Use HTTPS instead of HTTP for main files
+            </action>
+            <action date="b073ad2" dev="RyDroid" type="update" system="github" issue="455">
+                Use HTTPS instead of HTTP for resource files
+            </action>
+            <action date="2dbae11" dev="jaymoulin" type="update" system="github" issue="381">
+                Add annotations to allow IDE to reference correct classes
+            </action>
+            <action date="f2ae09f" dev="ravage84" type="update" system="github" issue="458">
+                Updated PHPCS dev dependency from 2.3.4 to 2.8.1
+            </action>
+            <action date="d106330" dev="ravage84" type="add" system="github" issue="459">
+                Integrate Stickler CI
+            </action>
+            <action date="24ff5a9" dev="ravage84" type="update" system="github" issue="458">
+                Update PHPCS &amp; add Composer scripts
+            </action>
+            <action date="4514235" dev="ravage84" type="add" system="github" issue="460">
+                Add ApiGen config file
+            </action>
+            <action date="9962dae" dev="eeree" type="update" system="github" issue="469">
+                Update to Coding Standard command
+            </action>
+            <action date="1ca30d0" dev="eeree" type="update" system="github" issue="470">
+                Changed HTTP to HTTPS
+            </action>
+            <action date="2b55442" dev="eeree" type="update" system="github" issue="471">
+                Modified default PHP installation directory to match Chocolatey package in AppVeyor config
+            </action>
+            <action date="716ecf5" dev="eeree" type="add" system="github" issue="472">
+                Add assignment within conditional rule
+            </action>
+            <action date="9f7b4d2" dev="ravage84" type="update" system="github" issue="474">
+                Put down Support for HHVM
+            </action>
+            <action date="63ff5bf" dev="eeree" type="update" system="github" issue="469">
+                Improvement to contributing guide for Linux / OS X users
+            </action>
+            <action date="4bc19bd" dev="eeree" type="add" system="github" issue="476">
+                Add empty catch block rule
+            </action>
+            <action date="d5c1372" dev="eeree" type="update" system="github" issue="475">
+                Support for chained methods (fluent interfaces) for UnusedPrivateMethod rule
+            </action>
+            <action date="3c6b69b" dev="ravage84" type="update" system="github" issue="477">
+                Some random fixes for issues found through PhpStorms code inspection
+            </action>
+            <action date="3c6b69b" dev="ravage84" due-to="richvigorito" type="update" system="github" issue="383">
+                Slightly improve the ElseExpression description
+            </action>
+            <action date="91c4ca8" dev="ravage84" due-to="KOLANICH" type="add" system="github" issue="478">
+                Implemented renderer autodiscovery
+            </action>
+            <action date="fff046c" dev="ravage84" type="update" system="github" issue="479">
+                Replace all file header doc blocks with uniform one
+            </action>
+            <action date="55ca654" dev="JulienPalard" type="add" system="github" issue="329">
+                Allowing one to whitelist variables in the UnusedLocalVariable rule
+            </action>
+            <action date="67bd7c6" dev="jaymoulin" type="fix" system="github" issue="378">
+                Fix warning/error when trying to export to a non-existing path
+            </action>
+            <action date="16e4eda" dev="ravage84" type="fix" system="github">
+                Fix invalid "array of strings" type hints
+            </action>
+            <action date="3e2e058" dev="eeree" type="fix" system="github" issue="480">
+                Start tag expected, '&lt;' not found
+            </action>
+            <action date="08a38d4" dev="ravage84" type="update" system="github" issue="481">
+                Doc block cleanups
+            </action>
+            <action date="9210116" dev="ravage84" due-to="jhoff" type="fix" system="github" issue="482">
+                Rename minimum property to maximum in CouplingBetweenObjects
+            </action>
+            <action date="eeea9ee" dev="ravage84" due-to="mermshaus" type="update" system="github" issue="483">
+                Remove broken link to Web Content Viewer
+            </action>
+            <action date="a295850" dev="eeree" due-to="rafalwrzeszcz" type="add" system="github" issue="484">
+                Duplicated array key rule
+            </action>
+            <action date="63047d9" dev="eeree" due-to="schinkel" type="update" system="github" issue="489">
+                Added new predefined variables to AbstractLocalVariable rule
+            </action>
+            <action date="63047d9" dev="eeree" due-to="schinkel" type="update" system="github" issue="489">
+                Added new predefined variables to AbstractLocalVariable rule
+            </action>
+            <action date="dcdd61a" dev="ravage84" type="update" system="github" issue="491">
+                Some Cleanup
+            </action>
+            <action date="9b18153" dev="ravage84" type="update" system="github" issue="492">
+                Adjust Stickler-CI config for ignoring test resource files
+            </action>
+            <action date="0e30d82" dev="eeree" type="add" system="github" issue="490">
+                Add CountInLoop rule
+            </action>
+            <action date="99f3ba9" dev="eeree" due-to="1ma" type="fix" system="github" issue="494">
+                Fix UnusedPrivateField false positive
+            </action>
+            <action date="b1c15f8" dev="eeree" type="update" system="github" issue="495">
+                Add test for SuppressWarnings for ExcessivePublicCount
+            </action>
+            <action date="609c6bb" dev="dxops" type="update" system="github" issue="382">
+                Ignore isser-, hasser-, wither-method for TooManyMethods
+            </action>
+            <action date="0a69edf" dev="liviascapin" type="update" system="github" issue="528">
+                Bump minimal PHP version to 5.4 since Travis-CI does not support anything below, anymore
+            </action>
+            <action date="71b52be" dev="RyDroid" type="add" system="github" issue="525">
+                Added new options to CLI
+            </action>
+            <action date="409b276" dev="RyDroid" type="update" system="github" issue="524">
+                Use HTTPS instead of HTTP in resource file
+            </action>
+            <action date="f1c145e" dev="emirb" type="update" system="github" issue="548">
+                Update PDepend to 2.5.2
+            </action>
+            <action date="252b178" dev="OndraM" type="update" system="github" issue="552">
+                Use PHP 7.1 in AppVeyor builds
+            </action>
+            <action date="e12e59c" dev="Marius786" type="update" system="github" issue="566">
+                Add CLI usage example
+            </action>
+            <action date="175b08f" dev="fbertolotti" type="fix" system="github" issue="567">
+                Minor fix to Clean Code Rules documentation
+            </action>
+            <action date="85e48ad" dev="BenjaminPaap" type="fix" system="github" issue="582">
+                Fixed a typo in Clean Code Rules documentation
+            </action>
+            <action date="42bf8ad" dev="HappyHippyHippo" due-to="duncancumming" type="fix" system="github" issue="583">
+                Apply LongNaming rule to private fields
+            </action>
+            <action date="cc06bfd" dev="vt-iwamoto" type="fix" system="github" issue="598">
+                Fix a bug in the renderer autodiscovery
+            </action>
+            <action date="0ca4eff" dev="kylekatarnls" type="fix" system="github" issue="599">
+                Fix Composer package type
+            </action>
+            <action date="6f56a8f" dev="kylekatarnls" due-to="edhgoose" type="add" system="github" issue="605">
+                Build the website as static files using pure PHP
+            </action>
+            <action date="e850660" dev="kylekatarnls" type="update" system="github" issue="606">
+                Use BSD 3-clause license template
+            </action>
+            <action date="6cf7a2d" dev="kylekatarnls" type="update" system="github" issue="608">
+                Handle anchor links and use direct links whenever possible in website build script
+            </action>
+            <action date="f66247f" dev="tvbeek" type="fix" system="github" issue="604">
+                Rename mikey179/vfsStream to mikey179/vfsstream to prevent Composer error
+            </action>
+            <action date="f3b68be" dev="kylekatarnls" type="fix" system="github" issue="609">
+                Fix main logo link in website build script
+            </action>
+            <action date="bb2cfe9" dev="choult" type="fix" system="github" issue="572">
+                Allow different letter casing for @suppressWarnings annotation
+            </action>
+            <action date="8790cbb" dev="avmnu-sng" due-to="EvgenyOrekhov" type="fix" system="github" issue="575">
+                Fix UnusedFormalParameter false positive in string compound variable
+            </action>
+            <action date="59551fc" dev="gbirke" type="add" system="github" issue="565">
+                Add example for modifying properties in a rule set
+            </action>
+            <action date="671760a" dev="ravage84" due-to="manuelpichler" type="update" system="github" issue="611">
+                Remove section about commercial support
+            </action>
+            <action date="671760a" dev="ravage84" type="update" system="github" issue="612">
+                Remove IRC, add Gitter &amp; reword  Support &amp; Contact section
+            </action>
+            <action date="3e94d6b" dev="ravage84" type="update" system="github" issue="612">
+                Remove IRC, add Gitter &amp; reword  Support &amp; Contact section
+            </action>
+            <action date="0ca4eff" dev="kylekatarnls" type="fix" system="github" issue="599">
+                Fix Composer package type
+            </action>
+            <action date="45de3be" dev="tominventisbe" type="add" system="github" issue="579">
+                Add support for setting a maximum priority
+            </action>
+            <action date="7c8d9bc" dev="ravage84" type="update" system="github" issue="614">
+                Remove API docs that do not exist anymore
+            </action>
+            <action date="7c8d9bc" dev="MarkVaughn" type="add" system="github" issue="615">
+                Added Gitter badge
+            </action>
+            <action date="8e1e9e8" dev="ravage84" type="update" system="github" issue="617">
+                Replace Travis build notification from IRC to the new Gitter core channel
+            </action>
+            <action date="1e86639" dev="tvbeek" type="update" system="github" issue="618">
+                Add badges for the monthly and total downloads
+            </action>
+            <action date="f1c05bf" dev="ravage84" type="add" system="github" issue="620">
+                Add PHPMD Gitter Community Channel notifications
+            </action>
+            <action date="c116054" dev="ravage84" type="update" system="github" issue="621">
+                Updated wording about PHPMD
+            </action>
+            <action date="7552089" dev="exploitfate" type="add" system="github" issue="405">
+                Add JSON Renderer for Report #405
+            </action>
+            <action date="a2c64bf" dev="kylekatarnls" type="update" system="github" issue="623">
+                Extend test matrix &amp; do only one job per build on Travis
+            </action>
+            <action date="43d4ed0" dev="ravage84" type="update" system="github" issue="625">
+                Skip DuplicatedArrayKey rule check, if there is no array key...
+            </action>
+            <action date="5305f5b" dev="ravage84" type="fix" system="github" issue="626">
+                Convert special chars in violation description for XML output
+            </action>
+            <action date="981c78f" dev="kylekatarnls" type="update" system="github" issue="627">
+                Remove composer.lock
+            </action>
+            <action date="3c5b534" dev="DmitryNaum" type="fix" system="github" issue="631">
+                Fix url to "How to create a custom rule set" documentation page
+            </action>
+            <action date="dfaa509" dev="kylekatarnls" type="fix" system="github" issue="632">
+                Use local PHPUnit in Scrutinizer
+            </action>
+            <action date="40189f3" dev="kylekatarnls" type="fix" system="github" issue="633">
+                Fix AppVeyor build
+            </action>
+            <action date="3a82eab" dev="DmitryNaum" due-to="mindplay-dk" type="add" system="github" issue="636">
+                Add missing import rule
+            </action>
+            <action date="858c9fd" dev="JeroenDeDauw" type="update" system="github" issue="639">
+                Use standard type syntax for arrays
+            </action>
+            <action date="d68e511" dev="kylekatarnls" type="update" system="github" issue="640">
+                Add type hint annotations
+            </action>
+        </release>
         <release version="2.6.1"
                  date="2019/07/06"
                  description="This is the first release of the new maintainer team of PHPMD. It is a re-tag of 2.6.0 but with PHAR build on Travis-CI and deployment to GitHub releases.">

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -98,7 +98,7 @@
                 Added annotations to allow IDEs to reference correct classes
             </action>
             <action date="858c9fd" dev="JeroenDeDauw" type="update" system="github" issue="639">
-                Used standard type syntax for arrays
+                Fixed arrays types to use standard type syntax
             </action>
             <action date="d68e511" dev="kylekatarnls" type="add" system="github" issue="640">
                 Added type hint annotations
@@ -155,7 +155,7 @@
                 Adjusted Stickler-CI config for ignoring test resource files
             </action>
             <action date="dfaa509" dev="kylekatarnls" type="fix" system="github" issue="632">
-                Used local PHPUnit in Scrutinizer
+                Changed Scrutinizer settings to use PHPUnit
             </action>
             <action date="4514235" dev="ravage84" type="add" system="github" issue="460">
                 Added ApiGen config file
@@ -164,7 +164,7 @@
                 Modified default PHP installation directory to match Chocolatey package in AppVeyor config
             </action>
             <action date="252b178" dev="OndraM" type="update" system="github" issue="552">
-                Used PHP 7.1 in AppVeyor builds
+                Update PHP in AppVeyor builds to 7.1
             </action>
             <action date="40189f3" dev="kylekatarnls" type="fix" system="github" issue="633">
                 Fixed AppVeyor build
@@ -206,19 +206,19 @@
                 Changed HTTP to HTTPS in some files
             </action>
             <action date="51eb887" dev="RyDroid" type="update" system="github" issue="448">
-                Used HTTPS instead of HTTP in some files
+                Switched from HTTP to HTTPS in some files
             </action>
             <action date="409b276" dev="RyDroid" type="update" system="github" issue="524">
-                Used HTTPS instead of HTTP in resource file
+                Switched from HTTP to HTTPS in resource file
             </action>
             <action date="f1c1426" dev="RyDroid" type="update" system="github" issue="454">
-                Used HTTPS instead of HTTP for test files
+                Switched from HTTP to HTTPS for test files
             </action>
             <action date="9a77c48" dev="RyDroid" type="update" system="github" issue="451">
-                Used HTTPS instead of HTTP for main files
+                Switched from HTTP to HTTPS for main files
             </action>
             <action date="b073ad2" dev="RyDroid" type="update" system="github" issue="455">
-                Used HTTPS instead of HTTP for resource files
+                Switched from HTTP to HTTPS for resource files
             </action>
             <action date="e12e59c" dev="Marius786" type="add" system="github" issue="566">
                 Added CLI usage example
@@ -227,7 +227,7 @@
                 Updated wording about PHPMD
             </action>
             <action date="e850660" dev="kylekatarnls" type="update" system="github" issue="606">
-                Used BSD 3-clause license template
+                Updated license according to BSD 3-clause template
             </action>
             <action date="63ff5bf" dev="eeree" type="update" system="github" issue="469">
                 Improved contributing guide for Linux / OS X users

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -14,8 +14,7 @@
                  date="2019/07/31"
                  description="This is the first minor release of the new PHPMD maintainer team.
                  It contains all the new features, improvements and fixes from two and a half years since 2.6.0.
-                 Please take note of a backwards compatibility breaking property renaming in the CouplingBetweenObjects rule.
-                 With this release we also drop support for PHP 5.3.">
+                 Please take note of a backwards compatibility breaking property renaming in the CouplingBetweenObjects rule.">
             <action date="716ecf5" dev="eeree" type="add" system="github" issue="472">
                 Added rule for assignment within conditional (IfStatementAssignment)
             </action>
@@ -86,7 +85,10 @@
                 Added support for both @SuppressWarnings and @suppressWarnings annotation cases
             </action>
             <action date="0a69edf" dev="liviascapin" type="update" system="github" issue="528">
-                Bumped minimal PHP version to 5.4 since Travis-CI does not support anything below, anymore
+                Fixed Travis-CI build by temporarily remove PHP 5.3
+            </action>
+            <action date="4a8a567" dev="kylekatarnls" type="update" system="github" issue="643">
+                Fixed Travis-CI build to run PHP 5.3 and fixed 5.3 compatibility
             </action>
             <action date="d5c1372" dev="eeree" type="update" system="github" issue="475">
                 Added tests that show support for chained methods (fluent interfaces) for UnusedPrivateMethod rule

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -232,7 +232,7 @@
             <action date="63ff5bf" dev="eeree" type="update" system="github" issue="469">
                 Improved contributing guide for Linux / OS X users
             </action>
-            <action date="3c6b69b" dev="ravage84" due-to="richvigorito" type="update" system="github" issue="383">
+            <action date="6f02406" dev="ravage84" due-to="richvigorito" type="update" system="github" issue="383">
                 Improved the ElseExpression description
             </action>
             <action date="85e48ad" dev="BenjaminPaap" type="fix" system="github" issue="582">

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -187,7 +187,7 @@
                 Removed section about commercial support from website
             </action>
             <action date="3e94d6b" dev="ravage84" type="update" system="github" issue="612">
-                Removed IRC, add Gitter &amp; reword  Support &amp; Contact section from website
+                Removed IRC, add Gitter &amp; reword Support &amp; Contact section from website
             </action>
             <action date="3c5b534" dev="DmitryNaum" type="fix" system="github" issue="631">
                 Fixed URL to "How to create a custom rule set" documentation page from website

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -14,7 +14,7 @@
                  date="2019/07/30"
                  description="This is the first minor release of the new PHPMD maintainer team.
                  It contains all the new features, improvements and fixes from two and a half years since 2.6.0.
-                 Please take note of a backwards compatibility breaking property renaming in the CouplingBetweenObjects rule.">
+                 Please take note of a backwards incompatible property renaming in the CouplingBetweenObjects rule.">
             <action date="716ecf5" dev="eeree" type="add" system="github" issue="472">
                 Added rule for assignment within conditional (IfStatementAssignment)
             </action>

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -85,7 +85,7 @@
                 Added support for both @SuppressWarnings and @suppressWarnings annotation cases
             </action>
             <action date="0a69edf" dev="liviascapin" type="update" system="github" issue="528">
-                Fixed Travis-CI build by temporarily remove PHP 5.3
+                Fixed Travis-CI build by temporarily removing PHP 5.3
             </action>
             <action date="4a8a567" dev="kylekatarnls" type="update" system="github" issue="643">
                 Fixed Travis-CI build to run PHP 5.3 and fixed 5.3 compatibility

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -142,13 +142,13 @@
                 Renamed mikey179/vfsStream to mikey179/vfsstream to prevent Composer error
             </action>
             <action date="a2c64bf" dev="kylekatarnls" type="update" system="github" issue="623">
-                Extended test matrix &amp; do only one job per build on Travis
+                Extended test matrix &amp; do only one job per build on Travis-CI
             </action>
             <action date="e1a4cd7" dev="ravage84" type="update" system="github" issue="617">
-                Replaced Travis build notification from IRC to the new Gitter core channel
+                Replaced Travis-CI build notification from IRC to the new Gitter core channel
             </action>
             <action date="f1c05bf" dev="ravage84" type="add" system="github" issue="620">
-                Added PHPMD Gitter Community Channel notifications for Travis
+                Added PHPMD Gitter Community Channel notifications for Travis-CI
             </action>
             <action date="d106330" dev="ravage84" type="add" system="github" issue="459">
                 Integrated Stickler CI

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -58,7 +58,7 @@
                 Fixed DuplicatedArrayKey rule to check only arrays with keys
             </action>
             <action date="9210116" dev="ravage84" due-to="jhoff" type="fix" system="github" issue="482">
-                Renamed minimum property to maximum in CouplingBetweenObjects rule
+                Renamed minimum property to maximum in CouplingBetweenObjects rule (backwards incompatible)
             </action>
             <action date="5305f5b" dev="ravage84" type="fix" system="github" issue="626">
                 Fixed special chars escaping in violation description for XML output

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -17,241 +17,241 @@
                  Please take note of a backwards compatibility breaking property renaming in the CouplingBetweenObjects rule.
                  With this release we also drop support for PHP 5.3.">
             <action date="716ecf5" dev="eeree" type="add" system="github" issue="472">
-                Add rule for assignment within conditional (IfStatementAssignment)
+                Added rule for assignment within conditional (IfStatementAssignment)
             </action>
             <action date="0e30d82" dev="eeree" type="add" system="github" issue="490">
-                Add rule for count in loop (CountInLoop)
+                Added rule for count in loop (CountInLoop)
             </action>
             <action date="a295850" dev="eeree" due-to="rafalwrzeszcz" type="add" system="github" issue="484">
-                Add rule for duplicated array key (DuplicatedArrayKey)
+                Added rule for duplicated array key (DuplicatedArrayKey)
             </action>
             <action date="4bc19bd" dev="eeree" type="add" system="github" issue="476">
-                Add rule for empty catch block (EmptyCatchBlock)
+                Added rule for empty catch block (EmptyCatchBlock)
             </action>
             <action date="3a82eab" dev="DmitryNaum" due-to="mindplay-dk" type="add" system="github" issue="636">
-                Add rule for missing import (MissingImport)
+                Added rule for missing import (MissingImport)
             </action>
             <action date="c7009d5" dev="john-whitley" type="add" system="github" issue="443">
-                Add support for compound variables in UnusedLocalVariable rule
+                Added support for compound variables in UnusedLocalVariable rule
             </action>
             <action date="55ca654" dev="JulienPalard" type="add" system="github" issue="329">
-                Add support to whitelist variables in the UnusedLocalVariable rule
+                Added support to whitelist variables in the UnusedLocalVariable rule
             </action>
             <action date="91c4ca8" dev="ravage84" due-to="KOLANICH" type="add" system="github" issue="478">
                 Implemented renderer auto-discovery
             </action>
             <action date="7552089" dev="exploitfate" type="add" system="github" issue="405">
-                Add JSON output format
+                Added JSON output format
             </action>
             <action date="71b52be" dev="RyDroid" type="add" system="github" issue="525">
-                Add new options to CLI (min-priority, minimum-priority, report-file, input-file, not-strict)
+                Added new options to CLI (min-priority, minimum-priority, report-file, input-file, not-strict)
             </action>
             <action date="45de3be" dev="tominventisbe" type="add" system="github" issue="579">
-                Add support for setting a maximum execution priority through CLI (max-priority, maximum-priority, maximumpriority)
+                Added support for setting a maximum execution priority through CLI (max-priority, maximum-priority, maximumpriority)
             </action>
             <action date="63047d9" dev="eeree" due-to="schinkel" type="update" system="github" issue="489">
                 Added new predefined variables to AbstractLocalVariable rule
             </action>
             <action date="609c6bb" dev="dxops" type="update" system="github" issue="382">
-                Ignore isser-, hasser-, wither-method for TooManyMethods
+                Ignored isser-, hasser-, wither-method for TooManyMethods
             </action>
             <action date="43d4ed0" dev="ravage84" type="update" system="github" issue="625">
-                Skip DuplicatedArrayKey rule check, if there is no array key...
+                Skipped DuplicatedArrayKey rule check, if there is no array key...
             </action>
             <action date="9210116" dev="ravage84" due-to="jhoff" type="fix" system="github" issue="482">
-                Rename minimum property to maximum in CouplingBetweenObjects rule
+                Renamed minimum property to maximum in CouplingBetweenObjects rule
             </action>
             <action date="5305f5b" dev="ravage84" type="fix" system="github" issue="626">
-                Convert special chars in violation description for XML output
+                Fixed special chars escaping in violation description for XML output
             </action>
             <action date="67bd7c6" dev="jaymoulin" type="fix" system="github" issue="378">
-                Fix warning/error when trying to export to a non-existing path
+                Fixed warning/error when trying to export to a non-existing path
             </action>
             <action date="8790cbb" dev="avmnu-sng" due-to="EvgenyOrekhov" type="fix" system="github" issue="575">
-                Fix UnusedFormalParameter false positive in string compound variable
+                Fixed UnusedFormalParameter false positive in string compound variable
             </action>
             <action date="3e2e058" dev="eeree" type="fix" system="github" issue="480">
-                Fix "Start tag expected, '&lt;' not found" error
+                Fixed "Start tag expected, '&lt;' not found" error
             </action>
             <action date="99f3ba9" dev="eeree" due-to="1ma" type="fix" system="github" issue="494">
-                Fix UnusedPrivateField false positive
+                Fixed UnusedPrivateField false positive
             </action>
             <action date="42bf8ad" dev="HappyHippyHippo" due-to="duncancumming" type="fix" system="github" issue="583">
-                Apply LongNaming rule on private fields, too
+                Changed LongNaming rule to apply on private fields too
             </action>
             <action date="cc06bfd" dev="vt-iwamoto" type="fix" system="github" issue="598">
-                Fix a bug in the renderer auto-discovery
+                Fixed a bug in the renderer auto-discovery
             </action>
             <action date="bb2cfe9" dev="choult" type="fix" system="github" issue="572">
-                Allow different letter casing for @suppressWarnings annotation
+                Added support for both @SuppressWarnings and @suppressWarnings annotation cases
             </action>
             <action date="0a69edf" dev="liviascapin" type="update" system="github" issue="528">
-                Bump minimal PHP version to 5.4 since Travis-CI does not support anything below, anymore
+                Bumped minimal PHP version to 5.4 since Travis-CI does not support anything below, anymore
             </action>
             <action date="d5c1372" dev="eeree" type="update" system="github" issue="475">
-                Add tests that show support for chained methods (fluent interfaces) for UnusedPrivateMethod rule
+                Added tests that show support for chained methods (fluent interfaces) for UnusedPrivateMethod rule
             </action>
             <action date="b1c15f8" dev="eeree" type="update" system="github" issue="495">
-                Add test for SuppressWarnings for ExcessivePublicCount
+                Added test for SuppressWarnings for ExcessivePublicCount
             </action>
             <action date="2dbae11" dev="jaymoulin" type="update" system="github" issue="381">
-                Add annotations to allow IDEs to reference correct classes
+                Added annotations to allow IDEs to reference correct classes
             </action>
             <action date="858c9fd" dev="JeroenDeDauw" type="update" system="github" issue="639">
                 Use standard type syntax for arrays
             </action>
             <action date="d68e511" dev="kylekatarnls" type="update" system="github" issue="640">
-                Add type hint annotations
+                Added type hint annotations
             </action>
             <action date="08a38d4" dev="ravage84" type="update" system="github" issue="481">
-                Doc block cleanups
+                Cleaned boc block comments
             </action>
             <action date="16e4eda" dev="ravage84" type="fix" system="github">
-                Fix invalid "array of strings" type hints
+                Fixed invalid "array of strings" type hints
             </action>
             <action date="dcdd61a" dev="ravage84" type="update" system="github" issue="491">
-                Some Cleanup
+                Cleaned whitespaces
             </action>
             <action date="3c6b69b" dev="ravage84" type="update" system="github" issue="477">
-                Some random fixes for issues found through PhpStorms code inspection
+                Fixed code formatting
             </action>
             <action date="f1c145e" dev="emirb" type="update" system="github" issue="548">
-                Update PDepend to 2.5.2
+                Updated PDepend to 2.5.2
             </action>
             <action date="9f7b4d2" dev="ravage84" type="update" system="github" issue="474">
-                Put down Support for HHVM
+                Dropped HHVM support
             </action>
             <action date="f2ae09f" dev="ravage84" type="update" system="github" issue="458">
                 Updated PHPCS dev dependency from 2.3.4 to 2.8.1
             </action>
             <action date="24ff5a9" dev="ravage84" type="update" system="github" issue="458">
-                Update PHPCS &amp; add Composer scripts
+                Updated PHPCS &amp; added Composer scripts
             </action>
             <action date="9962dae" dev="eeree" type="update" system="github" issue="469">
-                Update to Coding Standard command
+                Updated Coding Standard command
             </action>
             <action date="0ca4eff" dev="kylekatarnls" type="fix" system="github" issue="599">
-                Fix Composer package type
+                Fixed Composer package type
             </action>
             <action date="981c78f" dev="kylekatarnls" type="update" system="github" issue="627">
-                Remove composer.lock
+                Removed composer.lock
             </action>
             <action date="f66247f" dev="tvbeek" type="fix" system="github" issue="604">
-                Rename mikey179/vfsStream to mikey179/vfsstream to prevent Composer error
+                Renamed mikey179/vfsStream to mikey179/vfsstream to prevent Composer error
             </action>
             <action date="a2c64bf" dev="kylekatarnls" type="update" system="github" issue="623">
-                Extend test matrix &amp; do only one job per build on Travis
+                Extended test matrix &amp; do only one job per build on Travis
             </action>
             <action date="8e1e9e8" dev="ravage84" type="update" system="github" issue="617">
-                Replace Travis build notification from IRC to the new Gitter core channel
+                Replaced Travis build notification from IRC to the new Gitter core channel
             </action>
             <action date="f1c05bf" dev="ravage84" type="add" system="github" issue="620">
-                Add PHPMD Gitter Community Channel notifications for Travis
+                Added PHPMD Gitter Community Channel notifications for Travis
             </action>
             <action date="d106330" dev="ravage84" type="add" system="github" issue="459">
-                Integrate Stickler CI
+                Integrated Stickler CI
             </action>
             <action date="9b18153" dev="ravage84" type="update" system="github" issue="492">
-                Adjust Stickler-CI config for ignoring test resource files
+                Adjusted Stickler-CI config for ignoring test resource files
             </action>
             <action date="dfaa509" dev="kylekatarnls" type="fix" system="github" issue="632">
-                Use local PHPUnit in Scrutinizer
+                Used local PHPUnit in Scrutinizer
             </action>
             <action date="4514235" dev="ravage84" type="add" system="github" issue="460">
-                Add ApiGen config file
+                Added ApiGen config file
             </action>
             <action date="2b55442" dev="eeree" type="update" system="github" issue="471">
                 Modified default PHP installation directory to match Chocolatey package in AppVeyor config
             </action>
             <action date="252b178" dev="OndraM" type="update" system="github" issue="552">
-                Use PHP 7.1 in AppVeyor builds
+                Used PHP 7.1 in AppVeyor builds
             </action>
             <action date="40189f3" dev="kylekatarnls" type="fix" system="github" issue="633">
-                Fix AppVeyor build
+                Fixed AppVeyor build
             </action>
             <action date="6f56a8f" dev="kylekatarnls" due-to="edhgoose" type="add" system="github" issue="605">
-                Build the website as static files using pure PHP
+                Built the website as static files using pure PHP
             </action>
             <action date="6cf7a2d" dev="kylekatarnls" type="update" system="github" issue="608">
-                Handle anchor links and use direct links whenever possible in website build script
+                Handled anchor links and use direct links whenever possible in website build script
             </action>
             <action date="f3b68be" dev="kylekatarnls" type="fix" system="github" issue="609">
-                Fix main logo link in website build script
+                Fixed main logo link in website build script
             </action>
             <action date="eeea9ee" dev="ravage84" due-to="mermshaus" type="update" system="github" issue="483">
-                Remove broken link to Web Content Viewer from website
+                Removed broken link to Web Content Viewer from website
             </action>
             <action date="671760a" dev="ravage84" due-to="manuelpichler" type="update" system="github" issue="611">
-                Remove section about commercial support from website
+                Removed section about commercial support from website
             </action>
             <action date="3e94d6b" dev="ravage84" type="update" system="github" issue="612">
-                Remove IRC, add Gitter &amp; reword  Support &amp; Contact section from website
+                Removed IRC, add Gitter &amp; reword  Support &amp; Contact section from website
             </action>
             <action date="3c5b534" dev="DmitryNaum" type="fix" system="github" issue="631">
-                Fix URL to "How to create a custom rule set" documentation page from website
+                Fixed URL to "How to create a custom rule set" documentation page from website
             </action>
             <action date="67cdab2" dev="RyDroid" type="fix" system="github" issue="449">
-                Code style improvements
+                Improved code style
             </action>
             <action date="3ef4ba8" dev="RyDroid" type="fix" system="github" issue="447">
-                Code style improvements
+                Improved code style
             </action>
             <action date="9525da7" dev="RyDroid" type="fix" system="github" issue="450">
-                Code style improvements
+                Improved code style
             </action>
             <action date="fff046c" dev="ravage84" type="update" system="github" issue="479">
-                Replace all file header doc blocks with uniform one
+                Replaced all file header doc blocks with uniform one
             </action>
             <action date="1ca30d0" dev="eeree" type="update" system="github" issue="470">
                 Changed HTTP to HTTPS in some files
             </action>
             <action date="51eb887" dev="RyDroid" type="update" system="github" issue="448">
-                Use HTTPS instead of HTTP in some files
+                Used HTTPS instead of HTTP in some files
             </action>
             <action date="409b276" dev="RyDroid" type="update" system="github" issue="524">
-                Use HTTPS instead of HTTP in resource file
+                Used HTTPS instead of HTTP in resource file
             </action>
             <action date="f1c1426" dev="RyDroid" type="update" system="github" issue="454">
-                Use HTTPS instead of HTTP for test files
+                Used HTTPS instead of HTTP for test files
             </action>
             <action date="9a77c48" dev="RyDroid" type="update" system="github" issue="451">
-                Use HTTPS instead of HTTP for main files
+                Used HTTPS instead of HTTP for main files
             </action>
             <action date="b073ad2" dev="RyDroid" type="update" system="github" issue="455">
-                Use HTTPS instead of HTTP for resource files
+                Used HTTPS instead of HTTP for resource files
             </action>
             <action date="e12e59c" dev="Marius786" type="update" system="github" issue="566">
-                Add CLI usage example
+                Added CLI usage example
             </action>
             <action date="c116054" dev="ravage84" type="update" system="github" issue="621">
                 Updated wording about PHPMD
             </action>
             <action date="e850660" dev="kylekatarnls" type="update" system="github" issue="606">
-                Use BSD 3-clause license template
+                Used BSD 3-clause license template
             </action>
             <action date="63ff5bf" dev="eeree" type="update" system="github" issue="469">
-                Improvement to contributing guide for Linux / OS X users
+                Improved contributing guide for Linux / OS X users
             </action>
             <action date="3c6b69b" dev="ravage84" due-to="richvigorito" type="update" system="github" issue="383">
-                Slightly improve the ElseExpression description
+                Improved the ElseExpression description
             </action>
             <action date="85e48ad" dev="BenjaminPaap" type="fix" system="github" issue="582">
                 Fixed a typo in Clean Code Rules documentation
             </action>
             <action date="175b08f" dev="fbertolotti" type="fix" system="github" issue="567">
-                Minor fix to Clean Code Rules documentation
+                Fixed a typo in Clean Code Rules documentation
             </action>
             <action date="59551fc" dev="gbirke" type="add" system="github" issue="565">
-                Add example for modifying properties in a rule set
+                Added example for modifying properties in a rule set
             </action>
             <action date="7c8d9bc" dev="ravage84" type="update" system="github" issue="614">
-                Remove API docs that do not exist anymore
+                Removed API docs that do not exist anymore
             </action>
             <action date="7c8d9bc" dev="MarkVaughn" type="add" system="github" issue="615">
                 Added Gitter badge
             </action>
             <action date="1e86639" dev="tvbeek" type="update" system="github" issue="618">
-                Add badges for the monthly and total downloads
+                Added badges for the monthly and total downloads
             </action>
         </release>
         <release version="2.6.1"

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -170,10 +170,10 @@
                 Fixed AppVeyor build
             </action>
             <action date="6f56a8f" dev="kylekatarnls" due-to="edhgoose" type="add" system="github" issue="605">
-                Built the website as static files using pure PHP
+                Added a pure PHP build script to generate the website as static files
             </action>
             <action date="6cf7a2d" dev="kylekatarnls" type="update" system="github" issue="608">
-                Handled anchor links and use direct links whenever possible in website build script
+                Updated the website build script to handle anchor links and to use direct links whenever possible
             </action>
             <action date="f3b68be" dev="kylekatarnls" type="fix" system="github" issue="609">
                 Fixed main logo link in website build script

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -61,7 +61,7 @@
                 Renamed minimum property to maximum in CouplingBetweenObjects rule (backwards incompatible)
             </action>
             <action date="5305f5b" dev="ravage84" type="fix" system="github" issue="626">
-                Fixed special chars escaping in violation description for XML output
+                Fixed special characters escaping in violation description for XML output
             </action>
             <action date="67bd7c6" dev="jaymoulin" type="fix" system="github" issue="378">
                 Fixed warning/error when trying to export to a non-existing path

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -29,7 +29,7 @@
                 Add rule for empty catch block (EmptyCatchBlock)
             </action>
             <action date="3a82eab" dev="DmitryNaum" due-to="mindplay-dk" type="add" system="github" issue="636">
-                Add rule for missing import (MissingImport(
+                Add rule for missing import (MissingImport)
             </action>
             <action date="c7009d5" dev="john-whitley" type="add" system="github" issue="443">
                 Add support for compound variables in UnusedLocalVariable rule

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -11,10 +11,184 @@
 
     <body>
         <release version="2.7.0"
-                 date="2019/07/29"
-                 description="This is the first minor release of the new PHPMD maintainer team. It contains all the new features, improvements and fixes from two and a half years since 2.6.0.">
+                 date="2019/07/31"
+                 description="This is the first minor release of the new PHPMD maintainer team.
+                 It contains all the new features, improvements and fixes from two and a half years since 2.6.0.
+                 Please take note of a backwards compatibility breaking property renaming in the CouplingBetweenObjects rule.
+                 With this release we also drop support for PHP 5.3.">
+            <action date="716ecf5" dev="eeree" type="add" system="github" issue="472">
+                Add rule for assignment within conditional (IfStatementAssignment)
+            </action>
+            <action date="0e30d82" dev="eeree" type="add" system="github" issue="490">
+                Add rule for count in loop (CountInLoop)
+            </action>
+            <action date="a295850" dev="eeree" due-to="rafalwrzeszcz" type="add" system="github" issue="484">
+                Add rule for duplicated array key (DuplicatedArrayKey)
+            </action>
+            <action date="4bc19bd" dev="eeree" type="add" system="github" issue="476">
+                Add rule for empty catch block (EmptyCatchBlock)
+            </action>
+            <action date="3a82eab" dev="DmitryNaum" due-to="mindplay-dk" type="add" system="github" issue="636">
+                Add rule for missing import (MissingImport(
+            </action>
             <action date="c7009d5" dev="john-whitley" type="add" system="github" issue="443">
-                Support for compound variables in UnusedLocalVariable
+                Add support for compound variables in UnusedLocalVariable rule
+            </action>
+            <action date="55ca654" dev="JulienPalard" type="add" system="github" issue="329">
+                Add support to whitelist variables in the UnusedLocalVariable rule
+            </action>
+            <action date="91c4ca8" dev="ravage84" due-to="KOLANICH" type="add" system="github" issue="478">
+                Implemented renderer auto-discovery
+            </action>
+            <action date="7552089" dev="exploitfate" type="add" system="github" issue="405">
+                Add JSON output format
+            </action>
+            <action date="71b52be" dev="RyDroid" type="add" system="github" issue="525">
+                Add new options to CLI (min-priority, minimum-priority, report-file, input-file, not-strict)
+            </action>
+            <action date="45de3be" dev="tominventisbe" type="add" system="github" issue="579">
+                Add support for setting a maximum execution priority through CLI (max-priority, maximum-priority, maximumpriority)
+            </action>
+            <action date="63047d9" dev="eeree" due-to="schinkel" type="update" system="github" issue="489">
+                Added new predefined variables to AbstractLocalVariable rule
+            </action>
+            <action date="609c6bb" dev="dxops" type="update" system="github" issue="382">
+                Ignore isser-, hasser-, wither-method for TooManyMethods
+            </action>
+            <action date="43d4ed0" dev="ravage84" type="update" system="github" issue="625">
+                Skip DuplicatedArrayKey rule check, if there is no array key...
+            </action>
+            <action date="9210116" dev="ravage84" due-to="jhoff" type="fix" system="github" issue="482">
+                Rename minimum property to maximum in CouplingBetweenObjects rule
+            </action>
+            <action date="5305f5b" dev="ravage84" type="fix" system="github" issue="626">
+                Convert special chars in violation description for XML output
+            </action>
+            <action date="67bd7c6" dev="jaymoulin" type="fix" system="github" issue="378">
+                Fix warning/error when trying to export to a non-existing path
+            </action>
+            <action date="8790cbb" dev="avmnu-sng" due-to="EvgenyOrekhov" type="fix" system="github" issue="575">
+                Fix UnusedFormalParameter false positive in string compound variable
+            </action>
+            <action date="3e2e058" dev="eeree" type="fix" system="github" issue="480">
+                Fix "Start tag expected, '&lt;' not found" error
+            </action>
+            <action date="99f3ba9" dev="eeree" due-to="1ma" type="fix" system="github" issue="494">
+                Fix UnusedPrivateField false positive
+            </action>
+            <action date="42bf8ad" dev="HappyHippyHippo" due-to="duncancumming" type="fix" system="github" issue="583">
+                Apply LongNaming rule on private fields, too
+            </action>
+            <action date="cc06bfd" dev="vt-iwamoto" type="fix" system="github" issue="598">
+                Fix a bug in the renderer auto-discovery
+            </action>
+            <action date="bb2cfe9" dev="choult" type="fix" system="github" issue="572">
+                Allow different letter casing for @suppressWarnings annotation
+            </action>
+            <action date="0a69edf" dev="liviascapin" type="update" system="github" issue="528">
+                Bump minimal PHP version to 5.4 since Travis-CI does not support anything below, anymore
+            </action>
+            <action date="d5c1372" dev="eeree" type="update" system="github" issue="475">
+                Add tests that show support for chained methods (fluent interfaces) for UnusedPrivateMethod rule
+            </action>
+            <action date="b1c15f8" dev="eeree" type="update" system="github" issue="495">
+                Add test for SuppressWarnings for ExcessivePublicCount
+            </action>
+            <action date="2dbae11" dev="jaymoulin" type="update" system="github" issue="381">
+                Add annotations to allow IDEs to reference correct classes
+            </action>
+            <action date="858c9fd" dev="JeroenDeDauw" type="update" system="github" issue="639">
+                Use standard type syntax for arrays
+            </action>
+            <action date="d68e511" dev="kylekatarnls" type="update" system="github" issue="640">
+                Add type hint annotations
+            </action>
+            <action date="08a38d4" dev="ravage84" type="update" system="github" issue="481">
+                Doc block cleanups
+            </action>
+            <action date="16e4eda" dev="ravage84" type="fix" system="github">
+                Fix invalid "array of strings" type hints
+            </action>
+            <action date="dcdd61a" dev="ravage84" type="update" system="github" issue="491">
+                Some Cleanup
+            </action>
+            <action date="3c6b69b" dev="ravage84" type="update" system="github" issue="477">
+                Some random fixes for issues found through PhpStorms code inspection
+            </action>
+            <action date="f1c145e" dev="emirb" type="update" system="github" issue="548">
+                Update PDepend to 2.5.2
+            </action>
+            <action date="9f7b4d2" dev="ravage84" type="update" system="github" issue="474">
+                Put down Support for HHVM
+            </action>
+            <action date="f2ae09f" dev="ravage84" type="update" system="github" issue="458">
+                Updated PHPCS dev dependency from 2.3.4 to 2.8.1
+            </action>
+            <action date="24ff5a9" dev="ravage84" type="update" system="github" issue="458">
+                Update PHPCS &amp; add Composer scripts
+            </action>
+            <action date="9962dae" dev="eeree" type="update" system="github" issue="469">
+                Update to Coding Standard command
+            </action>
+            <action date="0ca4eff" dev="kylekatarnls" type="fix" system="github" issue="599">
+                Fix Composer package type
+            </action>
+            <action date="981c78f" dev="kylekatarnls" type="update" system="github" issue="627">
+                Remove composer.lock
+            </action>
+            <action date="f66247f" dev="tvbeek" type="fix" system="github" issue="604">
+                Rename mikey179/vfsStream to mikey179/vfsstream to prevent Composer error
+            </action>
+            <action date="a2c64bf" dev="kylekatarnls" type="update" system="github" issue="623">
+                Extend test matrix &amp; do only one job per build on Travis
+            </action>
+            <action date="8e1e9e8" dev="ravage84" type="update" system="github" issue="617">
+                Replace Travis build notification from IRC to the new Gitter core channel
+            </action>
+            <action date="f1c05bf" dev="ravage84" type="add" system="github" issue="620">
+                Add PHPMD Gitter Community Channel notifications for Travis
+            </action>
+            <action date="d106330" dev="ravage84" type="add" system="github" issue="459">
+                Integrate Stickler CI
+            </action>
+            <action date="9b18153" dev="ravage84" type="update" system="github" issue="492">
+                Adjust Stickler-CI config for ignoring test resource files
+            </action>
+            <action date="dfaa509" dev="kylekatarnls" type="fix" system="github" issue="632">
+                Use local PHPUnit in Scrutinizer
+            </action>
+            <action date="4514235" dev="ravage84" type="add" system="github" issue="460">
+                Add ApiGen config file
+            </action>
+            <action date="2b55442" dev="eeree" type="update" system="github" issue="471">
+                Modified default PHP installation directory to match Chocolatey package in AppVeyor config
+            </action>
+            <action date="252b178" dev="OndraM" type="update" system="github" issue="552">
+                Use PHP 7.1 in AppVeyor builds
+            </action>
+            <action date="40189f3" dev="kylekatarnls" type="fix" system="github" issue="633">
+                Fix AppVeyor build
+            </action>
+            <action date="6f56a8f" dev="kylekatarnls" due-to="edhgoose" type="add" system="github" issue="605">
+                Build the website as static files using pure PHP
+            </action>
+            <action date="6cf7a2d" dev="kylekatarnls" type="update" system="github" issue="608">
+                Handle anchor links and use direct links whenever possible in website build script
+            </action>
+            <action date="f3b68be" dev="kylekatarnls" type="fix" system="github" issue="609">
+                Fix main logo link in website build script
+            </action>
+            <action date="eeea9ee" dev="ravage84" due-to="mermshaus" type="update" system="github" issue="483">
+                Remove broken link to Web Content Viewer from website
+            </action>
+            <action date="671760a" dev="ravage84" due-to="manuelpichler" type="update" system="github" issue="611">
+                Remove section about commercial support from website
+            </action>
+            <action date="3e94d6b" dev="ravage84" type="update" system="github" issue="612">
+                Remove IRC, add Gitter &amp; reword  Support &amp; Contact section from website
+            </action>
+            <action date="3c5b534" dev="DmitryNaum" type="fix" system="github" issue="631">
+                Fix URL to "How to create a custom rule set" documentation page from website
             </action>
             <action date="67cdab2" dev="RyDroid" type="fix" system="github" issue="449">
                 Code style improvements
@@ -25,8 +199,17 @@
             <action date="9525da7" dev="RyDroid" type="fix" system="github" issue="450">
                 Code style improvements
             </action>
+            <action date="fff046c" dev="ravage84" type="update" system="github" issue="479">
+                Replace all file header doc blocks with uniform one
+            </action>
+            <action date="1ca30d0" dev="eeree" type="update" system="github" issue="470">
+                Changed HTTP to HTTPS in some files
+            </action>
             <action date="51eb887" dev="RyDroid" type="update" system="github" issue="448">
-                Use HTTPS instead of HTTP
+                Use HTTPS instead of HTTP in some files
+            </action>
+            <action date="409b276" dev="RyDroid" type="update" system="github" issue="524">
+                Use HTTPS instead of HTTP in resource file
             </action>
             <action date="f1c1426" dev="RyDroid" type="update" system="github" issue="454">
                 Use HTTPS instead of HTTP for test files
@@ -37,176 +220,29 @@
             <action date="b073ad2" dev="RyDroid" type="update" system="github" issue="455">
                 Use HTTPS instead of HTTP for resource files
             </action>
-            <action date="2dbae11" dev="jaymoulin" type="update" system="github" issue="381">
-                Add annotations to allow IDE to reference correct classes
-            </action>
-            <action date="f2ae09f" dev="ravage84" type="update" system="github" issue="458">
-                Updated PHPCS dev dependency from 2.3.4 to 2.8.1
-            </action>
-            <action date="d106330" dev="ravage84" type="add" system="github" issue="459">
-                Integrate Stickler CI
-            </action>
-            <action date="24ff5a9" dev="ravage84" type="update" system="github" issue="458">
-                Update PHPCS &amp; add Composer scripts
-            </action>
-            <action date="4514235" dev="ravage84" type="add" system="github" issue="460">
-                Add ApiGen config file
-            </action>
-            <action date="9962dae" dev="eeree" type="update" system="github" issue="469">
-                Update to Coding Standard command
-            </action>
-            <action date="1ca30d0" dev="eeree" type="update" system="github" issue="470">
-                Changed HTTP to HTTPS
-            </action>
-            <action date="2b55442" dev="eeree" type="update" system="github" issue="471">
-                Modified default PHP installation directory to match Chocolatey package in AppVeyor config
-            </action>
-            <action date="716ecf5" dev="eeree" type="add" system="github" issue="472">
-                Add assignment within conditional rule
-            </action>
-            <action date="9f7b4d2" dev="ravage84" type="update" system="github" issue="474">
-                Put down Support for HHVM
-            </action>
-            <action date="63ff5bf" dev="eeree" type="update" system="github" issue="469">
-                Improvement to contributing guide for Linux / OS X users
-            </action>
-            <action date="4bc19bd" dev="eeree" type="add" system="github" issue="476">
-                Add empty catch block rule
-            </action>
-            <action date="d5c1372" dev="eeree" type="update" system="github" issue="475">
-                Support for chained methods (fluent interfaces) for UnusedPrivateMethod rule
-            </action>
-            <action date="3c6b69b" dev="ravage84" type="update" system="github" issue="477">
-                Some random fixes for issues found through PhpStorms code inspection
-            </action>
-            <action date="3c6b69b" dev="ravage84" due-to="richvigorito" type="update" system="github" issue="383">
-                Slightly improve the ElseExpression description
-            </action>
-            <action date="91c4ca8" dev="ravage84" due-to="KOLANICH" type="add" system="github" issue="478">
-                Implemented renderer autodiscovery
-            </action>
-            <action date="fff046c" dev="ravage84" type="update" system="github" issue="479">
-                Replace all file header doc blocks with uniform one
-            </action>
-            <action date="55ca654" dev="JulienPalard" type="add" system="github" issue="329">
-                Allowing one to whitelist variables in the UnusedLocalVariable rule
-            </action>
-            <action date="67bd7c6" dev="jaymoulin" type="fix" system="github" issue="378">
-                Fix warning/error when trying to export to a non-existing path
-            </action>
-            <action date="16e4eda" dev="ravage84" type="fix" system="github">
-                Fix invalid "array of strings" type hints
-            </action>
-            <action date="3e2e058" dev="eeree" type="fix" system="github" issue="480">
-                Start tag expected, '&lt;' not found
-            </action>
-            <action date="08a38d4" dev="ravage84" type="update" system="github" issue="481">
-                Doc block cleanups
-            </action>
-            <action date="9210116" dev="ravage84" due-to="jhoff" type="fix" system="github" issue="482">
-                Rename minimum property to maximum in CouplingBetweenObjects
-            </action>
-            <action date="eeea9ee" dev="ravage84" due-to="mermshaus" type="update" system="github" issue="483">
-                Remove broken link to Web Content Viewer
-            </action>
-            <action date="a295850" dev="eeree" due-to="rafalwrzeszcz" type="add" system="github" issue="484">
-                Duplicated array key rule
-            </action>
-            <action date="63047d9" dev="eeree" due-to="schinkel" type="update" system="github" issue="489">
-                Added new predefined variables to AbstractLocalVariable rule
-            </action>
-            <action date="63047d9" dev="eeree" due-to="schinkel" type="update" system="github" issue="489">
-                Added new predefined variables to AbstractLocalVariable rule
-            </action>
-            <action date="dcdd61a" dev="ravage84" type="update" system="github" issue="491">
-                Some Cleanup
-            </action>
-            <action date="9b18153" dev="ravage84" type="update" system="github" issue="492">
-                Adjust Stickler-CI config for ignoring test resource files
-            </action>
-            <action date="0e30d82" dev="eeree" type="add" system="github" issue="490">
-                Add CountInLoop rule
-            </action>
-            <action date="99f3ba9" dev="eeree" due-to="1ma" type="fix" system="github" issue="494">
-                Fix UnusedPrivateField false positive
-            </action>
-            <action date="b1c15f8" dev="eeree" type="update" system="github" issue="495">
-                Add test for SuppressWarnings for ExcessivePublicCount
-            </action>
-            <action date="609c6bb" dev="dxops" type="update" system="github" issue="382">
-                Ignore isser-, hasser-, wither-method for TooManyMethods
-            </action>
-            <action date="0a69edf" dev="liviascapin" type="update" system="github" issue="528">
-                Bump minimal PHP version to 5.4 since Travis-CI does not support anything below, anymore
-            </action>
-            <action date="71b52be" dev="RyDroid" type="add" system="github" issue="525">
-                Added new options to CLI
-            </action>
-            <action date="409b276" dev="RyDroid" type="update" system="github" issue="524">
-                Use HTTPS instead of HTTP in resource file
-            </action>
-            <action date="f1c145e" dev="emirb" type="update" system="github" issue="548">
-                Update PDepend to 2.5.2
-            </action>
-            <action date="252b178" dev="OndraM" type="update" system="github" issue="552">
-                Use PHP 7.1 in AppVeyor builds
-            </action>
             <action date="e12e59c" dev="Marius786" type="update" system="github" issue="566">
                 Add CLI usage example
             </action>
-            <action date="175b08f" dev="fbertolotti" type="fix" system="github" issue="567">
-                Minor fix to Clean Code Rules documentation
-            </action>
-            <action date="85e48ad" dev="BenjaminPaap" type="fix" system="github" issue="582">
-                Fixed a typo in Clean Code Rules documentation
-            </action>
-            <action date="42bf8ad" dev="HappyHippyHippo" due-to="duncancumming" type="fix" system="github" issue="583">
-                Apply LongNaming rule to private fields
-            </action>
-            <action date="cc06bfd" dev="vt-iwamoto" type="fix" system="github" issue="598">
-                Fix a bug in the renderer autodiscovery
-            </action>
-            <action date="0ca4eff" dev="kylekatarnls" type="fix" system="github" issue="599">
-                Fix Composer package type
-            </action>
-            <action date="6f56a8f" dev="kylekatarnls" due-to="edhgoose" type="add" system="github" issue="605">
-                Build the website as static files using pure PHP
+            <action date="c116054" dev="ravage84" type="update" system="github" issue="621">
+                Updated wording about PHPMD
             </action>
             <action date="e850660" dev="kylekatarnls" type="update" system="github" issue="606">
                 Use BSD 3-clause license template
             </action>
-            <action date="6cf7a2d" dev="kylekatarnls" type="update" system="github" issue="608">
-                Handle anchor links and use direct links whenever possible in website build script
+            <action date="63ff5bf" dev="eeree" type="update" system="github" issue="469">
+                Improvement to contributing guide for Linux / OS X users
             </action>
-            <action date="f66247f" dev="tvbeek" type="fix" system="github" issue="604">
-                Rename mikey179/vfsStream to mikey179/vfsstream to prevent Composer error
+            <action date="3c6b69b" dev="ravage84" due-to="richvigorito" type="update" system="github" issue="383">
+                Slightly improve the ElseExpression description
             </action>
-            <action date="f3b68be" dev="kylekatarnls" type="fix" system="github" issue="609">
-                Fix main logo link in website build script
+            <action date="85e48ad" dev="BenjaminPaap" type="fix" system="github" issue="582">
+                Fixed a typo in Clean Code Rules documentation
             </action>
-            <action date="bb2cfe9" dev="choult" type="fix" system="github" issue="572">
-                Allow different letter casing for @suppressWarnings annotation
-            </action>
-            <action date="8790cbb" dev="avmnu-sng" due-to="EvgenyOrekhov" type="fix" system="github" issue="575">
-                Fix UnusedFormalParameter false positive in string compound variable
+            <action date="175b08f" dev="fbertolotti" type="fix" system="github" issue="567">
+                Minor fix to Clean Code Rules documentation
             </action>
             <action date="59551fc" dev="gbirke" type="add" system="github" issue="565">
                 Add example for modifying properties in a rule set
-            </action>
-            <action date="671760a" dev="ravage84" due-to="manuelpichler" type="update" system="github" issue="611">
-                Remove section about commercial support
-            </action>
-            <action date="671760a" dev="ravage84" type="update" system="github" issue="612">
-                Remove IRC, add Gitter &amp; reword  Support &amp; Contact section
-            </action>
-            <action date="3e94d6b" dev="ravage84" type="update" system="github" issue="612">
-                Remove IRC, add Gitter &amp; reword  Support &amp; Contact section
-            </action>
-            <action date="0ca4eff" dev="kylekatarnls" type="fix" system="github" issue="599">
-                Fix Composer package type
-            </action>
-            <action date="45de3be" dev="tominventisbe" type="add" system="github" issue="579">
-                Add support for setting a maximum priority
             </action>
             <action date="7c8d9bc" dev="ravage84" type="update" system="github" issue="614">
                 Remove API docs that do not exist anymore
@@ -214,50 +250,8 @@
             <action date="7c8d9bc" dev="MarkVaughn" type="add" system="github" issue="615">
                 Added Gitter badge
             </action>
-            <action date="8e1e9e8" dev="ravage84" type="update" system="github" issue="617">
-                Replace Travis build notification from IRC to the new Gitter core channel
-            </action>
             <action date="1e86639" dev="tvbeek" type="update" system="github" issue="618">
                 Add badges for the monthly and total downloads
-            </action>
-            <action date="f1c05bf" dev="ravage84" type="add" system="github" issue="620">
-                Add PHPMD Gitter Community Channel notifications
-            </action>
-            <action date="c116054" dev="ravage84" type="update" system="github" issue="621">
-                Updated wording about PHPMD
-            </action>
-            <action date="7552089" dev="exploitfate" type="add" system="github" issue="405">
-                Add JSON Renderer for Report #405
-            </action>
-            <action date="a2c64bf" dev="kylekatarnls" type="update" system="github" issue="623">
-                Extend test matrix &amp; do only one job per build on Travis
-            </action>
-            <action date="43d4ed0" dev="ravage84" type="update" system="github" issue="625">
-                Skip DuplicatedArrayKey rule check, if there is no array key...
-            </action>
-            <action date="5305f5b" dev="ravage84" type="fix" system="github" issue="626">
-                Convert special chars in violation description for XML output
-            </action>
-            <action date="981c78f" dev="kylekatarnls" type="update" system="github" issue="627">
-                Remove composer.lock
-            </action>
-            <action date="3c5b534" dev="DmitryNaum" type="fix" system="github" issue="631">
-                Fix url to "How to create a custom rule set" documentation page
-            </action>
-            <action date="dfaa509" dev="kylekatarnls" type="fix" system="github" issue="632">
-                Use local PHPUnit in Scrutinizer
-            </action>
-            <action date="40189f3" dev="kylekatarnls" type="fix" system="github" issue="633">
-                Fix AppVeyor build
-            </action>
-            <action date="3a82eab" dev="DmitryNaum" due-to="mindplay-dk" type="add" system="github" issue="636">
-                Add missing import rule
-            </action>
-            <action date="858c9fd" dev="JeroenDeDauw" type="update" system="github" issue="639">
-                Use standard type syntax for arrays
-            </action>
-            <action date="d68e511" dev="kylekatarnls" type="update" system="github" issue="640">
-                Add type hint annotations
             </action>
         </release>
         <release version="2.6.1"

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -53,10 +53,10 @@
                 Added new predefined variables to AbstractLocalVariable rule
             </action>
             <action date="609c6bb" dev="dxops" type="update" system="github" issue="382">
-                Ignored isser-, hasser-, wither-method for TooManyMethods
+                Changed TooManyMethods rule to ignore isser-, hasser-, wither-methods
             </action>
             <action date="43d4ed0" dev="ravage84" type="update" system="github" issue="625">
-                Skipped DuplicatedArrayKey rule check, if there is no array key...
+                Fixed DuplicatedArrayKey rule to check only arrays with keys
             </action>
             <action date="9210116" dev="ravage84" due-to="jhoff" type="fix" system="github" issue="482">
                 Renamed minimum property to maximum in CouplingBetweenObjects rule
@@ -155,7 +155,7 @@
                 Adjusted Stickler-CI config for ignoring test resource files
             </action>
             <action date="dfaa509" dev="kylekatarnls" type="fix" system="github" issue="632">
-                Changed Scrutinizer settings to use PHPUnit
+                Changed Scrutinizer settings to use local PHPUnit
             </action>
             <action date="4514235" dev="ravage84" type="add" system="github" issue="460">
                 Added ApiGen config file
@@ -164,7 +164,7 @@
                 Modified default PHP installation directory to match Chocolatey package in AppVeyor config
             </action>
             <action date="252b178" dev="OndraM" type="update" system="github" issue="552">
-                Update PHP in AppVeyor builds to 7.1
+                Updated PHP in AppVeyor builds to 7.1
             </action>
             <action date="40189f3" dev="kylekatarnls" type="fix" system="github" issue="633">
                 Fixed AppVeyor build

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -6,7 +6,7 @@
 
     <properties>
         <title>PHPMD</title>
-        <author email="mapi@phpmd.org">Manuel Pichler</author>
+        <author email="github@phpmd.org">PHPMD maintainer team</author>
     </properties>
 
     <body>

--- a/src/site/docx/changes.xml
+++ b/src/site/docx/changes.xml
@@ -46,7 +46,7 @@
                 Added new options to CLI (min-priority, minimum-priority, report-file, input-file, not-strict)
             </action>
             <action date="45de3be" dev="tominventisbe" type="add" system="github" issue="579">
-                Added support for setting a maximum execution priority through CLI (max-priority, maximum-priority, maximumpriority)
+                Added support for setting the maximum execution priority through CLI (max-priority, maximum-priority, maximumpriority)
             </action>
             <action date="63047d9" dev="eeree" due-to="schinkel" type="add" system="github" issue="489">
                 Added new predefined variables to AbstractLocalVariable rule


### PR DESCRIPTION
We are finally ready to release PHPMD 2.7.0! :rocket: 

This release contains [a lot changes](https://github.com/phpmd/phpmd/commits/master?after=dfaa509cb69d6ad796c90b9e084cb311eb26a2fa+244), actually [over 250 commits](https://github.com/phpmd/phpmd/compare/2.6.0...master).
The release, which includes new features, improvements & fixes is long overdue.

It really needs to get out of the window.
Nonetheless, it should not be rushed.
I targeted the actual merge of this and the tag & GH release for tomorrow, 29.07.2019.

 I kindly ask you to review this thoroughly.

For this, I created a check list:

- [x] All relevant pull requests and commits for 2.7.0 are included in changes.xml
- [x] All the 2.7.0 change entries in changes.xml have the correct date (commit hash)
- [x] All the 2.7.0 change entries in changes.xml have the correct developer
- [x] All the 2.7.0 change entries in changes.xml have the correct type of change
- [x] All the 2.7.0 change entries in changes.xml have the correct change system (all github)
- [x] All the 2.7.0 change entries in changes.xml have the correct issue number
- [x] All the 2.7.0 change entries in changes.xml have have a understandable change text
- [x] All the 2.7.0 change entries in changes.xml have the type of due to mention, if relevant

Please, take note that you cannot simply use the [comparison between 2.6.0 and master](https://github.com/phpmd/phpmd/compare/2.6.0...master), as it only shows the 250 newest changes. For the first few commits, you have to use [the commit history starting after the last commit for 2.6.0](https://github.com/phpmd/phpmd/commits/master?after=dfaa509cb69d6ad796c90b9e084cb311eb26a2fa+244).

Please state which checks you performed in your review.