### PR TITLE
Report mock convenience methods

### DIFF
--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -38,6 +38,15 @@ use PHPUnit_Framework_MockObject_MockBuilder;
  */
 abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var int At least one violation is expected */
+    const AL_LEAST_ONE_VIOLATION = -1;
+
+    /** @var int No violation is expected */
+    const NO_VIOLATION = 0;
+
+    /** @var int One violation is expected */
+    const ONE_VIOLATION = 1;
+
     /**
      * Directory with test files.
      *
@@ -358,11 +367,11 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     protected function getReportMock($expectedInvokes = -1)
     {
-        if ($expectedInvokes < 0) {
+        if ($expectedInvokes === self::AL_LEAST_ONE_VIOLATION) {
             $expects = $this->atLeastOnce();
-        } elseif ($expectedInvokes === 0) {
+        } elseif ($expectedInvokes === self::NO_VIOLATION) {
             $expects = $this->never();
-        } elseif ($expectedInvokes === 1) {
+        } elseif ($expectedInvokes === self::ONE_VIOLATION) {
             $expects = $this->once();
         } else {
             $expects = $this->exactly($expectedInvokes);
@@ -382,7 +391,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     public function getReportWithOneViolation()
     {
-        return $this->getReportMock(1);
+        return $this->getReportMock(self::ONE_VIOLATION);
     }
 
     /**
@@ -392,7 +401,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     public function getReportWithNoViolation()
     {
-        return $this->getReportMock(0);
+        return $this->getReportMock(self::NO_VIOLATION);
     }
 
     /**
@@ -402,7 +411,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     public function getReportWithAtLeastOneViolation()
     {
-        return $this->getReportMock(-1);
+        return $this->getReportMock(self::AL_LEAST_ONE_VIOLATION);
     }
 
     protected function getMockFromBuilder(PHPUnit_Framework_MockObject_MockBuilder $builder)

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -375,6 +375,36 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
         return $report;
     }
 
+    /**
+     * Get a mocked report with one violation
+     *
+     * @return Report
+     */
+    public function getReportWithOneViolation()
+    {
+        return $this->getReportMock(1);
+    }
+
+    /**
+     * Get a mocked report with no violation
+     *
+     * @return Report
+     */
+    public function getReportWithNoViolation()
+    {
+        return $this->getReportMock(0);
+    }
+
+    /**
+     * Get a mocked report with at least one violation
+     *
+     * @return Report
+     */
+    public function getReportWithAtLeastOneViolation()
+    {
+        return $this->getReportMock(-1);
+    }
+
     protected function getMockFromBuilder(PHPUnit_Framework_MockObject_MockBuilder $builder)
     {
         if (version_compare(phpversion(), '7.4.0-dev', '<')) {

--- a/src/test/php/PHPMD/ParserFactoryTest.php
+++ b/src/test/php/PHPMD/ParserFactoryTest.php
@@ -47,7 +47,7 @@ class ParserFactoryTest extends AbstractTest
 
         $parser = $factory->create($phpmd);
         $parser->addRuleSet($ruleSet);
-        $parser->parse($this->getReportMock(0));
+        $parser->parse($this->getReportWithNoViolation());
     }
 
     /**
@@ -73,7 +73,7 @@ class ParserFactoryTest extends AbstractTest
 
         $parser = $factory->create($phpmd);
         $parser->addRuleSet($ruleSet);
-        $parser->parse($this->getReportMock(0));
+        $parser->parse($this->getReportWithNoViolation());
     }
 
     /**
@@ -100,7 +100,7 @@ class ParserFactoryTest extends AbstractTest
 
         $parser = $factory->create($phpmd);
         $parser->addRuleSet($ruleSet);
-        $parser->parse($this->getReportMock(0));
+        $parser->parse($this->getReportWithNoViolation());
     }
 
     /**
@@ -124,7 +124,7 @@ class ParserFactoryTest extends AbstractTest
 
         $parser = $factory->create($phpmd);
         $parser->addRuleSet($ruleSet);
-        $parser->parse($this->getReportMock(0));
+        $parser->parse($this->getReportWithNoViolation());
     }
 
     /**

--- a/src/test/php/PHPMD/ParserTest.php
+++ b/src/test/php/PHPMD/ParserTest.php
@@ -44,7 +44,7 @@ class ParserTest extends AbstractTest
 
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock('PHPMD\\Node\\ClassNode'));
-        $adapter->setReport($this->getReportMock(0));
+        $adapter->setReport($this->getReportWithNoViolation());
         $adapter->visitClass($mock);
     }
 
@@ -63,7 +63,7 @@ class ParserTest extends AbstractTest
 
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock());
-        $adapter->setReport($this->getReportMock(0));
+        $adapter->setReport($this->getReportWithNoViolation());
         $adapter->visitClass($mock);
     }
 
@@ -76,7 +76,7 @@ class ParserTest extends AbstractTest
     {
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock('PHPMD\\Node\\MethodNode'));
-        $adapter->setReport($this->getReportMock(0));
+        $adapter->setReport($this->getReportWithNoViolation());
         $adapter->visitMethod($this->getPHPDependMethodMock());
     }
 
@@ -90,7 +90,7 @@ class ParserTest extends AbstractTest
     {
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock());
-        $adapter->setReport($this->getReportMock(0));
+        $adapter->setReport($this->getReportWithNoViolation());
         $adapter->visitMethod($this->getPHPDependMethodMock(null));
     }
 
@@ -103,7 +103,7 @@ class ParserTest extends AbstractTest
     {
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock('PHPMD\\Node\\FunctionNode'));
-        $adapter->setReport($this->getReportMock(0));
+        $adapter->setReport($this->getReportWithNoViolation());
         $adapter->visitFunction($this->getPHPDependFunctionMock());
     }
 
@@ -117,7 +117,7 @@ class ParserTest extends AbstractTest
     {
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock());
-        $adapter->setReport($this->getReportMock(0));
+        $adapter->setReport($this->getReportWithNoViolation());
         $adapter->visitFunction($this->getPHPDependFunctionMock(null));
     }
 
@@ -129,7 +129,7 @@ class ParserTest extends AbstractTest
      */
     public function testParserStoreParsingExceptionsInReport()
     {
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('addError');
 

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015Test.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015Test.php
@@ -42,7 +42,7 @@ class ExcessivePublicCountRuleNeverExecutedTicket015Test extends AbstractTest
 
         $ruleSet = new RuleSet();
         $ruleSet->addRule($rule);
-        $ruleSet->setReport($this->getReportMock(1));
+        $ruleSet->setReport($this->getReportWithOneViolation());
 
         $ruleSet->apply($class);
     }

--- a/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007Test.php
+++ b/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007Test.php
@@ -35,7 +35,7 @@ class InvalidUnusedLocalVariableAndFormalParameterTicket007Test extends Abstract
     public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported()
     {
         $rule = new UnusedLocalVariable();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -47,7 +47,7 @@ class InvalidUnusedLocalVariableAndFormalParameterTicket007Test extends Abstract
     public function testFormalParameterUsedInDoubleQuoteStringGetsNotReported()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 }

--- a/src/test/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020Test.php
+++ b/src/test/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020Test.php
@@ -34,7 +34,7 @@ class StaticVariablesFlaggedAsUnusedTicket020Test extends AbstractTest
     public function testRuleDoesNotApplyToAnyStaticLocalVariable()
     {
         $rule = new UnusedLocalVariable();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 }

--- a/src/test/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019Test.php
+++ b/src/test/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019Test.php
@@ -34,7 +34,7 @@ class SuperGlobalsFlaggedAsUnusedTicket019Test extends AbstractTest
     public function testRuleDoesNotApplyToAnySuperGlobalVariable()
     {
         $rule = new UnusedLocalVariable();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 }

--- a/src/test/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036Test.php
+++ b/src/test/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036Test.php
@@ -36,7 +36,7 @@ class SuppressWarningsNotAppliesToUnusedPrivateMethod036Test extends AbstractTes
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new UnusedPrivateMethod());
-        $ruleSet->setReport($this->getReportMock(0));
+        $ruleSet->setReport($this->getReportWithNoViolation());
 
         $ruleSet->apply($this->getClass());
     }

--- a/src/test/php/PHPMD/Regression/UnusedParameterArgvTicket14990109Test.php
+++ b/src/test/php/PHPMD/Regression/UnusedParameterArgvTicket14990109Test.php
@@ -39,7 +39,7 @@ class UnusedParameterArgvTicket14990109Test extends AbstractTest
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new UnusedFormalParameter());
-        $ruleSet->setReport($this->getReportMock(0));
+        $ruleSet->setReport($this->getReportWithNoViolation());
 
         $ruleSet->apply($this->getFunction());
     }
@@ -53,7 +53,7 @@ class UnusedParameterArgvTicket14990109Test extends AbstractTest
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new UnusedFormalParameter());
-        $ruleSet->setReport($this->getReportMock(0));
+        $ruleSet->setReport($this->getReportWithNoViolation());
 
         $ruleSet->apply($this->getMethod());
     }

--- a/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
@@ -46,7 +46,7 @@ class AnsiRendererTest extends AbstractTest
             $this->getErrorMock(),
         );
 
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
         $report->expects($this->atLeastOnce())
             ->method('getRuleViolations')
             ->will($this->returnValue(new \ArrayIterator($violations)));
@@ -100,7 +100,7 @@ class AnsiRendererTest extends AbstractTest
     {
         $writer = new WriterStub();
 
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
         $report->expects($this->atLeastOnce())
             ->method('getRuleViolations')
             ->will($this->returnValue(new \ArrayIterator(array())));

--- a/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -44,7 +44,7 @@ class HTMLRendererTest extends AbstractTest
             $this->getRuleViolationMock('/foo.php', 3),
         );
 
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
             ->will($this->returnValue(new \ArrayIterator($violations)));
@@ -86,7 +86,7 @@ class HTMLRendererTest extends AbstractTest
             new ProcessingError('Failed for file "/tmp/baz.php".'),
         );
 
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
             ->will($this->returnValue(new \ArrayIterator(array())));

--- a/src/test/php/PHPMD/Renderer/JSONRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/JSONRendererTest.php
@@ -36,14 +36,14 @@ class JSONRendererTest extends AbstractTest
     public function testRendererCreatesExpectedNumberOfJsonElements()
     {
         $writer = new WriterStub();
-        
+
         $violations = array(
             $this->getRuleViolationMock('/bar.php'),
             $this->getRuleViolationMock('/foo.php'),
             $this->getRuleViolationMock('/bar.php'), // TODO Set with description "foo <?php bar".
         );
 
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
             ->will($this->returnValue(new \ArrayIterator($violations)));
@@ -80,7 +80,7 @@ class JSONRendererTest extends AbstractTest
             new ProcessingError('Cannot read file "/tmp/foo.php". Permission denied.'),
         );
 
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
             ->will($this->returnValue(new \ArrayIterator(array())));

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -44,7 +44,7 @@ class TextRendererTest extends AbstractTest
             $this->getRuleViolationMock('/foo.php', 3),
         );
 
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
             ->will($this->returnValue(new \ArrayIterator($violations)));
@@ -83,7 +83,7 @@ class TextRendererTest extends AbstractTest
             new ProcessingError('Failed for file "/tmp/baz.php".'),
         );
 
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
             ->will($this->returnValue(new \ArrayIterator(array())));

--- a/src/test/php/PHPMD/Renderer/XMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/XMLRendererTest.php
@@ -44,7 +44,7 @@ class XMLRendererTest extends AbstractTest
             $this->getRuleViolationMock('/foo.php', 23, 42, null, 'foo <?php bar'),
         );
 
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
             ->will($this->returnValue(new \ArrayIterator($violations)));
@@ -82,7 +82,7 @@ class XMLRendererTest extends AbstractTest
             new ProcessingError('Failed for file "/tmp/baz.php".'),
         );
 
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
             ->will($this->returnValue(new \ArrayIterator(array())));

--- a/src/test/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
@@ -35,7 +35,7 @@ class DuplicatedArrayKeyTest extends AbstractTest
     public function testRuleNotAppliesToMethodWithoutArrayDefinition()
     {
         $rule = new DuplicatedArrayKey();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -47,7 +47,7 @@ class DuplicatedArrayKeyTest extends AbstractTest
     public function testRuleNotAppliesToMethodWithNonAssotiativeArrayDefinition()
     {
         $rule = new DuplicatedArrayKey();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -59,7 +59,7 @@ class DuplicatedArrayKeyTest extends AbstractTest
     public function testRuleNotAppliesToMethodWithAssotiativeArrayDefinitionWithoutDuplicatedKeys()
     {
         $rule = new DuplicatedArrayKey();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -119,7 +119,7 @@ class DuplicatedArrayKeyTest extends AbstractTest
     public function testRuleNotAppliesToFunctionWithoutArrayDefinition()
     {
         $rule = new DuplicatedArrayKey();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -131,7 +131,7 @@ class DuplicatedArrayKeyTest extends AbstractTest
     public function testRuleNotAppliesToFunctionWithNonAssotiativeArrayDefinition()
     {
         $rule = new DuplicatedArrayKey();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -143,7 +143,7 @@ class DuplicatedArrayKeyTest extends AbstractTest
     public function testRuleNotAppliesToFunctionWithAssotiativeArrayDefinitionWithoutDuplicatedKeys()
     {
         $rule = new DuplicatedArrayKey();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 

--- a/src/test/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
@@ -71,7 +71,7 @@ class DuplicatedArrayKeyTest extends AbstractTest
     public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys()
     {
         $rule = new DuplicatedArrayKey();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -83,7 +83,7 @@ class DuplicatedArrayKeyTest extends AbstractTest
     public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys()
     {
         $rule = new DuplicatedArrayKey();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -95,7 +95,7 @@ class DuplicatedArrayKeyTest extends AbstractTest
     public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys()
     {
         $rule = new DuplicatedArrayKey();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -155,7 +155,7 @@ class DuplicatedArrayKeyTest extends AbstractTest
     public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys()
     {
         $rule = new DuplicatedArrayKey();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -167,7 +167,7 @@ class DuplicatedArrayKeyTest extends AbstractTest
     public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys()
     {
         $rule = new DuplicatedArrayKey();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -179,7 +179,7 @@ class DuplicatedArrayKeyTest extends AbstractTest
     public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys()
     {
         $rule = new DuplicatedArrayKey();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 

--- a/src/test/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
@@ -31,7 +31,7 @@ class ElseExpressionTest extends AbstractTest
     public function testRuleAppliesToMethodWithElseExpression()
     {
         $rule = new ElseExpression();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 

--- a/src/test/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
@@ -24,7 +24,7 @@ class ElseExpressionTest extends AbstractTest
     public function testRuleNotAppliesToMethodWithoutElseExpression()
     {
         $rule = new ElseExpression();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 

--- a/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
@@ -66,14 +66,14 @@ class IfStatementAssignmentTest extends AbstractTest
     public function testRuleAppliesToFunctions()
     {
         $rule = new IfStatementAssignment();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
     public function testRuleAppliesMultipleIfConditions()
     {
         $rule = new IfStatementAssignment();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 

--- a/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
@@ -24,35 +24,35 @@ class IfStatementAssignmentTest extends AbstractTest
     public function testRuleNotAppliesInsideClosure()
     {
         $rule = new IfStatementAssignment();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
     public function testRuleNotAppliesInsideClosureCallbacks()
     {
         $rule = new IfStatementAssignment();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
     public function testRuleNotAppliesToIfsWithoutAssignment()
     {
         $rule = new IfStatementAssignment();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
     public function testRuleNotAppliesToIfsWithConditionsOnly()
     {
         $rule = new IfStatementAssignment();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
     public function testRuleNotAppliesToLogicalOperators()
     {
         $rule = new IfStatementAssignment();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 

--- a/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
@@ -118,7 +118,7 @@ class MissingImportTest extends AbstractTest
     public function testRuleAppliesToFunctionWithNotImportedDependencies()
     {
         $rule = new MissingImport();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 }

--- a/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
@@ -35,7 +35,7 @@ class MissingImportTest extends AbstractTest
     public function testRuleNotAppliesToClassWithoutAnyDependencies()
     {
         $rule = new MissingImport();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -49,7 +49,7 @@ class MissingImportTest extends AbstractTest
     public function testRuleNotAppliesToClassWithOnlyImportedDependencies()
     {
         $rule = new MissingImport();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -77,7 +77,7 @@ class MissingImportTest extends AbstractTest
     public function testRuleNotAppliesToClassWithSelfAndStaticCalls()
     {
         $rule = new MissingImport();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -90,7 +90,7 @@ class MissingImportTest extends AbstractTest
     public function testRuleNotAppliesToFunctionWithoutAnyDependencies()
     {
         $rule = new MissingImport();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -104,7 +104,7 @@ class MissingImportTest extends AbstractTest
     public function testRuleNotAppliesToFunctionWithOnlyImportedDependencies()
     {
         $rule = new MissingImport();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 

--- a/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
@@ -53,14 +53,14 @@ class StaticAccessTest extends AbstractTest
     public function testRuleAppliesToStaticMethodAccess()
     {
         $rule = new StaticAccess();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
     public function testRuleAppliesToStaticMethodAccessWhenNotAllExcluded()
     {
         $rule = new StaticAccess();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('exceptions', 'Excluded');
         $rule->apply($this->getMethod());
     }

--- a/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
@@ -24,28 +24,28 @@ class StaticAccessTest extends AbstractTest
     public function testRuleNotAppliesToParentStaticCall()
     {
         $rule = new StaticAccess();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
     public function testRuleNotAppliesToSelfStaticCall()
     {
         $rule = new StaticAccess();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
     public function testRuleNotAppliesToDynamicMethodCall()
     {
         $rule = new StaticAccess();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
     public function testRuleNotAppliesToStaticMethodAccessWhenExcluded()
     {
         $rule = new StaticAccess();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('exceptions', 'Excluded1,Excluded2');
         $rule->apply($this->getMethod());
     }
@@ -68,7 +68,7 @@ class StaticAccessTest extends AbstractTest
     public function testRuleNotAppliesToConstantAccess()
     {
         $rule = new StaticAccess();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 }

--- a/src/test/php/PHPMD/Rule/CleanCode/UndefinedValiableTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/UndefinedValiableTest.php
@@ -22,8 +22,7 @@ use PHPMD\AbstractTest;
 /**
  * Test case for the undefined variable rule.
  *
- * @covers \PHPMD\Rule\CleanCode\UndefinedVariable
- * @covers \PHPMD\Rule\AbstractLocalVariable
+ * @coversDefaultClass  \PHPMD\Rule\CleanCode\UndefinedVariable
  */
 class UndefinedVariableTest extends AbstractTest
 {
@@ -35,7 +34,7 @@ class UndefinedVariableTest extends AbstractTest
     public function testRuleAppliesToUndefinedVariable()
     {
         $rule = new UndefinedVariable();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -47,7 +46,7 @@ class UndefinedVariableTest extends AbstractTest
     public function testRuleAppliesToUndefinedVariableWithDefinedVariable()
     {
         $rule = new UndefinedVariable();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -59,7 +58,7 @@ class UndefinedVariableTest extends AbstractTest
     public function testRuleAppliesToUndefinedVariableOnArray()
     {
         $rule = new UndefinedVariable();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -71,7 +70,7 @@ class UndefinedVariableTest extends AbstractTest
     public function testRuleAppliesToUndefinedVariableOnArrayWithKeys()
     {
         $rule = new UndefinedVariable();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 

--- a/src/test/php/PHPMD/Rule/CleanCode/UndefinedValiableTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/UndefinedValiableTest.php
@@ -82,7 +82,7 @@ class UndefinedVariableTest extends AbstractTest
     public function testRuleDoesNotApplyToSuperGlobals()
     {
         $rule = new UndefinedVariable();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -94,7 +94,7 @@ class UndefinedVariableTest extends AbstractTest
     public function testRuleDoesNotApplyToUsedProperties()
     {
         $rule = new UndefinedVariable();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 }

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -34,7 +34,7 @@ class CamelCaseMethodNameTest extends AbstractTest
     public function testRuleDoesNotApplyForValidMethodName()
     {
         //$method = $this->getMethod();
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new CamelCaseMethodName();
         $rule->setReport($report);
@@ -108,7 +108,7 @@ class CamelCaseMethodNameTest extends AbstractTest
     public function testRuleDoesNotApplyForValidMethodNameWithUnderscoreWhenAllowed()
     {
         $method = $this->getMethod();
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new CamelCaseMethodName();
         $rule->setReport($report);
@@ -165,7 +165,7 @@ class CamelCaseMethodNameTest extends AbstractTest
     public function testRuleDoesNotApplyForTestMethodWithUnderscoreWhenAllowed()
     {
         $method = $this->getMethod();
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new CamelCaseMethodName();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -53,7 +53,7 @@ class CamelCaseMethodNameTest extends AbstractTest
     {
         // Test method name with capital at the beginning
         $method = $this->getMethod();
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new CamelCaseMethodName();
         $rule->setReport($report);
@@ -72,7 +72,7 @@ class CamelCaseMethodNameTest extends AbstractTest
     {
         // Test method name with underscores
         $method = $this->getMethod();
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new CamelCaseMethodName();
         $rule->setReport($report);
@@ -90,7 +90,7 @@ class CamelCaseMethodNameTest extends AbstractTest
     public function testRuleDoesApplyForValidMethodNameWithUnderscoreWhenNotAllowed()
     {
         $method = $this->getMethod();
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new CamelCaseMethodName();
         $rule->setReport($report);
@@ -147,7 +147,7 @@ class CamelCaseMethodNameTest extends AbstractTest
     public function testRuleDoesApplyForTestMethodWithUnderscoreWhenNotAllowed()
     {
         $method = $this->getMethod();
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new CamelCaseMethodName();
         $rule->setReport($report);
@@ -183,7 +183,7 @@ class CamelCaseMethodNameTest extends AbstractTest
     public function testRuleAppliesToTestMethodWithTwoUnderscoresEvenWhenOneIsAllowed()
     {
         $method = $this->getMethod();
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new CamelCaseMethodName();
         $rule->setReport($report);
@@ -201,7 +201,7 @@ class CamelCaseMethodNameTest extends AbstractTest
     public function testRuleAppliesToTestMethodWithUnderscoreFollowedByCapital()
     {
         $method = $this->getMethod();
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new CamelCaseMethodName();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
@@ -67,7 +67,7 @@ class CamelCaseParameterNameTest extends AbstractTest
      */
     public function testRuleDoesNotApplyForValidParameterName()
     {
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         foreach ($this->getClass()->getMethods() as $method) {
             $rule = new CamelCaseParameterName();
@@ -85,7 +85,7 @@ class CamelCaseParameterNameTest extends AbstractTest
      */
     public function testRuleDoesNotApplyForValidParameterNameWithUnderscoreWhenAllowed()
     {
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         foreach ($this->getClass()->getMethods() as $method) {
             $rule = new CamelCaseParameterName();

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
@@ -32,7 +32,7 @@ class CamelCaseParameterNameTest extends AbstractTest
      */
     public function testRuleDoesApplyForInparameterNameWithUnderscore()
     {
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         foreach ($this->getClass()->getMethods() as $method) {
             $rule = new CamelCaseParameterName();
@@ -50,7 +50,7 @@ class CamelCaseParameterNameTest extends AbstractTest
      */
     public function testRuleDoesApplyForParameterNameWithCapital()
     {
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         foreach ($this->getClass()->getMethods() as $method) {
             $rule = new CamelCaseParameterName();

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
@@ -67,7 +67,7 @@ class CamelCasePropertyNameTest extends AbstractTest
     public function testRuleDoesApplyForPropertyNameWithUnderscores()
     {
         // Test property name with underscores
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new CamelCasePropertyName();
         $rule->setReport($report);
@@ -83,7 +83,7 @@ class CamelCasePropertyNameTest extends AbstractTest
      */
     public function testRuleDoesApplyForValidPropertyNameWithUnderscoreWhenNotAllowed()
     {
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new CamelCasePropertyName();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
@@ -33,7 +33,7 @@ class CamelCasePropertyNameTest extends AbstractTest
      */
     public function testRuleDoesNotApplyForValidPropertyName()
     {
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new CamelCasePropertyName();
         $rule->setReport($report);
@@ -50,7 +50,7 @@ class CamelCasePropertyNameTest extends AbstractTest
     public function testRuleDoesNotApplyForPropertyNameWithCapital()
     {
         // Test property name with capital at the beginning
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new CamelCasePropertyName();
         $rule->setReport($report);
@@ -99,7 +99,7 @@ class CamelCasePropertyNameTest extends AbstractTest
      */
     public function testRuleDoesNotApplyForValidPropertyNameWithNoUnderscoreWhenAllowed()
     {
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new CamelCasePropertyName();
         $rule->setReport($report);
@@ -115,7 +115,7 @@ class CamelCasePropertyNameTest extends AbstractTest
      */
     public function testRuleDoesNotApplyForValidPropertyNameWithUnderscoreWhenAllowed()
     {
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new CamelCasePropertyName();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
@@ -32,7 +32,7 @@ class CamelCaseVariableNameTest extends AbstractTest
      */
     public function testRuleDoesApplyForInvariableNameWithUnderscore()
     {
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new CamelCaseVariableName();
         $rule->setReport($report);
@@ -48,7 +48,7 @@ class CamelCaseVariableNameTest extends AbstractTest
      */
     public function testRuleDoesApplyForVariableNameWithCapital()
     {
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new CamelCaseVariableName();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
@@ -63,7 +63,7 @@ class CamelCaseVariableNameTest extends AbstractTest
      */
     public function testRuleDoesNotApplyForValidVariableName()
     {
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new CamelCaseVariableName();
         $rule->setReport($report);
@@ -78,7 +78,7 @@ class CamelCaseVariableNameTest extends AbstractTest
      */
     public function testRuleDoesNotApplyForStaticVariableAccess()
     {
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new CamelCaseVariableName();
         $rule->setReport($report);
@@ -94,7 +94,7 @@ class CamelCaseVariableNameTest extends AbstractTest
      */
     public function testRuleDoesNotApplyForValidVariableNameWithUnderscoreWhenAllowed()
     {
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new CamelCaseVariableName();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
@@ -35,7 +35,7 @@ class CyclomaticComplexityTest extends AbstractTest
     public function testRuleAppliesForValueGreaterThanThreshold()
     {
         $method = $this->getMethodMock('ccn2', 42);
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new CyclomaticComplexity();
         $rule->setReport($report);
@@ -52,7 +52,7 @@ class CyclomaticComplexityTest extends AbstractTest
     public function testRuleAppliesForValueEqualToThreshold()
     {
         $method = $this->getMethodMock('ccn2', 42);
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new CyclomaticComplexity();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
@@ -69,7 +69,7 @@ class CyclomaticComplexityTest extends AbstractTest
     public function testRuleDoesNotApplyForValueLowerThanThreshold()
     {
         $method = $this->getMethodMock('ccn2', 22);
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new CyclomaticComplexity();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
@@ -46,7 +46,7 @@ class CountInLoopExpressionTest extends AbstractTest
     public function testRuleNotApplyToExpressionElsewhere()
     {
         $rule = new CountInLoopExpression();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -70,7 +70,7 @@ class CountInLoopExpressionTest extends AbstractTest
     public function testMutedRuleAtClassLevel()
     {
         $rule = new CountInLoopExpression();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -82,7 +82,7 @@ class CountInLoopExpressionTest extends AbstractTest
     public function testMutedRuleAtMethodLevel()
     {
         $rule = new CountInLoopExpression();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 }

--- a/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
@@ -48,7 +48,7 @@ class CouplingBetweenObjectsTest extends AbstractTest
     public function testRuleAppliesToClassWithCboEqualToThreshold()
     {
         $rule = new CouplingBetweenObjects();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('cbo', 42));
     }
@@ -61,7 +61,7 @@ class CouplingBetweenObjectsTest extends AbstractTest
     public function testRuleAppliesToClassWithCboGreaterThanThreshold()
     {
         $rule = new CouplingBetweenObjects();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('maximum', '41');
         $rule->apply($this->getClassMock('cbo', 42));
     }

--- a/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
@@ -35,7 +35,7 @@ class CouplingBetweenObjectsTest extends AbstractTest
     public function testRuleNotAppliesToClassWithCboLessThanThreshold()
     {
         $rule = new CouplingBetweenObjects();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('cbo', 41));
     }

--- a/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
@@ -47,7 +47,7 @@ class DepthOfInheritanceTest extends AbstractTest
     public function testRuleAppliesToClassWithNumberOfParentIdenticalToThreshold()
     {
         $rule = new DepthOfInheritance();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('minimum', '42');
         $rule->apply($this->getClassMock('dit', 42));
     }
@@ -60,7 +60,7 @@ class DepthOfInheritanceTest extends AbstractTest
     public function testRuleAppliesToClassWithNumberOfParentGreaterThanThreshold()
     {
         $rule = new DepthOfInheritance();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('minimum', '42');
         $rule->apply($this->getClassMock('dit', 43));
     }

--- a/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
@@ -34,7 +34,7 @@ class DepthOfInheritanceTest extends AbstractTest
     public function testRuleNotAppliesToClassWithNumberOfParentLessThanThreshold()
     {
         $rule = new DepthOfInheritance();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('minimum', '42');
         $rule->apply($this->getClassMock('dit', 41));
     }

--- a/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -49,7 +49,7 @@ class DevelopmentCodeFragmentTest extends AbstractTest
     public function testRuleAppliesToMethodWithSuspectFunctionCall()
     {
         $rule = $this->getRule();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -85,7 +85,7 @@ class DevelopmentCodeFragmentTest extends AbstractTest
     public function testRuleAppliesToFunctionWithSuspectFunctionCall()
     {
         $rule = $this->getRule();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -110,7 +110,7 @@ class DevelopmentCodeFragmentTest extends AbstractTest
     {
         $rule = $this->getRule();
         $rule->addProperty('ignore-namespaces', 'true');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 

--- a/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -37,7 +37,7 @@ class DevelopmentCodeFragmentTest extends AbstractTest
     public function testRuleNotAppliesToMethodWithoutSuspectFunctionCall()
     {
         $rule = $this->getRule();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -73,7 +73,7 @@ class DevelopmentCodeFragmentTest extends AbstractTest
     public function testRuleNotAppliesToFunctionWithoutSuspectFunctionCall()
     {
         $rule = $this->getRule();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -122,7 +122,7 @@ class DevelopmentCodeFragmentTest extends AbstractTest
     public function testRuleNotAppliesToMethodWithinNamespaceByDefault()
     {
         $rule = $this->getRule();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 

--- a/src/test/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
+++ b/src/test/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
@@ -83,7 +83,7 @@ class EmptyCatchBlockTest extends AbstractTest
     public function testRuleWorksWithNestedTryCatchBlocksAndNonSPLExceptions()
     {
         $rule = new EmptyCatchBlock();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 }

--- a/src/test/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
+++ b/src/test/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
@@ -35,7 +35,7 @@ class EmptyCatchBlockTest extends AbstractTest
     public function testRuleNotAppliesToMethodWithoutTryCatchBlock()
     {
         $rule = new EmptyCatchBlock();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -59,7 +59,7 @@ class EmptyCatchBlockTest extends AbstractTest
     public function testRuleNotAppliesToFunctionWithNonEmptyCatchBlock()
     {
         $rule = new EmptyCatchBlock();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -71,7 +71,7 @@ class EmptyCatchBlockTest extends AbstractTest
     public function testRuleNotAppliesToCatchBlockWithComments()
     {
         $rule = new EmptyCatchBlock();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 

--- a/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
@@ -46,7 +46,7 @@ class EvalExpressionTest extends AbstractTest
     public function testRuleAppliesToMethodWithEvalExpression()
     {
         $rule = new EvalExpression();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -82,7 +82,7 @@ class EvalExpressionTest extends AbstractTest
     public function testRuleAppliesToFunctionWithEvalExpression()
     {
         $rule = new EvalExpression();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 

--- a/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
@@ -34,7 +34,7 @@ class EvalExpressionTest extends AbstractTest
     public function testRuleNotAppliesToMethodWithoutEvalExpression()
     {
         $rule = new EvalExpression();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -70,7 +70,7 @@ class EvalExpressionTest extends AbstractTest
     public function testRuleNotAppliesToFunctionWithoutEvalExpression()
     {
         $rule = new EvalExpression();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 

--- a/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
@@ -34,7 +34,7 @@ class ExitExpressionTest extends AbstractTest
     public function testRuleNotAppliesToMethodWithoutExitExpression()
     {
         $rule = new ExitExpression();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -70,7 +70,7 @@ class ExitExpressionTest extends AbstractTest
     public function testRuleNotAppliesToFunctionWithoutExitExpression()
     {
         $rule = new ExitExpression();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 

--- a/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
@@ -46,7 +46,7 @@ class ExitExpressionTest extends AbstractTest
     public function testRuleAppliesToMethodWithExitExpression()
     {
         $rule = new ExitExpression();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -82,7 +82,7 @@ class ExitExpressionTest extends AbstractTest
     public function testRuleAppliesToFunctionWithExitExpression()
     {
         $rule = new ExitExpression();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 

--- a/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
+++ b/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
@@ -48,7 +48,7 @@ class GotoStatementTest extends AbstractTest
     public function testRuleAppliesToMethodWithGotoStatement()
     {
         $rule = new GotoStatement();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -72,7 +72,7 @@ class GotoStatementTest extends AbstractTest
     public function testRuleAppliesToFunctionWithGotoStatement()
     {
         $rule = new GotoStatement();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 }

--- a/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
+++ b/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
@@ -36,7 +36,7 @@ class GotoStatementTest extends AbstractTest
     public function testRuleNotAppliesToMethodWithoutGotoStatement()
     {
         $rule = new GotoStatement();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -60,7 +60,7 @@ class GotoStatementTest extends AbstractTest
     public function testRuleNotAppliesToFunctionWithoutGotoStatement()
     {
         $rule = new GotoStatement();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 

--- a/src/test/php/PHPMD/Rule/Design/LongClassTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongClassTest.php
@@ -71,7 +71,7 @@ class LongClassTest extends AbstractTest
     public function testRuleDoesNotApplyForValueLowerThanThreshold()
     {
         $class  = $this->getClassMock('loc', 22);
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new LongClass();
         $rule->setReport($report);
@@ -88,7 +88,7 @@ class LongClassTest extends AbstractTest
     public function testRuleUsesElocWhenIgnoreWhitespaceSet()
     {
         $class  = $this->getClassMock('eloc', 22);
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new LongClass();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/Design/LongClassTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongClassTest.php
@@ -35,7 +35,7 @@ class LongClassTest extends AbstractTest
     public function testRuleAppliesForValueGreaterThanThreshold()
     {
         $class  = $this->getClassMock('loc', 42);
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new LongClass();
         $rule->setReport($report);
@@ -53,7 +53,7 @@ class LongClassTest extends AbstractTest
     public function testRuleAppliesForValueEqualToThreshold()
     {
         $class  = $this->getClassMock('loc', 42);
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new LongClass();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
@@ -35,7 +35,7 @@ class LongMethodTest extends AbstractTest
     public function testRuleAppliesForValueGreaterThanThreshold()
     {
         $method = $this->getMethodMock('loc', 42);
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new LongMethod();
         $rule->setReport($report);
@@ -53,7 +53,7 @@ class LongMethodTest extends AbstractTest
     public function testRuleAppliesForValueEqualToThreshold()
     {
         $method = $this->getMethodMock('loc', 42);
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new LongMethod();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
@@ -71,7 +71,7 @@ class LongMethodTest extends AbstractTest
     public function testRuleDoesNotApplyForValueLowerThanThreshold()
     {
         $method = $this->getMethodMock('loc', 22);
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new LongMethod();
         $rule->setReport($report);
@@ -88,7 +88,7 @@ class LongMethodTest extends AbstractTest
     public function testRuleUsesElocWhenIgnoreWhitespaceSet()
     {
         $class  = $this->getClassMock('eloc', 22);
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new LongMethod();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
@@ -34,7 +34,7 @@ class LongParameterListTest extends AbstractTest
     public function testApplyIgnoresMethodsWithLessParametersThanMinimum()
     {
         $rule = new LongParameterList();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('minimum', '4');
         $rule->apply($this->createMethod(3));
     }
@@ -73,7 +73,7 @@ class LongParameterListTest extends AbstractTest
     public function testApplyIgnoresFunctionsWithLessParametersThanMinimum()
     {
         $rule = new LongParameterList();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('minimum', '4');
         $rule->apply($this->createFunction(3));
     }

--- a/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
@@ -47,7 +47,7 @@ class LongParameterListTest extends AbstractTest
     public function testApplyReportsMethodsWithIdenticalParametersAndMinimum()
     {
         $rule = new LongParameterList();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('minimum', '3');
         $rule->apply($this->createMethod(3));
     }
@@ -60,7 +60,7 @@ class LongParameterListTest extends AbstractTest
     public function testApplyReportsMethodsWithMoreParametersThanMinimum()
     {
         $rule = new LongParameterList();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('minimum', '3');
         $rule->apply($this->createMethod(42));
     }
@@ -86,7 +86,7 @@ class LongParameterListTest extends AbstractTest
     public function testApplyReportsFunctionsWithIdenticalParametersAndMinimum()
     {
         $rule = new LongParameterList();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('minimum', '3');
         $rule->apply($this->createFunction(3));
     }
@@ -99,7 +99,7 @@ class LongParameterListTest extends AbstractTest
     public function testApplyReportsFunctionsWithMoreParametersThanMinimum()
     {
         $rule = new LongParameterList();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('minimum', '3');
         $rule->apply($this->createFunction(42));
     }

--- a/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
@@ -35,7 +35,7 @@ class NpathComplexityTest extends AbstractTest
     public function testRuleAppliesForValueGreaterThanThreshold()
     {
         $method = $this->getMethodMock('npath', 42);
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new NpathComplexity();
         $rule->setReport($report);
@@ -52,7 +52,7 @@ class NpathComplexityTest extends AbstractTest
     public function testRuleAppliesForValueEqualToThreshold()
     {
         $method = $this->getMethodMock('npath', 42);
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new NpathComplexity();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
@@ -69,7 +69,7 @@ class NpathComplexityTest extends AbstractTest
     public function testRuleDoesNotApplyForValueLowerThanThreshold()
     {
         $method = $this->getMethodMock('npath', 22);
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new NpathComplexity();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
@@ -34,7 +34,7 @@ class NumberOfChildrenTest extends AbstractTest
     public function testRuleNotAppliesToClassWithChildrenLessThanThreshold()
     {
         $rule = new NumberOfChildren();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('minimum', '42');
         $rule->apply($this->getClassMock('nocc', 41));
     }

--- a/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
@@ -47,7 +47,7 @@ class NumberOfChildrenTest extends AbstractTest
     public function testRuleAppliesToClassWithChildrenIdenticalToThreshold()
     {
         $rule = new NumberOfChildren();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('minimum', '42');
         $rule->apply($this->getClassMock('nocc', 42));
     }
@@ -60,7 +60,7 @@ class NumberOfChildrenTest extends AbstractTest
     public function testRuleAppliesToClassWithChildrenGreaterThanThreshold()
     {
         $rule = new NumberOfChildren();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('minimum', '42');
         $rule->apply($this->getClassMock('nocc', 43));
     }

--- a/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
@@ -60,7 +60,7 @@ class TooManyFieldsTest extends AbstractTest
     public function testRuleAppliesToClassesWithMoreFieldsThanThreshold()
     {
         $rule = new TooManyFields();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('maxfields', '23');
         $rule->apply($this->getClassMock('vars', 42));
     }

--- a/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
@@ -34,7 +34,7 @@ class TooManyFieldsTest extends AbstractTest
     public function testRuleDoesNotApplyToClassesWithLessFieldsThanThreshold()
     {
         $rule = new TooManyFields();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxfields', '42');
         $rule->apply($this->getClassMock('vars', 23));
     }
@@ -47,7 +47,7 @@ class TooManyFieldsTest extends AbstractTest
     public function testRuleDoesNotApplyToClassesWithSameNumberOfFieldsAsThreshold()
     {
         $rule = new TooManyFields();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxfields', '42');
         $rule->apply($this->getClassMock('vars', 42));
     }

--- a/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -34,7 +34,7 @@ class TooManyMethodsTest extends AbstractTest
     public function testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold()
     {
         $rule = new TooManyMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '42');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(23));
@@ -48,7 +48,7 @@ class TooManyMethodsTest extends AbstractTest
     public function testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold()
     {
         $rule = new TooManyMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '42');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(42));
@@ -76,7 +76,7 @@ class TooManyMethodsTest extends AbstractTest
     public function testRuleIgnoresGetterMethodsInTest()
     {
         $rule = new TooManyMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, array('invoke', 'getClass')));
@@ -90,7 +90,7 @@ class TooManyMethodsTest extends AbstractTest
     public function testRuleIgnoresSetterMethodsInTest()
     {
         $rule = new TooManyMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, array('invoke', 'setClass')));
@@ -104,7 +104,7 @@ class TooManyMethodsTest extends AbstractTest
     public function testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven()
     {
         $rule = new TooManyMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, array('invoke', 'injectClass')));
@@ -118,7 +118,7 @@ class TooManyMethodsTest extends AbstractTest
     public function testRuleIgnoresGetterAndSetterMethodsInTest()
     {
         $rule = new TooManyMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '2');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(3, array('invoke', 'getClass', 'setClass')));
@@ -130,7 +130,7 @@ class TooManyMethodsTest extends AbstractTest
     public function testRuleIgnoresHassers()
     {
         $rule = new TooManyMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
         $rule->apply($this->createClassMock(2, array('invoke', 'hasClass')));
@@ -142,7 +142,7 @@ class TooManyMethodsTest extends AbstractTest
     public function testRuleIgnoresIssers()
     {
         $rule = new TooManyMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
         $rule->apply($this->createClassMock(2, array('invoke', 'isClass')));
@@ -154,7 +154,7 @@ class TooManyMethodsTest extends AbstractTest
     public function testRuleIgnoresWithers()
     {
         $rule = new TooManyMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
         $rule->apply($this->createClassMock(2, array('invoke', 'withClass')));

--- a/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -62,7 +62,7 @@ class TooManyMethodsTest extends AbstractTest
     public function testRuleAppliesToClassesWithMoreMethodsThanThreshold()
     {
         $rule = new TooManyMethods();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('maxmethods', '23');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));

--- a/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -35,7 +35,7 @@ class TooManyPublicMethodsTest extends AbstractTest
     public function testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold()
     {
         $rule = new TooManyPublicMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '42');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(23));
@@ -47,7 +47,7 @@ class TooManyPublicMethodsTest extends AbstractTest
     public function testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold()
     {
         $rule = new TooManyPublicMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '42');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(42));
@@ -71,7 +71,7 @@ class TooManyPublicMethodsTest extends AbstractTest
     public function testRuleIgnoresGetterMethodsInTest()
     {
         $rule = new TooManyPublicMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, array('invoke', 'getClass')));
@@ -83,7 +83,7 @@ class TooManyPublicMethodsTest extends AbstractTest
     public function testRuleIgnoresSetterMethodsInTest()
     {
         $rule = new TooManyPublicMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, array('invoke', 'setClass')));
@@ -95,7 +95,7 @@ class TooManyPublicMethodsTest extends AbstractTest
     public function testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven()
     {
         $rule = new TooManyPublicMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, array('invoke', 'injectClass')));
@@ -107,7 +107,7 @@ class TooManyPublicMethodsTest extends AbstractTest
     public function testRuleIgnoresGetterAndSetterMethodsInTest()
     {
         $rule = new TooManyPublicMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '2');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(3, array('foo', 'bar'), array('baz', 'bah')));
@@ -119,7 +119,7 @@ class TooManyPublicMethodsTest extends AbstractTest
     public function testRuleIgnoresPrivateMethods()
     {
         $rule = new TooManyPublicMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '2');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, array('invoke', 'getClass', 'setClass')));
@@ -131,7 +131,7 @@ class TooManyPublicMethodsTest extends AbstractTest
     public function testRuleIgnoresHassers()
     {
         $rule = new TooManyPublicMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
         $rule->apply($this->createClassMock(2, array('invoke', 'hasClass')));
@@ -143,7 +143,7 @@ class TooManyPublicMethodsTest extends AbstractTest
     public function testRuleIgnoresIssers()
     {
         $rule = new TooManyPublicMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
         $rule->apply($this->createClassMock(2, array('invoke', 'isClass')));
@@ -155,7 +155,7 @@ class TooManyPublicMethodsTest extends AbstractTest
     public function testRuleIgnoresWithers()
     {
         $rule = new TooManyPublicMethods();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maxmethods', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
         $rule->apply($this->createClassMock(2, array('invoke', 'withClass')));

--- a/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -59,7 +59,7 @@ class TooManyPublicMethodsTest extends AbstractTest
     public function testRuleAppliesToClassesWithMoreMethodsThanThreshold()
     {
         $rule = new TooManyPublicMethods();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('maxmethods', '23');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));

--- a/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
+++ b/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
@@ -68,7 +68,7 @@ class WeightedMethodCountTest extends AbstractTest
     public function testRuleNotAppliesForValueLowerThanThreshold()
     {
         $class  = $this->getClassMock('wmc', 42);
-        $report = $this->getReportMock(0);
+        $report = $this->getReportWithNoViolation();
 
         $rule = new WeightedMethodCount();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
+++ b/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
@@ -36,7 +36,7 @@ class WeightedMethodCountTest extends AbstractTest
     public function testRuleAppliesForValueGreaterThanThreshold()
     {
         $class  = $this->getClassMock('wmc', 42);
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new WeightedMethodCount();
         $rule->setReport($report);
@@ -52,7 +52,7 @@ class WeightedMethodCountTest extends AbstractTest
     public function testRuleAppliesForValueEqualToThreshold()
     {
         $class  = $this->getClassMock('wmc', 42);
-        $report = $this->getReportMock(1);
+        $report = $this->getReportWithOneViolation();
 
         $rule = new WeightedMethodCount();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
+++ b/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
@@ -34,7 +34,7 @@ class ExcessivePublicCountTest extends AbstractTest
     public function testRuleDoesNotApplyToClassesWithLessPublicMembersThanThreshold()
     {
         $rule = new ExcessivePublicCount();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('minimum', '42');
         $rule->apply($this->getClassMock('cis', 23));
     }

--- a/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
+++ b/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
@@ -47,7 +47,7 @@ class ExcessivePublicCountTest extends AbstractTest
     public function testRuleAppliesToClassesWithSameNumberOfPublicMembersAsThreshold()
     {
         $rule = new ExcessivePublicCount();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('minimum', '42');
         $rule->apply($this->getClassMock('cis', 42));
     }
@@ -60,7 +60,7 @@ class ExcessivePublicCountTest extends AbstractTest
     public function testRuleAppliesToClassesWithMorePublicMembersThanThreshold()
     {
         $rule = new ExcessivePublicCount();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->addProperty('minimum', '23');
         $rule->apply($this->getClassMock('cis', 42));
     }

--- a/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
@@ -87,7 +87,7 @@ class BooleanGetMethodNameTest extends AbstractTest
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'true');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
 
         $rule->apply($this->getMethod());
     }
@@ -101,7 +101,7 @@ class BooleanGetMethodNameTest extends AbstractTest
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
 
         $rule->apply($this->getMethod());
     }
@@ -115,7 +115,7 @@ class BooleanGetMethodNameTest extends AbstractTest
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
 
         $rule->apply($this->getMethod());
     }
@@ -129,7 +129,7 @@ class BooleanGetMethodNameTest extends AbstractTest
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
 
         $rule->apply($this->getMethod());
     }

--- a/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
@@ -35,7 +35,7 @@ class BooleanGetMethodNameTest extends AbstractTest
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -48,7 +48,7 @@ class BooleanGetMethodNameTest extends AbstractTest
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -61,7 +61,7 @@ class BooleanGetMethodNameTest extends AbstractTest
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -74,7 +74,7 @@ class BooleanGetMethodNameTest extends AbstractTest
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 

--- a/src/test/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
@@ -58,7 +58,7 @@ class ConstantNamingConventionsTest extends AbstractTest
     public function testRuleNotAppliesToClassConstantWithUpperCaseCharacters()
     {
         $rule = new ConstantNamingConventions();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -70,7 +70,7 @@ class ConstantNamingConventionsTest extends AbstractTest
     public function testRuleNotAppliesToInterfaceConstantWithUpperCaseCharacters()
     {
         $rule = new ConstantNamingConventions();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getInterface());
     }
 }

--- a/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
@@ -34,7 +34,7 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTest
     public function testRuleAppliesToConstructorMethodNamedAsEnclosingClass()
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -46,7 +46,7 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTest
     public function testRuleAppliesToConstructorMethodNamedAsEnclosingClassCaseInsensitive()
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 

--- a/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
@@ -58,21 +58,21 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTest
     public function testRuleNotAppliesToMethodNamedSimilarToEnclosingClass()
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
     public function testRuleNotAppliesToMethodNamedAsEnclosingInterface()
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
     public function testRuleNotAppliesToMethodInNamespaces()
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 }

--- a/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
@@ -48,7 +48,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -61,7 +61,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 6);
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -87,7 +87,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -119,7 +119,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 6);
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -132,7 +132,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -164,7 +164,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -190,7 +190,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 6);
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -203,7 +203,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 8);
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -235,7 +235,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 3);
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 

--- a/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
@@ -35,7 +35,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -74,7 +74,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -100,7 +100,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
 
         $class = $this->getClass();
         $rule->apply($class);
@@ -145,7 +145,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 3);
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
 
         $class = $this->getClass();
         $rule->apply($class);
@@ -177,7 +177,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -280,7 +280,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -294,7 +294,7 @@ class LongVariableTest extends AbstractTest
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 }

--- a/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
@@ -50,7 +50,7 @@ class ShortMethodNameTest extends AbstractTest
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 52);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -64,7 +64,7 @@ class ShortMethodNameTest extends AbstractTest
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 54);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
     /**
@@ -91,7 +91,7 @@ class ShortMethodNameTest extends AbstractTest
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 50);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -105,7 +105,7 @@ class ShortMethodNameTest extends AbstractTest
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 52);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -119,7 +119,7 @@ class ShortMethodNameTest extends AbstractTest
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 100);
         $rule->addProperty('exceptions', 'testRuleNotAppliesToMethodWithShortNameWhenException,another');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -135,7 +135,7 @@ class ShortMethodNameTest extends AbstractTest
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 100);
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethodMock());
     }
 }

--- a/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
@@ -36,7 +36,7 @@ class ShortMethodNameTest extends AbstractTest
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 54);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -77,7 +77,7 @@ class ShortMethodNameTest extends AbstractTest
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 52);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -37,7 +37,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -79,7 +79,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -107,7 +107,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
 
         $class = $this->getClass();
         $rule->apply($class);
@@ -155,7 +155,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
 
         $class = $this->getClass();
         $rule->apply($class);
@@ -189,7 +189,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -51,7 +51,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 2);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -65,7 +65,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -93,7 +93,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -127,7 +127,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -141,7 +141,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 2);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -175,7 +175,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 2);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -203,7 +203,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -217,7 +217,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 2);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -251,7 +251,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -265,7 +265,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -279,7 +279,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -293,7 +293,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -341,7 +341,7 @@ class ShortVariableTest extends AbstractTest
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', 'id');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
 
         $rule->apply($this->getClass());
     }

--- a/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -112,7 +112,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleNotAppliesToFormalParameterUsedInPropertyCompoundVariable()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -132,7 +132,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleNotAppliesToFormalParameterUsedInMethodCompoundVariable()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -144,7 +144,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToAbstractMethodFormalParameter()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -156,7 +156,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToInterfaceMethodFormalParameter()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -168,7 +168,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToInnerFunctionDeclaration()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -189,7 +189,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToFormalParameterUsedInCompoundExpression()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -209,7 +209,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToMethodArgument()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -221,7 +221,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToMethodArgumentUsedAsArrayIndex()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -241,7 +241,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToParameterUsedAsArrayIndex()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -261,7 +261,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToParameterUsedAsStringIndex()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -285,7 +285,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToMethodWithFuncGetArgs()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -297,7 +297,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testFuncGetArgsRuleWorksCaseInsensitive()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -310,7 +310,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToInheritMethod()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -323,7 +323,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToImplementedAbstractMethod()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -336,7 +336,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToImplementedInterfaceMethod()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -352,7 +352,7 @@ class UnusedFormalParameterTest extends AbstractTest
         });
 
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply(reset($methods));
     }
 
@@ -362,7 +362,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToMethodWithInheritdocAnnotation()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -372,7 +372,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -384,7 +384,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testCompactFunctionRuleDoesNotApply()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -408,7 +408,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testCompactFunctionRuleWorksCaseInsensitive()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -420,7 +420,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testNamespacedCompactFunctionRuleDoesNotApply()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -444,7 +444,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testNamespacedCompactFunctionRuleWorksCaseInsensitive()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -464,7 +464,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToFormalParameterUsedInStringCompoundVariable()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -488,7 +488,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleDoesNotApplyToFormalParameterUsedAsParameterInStringCompoundVariable()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 }

--- a/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -35,7 +35,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleAppliesToFunctionUnusedFormalParameter()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -59,7 +59,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleAppliesToMethodUnusedFormalParameter()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -92,7 +92,7 @@ class UnusedFormalParameterTest extends AbstractTest
     public function testRuleAppliesToFormalParameterWhenSimilarStaticMemberIsAccessed()
     {
         $rule = new UnusedFormalParameter();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 

--- a/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
@@ -117,7 +117,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -141,7 +141,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -154,7 +154,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -167,7 +167,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -180,7 +180,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -202,7 +202,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -215,7 +215,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -228,7 +228,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -241,7 +241,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -254,7 +254,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -267,7 +267,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -280,7 +280,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -293,7 +293,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -306,7 +306,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -319,7 +319,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -332,7 +332,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -345,7 +345,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -358,7 +358,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -371,7 +371,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -384,7 +384,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -397,7 +397,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -410,7 +410,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -423,7 +423,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -446,7 +446,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -485,7 +485,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'true');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -499,7 +499,7 @@ class UnusedLocalVariableTest extends AbstractTest
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
         $rule->addProperty('exceptions', '_');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -513,7 +513,7 @@ class UnusedLocalVariableTest extends AbstractTest
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
         $rule->addProperty('exceptions', '_');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -540,7 +540,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'true');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -563,7 +563,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -586,7 +586,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -608,7 +608,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -621,7 +621,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -645,7 +645,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -658,7 +658,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 

--- a/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
@@ -36,7 +36,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -49,7 +49,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
@@ -72,7 +72,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -95,7 +95,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -459,7 +459,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -472,7 +472,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -527,7 +527,7 @@ class UnusedLocalVariableTest extends AbstractTest
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
         $rule->addProperty('exceptions', '_');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
@@ -671,7 +671,7 @@ class UnusedLocalVariableTest extends AbstractTest
     {
         $rule = new UnusedLocalVariable();
         $rule->addProperty('allow-unused-foreach-variables', 'false');
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 }

--- a/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
@@ -138,7 +138,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleDoesNotApplyToUnusedPublicField()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -150,7 +150,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleDoesNotApplyToUnusedProtectedField()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -162,7 +162,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleDoesNotApplyToThisAccessedPrivateField()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -174,7 +174,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleDoesNotApplyToSelfAccessedPrivateField()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -186,7 +186,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleDoesNotApplyToStaticAccessedPrivateField()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -198,7 +198,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleDoesNotApplyToClassNameAccessedPrivateField()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -220,7 +220,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleDoesNotApplyToPrivateFieldInChainedMethodCall()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -242,7 +242,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleDoesNotApplyToPrivateArrayFieldAccess()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -264,7 +264,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleDoesNotApplyToPrivateStringIndexFieldAccess()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -276,7 +276,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleDoesNotApplyToFieldWithMethodsThatReturnArray()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 }

--- a/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
@@ -34,7 +34,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleAppliesToUnusedPrivateField()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -46,7 +46,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleAppliesWhenFieldWithSameNameIsAccessedOnDifferentObject()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -58,7 +58,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleAppliesToUnusedPrivateStaticField()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -70,7 +70,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnDifferentClass()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -82,7 +82,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnParent()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -104,7 +104,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleAppliesWhenLocalVariableIsUsedInStaticMemberPrefix()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -126,7 +126,7 @@ class UnusedPrivateFieldTest extends AbstractTest
     public function testRuleDoesNotResultInFatalErrorByCallingNonObject()
     {
         $rule = new UnusedPrivateField();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 

--- a/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
@@ -128,7 +128,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleDoesNotApplyToPrivateConstructor()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -140,7 +140,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleDoesNotApplyToPrivatePhp4Constructor()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -152,7 +152,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleDoesNotApplyToPrivateCloneMethod()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -164,7 +164,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleDoesNotApplyToThisReferencedMethod()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -176,7 +176,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleDoesNotApplyToSelfReferencedMethod()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -188,7 +188,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleDoesNotApplyToStaticReferencedMethod()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -200,7 +200,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleDoesNotApplyToClassNameReferencedMethod()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -223,7 +223,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleDoesNotApplyToPrivateMethodInChainedMethodCall()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 
@@ -235,7 +235,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(0));
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
 }

--- a/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
@@ -34,7 +34,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleAppliesToUnusedPrivateMethod()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -46,7 +46,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleAppliesToUnusedStaticPrivateMethod()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -58,7 +58,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleAppliesToParentReferencedUnusedPrivateMethod()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -70,7 +70,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleAppliesWhenMethodIsReferencedOnDifferentObject()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -82,7 +82,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleAppliesWhenMethodIsReferencedOnDifferentClass()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -94,7 +94,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleAppliesWhenPropertyWithSimilarNameIsReferenced()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 
@@ -116,7 +116,7 @@ class UnusedPrivateMethodTest extends AbstractTest
     public function testRuleAppliesWhenMethodWithSimilarNameIsInInvocationChain()
     {
         $rule = new UnusedPrivateMethod();
-        $rule->setReport($this->getReportMock(1));
+        $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getClass());
     }
 

--- a/src/test/php/PHPMD/RuleSetTest.php
+++ b/src/test/php/PHPMD/RuleSetTest.php
@@ -58,7 +58,7 @@ class RuleSetTest extends AbstractTest
     public function testApplyNotInvokesRuleWhenSuppressAnnotationExists()
     {
         $ruleSet = $this->createRuleSetFixture(__FUNCTION__);
-        $ruleSet->setReport($this->getReportMock(0));
+        $ruleSet->setReport($this->getReportWithNoViolation());
         $ruleSet->apply($this->getClass());
 
         $this->assertNull($ruleSet->getRuleByName(__FUNCTION__)->node);
@@ -72,7 +72,7 @@ class RuleSetTest extends AbstractTest
     public function testApplyInvokesRuleWhenStrictModeIsSet()
     {
         $ruleSet = $this->createRuleSetFixture(__FUNCTION__);
-        $ruleSet->setReport($this->getReportMock(0));
+        $ruleSet->setReport($this->getReportWithNoViolation());
         $ruleSet->setStrict();
 
         $class = $this->getClass();


### PR DESCRIPTION
Two remarks

1. We slightly change the previous behavior which allowed any value below zero to be understood as "at least once". I think there should be one valid value for this intention, instead. Alternatively, we could deprecate this usage with a warning.
2. The "at least once" case using ``$this->getReportMock(-*)`` was actually never used. The reason for this can be twofold, in my opinion:
2.1. There is (currently) actually no use case for this. May be but unlikely.
2.2. This feature was simply overlooked as the current API was not very expressive. Having a dedicated method increases the visibility of this feature.