### PR TITLE
Change 'less than' to 'fewer than' for grammar

### DIFF
--- a/src/main/resources/rulesets/codesize.xml
+++ b/src/main/resources/rulesets/codesize.xml
@@ -155,7 +155,7 @@ class Foo {
 
     <rule name="ExcessiveParameterList"
           since="0.1"
-          message="The {0} {1} has {2} parameters. Consider reducing the number of parameters to less than {3}."
+          message="The {0} {1} has {2} parameters. Consider reducing the number of parameters to fewer than {3}."
           class="PHPMD\Rule\Design\LongParameterList"
           externalInfoUrl="https://phpmd.org/rules/codesize.html#excessiveparameterlist">
         <description>
@@ -181,7 +181,7 @@ class Foo {
 
     <rule name="ExcessivePublicCount"
           since="0.1"
-          message="The {0} {1} has {2} public methods and attributes. Consider reducing the number of public items to less than {3}."
+          message="The {0} {1} has {2} public methods and attributes. Consider reducing the number of public items to fewer than {3}."
           class="PHPMD\Rule\ExcessivePublicCount"
           externalInfoUrl="https://phpmd.org/rules/codesize.html#excessivepubliccount">
         <description>


### PR DESCRIPTION
Type: error message wording / documentation update  
Breaking change: no

Changed the phrasing from "less than _n_" to "fewer than _n_" to correct the grammar.

For example,

The method __construct has 15 parameters. Consider reducing the number of parameters to less than 10.

Becomes

The method __construct has 15 parameters. Consider reducing the number of parameters to fewer than 10.