### PR TITLE
Fix #718 Handle anonymous class in "undefined variable" rule

### DIFF
--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -71,6 +71,11 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
         }
     }
 
+    /**
+     * Collect variables defined inside a PHPMD entry node (such as MethodNode).
+     *
+     * @param AbstractNode $node
+     */
     private function collect(AbstractNode $node) {
         $this->collectPropertyPostfix($node);
         $this->collectClosureParameters($node);

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\CleanCode;
 
+use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTUnaryExpression;
 use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\State;
@@ -52,14 +53,13 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
     {
         $this->images = array();
 
-        $this->collectPropertyPostfix($node);
-        $this->collectClosureParameters($node);
-        $this->collectForeachStatements($node);
-        $this->collectListExpressions($node);
-        $this->collectAssignments($node);
-        $this->collectParameters($node);
-        $this->collectExceptionCatches($node);
-        $this->collectGlobalStatements($node);
+        $this->collect($node);
+
+        foreach ($node->findChildrenOfType('Class') as $class) {
+            foreach ($class->getMethods() as $method) {
+                $this->collect(new MethodNode($method));
+            }
+        }
 
         foreach ($node->findChildrenOfType('Variable') as $variable) {
             if (! $this->isNotSuperGlobal($variable)) {
@@ -69,6 +69,17 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
                 $this->addViolation($variable, array($variable->getImage()));
             }
         }
+    }
+
+    private function collect(AbstractNode $node) {
+        $this->collectPropertyPostfix($node);
+        $this->collectClosureParameters($node);
+        $this->collectForeachStatements($node);
+        $this->collectListExpressions($node);
+        $this->collectAssignments($node);
+        $this->collectParameters($node);
+        $this->collectExceptionCatches($node);
+        $this->collectGlobalStatements($node);
     }
 
     /**

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToVariablesUsedInAnonymousClass.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToVariablesUsedInAnonymousClass.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyToVariablesUsedInAnonymousClass
+{
+    function testRuleDoesNotApplyToVariablesUsedInAnonymousClass()
+    {
+        return new class() {
+            public function checkFoo(User $user): bool
+            {
+                return $user->addFailedLoginAttempt() > 1;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix #718
Breaking change: no

This makes that:
```php
return new class() {
    public function checkFoo(User $user): bool
    {
        return $user->addFailedLoginAttempt() > 1;
    }
};
```
no longer trigger the "undefined variable" rule.