### PR TITLE
Revert #528 as CI tool is not a sufficient reason to drop a PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ matrix:
     # Could be enabled when we'll upgrade PHPUnit
     # - php: 7.3
     #   env: DEPENDENCIES=low
-    - php: 5.3
-      dist: precise
+    - php: 5.4
+      dist: trusty
       env: BUILD_PHAR=true
     - php: 7.3
       env: WEBSITE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: php
 
 matrix:
   include:
+    - php: 5.3
+      dist: precise
+    - php: 5.3
+      dist: trusty
+      env: DEPENDENCIES=low
     - php: 5.4
       dist: trusty
     - php: 5.4
@@ -29,8 +34,8 @@ matrix:
     # Could be enabled when we'll upgrade PHPUnit
     # - php: 7.3
     #   env: DEPENDENCIES=low
-    - php: 5.4
-      dist: trusty
+    - php: 5.3
+      dist: precise
       env: BUILD_PHAR=true
     - php: 7.3
       env: WEBSITE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - php: 5.3
       dist: precise
     - php: 5.3
-      dist: trusty
+      dist: precise
       env: DEPENDENCIES=low
     - php: 5.4
       dist: trusty

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
   },
   "minimum-stability": "stable",
   "require": {
-    "php": ">=5.4.0",
+    "php": ">=5.3.9",
     "pdepend/pdepend": "^2.5",
     "ext-xml": "*"
   },

--- a/src/main/php/PHPMD/Renderer/JSONRenderer.php
+++ b/src/main/php/PHPMD/Renderer/JSONRenderer.php
@@ -65,7 +65,7 @@ class JSONRenderer extends AbstractRenderer
      */
     private function addViolationsToReport(Report $report, array $data)
     {
-        $filesList = [];
+        $filesList = array();
         /** @var RuleViolation $violation */
         foreach ($report->getRuleViolations() as $violation) {
             $fileName = $violation->getFileName();

--- a/src/main/php/PHPMD/Renderer/JSONRenderer.php
+++ b/src/main/php/PHPMD/Renderer/JSONRenderer.php
@@ -121,7 +121,8 @@ class JSONRenderer extends AbstractRenderer
      */
     private function encodeReport($data)
     {
-        $encodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_PRETTY_PRINT;
+        $encodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP |
+            (defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0);
 
         return json_encode($data, $encodeOptions);
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
@@ -33,7 +33,7 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
     /**
      * @var array Self reference class names.
      */
-    protected $selfReferences = ['self', 'static'];
+    protected $selfReferences = array('self', 'static');
 
     /**
      * Checks for missing class imports and warns about it

--- a/src/site/rst/download/index.rst
+++ b/src/site/rst/download/index.rst
@@ -62,7 +62,7 @@ PHPMD itself is considered as an early development version at its
 current state. It relies on the following software products:
 
 - `PHP_Depend >= 2.0.0`__
-- `PHP >= 5.4.0`__
+- `PHP >= 5.3.9`__
 
 __ https://github.com/phpmd/phpmd
 __ http://getcomposer.org/composer.phar


### PR DESCRIPTION
Then Travis supports PHP 5.3 on Precise/Trusty distributions