### PR TITLE
Fixing a part of the PHPMD violations in PHPMD

### DIFF
--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -95,11 +95,12 @@ class ParserFactory
     private function initInput(Engine $pdepend, PHPMD $phpmd)
     {
         foreach (explode(',', $phpmd->getInput()) as $path) {
-            if (is_dir(trim($path))) {
-                $pdepend->addDirectory(trim($path));
+            $trimmedPath = trim($path);
+            if (is_dir($trimmedPath)) {
+                $pdepend->addDirectory($trimmedPath);
                 continue;
             }
-            $pdepend->addFile(trim($path));
+            $pdepend->addFile($trimmedPath);
         }
     }
 

--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -97,9 +97,9 @@ class ParserFactory
         foreach (explode(',', $phpmd->getInput()) as $path) {
             if (is_dir(trim($path))) {
                 $pdepend->addDirectory(trim($path));
-            } else {
-                $pdepend->addFile(trim($path));
+                continue;
             }
+            $pdepend->addFile(trim($path));
         }
     }
 

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -57,16 +57,17 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
                     $this->checkNodeImage($declarator);
                 }
             }
-        } else {
-            $declarators = $node->findChildrenOfType('VariableDeclarator');
-            foreach ($declarators as $declarator) {
-                $this->checkNodeImage($declarator);
-            }
+            $this->resetProcessed();
+            return;
+        }
+        $declarators = $node->findChildrenOfType('VariableDeclarator');
+        foreach ($declarators as $declarator) {
+            $this->checkNodeImage($declarator);
+        }
 
-            $variables = $node->findChildrenOfType('Variable');
-            foreach ($variables as $variable) {
-                $this->checkNodeImage($variable);
-            }
+        $variables = $node->findChildrenOfType('Variable');
+        foreach ($variables as $variable) {
+            $this->checkNodeImage($variable);
         }
 
         $this->resetProcessed();

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -50,11 +50,11 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
         $this->resetProcessed();
 
         if ($node->getType() === 'class') {
-            $this->applyClass();
+            $this->applyClass($node);
             return;
         }
 
-        $this->applyNoClass();
+        $this->applyNoClass($node);
     }
 
     private function applyClass(AbstractNode $node)

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -57,6 +57,14 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
         $this->applyNoClass($node);
     }
 
+    /**
+     * Extracts all variable and variable declarator nodes from the given class node
+     * and checks the variable name length against the configured minimum
+     * length.
+     *
+     * @param AbstractNode $node
+     * @return void
+     */
     private function applyClass(AbstractNode $node)
     {
         $fields = $node->findChildrenOfType('FieldDeclaration');
@@ -69,6 +77,14 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
         $this->resetProcessed();
     }
 
+    /**
+     * Extracts all variable and variable declarator nodes from the given no class node
+     * and checks the variable name length against the configured minimum
+     * length.
+     *
+     * @param AbstractNode $node
+     * @return void
+     */
     private function applyNoClass(AbstractNode $node)
     {
         $declarators = $node->findChildrenOfType('VariableDeclarator');

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -50,25 +50,36 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
         $this->resetProcessed();
 
         if ($node->getType() === 'class') {
-            $fields = $node->findChildrenOfType('FieldDeclaration');
-            foreach ($fields as $field) {
-                $declarators = $field->findChildrenOfType('VariableDeclarator');
-                foreach ($declarators as $declarator) {
-                    $this->checkNodeImage($declarator);
-                }
-            }
-        } else {
-            $declarators = $node->findChildrenOfType('VariableDeclarator');
+            $this->applyClass();
+            return;
+        }
+
+        $this->applyNoClass();
+    }
+
+    private function applyClass(AbstractNode $node)
+    {
+        $fields = $node->findChildrenOfType('FieldDeclaration');
+        foreach ($fields as $field) {
+            $declarators = $field->findChildrenOfType('VariableDeclarator');
             foreach ($declarators as $declarator) {
                 $this->checkNodeImage($declarator);
             }
+        }
+        $this->resetProcessed();
+    }
 
-            $variables = $node->findChildrenOfType('Variable');
-            foreach ($variables as $variable) {
-                $this->checkNodeImage($variable);
-            }
+    private function applyNoClass(AbstractNode $node)
+    {
+        $declarators = $node->findChildrenOfType('VariableDeclarator');
+        foreach ($declarators as $declarator) {
+            $this->checkNodeImage($declarator);
         }
 
+        $variables = $node->findChildrenOfType('Variable');
+        foreach ($variables as $variable) {
+            $this->checkNodeImage($variable);
+        }
         $this->resetProcessed();
     }
 

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -61,9 +61,9 @@ class RuleSetFactory
         // PEAR installer workaround
         if (strpos($this->location, '@data_dir') === 0) {
             $this->location = __DIR__ . '/../../resources';
-        } else {
-            $this->location .= '/PHPMD/resources';
+            return;
         }
+        $this->location .= '/PHPMD/resources';
     }
 
     /**
@@ -248,11 +248,13 @@ class RuleSetFactory
     {
         if (substr($node['ref'], -3, 3) === 'xml') {
             $this->parseRuleSetReferenceNode($ruleSet, $node);
-        } elseif ('' === (string) $node['ref']) {
-            $this->parseSingleRuleNode($ruleSet, $node);
-        } else {
-            $this->parseRuleReferenceNode($ruleSet, $node);
+            return;
         }
+        if ('' === (string) $node['ref']) {
+            $this->parseSingleRuleNode($ruleSet, $node);
+            return;
+        }
+        $this->parseRuleReferenceNode($ruleSet, $node);
     }
 
     /**

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -27,6 +27,8 @@ use PHPMD\Rule;
 /**
  * This is a helper class that collects the specified cli arguments and puts them
  * into accessible properties.
+ * 
+ * @SuppressWarnings(PHPMD.LongVariable)
  */
 class CommandLineOptions
 {

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -125,7 +125,7 @@ class CommandLineOptions
      *
      * @var boolean
      */
-    protected $ignoreViolationsOnExit = false;
+    protected $dontExitOnViolations = false;
 
     /**
      * List of available rule-sets.
@@ -199,7 +199,7 @@ class CommandLineOptions
                     $this->strict = false;
                     break;
                 case '--ignore-violations-on-exit':
-                    $this->ignoreViolationsOnExit = true;
+                    $this->dontExitOnViolations = true;
                     break;
                 case '--reportfile-html':
                 case '--reportfile-text':
@@ -356,7 +356,7 @@ class CommandLineOptions
      */
     public function ignoreViolationsOnExit()
     {
-        return $this->ignoreViolationsOnExit;
+        return $this->dontExitOnViolations;
     }
 
     /**

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -125,7 +125,7 @@ class CommandLineOptions
      *
      * @var boolean
      */
-    protected $dontExitOnViolations = false;
+    protected $ignoreViolationsOnExit = false;
 
     /**
      * List of available rule-sets.
@@ -199,7 +199,7 @@ class CommandLineOptions
                     $this->strict = false;
                     break;
                 case '--ignore-violations-on-exit':
-                    $this->dontExitOnViolations = true;
+                    $this->ignoreViolationsOnExit = true;
                     break;
                 case '--reportfile-html':
                 case '--reportfile-text':
@@ -356,7 +356,7 @@ class CommandLineOptions
      */
     public function ignoreViolationsOnExit()
     {
-        return $this->dontExitOnViolations;
+        return $this->ignoreViolationsOnExit;
     }
 
     /**

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -40,18 +40,18 @@ class StreamWriter extends AbstractWriter
     {
         if (is_resource($streamResourceOrUri) === true) {
             $this->stream = $streamResourceOrUri;
-        } else {
-            $dirName = dirname($streamResourceOrUri);
-            if (file_exists($dirName) === false) {
-                mkdir($dirName, 0777, true);
-            }
-            if (file_exists($dirName) === false) {
-                $message = 'Cannot find output directory "' . $dirName . '".';
-                throw new \RuntimeException($message);
-            }
-
-            $this->stream = fopen($streamResourceOrUri, 'wb');
+            return;
         }
+        $dirName = dirname($streamResourceOrUri);
+        if (file_exists($dirName) === false) {
+            mkdir($dirName, 0777, true);
+        }
+        if (file_exists($dirName) === false) {
+            $message = 'Cannot find output directory "' . $dirName . '".';
+            throw new \RuntimeException($message);
+        }
+
+        $this->stream = fopen($streamResourceOrUri, 'wb');
     }
 
     /**


### PR DESCRIPTION
I have done this with PHPMD V2.6.0

* I resolved some cleancode errors and ruleset doesn't give any error anymore.
* I resolved a naming error but there is one left that I can't change without creating a BC break.
  * src/main/php/PHPMD/Rule.php:191  The 'getBooleanProperty()' method which returns a boolean should be named 'is...()' or 'has...()'
* Codesize ruleset has multiple issues that require more refactoring where I'm not sure if it is possible without any BC break.
* The controversial ruleset didn't had any issues.
* The design ruleset has an error with the Coupling of the Parser. I think we create a BC break if we change that.
  * src/main/php/PHPMD/Parser.php:37 The class Parser has a coupling between objects value of 17. Consider to reduce the number of dependencies under 13.
* The unusedcode ruleset didn't had any issues.

