### PR TITLE
Add the latest phar file to the GitHub Pages to have a consistent URL

### DIFF
--- a/bin/build-website.php
+++ b/bin/build-website.php
@@ -246,12 +246,9 @@ usort($releaseVersions,'version_compare');
 $rstDir = __DIR__.'/../src/site/rst';
 $websiteDirectory = __DIR__.'/../dist/website';
 
-// The total limit of all the phar files, size in bytes
+// The total limit of all the phar files, size in bytes.
 // 94.371.840 B = 90 MB
 $totalLimitPharFiles = 94371840;
-
-$pharDestinationDirectory = $websiteDirectory.'/static/latest';
-$pharUrl = 'https://github.com/phpmd/phpmd/releases/download/'.$pharVersion.'/phpmd.phar';
 
 $parser = new Parser;
 $baseHref = ltrim(getenv('BASE_HREF') ?: '', ':');

--- a/bin/build-website.php
+++ b/bin/build-website.php
@@ -234,8 +234,13 @@ function buildMenu($uri, $rstDir, $baseHref)
 
 include __DIR__.'/../vendor/autoload.php';
 
+// This is the version we download for the latest phar file
+$pharVersion = '2.7.0';
+
 $rstDir = __DIR__.'/../src/site/rst';
 $websiteDirectory = __DIR__.'/../dist/website';
+$pharDestinationDirectory = $websiteDirectory . '/static/latest';
+$pharUrl = 'https://github.com/phpmd/phpmd/releases/download/'.$pharVersion.'/phpmd.phar';
 
 $parser = new Parser;
 $baseHref = ltrim(getenv('BASE_HREF') ?: '', ':');
@@ -246,6 +251,10 @@ removeDirectory($websiteDirectory);
 copyDirectory(__DIR__.'/../src/site/resources/web', $websiteDirectory);
 buildWebsite($rstDir, $parser, $websiteDirectory, $changelogContent, $rstDir, $baseHref);
 copy($websiteDirectory.'/about.html', $websiteDirectory.'/index.html');
+
+// Copy the phar file to the destination
+@mkdir($pharDestinationDirectory, 0777, true);
+copy($pharUrl, $pharDestinationDirectory . '/phpmd.phar');
 
 if ($cname = getenv('CNAME')) {
     file_put_contents($websiteDirectory.'/CNAME', $cname);

--- a/bin/build-website.php
+++ b/bin/build-website.php
@@ -239,7 +239,7 @@ $pharVersion = '2.7.0';
 
 $rstDir = __DIR__.'/../src/site/rst';
 $websiteDirectory = __DIR__.'/../dist/website';
-$pharDestinationDirectory = $websiteDirectory . '/static/latest';
+$pharDestinationDirectory = $websiteDirectory.'/static/latest';
 $pharUrl = 'https://github.com/phpmd/phpmd/releases/download/'.$pharVersion.'/phpmd.phar';
 
 $parser = new Parser;

--- a/bin/build-website.php
+++ b/bin/build-website.php
@@ -234,12 +234,22 @@ function buildMenu($uri, $rstDir, $baseHref)
 
 include __DIR__.'/../vendor/autoload.php';
 
-// We get the latest version from the GitHub API
-$latestRelease = json_decode(file_get_contents('https://api.github.com/repos/phpmd/phpmd/releases/latest'));
-$pharVersion = $latestRelease->tag_name;
+// We get the releases from the GitHub API
+$releases = json_decode(file_get_contents('https://api.github.com/repos/phpmd/phpmd/releases'));
+$releaseVersions = array_map(static function ($release) {
+    return $release->tag_name;
+}, $releases);
+
+// we sort the releases with version_compare
+usort($releaseVersions,'version_compare');
 
 $rstDir = __DIR__.'/../src/site/rst';
 $websiteDirectory = __DIR__.'/../dist/website';
+
+// The total limit of all the phar files, size in bytes
+// 94.371.840 B = 90 MB
+$totalLimitPharFiles = 94371840;
+
 $pharDestinationDirectory = $websiteDirectory.'/static/latest';
 $pharUrl = 'https://github.com/phpmd/phpmd/releases/download/'.$pharVersion.'/phpmd.phar';
 
@@ -253,9 +263,31 @@ copyDirectory(__DIR__.'/../src/site/resources/web', $websiteDirectory);
 buildWebsite($rstDir, $parser, $websiteDirectory, $changelogContent, $rstDir, $baseHref);
 copy($websiteDirectory.'/about.html', $websiteDirectory.'/index.html');
 
-// Copy the phar file to the destination
-@mkdir($pharDestinationDirectory, 0777, true);
-copy($pharUrl, $pharDestinationDirectory . '/phpmd.phar');
+
+// A counter for the total size for all the downloaded phar files.
+$totalPharSize = 0;
+
+// we iterate each version
+foreach ($releaseVersions as $version) {
+    $pharUrl = 'https://github.com/phpmd/phpmd/releases/download/'.$version.'/phpmd.phar';
+    $pharDestinationDirectory = $websiteDirectory.'/static/' . $version;
+    @mkdir($pharDestinationDirectory, 0777, true);
+    copy($pharUrl, $pharDestinationDirectory . '/phpmd.phar');
+    $filesize = filesize($pharDestinationDirectory . '/phpmd.phar');
+
+    if ($totalPharSize === 0) {
+        // the first one is the latest
+        $pharDestinationDirectory = $websiteDirectory.'/static/latest';
+        @mkdir($pharDestinationDirectory, 0777, true);
+        copy($pharUrl, $pharDestinationDirectory . '/phpmd.phar');
+        $totalPharSize += $filesize;
+    }
+    $totalPharSize += $filesize;
+    if ($totalPharSize > $totalLimitPharFiles) {
+        // we have reached the limit
+        break;
+    }
+}
 
 if ($cname = getenv('CNAME')) {
     file_put_contents($websiteDirectory.'/CNAME', $cname);

--- a/bin/build-website.php
+++ b/bin/build-website.php
@@ -234,8 +234,9 @@ function buildMenu($uri, $rstDir, $baseHref)
 
 include __DIR__.'/../vendor/autoload.php';
 
-// This is the version we download for the latest phar file
-$pharVersion = '2.7.0';
+// We get the latest version from the GitHub API
+$latestRelease = json_decode(file_get_contents('https://api.github.com/repos/phpmd/phpmd/releases/latest'));
+$pharVersion = $latestRelease->tag_name;
 
 $rstDir = __DIR__.'/../src/site/rst';
 $websiteDirectory = __DIR__.'/../dist/website';

--- a/src/site/rst/download/index.rst
+++ b/src/site/rst/download/index.rst
@@ -8,7 +8,7 @@ Installing as a Phar
 You can always fetch the latest stable version as a phar archive through
 the following version agnostic link: ::
 
-  ~ $ wget -c http://static.phpmd.org/php/latest/phpmd.phar
+  ~ $ wget -c https://phpmd.org/static/latest/phpmd.phar
 
 Installing via Composer
 =======================


### PR DESCRIPTION
Type: feature / documentation update
Issue: #619
Breaking change: no

This PR adds the phpmd.phar to the GitHub pages and update the url in the documentation to 

~~I use a variable with the version (line 238) that need to be updated with every new version. Another approach is to read the latest version from the api: https://api.github.com/repos/phpmd/phpmd/releases/latest But then there is a change that we have a version that is the latest but not really the latest that conflicts. (Like if we have a 2.7.0 but after that release a 2.6.2)
If wanted I can refactor this to use the api for the latest version.~~

After feedback I changed it to use the GitHub Api