### PR TITLE
Add the new issue template config for GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Gitter
     url: https://gitter.im/phpmd/community
-    about: Chat to us on Gitter
+    about: Chat with us on Gitter

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Gitter
+    url: https://gitter.im/phpmd/community
+    about: Chat to us on Gitter


### PR DESCRIPTION
Type: feature / documentation update  
Issue: none
Breaking change: no

I choose to disable the blank issue to try to prevent more that people don't use the template issues.
And I added a contact link to gitter.
See: https://github.blog/changelog/2019-10-28-new-issue-template-configuration-options/