### PR TITLE
Fix arrival version of UndefinedVariable

### DIFF
--- a/src/main/resources/rulesets/cleancode.xml
+++ b/src/main/resources/rulesets/cleancode.xml
@@ -179,7 +179,7 @@ function make() {
     </rule>
 
     <rule name="UndefinedVariable"
-          since="2.7"
+          since="2.8.0"
           message="Avoid using undefined variables such as '{0}' which will lead to PHP notices."
           class="PHPMD\Rule\CleanCode\UndefinedVariable"
           externalInfoUrl="">


### PR DESCRIPTION
Type: documentation update
Breaking change: no

UndefinedVariable was not present in 2.7.0, this fixes the version in the doc.