### PR TITLE
Removal of PEAR related Code

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,7 +4,7 @@ project.name      = phpmd
 project.version   = 2.8.1
 project.stability = stable
 
-# Disable pear support
+# Disable pear support. This cannot be removed as long as setup tool is used
 project.pear.uri = pear.example.com
 
 vendor.dir.includes = symfony/**/*,composer/**/*,pdepend/**/*,autoload.php

--- a/src/bin/phpmd
+++ b/src/bin/phpmd
@@ -24,17 +24,6 @@ if (file_exists(__DIR__ . '/../../../../autoload.php')) {
     require_once __DIR__ . '/../../../../autoload.php';
 } else {
     require_once __DIR__ . '/../../vendor/autoload.php';
-
-    // PEAR installation workaround
-    if (strpos('@package_version@', '@package_version') === 0) {
-        set_include_path(
-            dirname(__FILE__) . '/../main/php' .
-            PATH_SEPARATOR .
-            dirname(__FILE__) . '/../../vendor/pdepend/pdepend/src/main/php' .
-            PATH_SEPARATOR .
-            '.'
-        );
-    }
 }
 
 // Restart if xdebug is loading, unless the environment variable PHPMD_ALLOW_XDEBUG is set.

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -32,12 +32,11 @@ class RuleSetFactory
     private $strict = false;
 
     /**
-     * The data directory set by PEAR or a dynamic property set within the class
-     * constructor.
+     * The data directory set within the class constructor.
      *
      * @var string
      */
-    private $location = '@data_dir@';
+    private $location;
 
     /**
      * The minimum priority for rules to load.
@@ -58,12 +57,7 @@ class RuleSetFactory
      */
     public function __construct()
     {
-        // PEAR installer workaround
-        if (strpos($this->location, '@data_dir') === 0) {
-            $this->location = __DIR__ . '/../../resources';
-            return;
-        }
-        $this->location .= '/PHPMD/resources';
+        $this->location = __DIR__ . '/../../resources';
     }
 
     /**

--- a/src/site/rst/download/releases/1.0.0/changelog.rst
+++ b/src/site/rst/download/releases/1.0.0/changelog.rst
@@ -21,10 +21,8 @@ Bugfixes
 Download
 --------
 
-You can download release 1.0.1 through PHPMD's `PEAR Channel Server`__ or you
-can download the release as a `Phar archive`__
+You can download release 1.0.1 as a `Phar archive`__
 
 __ https://www.pivotaltracker.com/story/show/9626017
 __ https://github.com/phpmd/phpmd/commit/b385f15
-__ http://pear.phpmd.org
 __ http://static.phpmd.org/php/1.0.1/phpmd.phar

--- a/src/site/rst/download/releases/1.0.1/changelog.rst
+++ b/src/site/rst/download/releases/1.0.1/changelog.rst
@@ -22,12 +22,10 @@ Bugfixes
 Download
 --------
 
-You can download release 1.0.1 through PHPMD's `PEAR Channel Server`__ or you
-can download the release as a `Phar archive`__
+You can download release 1.0.1 as a `Phar archive`__
 
 __ https://www.pivotaltracker.com/story/show/9930643
 __ https://github.com/phpmd/phpmd/commit/531be78
 __ https://www.pivotaltracker.com/story/show/9626017
 __ https://github.com/phpmd/phpmd/commit/b385f15
-__ http://pear.phpmd.org
 __ http://static.phpmd.org/php/1.0.1/phpmd.phar

--- a/src/site/rst/download/releases/1.1.0/changelog.rst
+++ b/src/site/rst/download/releases/1.1.0/changelog.rst
@@ -40,8 +40,7 @@ Bugfixes
 Download
 --------
 
-You can download release 1.1.0 through PHPMD's `PEAR Channel Server`__ or you
-can download the release as a `Phar archive`__
+You can download release 1.1.0 as a `Phar archive`__
 
 __ http://pdepend.org/documentation/software-metrics/coupling-between-objects.html
 __ https://www.pivotaltracker.com/story/show/10474873
@@ -52,5 +51,4 @@ __ https://www.pivotaltracker.com/story/show/11012465
 __ https://github.com/phpmd/phpmd/commit/4adb88d
 __ https://www.pivotaltracker.com/story/show/10096717
 __ https://github.com/phpmd/phpmd/commit/f063bc9
-__ http://pear.phpmd.org
 __ http://static.phpmd.org/php/1.1.0/phpmd.phar

--- a/src/site/rst/download/releases/1.1.1/changelog.rst
+++ b/src/site/rst/download/releases/1.1.1/changelog.rst
@@ -21,8 +21,6 @@ Bugfixes
 Download
 --------
 
-You can download release 1.1.0 through PHPMD's `PEAR Channel Server`__ or you
-can download the release as a `Phar archive`__
+You can download release 1.1.0 as a `Phar archive`__
 
-__ http://pear.phpmd.org
 __ http://static.phpmd.org/php/1.1.0/phpmd.phar


### PR DESCRIPTION
Type: refactoring
Issue: Resolves none
Breaking change: no

Some of this code was introduced over 11 years ago and is now superfluous as we removed the support for PEAR quite some time ago.

Not ready, yet.