### PR TITLE
Change `Chat to us` to `Chat with us`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ https://phpmd.org
 
 .. image:: https://badges.gitter.im/phpmd/community.svg
    :target: https://gitter.im/phpmd/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
-   :alt: Chat to us on Gitter
+   :alt: Chat with us on Gitter
 
 .. image:: https://poser.pugx.org/phpmd/phpmd/d/monthly
    :target: https://packagist.org/packages/phpmd/phpmd


### PR DESCRIPTION
Type:  documentation update)
Issue: none
Breaking change: no

This incorrect text was found in the feedback for #690 Because I copied the text from this place it should be a good idea to change it.