### PR TITLE
Fix #717 restore RST files in website

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_script:
   - if [[ ! $DEPENDENCIES ]]; then composer install; fi
 
 script:
-  - if [[ $WEBSITE  = 'true' ]]; then composer build-website; fi
+  - if [[ $WEBSITE  = 'true' ]]; then cp src/site/rst/* src/site/resources/web/ -r && composer build-website; fi
   - if [[ $WEBSITE != 'true' && $BUILD_PHAR != 'true' && $COVERAGE != 'true' ]]; then vendor/bin/phpunit --configuration $TEST_CONFIG --colors; fi
   - if [[ $WEBSITE != 'true' && $BUILD_PHAR != 'true' && $COVERAGE = 'true' ]]; then phpdbg -qrr vendor/bin/phpunit --configuration $TEST_CONFIG --colors --coverage-text --coverage-clover=coverage.xml; fi
   - if [[ $BUILD_PHAR = 'true' ]]; then git submodule update --init && ant package -D-phar:filename=./phpmd.phar && ./phpmd.phar --version; fi

--- a/src/site/resources/layout.php
+++ b/src/site/resources/layout.php
@@ -53,6 +53,19 @@
     By <strong>Manuel Pichler</strong>
     licensed under <a href="https://opensource.org/licenses/bsd-license.php" title="BSD 3-Clause">BSD 3-Clause</a>
 </div>
+
+<div id="formats">
+    <?php
+
+    $uri = $uri ?? '';
+    $sourceUri = substr($uri, -5) === '.html' ? substr($uri, 0, -5).'.rst' : rtrim($uri, '/').'/index.rst';
+
+    ?>
+    <a href="/<?php echo $sourceUri; ?>">Source</a>
+    |
+    <a href="https://github.com/phpmd/phpmd/edit/master/src/site/rst/<?php echo $sourceUri; ?>">Edit</a>
+</div>
+
 <script>
     [].forEach.call(document.querySelectorAll('pre > code'), function (code) {
         code.className += ' block';

--- a/src/site/resources/layout.php
+++ b/src/site/resources/layout.php
@@ -58,10 +58,10 @@
     <?php
 
     $uri = $uri ?? '';
-    $sourceUri = substr($uri, -5) === '.html' ? substr($uri, 0, -5).'.rst' : rtrim($uri, '/').'/index.rst';
+    $sourceUri = ltrim(substr($uri, -5) === '.html' ? substr($uri, 0, -5).'.rst' : rtrim($uri, '/').'/index.rst', '/');
 
     ?>
-    <a href="/<?php echo $sourceUri; ?>">Source</a>
+    <a href="https://raw.githubusercontent.com/phpmd/phpmd/master/src/site/rst/<?php echo $sourceUri; ?>">Source</a>
     |
     <a href="https://github.com/phpmd/phpmd/edit/master/src/site/rst/<?php echo $sourceUri; ?>">Edit</a>
 </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5966783/71645441-f993ea00-2cd8-11ea-9b90-2728ebe4838a.png)

Source URL example: https://raw.githubusercontent.com/phpmd/phpmd/master/src/site/rst/rules/cleancode.rst
Edit URL example: https://github.com/phpmd/phpmd/edit/master/src/site/rst/rules/cleancode.rst
And the PR will also make RST files downloable on phpmd.org: https://phpmd.org/rules/cleancode.rst (see https://kylekatarnls.github.io/phpmd/rules/cleancode.rst)