### PR TITLE
Get string/boolean/integer property fallback

### DIFF
--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -335,7 +335,7 @@ abstract class AbstractRule implements Rule
      */
     public function getBooleanProperty($name, $default = null)
     {
-        return in_array($this->getgetProperty($name, $default), array('true', 'on', 1), false);
+        return in_array($this->getProperty($name, $default), array('true', 'on', 1), false);
     }
 
     /**
@@ -352,7 +352,7 @@ abstract class AbstractRule implements Rule
      */
     public function getIntProperty($name, $default = null)
     {
-        return (int) $this->getgetProperty($name, $default);
+        return (int)$this->getProperty($name, $default);
     }
 
     /**
@@ -369,7 +369,7 @@ abstract class AbstractRule implements Rule
      */
     public function getStringProperty($name, $default = null)
     {
-        return (string) $this->getgetProperty($name, $default);
+        return (string)$this->getProperty($name, $default);
     }
 
     /**

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -314,18 +314,26 @@ abstract class AbstractRule implements Rule
     }
 
     /**
-     * Returns the value of a configured property as an integer or throws an
-     * exception when no property with <b>$name</b> exists.
+     * Returns the value of a configured property as an integer
      *
-     * @param string $name
-     * @return integer
-     * @throws \OutOfBoundsException When no property for <b>$name</b> exists.
+     * Throws an exception when no property with <b>$name</b> exists
+     * and no default value to fall back was given.
+     *
+     * @param string $name The name of the property, e.g. "minimum".
+     * @param string|null $default An optional default value to fall back instead of throwing an exception.
+     * @return integer The value of a configured property as an integer.
+     * @throws \OutOfBoundsException When no property for <b>$name</b> exists and
+     * no default value to fall back was given.
      */
-    public function getIntProperty($name)
+    public function getIntProperty($name, $default = null)
     {
         if (isset($this->properties[$name])) {
             return (int) $this->properties[$name];
         }
+        if ($default !== null) {
+            return $default;
+        }
+
         throw new \OutOfBoundsException('Property "' . $name . '" does not exist.');
     }
 

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -330,18 +330,26 @@ abstract class AbstractRule implements Rule
     }
 
     /**
-     * Returns the raw string value of a configured property or throws an
-     * exception when no property with <b>$name</b> exists.
+     * Returns the raw string value of a configured property
      *
-     * @param string $name
-     * @return string
-     * @throws \OutOfBoundsException When no property for <b>$name</b> exists.
+     * Throws an exception when no property with <b>$name</b> exists
+     * and no default value to fall back was given.
+     *
+     * @param string $name The name of the property, e.g. "exceptions".
+     * @param string|null $default An optional default value to fall back instead of throwing an exception.
+     * @return string The raw string value of a configured property.
+     * @throws \OutOfBoundsException When no property for <b>$name</b> exists and
+     * no default value to fall back was given.
      */
-    public function getStringProperty($name)
+    public function getStringProperty($name, $default = null)
     {
         if (isset($this->properties[$name])) {
             return $this->properties[$name];
         }
+        if ($default !== null) {
+            return $default;
+        }
+
         throw new \OutOfBoundsException('Property "' . $name . '" does not exist.');
     }
 

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -298,6 +298,30 @@ abstract class AbstractRule implements Rule
     }
 
     /**
+     * Returns the value of a configured property
+     *
+     * Throws an exception when no property with <b>$name</b> exists
+     * and no default value to fall back was given.
+     *
+     * @param string $name The name of the property, e.g. "ignore-whitespace".
+     * @param mixed $default An optional default value to fall back instead of throwing an exception.
+     * @return mixed The value of a configured property.
+     * @throws \OutOfBoundsException When no property for <b>$name</b> exists and
+     * no default value to fall back was given.
+     */
+    protected function getProperty($name, $default = null)
+    {
+        if (isset($this->properties[$name])) {
+            return $this->properties[$name];
+        }
+        if ($default !== null) {
+            return $default;
+        }
+
+        throw new \OutOfBoundsException('Property "' . $name . '" does not exist.');
+    }
+
+    /**
      * Returns the value of a configured property as a boolean
      *
      * Throws an exception when no property with <b>$name</b> exists
@@ -311,14 +335,7 @@ abstract class AbstractRule implements Rule
      */
     public function getBooleanProperty($name, $default = null)
     {
-        if (isset($this->properties[$name])) {
-            return in_array($this->properties[$name], array('true', 'on', 1), false);
-        }
-        if ($default !== null) {
-            return (bool)$default;
-        }
-
-        throw new \OutOfBoundsException('Property "' . $name . '" does not exist.');
+        return in_array($this->getgetProperty($name, $default), array('true', 'on', 1), false);
     }
 
     /**
@@ -335,14 +352,7 @@ abstract class AbstractRule implements Rule
      */
     public function getIntProperty($name, $default = null)
     {
-        if (isset($this->properties[$name])) {
-            return (int)$this->properties[$name];
-        }
-        if ($default !== null) {
-            return (int)$default;
-        }
-
-        throw new \OutOfBoundsException('Property "' . $name . '" does not exist.');
+        return (int) $this->getgetProperty($name, $default);
     }
 
     /**
@@ -359,14 +369,7 @@ abstract class AbstractRule implements Rule
      */
     public function getStringProperty($name, $default = null)
     {
-        if (isset($this->properties[$name])) {
-            return $this->properties[$name];
-        }
-        if ($default !== null) {
-            return $default;
-        }
-
-        throw new \OutOfBoundsException('Property "' . $name . '" does not exist.');
+        return (string) $this->getgetProperty($name, $default);
     }
 
     /**

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -298,18 +298,26 @@ abstract class AbstractRule implements Rule
     }
 
     /**
-     * Returns the value of a configured property as a boolean or throws an
-     * exception when no property with <b>$name</b> exists.
+     * Returns the value of a configured property as a boolean
      *
-     * @param string $name
-     * @return boolean
-     * @throws \OutOfBoundsException When no property for <b>$name</b> exists.
+     * Throws an exception when no property with <b>$name</b> exists
+     * and no default value to fall back was given.
+     *
+     * @param string $name The name of the property, e.g. "ignore-whitespace".
+     * @param string|null $default An optional default value to fall back instead of throwing an exception.
+     * @return boolean The value of a configured property as a boolean.
+     * @throws \OutOfBoundsException When no property for <b>$name</b> exists and
+     * no default value to fall back was given.
      */
-    public function getBooleanProperty($name)
+    public function getBooleanProperty($name, $default = null)
     {
         if (isset($this->properties[$name])) {
             return in_array($this->properties[$name], array('true', 'on', 1));
         }
+        if ($default !== null) {
+            return $default;
+        }
+
         throw new \OutOfBoundsException('Property "' . $name . '" does not exist.');
     }
 

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -312,7 +312,7 @@ abstract class AbstractRule implements Rule
     public function getBooleanProperty($name, $default = null)
     {
         if (isset($this->properties[$name])) {
-            return in_array($this->properties[$name], array('true', 'on', 1));
+            return in_array($this->properties[$name], array('true', 'on', 1), false);
         }
         if ($default !== null) {
             return $default;

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -304,8 +304,8 @@ abstract class AbstractRule implements Rule
      * and no default value to fall back was given.
      *
      * @param string $name The name of the property, e.g. "ignore-whitespace".
-     * @param string|null $default An optional default value to fall back instead of throwing an exception.
-     * @return boolean The value of a configured property as a boolean.
+     * @param bool $default An optional default value to fall back instead of throwing an exception.
+     * @return bool The value of a configured property as a boolean.
      * @throws \OutOfBoundsException When no property for <b>$name</b> exists and
      * no default value to fall back was given.
      */
@@ -315,7 +315,7 @@ abstract class AbstractRule implements Rule
             return in_array($this->properties[$name], array('true', 'on', 1), false);
         }
         if ($default !== null) {
-            return $default;
+            return (bool)$default;
         }
 
         throw new \OutOfBoundsException('Property "' . $name . '" does not exist.');

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -328,18 +328,18 @@ abstract class AbstractRule implements Rule
      * and no default value to fall back was given.
      *
      * @param string $name The name of the property, e.g. "minimum".
-     * @param string|null $default An optional default value to fall back instead of throwing an exception.
-     * @return integer The value of a configured property as an integer.
+     * @param int $default An optional default value to fall back instead of throwing an exception.
+     * @return int The value of a configured property as an integer.
      * @throws \OutOfBoundsException When no property for <b>$name</b> exists and
      * no default value to fall back was given.
      */
     public function getIntProperty($name, $default = null)
     {
         if (isset($this->properties[$name])) {
-            return (int) $this->properties[$name];
+            return (int)$this->properties[$name];
         }
         if ($default !== null) {
-            return $default;
+            return (int)$default;
         }
 
         throw new \OutOfBoundsException('Property "' . $name . '" does not exist.');

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -20,7 +20,7 @@ namespace PHPMD;
 /**
  * Test case for the {@link \PHPMD\AbstractRule} class.
  *
- * @covers \PHPMD\AbstractRule
+ * @coversDefaultClass \PHPMD\AbstractRule
  */
 class RuleTest extends AbstractTest
 {
@@ -28,6 +28,7 @@ class RuleTest extends AbstractTest
      * testGetIntPropertyReturnsValueOfTypeInteger
      *
      * @return void
+     * @covers ::getIntProperty
      */
     public function testGetIntPropertyReturnsValueOfTypeInteger()
     {
@@ -42,6 +43,7 @@ class RuleTest extends AbstractTest
      * testGetBooleanPropertyReturnsTrueForStringValue1
      *
      * @return void
+     * @covers ::getBooleanProperty
      */
     public function testGetBooleanPropertyReturnsTrueForStringValue1()
     {
@@ -56,6 +58,7 @@ class RuleTest extends AbstractTest
      * testGetBooleanPropertyReturnsTrueForStringValueOn
      *
      * @return void
+     * @covers ::getBooleanProperty
      */
     public function testGetBooleanPropertyReturnsTrueForStringValueOn()
     {
@@ -70,6 +73,7 @@ class RuleTest extends AbstractTest
      * testGetBooleanPropertyReturnsTrueForStringValueTrue
      *
      * @return void
+     * @covers ::getBooleanProperty
      */
     public function testGetBooleanPropertyReturnsTrueForStringValueTrue()
     {
@@ -84,6 +88,7 @@ class RuleTest extends AbstractTest
      * testGetBooleanPropertyReturnsTrueForDifferentStringValue
      *
      * @return void
+     * @covers ::getBooleanProperty
      */
     public function testGetBooleanPropertyReturnsTrueForDifferentStringValue()
     {
@@ -99,6 +104,7 @@ class RuleTest extends AbstractTest
      *
      * @return void
      * @expectedException \OutOfBoundsException
+     * @covers ::getIntProperty
      */
     public function testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
@@ -112,6 +118,7 @@ class RuleTest extends AbstractTest
      *
      * @return void
      * @expectedException \OutOfBoundsException
+     * @covers ::getBooleanProperty
      */
     public function testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
@@ -121,10 +128,11 @@ class RuleTest extends AbstractTest
     }
 
     /**
-     * testStringPropertyThrowsExceptionWhenNoPropertyForNameExists
+     * testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
      * @expectedException \OutOfBoundsException
+     * @covers ::getStringProperty
      */
     public function testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
@@ -137,6 +145,7 @@ class RuleTest extends AbstractTest
      * testGetStringPropertyReturnsStringValue
      *
      * @return void
+     * @covers ::getStringProperty
      */
     public function testGetStringPropertyReturnsString()
     {

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -25,21 +25,6 @@ namespace PHPMD;
 class RuleTest extends AbstractTest
 {
     /**
-     * testGetIntPropertyReturnsValueOfTypeInteger
-     *
-     * @return void
-     * @covers ::getIntProperty
-     */
-    public function testGetIntPropertyReturnsValueOfTypeInteger()
-    {
-        /** @var AbstractRule $rule */
-        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
-        $rule->addProperty(__FUNCTION__, '42.3');
-
-        $this->assertSame(42, $rule->getIntProperty(__FUNCTION__));
-    }
-
-    /**
      * testGetBooleanPropertyReturnsTrueForStringValue1
      *
      * @return void
@@ -97,6 +82,21 @@ class RuleTest extends AbstractTest
         $rule->addProperty(__FUNCTION__, 'True');
 
         $this->assertFalse($rule->getBooleanProperty(__FUNCTION__));
+    }
+
+    /**
+     * testGetIntPropertyReturnsValueOfTypeInteger
+     *
+     * @return void
+     * @covers ::getIntProperty
+     */
+    public function testGetIntPropertyReturnsValueOfTypeInteger()
+    {
+        /** @var AbstractRule $rule */
+        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        $rule->addProperty(__FUNCTION__, '42.3');
+
+        $this->assertSame(42, $rule->getIntProperty(__FUNCTION__));
     }
 
     /**

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -138,7 +138,7 @@ class RuleTest extends AbstractTest
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
 
-        $this->assertSame('123', $rule->getIntProperty(__FUNCTION__, '123'));
+        $this->assertSame(123, $rule->getIntProperty(__FUNCTION__, '123'));
     }
 
     /**

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -155,4 +155,18 @@ class RuleTest extends AbstractTest
 
         $this->assertSame('Fourty Two', $rule->getStringProperty(__FUNCTION__));
     }
+
+    /**
+     * Tests the getStringProperty method with a fallback value
+     *
+     * @return void
+     * @covers ::getStringProperty
+     */
+    public function testGetStringPropertyReturnsFallbackString()
+    {
+        /** @var AbstractRule $rule */
+        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+
+        $this->assertSame('fallback', $rule->getStringProperty(__FUNCTION__, 'fallback'));
+    }
 }

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -31,6 +31,7 @@ class RuleTest extends AbstractTest
      */
     public function testGetIntPropertyReturnsValueOfTypeInteger()
     {
+        /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->addProperty(__FUNCTION__, '42.3');
 
@@ -44,6 +45,7 @@ class RuleTest extends AbstractTest
      */
     public function testGetBooleanPropertyReturnsTrueForStringValue1()
     {
+        /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->addProperty(__FUNCTION__, '1');
 
@@ -57,6 +59,7 @@ class RuleTest extends AbstractTest
      */
     public function testGetBooleanPropertyReturnsTrueForStringValueOn()
     {
+        /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->addProperty(__FUNCTION__, 'on');
 
@@ -70,6 +73,7 @@ class RuleTest extends AbstractTest
      */
     public function testGetBooleanPropertyReturnsTrueForStringValueTrue()
     {
+        /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->addProperty(__FUNCTION__, 'true');
 
@@ -83,6 +87,7 @@ class RuleTest extends AbstractTest
      */
     public function testGetBooleanPropertyReturnsTrueForDifferentStringValue()
     {
+        /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->addProperty(__FUNCTION__, 'True');
 
@@ -97,6 +102,7 @@ class RuleTest extends AbstractTest
      */
     public function testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
+        /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->getIntProperty(__FUNCTION__);
     }
@@ -109,6 +115,7 @@ class RuleTest extends AbstractTest
      */
     public function testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
+        /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->getBooleanProperty(__FUNCTION__);
     }
@@ -121,6 +128,7 @@ class RuleTest extends AbstractTest
      */
     public function testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
+        /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->getStringProperty(__FUNCTION__);
     }
@@ -132,6 +140,7 @@ class RuleTest extends AbstractTest
      */
     public function testGetStringPropertyReturnsString()
     {
+        /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->addProperty(__FUNCTION__, 'Fourty Two');
 

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -29,6 +29,7 @@ class RuleTest extends AbstractTest
      *
      * @return void
      * @covers ::getBooleanProperty
+     * @covers ::getProperty
      */
     public function testGetBooleanPropertyReturnsTrueForStringValue1()
     {
@@ -44,6 +45,7 @@ class RuleTest extends AbstractTest
      *
      * @return void
      * @covers ::getBooleanProperty
+     * @covers ::getProperty
      */
     public function testGetBooleanPropertyReturnsTrueForStringValueOn()
     {
@@ -59,6 +61,7 @@ class RuleTest extends AbstractTest
      *
      * @return void
      * @covers ::getBooleanProperty
+     * @covers ::getProperty
      */
     public function testGetBooleanPropertyReturnsTrueForStringValueTrue()
     {
@@ -74,6 +77,7 @@ class RuleTest extends AbstractTest
      *
      * @return void
      * @covers ::getBooleanProperty
+     * @covers ::getProperty
      */
     public function testGetBooleanPropertyReturnsTrueForDifferentStringValue()
     {
@@ -89,6 +93,7 @@ class RuleTest extends AbstractTest
      *
      * @return void
      * @covers ::getBooleanProperty
+     * @covers ::getProperty
      */
     public function testGetBooleanPropertyReturnsFallbackString()
     {
@@ -103,6 +108,7 @@ class RuleTest extends AbstractTest
      *
      * @return void
      * @covers ::getIntProperty
+     * @covers ::getProperty
      */
     public function testGetIntPropertyReturnsValueOfTypeInteger()
     {
@@ -119,6 +125,7 @@ class RuleTest extends AbstractTest
      * @return void
      * @expectedException \OutOfBoundsException
      * @covers ::getIntProperty
+     * @covers ::getProperty
      */
     public function testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
@@ -132,6 +139,7 @@ class RuleTest extends AbstractTest
      *
      * @return void
      * @covers ::getIntProperty
+     * @covers ::getProperty
      */
     public function testGetIntPropertyReturnsFallbackString()
     {
@@ -147,6 +155,7 @@ class RuleTest extends AbstractTest
      * @return void
      * @expectedException \OutOfBoundsException
      * @covers ::getBooleanProperty
+     * @covers ::getProperty
      */
     public function testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
@@ -161,6 +170,7 @@ class RuleTest extends AbstractTest
      * @return void
      * @expectedException \OutOfBoundsException
      * @covers ::getStringProperty
+     * @covers ::getProperty
      */
     public function testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
@@ -174,6 +184,7 @@ class RuleTest extends AbstractTest
      *
      * @return void
      * @covers ::getStringProperty
+     * @covers ::getProperty
      */
     public function testGetStringPropertyReturnsString()
     {
@@ -189,6 +200,7 @@ class RuleTest extends AbstractTest
      *
      * @return void
      * @covers ::getStringProperty
+     * @covers ::getProperty
      */
     public function testGetStringPropertyReturnsFallbackString()
     {

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -85,6 +85,20 @@ class RuleTest extends AbstractTest
     }
 
     /**
+     * Tests the getBooleanProperty method with a fallback value
+     *
+     * @return void
+     * @covers ::getBooleanProperty
+     */
+    public function testGetBooleanPropertyReturnsFallbackString()
+    {
+        /** @var AbstractRule $rule */
+        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+
+        $this->assertTrue($rule->getBooleanProperty(__FUNCTION__, true));
+    }
+
+    /**
      * testGetIntPropertyReturnsValueOfTypeInteger
      *
      * @return void

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -114,6 +114,20 @@ class RuleTest extends AbstractTest
     }
 
     /**
+     * Tests the getIntProperty method with a fallback value
+     *
+     * @return void
+     * @covers ::getIntProperty
+     */
+    public function testGetIntPropertyReturnsFallbackString()
+    {
+        /** @var AbstractRule $rule */
+        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+
+        $this->assertSame('123', $rule->getIntProperty(__FUNCTION__, '123'));
+    }
+
+    /**
      * testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void


### PR DESCRIPTION
Type: feature
Issue: Resolves none
Breaking change: no

Refers to https://github.com/phpmd/phpmd/pull/747#discussion_r408737780

I did not use the new fall back values it in any call ,yet.

Self critique::
Theoretically, this could lead to two cases of unclean code:

1. It copies or changes the default value set in the rule set XML.
2. It allows to use properties that do not exist in the rule set XML.