### PR TITLE
Fix #720 undefined variable in foreach when passed by reference

### DIFF
--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\CleanCode;
 
+use PDepend\Source\AST\ASTUnaryExpression;
 use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\State;
 use PHPMD\AbstractNode;
@@ -138,6 +139,12 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
             foreach ($foreachStatement->getChildren() as $children) {
                 if ($children instanceof ASTVariable) {
                     $this->addVariableDefinition($children);
+                } elseif ($children instanceof ASTUnaryExpression) {
+                    foreach ($children->getChildren() as $refChildren) {
+                        if ($refChildren instanceof ASTVariable) {
+                            $this->addVariableDefinition($refChildren);
+                        }
+                    }
                 }
             }
         }

--- a/src/test/php/PHPMD/Rule/CleanCode/UndefinedValiableTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/UndefinedValiableTest.php
@@ -110,4 +110,28 @@ class UndefinedVariableTest extends AbstractTest
         $rule->setReport($this->getReportMock(0));
         $rule->apply($this->getMethod());
     }
+
+    /**
+     * testRuleDoesNotApplyToKeyValuePair
+     *
+     * @return void
+     */
+    public function testRuleDoesNotApplyToKeyValuePair()
+    {
+        $rule = new UndefinedVariable();
+        $rule->setReport($this->getReportMock(0));
+        $rule->apply($this->getMethod());
+    }
+
+    /**
+     * testRuleDoesNotApplyToKeyReferencePair
+     *
+     * @return void
+     */
+    public function testRuleDoesNotApplyToKeyReferencePair()
+    {
+        $rule = new UndefinedVariable();
+        $rule->setReport($this->getReportMock(0));
+        $rule->apply($this->getMethod());
+    }
 }

--- a/src/test/php/PHPMD/Rule/CleanCode/UndefinedValiableTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/UndefinedValiableTest.php
@@ -98,4 +98,16 @@ class UndefinedVariableTest extends AbstractTest
         $rule->setReport($this->getReportMock(0));
         $rule->apply($this->getMethod());
     }
+
+    /**
+     * testRuleDoesNotApplyToReferences
+     *
+     * @return void
+     */
+    public function testRuleDoesNotApplyToReferences()
+    {
+        $rule = new UndefinedVariable();
+        $rule->setReport($this->getReportMock(0));
+        $rule->apply($this->getMethod());
+    }
 }

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToKeyReferencePair.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToKeyReferencePair.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyToKeyReferencePair
+{
+    function testRuleDoesNotApplyToKeyReferencePair($array)
+    {
+        foreach ($array as $key => &$item) {
+            $item++;
+        }
+
+        return $array;
+    }
+}

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToKeyValuePair.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToKeyValuePair.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyToKeyValuePair
+{
+    function testRuleDoesNotApplyToKeyValuePair($array)
+    {
+        foreach ($array as $key => $item) {
+            $item++;
+        }
+
+        return $array;
+    }
+}

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToReferences.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToReferences.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyToReferences
+{
+    function testRuleDoesNotApplyToReferences($array)
+    {
+        foreach ($array as &$item) {
+            $item++;
+        }
+
+        return $array;
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix #720
Breaking change: no

The root cause of this bug is more likely in PDepend, but the following proposition of @char101 fix it properly (as unary operator can only be `&` in `foreach`) until PDepend would provide better tooling for read/write variables.