### PR TITLE
Fix the doc of Clean Code Rules.

### DIFF
--- a/src/site/rst/rules/cleancode.rst
+++ b/src/site/rst/rules/cleancode.rst
@@ -86,7 +86,7 @@ Example: ::
       }
   }
 
-DuplicateArrayKey
+DuplicatedArrayKey
 =================
 
 Since: PHPMD 2.7.0

--- a/src/site/rst/rules/cleancode.rst
+++ b/src/site/rst/rules/cleancode.rst
@@ -87,7 +87,7 @@ Example: ::
   }
 
 DuplicatedArrayKey
-=================
+==================
 
 Since: PHPMD 2.7.0
 


### PR DESCRIPTION
The rule name "DuplicateArrayKey" is wrong, while it should be "DuplicatedArrayKey"