### PR TITLE
Replace deprecated expectedException annotation

### DIFF
--- a/src/test/php/PHPMD/Node/FunctionTest.php
+++ b/src/test/php/PHPMD/Node/FunctionTest.php
@@ -49,10 +49,10 @@ class FunctionNodeTest extends AbstractTest
      * testMagicCallThrowsExceptionWhenNoMatchingMethodExists
      *
      * @return void
-     * @expectedException BadMethodCallException
      */
     public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists()
     {
+        $this->expectException('\BadMethodCallException');
         $node = new FunctionNode(new ASTFunction(null));
         $node->getFooBar();
     }

--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -51,10 +51,10 @@ class MethodNodeTest extends AbstractTest
      * testMagicCallThrowsExceptionWhenNoMatchingMethodExists
      *
      * @return void
-     * @expectedException \BadMethodCallException
      */
     public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists()
     {
+        $this->expectException('\BadMethodCallException');
         $node = new MethodNode(new ASTMethod(null));
         $node->getFooBar();
     }

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -616,10 +616,11 @@ class RuleSetFactoryTest extends AbstractTest
      *
      * @return void
      * @covers \PHPMD\RuleClassNotFoundException
-     * @expectedException \RuntimeException
+     *
      */
     public function testCreateRuleSetsThrowsExpectedExceptionForInvalidXmlFile()
     {
+        $this->expectException('\RuntimeException');
         $fileName = self::createFileUri('rulesets/set-invalid-xml.xml');
 
         $factory = new RuleSetFactory();

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -93,10 +93,10 @@ class RuleTest extends AbstractTest
      * testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
-     * @expectedException \OutOfBoundsException
      */
     public function testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
+        $this->expectException('\OutOfBoundsException');
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->getIntProperty(__FUNCTION__);
     }
@@ -105,10 +105,10 @@ class RuleTest extends AbstractTest
      * testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
-     * @expectedException \OutOfBoundsException
      */
     public function testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
+        $this->expectException('\OutOfBoundsException');
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->getBooleanProperty(__FUNCTION__);
     }
@@ -117,10 +117,10 @@ class RuleTest extends AbstractTest
      * testStringPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
-     * @expectedException \OutOfBoundsException
      */
     public function testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
+        $this->expectException('\OutOfBoundsException');
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->getStringProperty(__FUNCTION__);
     }

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -92,10 +92,10 @@ class CommandLineOptionsTest extends AbstractTest
      *
      * @return void
      * @since 1.1.0
-     * @expectedException \InvalidArgumentException
      */
     public function testThrowsExpectedExceptionWhenRequiredArgumentsNotSet()
     {
+        $this->expectException('\InvalidArgumentException');
         $args = array(__FILE__, 'text', 'design');
         new CommandLineOptions($args);
     }
@@ -153,10 +153,10 @@ class CommandLineOptionsTest extends AbstractTest
      *
      * @return void
      * @since 1.1.0
-     * @expectedException \InvalidArgumentException
      */
     public function testThrowsExpectedExceptionWhenInputFileNotExists()
     {
+        $this->expectException('\InvalidArgumentException');
         $args = array('foo.php', 'text', 'design', '--inputfile', 'inputfail.txt');
         new CommandLineOptions($args);
     }
@@ -375,28 +375,33 @@ class CommandLineOptionsTest extends AbstractTest
     }
 
     /**
-     * @param string $reportFormat
+     * Tests the createRenderer method when an empty format was given
+     *
      * @return void
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp (^Can\'t )
-     * @dataProvider dataProviderCreateRendererThrowsException
      */
-    public function testCreateRendererThrowsException($reportFormat)
+    public function testCreateRendererEmptyFormatThrowsException()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage("Can't create report with empty format.");
+        $reportFormat = '';
         $args = array(__FILE__, __FILE__, $reportFormat, 'codesize');
         $opts = new CommandLineOptions($args);
         $opts->createRenderer();
     }
 
     /**
-     * @return array
+     * Tests the createRenderer method when an empty format was given
+     *
+     * @return void
      */
-    public function dataProviderCreateRendererThrowsException()
+    public function testCreateRendererNonExistingRendererThrowsException()
     {
-        return array(
-            array(''),
-            array('PHPMD\\Test\\Renderer\\NotExistsRenderer')
-        );
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage("Can't find the custom report class: PHPMD\Test\Renderer\NotExistsRenderer");
+        $reportFormat = 'PHPMD\\Test\\Renderer\\NotExistsRenderer';
+        $args = array(__FILE__, __FILE__, $reportFormat, 'codesize');
+        $opts = new CommandLineOptions($args);
+        $opts->createRenderer();
     }
 
     /**


### PR DESCRIPTION
Use expectException() method instead.

Unfortunately, we cannot use the ``class`` constants as we keep PHP 5.3 compatibility.
https://github.com/phpmd/phpmd/blob/fdfde5db7cce855ca43b7d34c7a9c16b749b4de5/composer.json#L38