### PR TITLE
Fix #732: Add __serialize and __unserialize to list of ignored methods for camelCase rule

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+phpmd-2.8.2 (?)
+========================
+
+- Fixed #732: Added __serialize and __unserialize to list of ignored methods for camelCase rule.
+
 phpmd-2.8.1 (2019/12/27)
 ========================
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   "minimum-stability": "stable",
   "require": {
     "php": ">=5.3.9",
-    "pdepend/pdepend": "^2.6",
+    "pdepend/pdepend": "^2.7.1",
     "ext-xml": "*",
     "composer/xdebug-handler": "^1.0"
   },

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -45,6 +45,8 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
         '__set_state',
         '__clone',
         '__debugInfo',
+        '__serialize',
+        '__unserialize',
     );
 
     /**

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -118,6 +118,27 @@ class CamelCaseMethodNameTest extends AbstractTest
     }
 
     /**
+     * Tests that the rule does not apply for a valid method name
+     * with an underscore at the beginning when it is not allowed.
+     *
+     * @return void
+     */
+    public function testRuleDoesNotApplyForMagicMethods()
+    {
+        $methods = $this->getClass()->getMethods();
+
+        foreach ($methods as $method) {
+            $report = $this->getReportMock($method->getName() === '__notAllowed' ? 1 : 0);
+
+            $rule = new CamelCaseMethodName();
+            $rule->setReport($report);
+            $rule->addProperty('allow-underscore', 'false');
+            $rule->addProperty('allow-underscore-test', 'false');
+            $rule->apply($method);
+        }
+    }
+
+    /**
      * Tests that the rule does apply for a valid test method name
      * with an underscore.
      *

--- a/src/test/resources/files/Rule/Controversial/CamelCaseMethodName/testRuleDoesNotApplyForMagicMethods.php
+++ b/src/test/resources/files/Rule/Controversial/CamelCaseMethodName/testRuleDoesNotApplyForMagicMethods.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyForMagicMethods
+{
+    public function __construct()
+    {
+    }
+
+    public function __debugInfo()
+    {
+    }
+
+    public function __destruct()
+    {
+    }
+
+    public function __call($name, $arguments)
+    {
+    }
+
+    public function __clone()
+    {
+    }
+
+    public function __get($name)
+    {
+    }
+
+    public function __serialize(): array
+    {
+    }
+
+    public function __invoke()
+    {
+    }
+
+    public function __isset($name)
+    {
+    }
+
+    public function __set($name, $value)
+    {
+    }
+
+    public function __sleep()
+    {
+    }
+
+    public function __toString()
+    {
+        return '';
+    }
+
+    public function __unserialize(array $data): void
+    {
+    }
+
+    public function __unset($name)
+    {
+    }
+
+    public function __wakeup()
+    {
+    }
+
+    public static function __callStatic($name, $arguments)
+    {
+    }
+
+    public static function __set_state($an_array)
+    {
+    }
+
+    public function __notAllowed()
+    {
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: Resolves #732
Breaking change: no

Support https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.standard.magic-serialize