### PR TITLE
Rename setIgnorePattern to addIgnorePatterns and getIgnorePattern to …

### DIFF
--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -114,8 +114,23 @@ class PHPMD
      *
      * @return string[]
      * @since 0.2.0
+     *
+     * @deprecated
+     * @see getIgnorePatterns
      */
     public function getIgnorePattern()
+    {
+        return $this->getIgnorePatterns();
+    }
+
+
+    /**
+     * Returns an array with string patterns that mark a file path as invalid.
+     *
+     * @return string[]
+     * @since 0.2.0
+     */
+    public function getIgnorePatterns()
     {
         return $this->ignorePatterns;
     }
@@ -126,8 +141,24 @@ class PHPMD
      *
      * @param array<string> $ignorePatterns List of ignore patterns.
      * @return void
+     *
+     * @deprecated
+     * @see addIgnorePatterns
      */
     public function setIgnorePattern(array $ignorePatterns)
+    {
+        $this->addIgnorePatterns($ignorePatterns);
+    }
+
+
+    /**
+     * Add a list of ignore patterns that is used to exclude directories from
+     * the source analysis.
+     *
+     * @param array<string> $ignorePatterns List of ignore patterns.
+     * @return void
+     */
+    public function addIgnorePatterns(array $ignorePatterns)
     {
         $this->ignorePatterns = array_merge(
             $this->ignorePatterns,
@@ -175,7 +206,7 @@ class PHPMD
     ) {
 
         // Merge parsed excludes
-        $this->setIgnorePattern($ruleSetFactory->getIgnorePattern($ruleSets));
+        $this->addIgnorePatterns($ruleSetFactory->getIgnorePattern($ruleSets));
 
         $this->input = $inputPath;
 

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -114,9 +114,7 @@ class PHPMD
      *
      * @return string[]
      * @since 0.2.0
-     *
-     * @deprecated
-     * @see getIgnorePatterns
+     * @deprecated 3.0.0 Use getIgnorePatterns() instead, you always get a list of patterns.
      */
     public function getIgnorePattern()
     {
@@ -125,10 +123,10 @@ class PHPMD
 
 
     /**
-     * Returns an array with string patterns that mark a file path as invalid.
+     * Returns an array with string patterns that mark a file path invalid.
      *
      * @return string[]
-     * @since 0.2.0
+     * @since 2.9.0
      */
     public function getIgnorePatterns()
     {
@@ -141,9 +139,7 @@ class PHPMD
      *
      * @param array<string> $ignorePatterns List of ignore patterns.
      * @return void
-     *
-     * @deprecated
-     * @see addIgnorePatterns
+     * @deprecated 3.0.0 Use addIgnorePatterns() instead, both will add an not set the patterns.
      */
     public function setIgnorePattern(array $ignorePatterns)
     {
@@ -152,11 +148,12 @@ class PHPMD
 
 
     /**
-     * Add a list of ignore patterns that is used to exclude directories from
+     * Add a list of ignore patterns which is used to exclude directories from
      * the source analysis.
      *
      * @param array<string> $ignorePatterns List of ignore patterns.
-     * @return void
+     * @return self
+     * @since 2.9.0
      */
     public function addIgnorePatterns(array $ignorePatterns)
     {
@@ -164,6 +161,7 @@ class PHPMD
             $this->ignorePatterns,
             $ignorePatterns
         );
+        return $this;
     }
 
     /**

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -150,7 +150,7 @@ class PHPMD
      * the source analysis.
      *
      * @param array<string> $ignorePatterns List of ignore patterns.
-     * @return self
+     * @return $this
      * @since 2.9.0
      */
     public function addIgnorePatterns(array $ignorePatterns)
@@ -159,6 +159,7 @@ class PHPMD
             $this->ignorePatterns,
             $ignorePatterns
         );
+
         return $this;
     }
 

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -121,7 +121,6 @@ class PHPMD
         return $this->getIgnorePatterns();
     }
 
-
     /**
      * Returns an array with string patterns that mark a file path invalid.
      *
@@ -145,7 +144,6 @@ class PHPMD
     {
         $this->addIgnorePatterns($ignorePatterns);
     }
-
 
     /**
      * Add a list of ignore patterns which is used to exclude directories from

--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -120,9 +120,9 @@ class ParserFactory
      */
     private function initIgnores(Engine $pdepend, PHPMD $phpmd)
     {
-        if (count($phpmd->getIgnorePattern()) > 0) {
+        if (count($phpmd->getIgnorePatterns()) > 0) {
             $pdepend->addFileFilter(
-                new ExcludePathFilter($phpmd->getIgnorePattern())
+                new ExcludePathFilter($phpmd->getIgnorePatterns())
             );
         }
     }

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -95,7 +95,7 @@ class Command
 
         $ignore = $opts->getIgnore();
         if ($ignore !== null) {
-            $phpmd->setIgnorePattern(explode(',', $ignore));
+            $phpmd->addIgnorePatterns(explode(',', $ignore));
         }
 
         $phpmd->processFiles(

--- a/src/test/php/PHPMD/ParserFactoryTest.php
+++ b/src/test/php/PHPMD/ParserFactoryTest.php
@@ -140,10 +140,10 @@ class ParserFactoryTest extends AbstractTest
 
         $phpmd = $this->getMockFromBuilder(
             $this->getMockBuilder('PHPMD\\PHPMD')
-                ->setMethods(array('getIgnorePattern', 'getInput'))
+                ->setMethods(array('getIgnorePatterns', 'getInput'))
         );
         $phpmd->expects($this->exactly(2))
-            ->method('getIgnorePattern')
+            ->method('getIgnorePatterns')
             ->will($this->returnValue(array('Test')));
         $phpmd->expects($this->once())
             ->method('getInput')


### PR DESCRIPTION
…getIgnorePatterns so they are less confusion.

Type: refactoring
Issue: Pointed out in #744 and #746 we found it a good idea to give the functions a less confusing name and deprecate the old names.
Breaking change: no 

Deprecate: getIgnorePattern and setIgnorePattern on PHPMD\PHPMD
