### PR TITLE
Optimize Composer autoloader when building Phar

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -77,6 +77,7 @@
             <arg line="composer.phar" />
             <arg line="update" />
             <arg line="--no-dev" />
+            <arg line="--optimize-autoloader"/>
             <arg line="--prefer-dist" />
             <arg line="--prefer-lowest" />
             <arg line="--prefer-stable" />


### PR DESCRIPTION
This could improve the speed of the Phar file, but I have no proof.
On the other hand, it should not have any negative effects, except taking a bit longer to build.

> --optimize-autoloader (-o): Convert PSR-0/4 autoloading to classmap to get a faster autoloader. __This is recommended especially for production, but can take a bit of time to run so it is currently not done by default__.

https://getcomposer.org/doc/03-cli.md#update-u