### PR TITLE
Use traditional array syntax to keep PHP 5.3 compatibility

### DIFF
--- a/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
@@ -70,7 +70,7 @@ class AnsiRendererTest extends AbstractTest
         $renderer->renderReport($report);
         $renderer->end();
 
-        $expectedChunks = [
+        $expectedChunks = array(
             PHP_EOL . "FILE: /bar.php" . PHP_EOL . "--------------" . PHP_EOL,
             " 1 | \e[31mVIOLATION\e[0m | Test description" . PHP_EOL,
             PHP_EOL . "FILE: /foo.php" . PHP_EOL . "--------------" . PHP_EOL,
@@ -79,7 +79,7 @@ class AnsiRendererTest extends AbstractTest
             PHP_EOL . "\e[33mERROR\e[0m while parsing /foo/baz.php" . PHP_EOL . "--------------------------------" . PHP_EOL,
             "Error in file \"/foo/baz.php\"" . PHP_EOL,
             PHP_EOL . "Found 3 violations and 1 error in 200ms" . PHP_EOL,
-        ];
+        );
 
         foreach($writer->getChunks() as $i => $chunk) {
             $this->assertEquals(
@@ -102,7 +102,7 @@ class AnsiRendererTest extends AbstractTest
         $report = $this->getReportMock(0);
         $report->expects($this->atLeastOnce())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new \ArrayIterator(array())));
         $report->expects($this->atLeastOnce())
             ->method('isEmpty')
             ->will($this->returnValue(true));
@@ -111,7 +111,7 @@ class AnsiRendererTest extends AbstractTest
             ->will($this->returnValue(false));
         $report->expects($this->atLeastOnce())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new \ArrayIterator(array())));
         $report->expects($this->once())
             ->method('getElapsedTimeInMillis')
             ->will($this->returnValue(200));
@@ -123,10 +123,10 @@ class AnsiRendererTest extends AbstractTest
         $renderer->renderReport($report);
         $renderer->end();
 
-        $expectedChunks = [
+        $expectedChunks = array(
             PHP_EOL . "Found 0 violations and 0 errors in 200ms" . PHP_EOL,
             PHP_EOL . "\e[32mNo mess detected\e[0m" . PHP_EOL,
-        ];
+        );
 
         foreach($writer->getChunks() as $i => $chunk) {
             $this->assertEquals(

--- a/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
@@ -76,7 +76,8 @@ class AnsiRendererTest extends AbstractTest
             PHP_EOL . "FILE: /foo.php" . PHP_EOL . "--------------" . PHP_EOL,
             " 2 | \e[31mVIOLATION\e[0m | Test description" . PHP_EOL,
             " 3 | \e[31mVIOLATION\e[0m | Test description" . PHP_EOL,
-            PHP_EOL . "\e[33mERROR\e[0m while parsing /foo/baz.php" . PHP_EOL . "--------------------------------" . PHP_EOL,
+            PHP_EOL . "\e[33mERROR\e[0m while parsing /foo/baz.php" . PHP_EOL . "--------------------------------" .
+            (version_compare(PHP_VERSION, '5.4.0-dev', '<') ? '--' : '') . PHP_EOL,
             "Error in file \"/foo/baz.php\"" . PHP_EOL,
             PHP_EOL . "Found 3 violations and 1 error in 200ms" . PHP_EOL,
         );


### PR DESCRIPTION
Found through  #653