### PR TITLE
Allowing custom exclusion for StaticAccess by extending the class

### DIFF
--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -51,12 +51,17 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
             }
 
             $className = $methodCall->getChild(0)->getNode()->getImage();
-            if (in_array(trim($className, " \t\n\r\0\x0B\\"), $exceptions)) {
+            if ($this->isExcludedFromAnalysis($className, $exceptions)) {
                 continue;
             }
 
             $this->addViolation($methodCall, array($className, $node->getName()));
         }
+    }
+    
+    protected function isExcludedFromAnalysis($className, $exceptions)
+    {
+        return in_array(trim($className, " \t\n\r\0\x0B\\"), $exceptions);
     }
 
     private function isStaticMethodCall(AbstractNode $methodCall)


### PR DESCRIPTION
Type:  feature / refactoring 
Breaking change: no

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
-->

### Description / Reason
In a project we need a custom exclusion rules for this rule. Looking at the code it doesn't allow easy extension so I would like to enable that. 

### Actions taken
Extracted exclusion into a protected function which enabled extending this class and customise the functionality.
