### PR TITLE
Update RuleSetFactory.php

### DIFF
--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -572,6 +572,6 @@ class RuleSetFactory
             $filePathParts[] = array($includePath, $fileName . '.xml');
         }
 
-        return array_map('implode', $filePathParts, array_fill(0, count($filePathParts), DIRECTORY_SEPARATOR));
+        return array_map('implode', array_fill(0, count($filePathParts), DIRECTORY_SEPARATOR), $filePathParts);
     }
 }


### PR DESCRIPTION
Deprecated: implode(): Passing glue string after array is deprecated

Fixes #658