### PR TITLE
Replace dead link by GitHub link

### DIFF
--- a/src/site/rst/download/index.rst
+++ b/src/site/rst/download/index.rst
@@ -8,7 +8,7 @@ Installing as a Phar
 You can always fetch the latest stable version as a phar archive through
 the following version agnostic link: ::
 
-  ~ $ wget -c http://static.phpmd.org/php/latest/phpmd.phar
+  ~ $ wget -c https://github.com/phpmd/phpmd/releases/latest/download/phpmd.phar
 
 Installing via Composer
 =======================


### PR DESCRIPTION
Type: documentation update) 
Issue: Fixes #619

As discussed in the issue, we now the GitHub link is not exactly what we would like (ideally a link to the highest stable release number).

Here we have a link to the latest (by date) stable release that is good enough for now (and better than a dead link).