### PR TITLE
Update pdepend to a version compatible with PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   "minimum-stability": "stable",
   "require": {
     "php": ">=5.3.9",
-    "pdepend/pdepend": "^2.5",
+    "pdepend/pdepend": "^2.5.2",
     "ext-xml": "*",
     "composer/xdebug-handler": "^1.0"
   },


### PR DESCRIPTION
Currently phpmd is not really all that nice at playing with PHP@7.2

The issue is with dependency pdepend. The issue was fixed upstream in pdepend 2.5.2 but you are currently relying on 2.5 in composer.

This PR fixes that - rebuilding the phar immediately fixes the issue with PHP7.2

See: #501 for first report, #553 for users rebuiding themselves to work around the issue.