### PR TITLE
Remove the --prefer-lowest and add a platform config for the phar file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -77,7 +77,7 @@
             <arg line="composer.phar" />
             <arg line="config" />
             <arg line="platform.php" />
-            <arg line="5.3"/>
+            <arg line="5.3.9"/>
         </exec>
         <exec executable="php" failonerror="true">
             <arg line="composer.phar" />

--- a/build.xml
+++ b/build.xml
@@ -75,11 +75,16 @@
     <target name="-copy-vendor-dir:before~hooked" extensionOf="-copy-vendor-dir:before~hook">
         <exec executable="php" failonerror="true">
             <arg line="composer.phar" />
+            <arg line="config" />
+            <arg line="platform.php" />
+            <arg line="5.3"/>
+        </exec>
+        <exec executable="php" failonerror="true">
+            <arg line="composer.phar" />
             <arg line="update" />
             <arg line="--no-dev" />
             <arg line="--optimize-autoloader"/>
             <arg line="--prefer-dist" />
-            <arg line="--prefer-lowest" />
             <arg line="--prefer-stable" />
         </exec>
     </target>


### PR DESCRIPTION
Remove the --prefer-lowest and add a platform config to the composer commands for building the phar file.

This is pointed out in https://github.com/phpmd/phpmd/pull/653#discussion_r313823632 and I suspect a fix for #569