### PR TITLE
Thorough Code Style Fixes

### DIFF
--- a/src/bin/phpmd
+++ b/src/bin/phpmd
@@ -53,7 +53,7 @@ if (extension_loaded('suhosin') && is_numeric(ini_get('suhosin.memory_limit'))) 
 if (!isset($_SERVER['argv']) && !isset($argv)) {
     fwrite(STDERR, 'Please enable the "register_argc_argv" directive in your php.ini', PHP_EOL);
     exit(1);
-} else if (!isset($argv)) {
+} elseif (!isset($argv)) {
     $argv = $_SERVER['argv'];
 }
 

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -65,6 +65,7 @@ abstract class AbstractNode
                 sprintf('Invalid method %s() called.', $name)
             );
         }
+
         return call_user_func_array(array($node, $name), $args);
     }
 
@@ -80,6 +81,7 @@ abstract class AbstractNode
         if ($node === null) {
             return null;
         }
+
         return new ASTNode($node, $this->getFileName());
     }
 
@@ -144,6 +146,7 @@ abstract class AbstractNode
     public function isInstanceOf($type)
     {
         $class = 'PDepend\Source\AST\AST' . $type;
+
         return ($this->node instanceof $class);
     }
 
@@ -216,6 +219,7 @@ abstract class AbstractNode
     public function getType()
     {
         $type = explode('\\', get_class($this));
+
         return preg_replace('(node$)', '', strtolower(array_pop($type)));
     }
 
@@ -231,6 +235,7 @@ abstract class AbstractNode
         if (isset($this->metrics[$name])) {
             return $this->metrics[$name];
         }
+
         return null;
     }
 

--- a/src/main/php/PHPMD/Node/AbstractNode.php
+++ b/src/main/php/PHPMD/Node/AbstractNode.php
@@ -43,6 +43,7 @@ abstract class AbstractNode extends \PHPMD\AbstractNode
         if ($this->annotations === null) {
             $this->annotations = new Annotations($this);
         }
+
         return $this->annotations->suppresses($rule);
     }
 }

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -53,6 +53,7 @@ abstract class AbstractTypeNode extends AbstractNode
         foreach ($this->node->getMethods() as $method) {
             $methods[] = new MethodNode($method);
         }
+
         return $methods;
     }
 
@@ -68,6 +69,7 @@ abstract class AbstractTypeNode extends AbstractNode
         foreach ($this->node->getMethods() as $method) {
             $names[] = $method->getName();
         }
+
         return $names;
     }
 

--- a/src/main/php/PHPMD/Node/Annotation.php
+++ b/src/main/php/PHPMD/Node/Annotation.php
@@ -66,6 +66,7 @@ class Annotation
         if (lcfirst($this->name) === self::SUPPRESS_ANNOTATION) {
             return $this->isSuppressed($rule);
         }
+
         return false;
     }
 
@@ -82,6 +83,7 @@ class Annotation
         } elseif (preg_match('/^(PH)?PMD\.' . $rule->getName() . '/', $this->value)) {
             return true;
         }
+
         return (stripos($rule->getName(), $this->value) !== false);
     }
 }

--- a/src/main/php/PHPMD/Node/Annotations.php
+++ b/src/main/php/PHPMD/Node/Annotations.php
@@ -67,6 +67,7 @@ class Annotations
                 return true;
             }
         }
+
         return false;
     }
 }

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -27,7 +27,7 @@ use PHPMD\Rule;
  *
  * Methods available on $node via PHPMD\AbstractNode::__call
  *
- * @method bool isPrivate() Returns true if this node is marked as private.
+ * @method bool isPrivate() Returns true if this node is marked as private .
  */
 class MethodNode extends AbstractCallableNode
 {
@@ -101,6 +101,7 @@ class MethodNode extends AbstractCallableNode
         if (parent::hasSuppressWarningsAnnotationFor($rule)) {
             return true;
         }
+
         return $this->getParentType()->hasSuppressWarningsAnnotationFor($rule);
     }
 

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -27,7 +27,7 @@ use PHPMD\Rule;
  *
  * Methods available on $node via PHPMD\AbstractNode::__call
  *
- * @method bool isPrivate() Returns true if this node is marked as private .
+ * @method bool isPrivate() Returns true if this node is marked as private.
  */
 class MethodNode extends AbstractCallableNode
 {

--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -39,7 +39,7 @@ class ParserFactory
      * @var array
      */
     private $phpmd2pdepend = array(
-        'coverage' => 'coverage-report'
+        'coverage' => 'coverage-report',
     );
 
     /**

--- a/src/main/php/PHPMD/ProcessingError.php
+++ b/src/main/php/PHPMD/ProcessingError.php
@@ -19,6 +19,7 @@ namespace PHPMD;
 
 /**
  * Simple data class that we use to keep parsing errors for the report renderer.
+ *
  * @since 1.2.1
  */
 class ProcessingError
@@ -84,6 +85,7 @@ class ProcessingError
         if (isset($match[1])) {
             return $match[1];
         }
+
         return '';
     }
 }

--- a/src/main/php/PHPMD/Renderer/AnsiRenderer.php
+++ b/src/main/php/PHPMD/Renderer/AnsiRenderer.php
@@ -58,6 +58,7 @@ class AnsiRenderer extends AbstractRenderer
                 $maxLength = strlen($violation->getBeginLine());
             }
         }
+
         return $maxLength;
     }
 

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -463,7 +463,6 @@ class HTMLRenderer extends AbstractRenderer
             });
 
             self::$compiledHighlightRegex = "#(" . implode('|', $prepared) . ")#";
-
         }
 
         $rules = self::$descHighlightRules;
@@ -525,7 +524,6 @@ class HTMLRenderer extends AbstractRenderer
                 <td class='t-pct'>$pct %</td>
                 <th class='t-n'>{$name}{$bar}</th>
             </tr>";
-
         }
 
         $header = "<thead><tr><th>Count</th><th>%</th><th>$itemsTitle</th></tr></thead>";
@@ -568,7 +566,6 @@ class HTMLRenderer extends AbstractRenderer
 
             $ref = &$result[self::CATEGORY_RULE][$rule->getName()];
             $ref = isset($ref) ? $ref + 1 : 1;
-
         }
 
         // Sort numbers in each category from high to low.

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -96,10 +96,12 @@ abstract class AbstractLocalVariable extends AbstractRule
             if ($primaryPrefix->getParent()->isInstanceOf('MemberPrimaryPrefix')) {
                 return !$primaryPrefix->getParent()->isStatic();
             }
+
             return ($parent->getChild(0)->getNode() !== $node->getNode()
                 || !$primaryPrefix->isStatic()
             );
         }
+
         return true;
     }
 
@@ -120,6 +122,7 @@ abstract class AbstractLocalVariable extends AbstractRule
         if ($parent->getChild(0)->getNode() === $node->getNode()) {
             return $this->stripWrappedIndexExpression($parent);
         }
+
         return $node;
     }
 

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -100,9 +100,10 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
         // non-associative - key name equals to its index
         if ($childCount === 0) {
             $node->setImage((string)$index);
+
             return $node;
         }
-        
+
         $node = $node->getChild(0);
         if (!($node instanceof ASTLiteral)) {
             // skip expressions, method calls, globals and constants

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -58,7 +58,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
             $this->addViolation($methodCall, array($className, $node->getName()));
         }
     }
-    
+
     protected function isExcludedFromAnalysis($className, $exceptions)
     {
         return in_array(trim($className, " \t\n\r\0\x0B\\"), $exceptions);
@@ -67,9 +67,9 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
     private function isStaticMethodCall(AbstractNode $methodCall)
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTClassOrInterfaceReference &&
-               $methodCall->getChild(1)->getNode() instanceof ASTMethodPostfix &&
-               !$this->isCallingParent($methodCall) &&
-               !$this->isCallingSelf($methodCall);
+            $methodCall->getChild(1)->getNode() instanceof ASTMethodPostfix &&
+            !$this->isCallingParent($methodCall) &&
+            !$this->isCallingSelf($methodCall);
     }
 
     private function isCallingParent(AbstractNode $methodCall)

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -76,7 +76,8 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      *
      * @param AbstractNode $node
      */
-    private function collect(AbstractNode $node) {
+    private function collect(AbstractNode $node)
+    {
         $this->collectPropertyPostfix($node);
         $this->collectClosureParameters($node);
         $this->collectForeachStatements($node);

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -62,10 +62,10 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
         }
 
         foreach ($node->findChildrenOfType('Variable') as $variable) {
-            if (! $this->isNotSuperGlobal($variable)) {
+            if (!$this->isNotSuperGlobal($variable)) {
                 $this->addVariableDefinition($variable);
             }
-            if (! $this->checkVariableDefined($variable, $node)) {
+            if (!$this->checkVariableDefined($variable, $node)) {
                 $this->addViolation($variable, array($variable->getImage()));
             }
         }
@@ -254,7 +254,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     private function addVariableDefinition($variable)
     {
-        if (! isset($this->images[$variable->getImage()])) {
+        if (!isset($this->images[$variable->getImage()])) {
             $this->images[$variable->getImage()] = $variable;
         }
     }

--- a/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
+++ b/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
@@ -32,14 +32,21 @@ class Superglobals extends AbstractRule implements MethodAware, FunctionAware
 {
     protected $superglobals = array(
         '$GLOBALS',
-        '$_SERVER', '$HTTP_SERVER_VARS',
-        '$_GET', '$HTTP_GET_VARS',
-        '$_POST', '$HTTP_POST_VARS',
-        '$_FILES', '$HTTP_POST_FILES',
-        '$_COOKIE', '$HTTP_COOKIE_VARS',
-        '$_SESSION', '$HTTP_SESSION_VARS',
+        '$_SERVER',
+        '$HTTP_SERVER_VARS',
+        '$_GET',
+        '$HTTP_GET_VARS',
+        '$_POST',
+        '$HTTP_POST_VARS',
+        '$_FILES',
+        '$HTTP_POST_FILES',
+        '$_COOKIE',
+        '$HTTP_COOKIE_VARS',
+        '$_SESSION',
+        '$HTTP_SESSION_VARS',
         '$_REQUEST',
-        '$_ENV', '$HTTP_ENV_VARS',
+        '$_ENV',
+        '$HTTP_ENV_VARS',
     );
 
     /**
@@ -57,7 +64,7 @@ class Superglobals extends AbstractRule implements MethodAware, FunctionAware
                     $node,
                     array(
                         $node->getName(),
-                        $variable->getImage()
+                        $variable->getImage(),
                     )
                 );
             }

--- a/src/main/php/PHPMD/Rule/CyclomaticComplexity.php
+++ b/src/main/php/PHPMD/Rule/CyclomaticComplexity.php
@@ -47,7 +47,7 @@ class CyclomaticComplexity extends AbstractRule implements FunctionAware, Method
                 $node->getType(),
                 $node->getName(),
                 $ccn,
-                $threshold
+                $threshold,
             )
         );
     }

--- a/src/main/php/PHPMD/Rule/Design/DepthOfInheritance.php
+++ b/src/main/php/PHPMD/Rule/Design/DepthOfInheritance.php
@@ -53,7 +53,7 @@ class DepthOfInheritance extends AbstractRule implements ClassAware
                     $node->getType(),
                     $node->getName(),
                     $dit,
-                    $threshold
+                    $threshold,
                 )
             );
         }

--- a/src/main/php/PHPMD/Rule/Design/LongMethod.php
+++ b/src/main/php/PHPMD/Rule/Design/LongMethod.php
@@ -57,7 +57,7 @@ class LongMethod extends AbstractRule implements FunctionAware, MethodAware
                 $node->getType(),
                 $node->getName(),
                 $loc,
-                $threshold
+                $threshold,
             )
         );
     }

--- a/src/main/php/PHPMD/Rule/Design/LongParameterList.php
+++ b/src/main/php/PHPMD/Rule/Design/LongParameterList.php
@@ -48,7 +48,7 @@ class LongParameterList extends AbstractRule implements FunctionAware, MethodAwa
                 $node->getType(),
                 $node->getName(),
                 $count,
-                $threshold
+                $threshold,
             )
         );
     }

--- a/src/main/php/PHPMD/Rule/Design/NpathComplexity.php
+++ b/src/main/php/PHPMD/Rule/Design/NpathComplexity.php
@@ -49,7 +49,7 @@ class NpathComplexity extends AbstractRule implements FunctionAware, MethodAware
                 $node->getType(),
                 $node->getName(),
                 $npath,
-                $threshold
+                $threshold,
             )
         );
     }

--- a/src/main/php/PHPMD/Rule/Design/NumberOfChildren.php
+++ b/src/main/php/PHPMD/Rule/Design/NumberOfChildren.php
@@ -44,7 +44,7 @@ class NumberOfChildren extends AbstractRule implements ClassAware
                     $node->getType(),
                     $node->getName(),
                     $nocc,
-                    $threshold
+                    $threshold,
                 )
             );
         }

--- a/src/main/php/PHPMD/Rule/Design/TooManyFields.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyFields.php
@@ -46,7 +46,7 @@ class TooManyFields extends AbstractRule implements ClassAware
                 $node->getType(),
                 $node->getName(),
                 $vars,
-                $threshold
+                $threshold,
             )
         );
     }

--- a/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
@@ -60,7 +60,7 @@ class TooManyMethods extends AbstractRule implements ClassAware
                 $node->getType(),
                 $node->getName(),
                 $nom,
-                $threshold
+                $threshold,
             )
         );
     }
@@ -79,6 +79,7 @@ class TooManyMethods extends AbstractRule implements ClassAware
                 ++$count;
             }
         }
+
         return $count;
     }
 }

--- a/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
@@ -60,7 +60,7 @@ class TooManyPublicMethods extends AbstractRule implements ClassAware
                 $node->getType(),
                 $node->getName(),
                 $nom,
-                $threshold
+                $threshold,
             )
         );
     }
@@ -79,6 +79,7 @@ class TooManyPublicMethods extends AbstractRule implements ClassAware
                 ++$count;
             }
         }
+
         return $count;
     }
 }

--- a/src/main/php/PHPMD/Rule/ExcessivePublicCount.php
+++ b/src/main/php/PHPMD/Rule/ExcessivePublicCount.php
@@ -46,7 +46,7 @@ class ExcessivePublicCount extends AbstractRule implements ClassAware
                 $node->getType(),
                 $node->getName(),
                 $cis,
-                $threshold
+                $threshold,
             )
         );
     }

--- a/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
@@ -54,8 +54,8 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
     private function isBooleanGetMethod(MethodNode $node)
     {
         return $this->isGetterMethodName($node)
-                && $this->isReturnTypeBoolean($node)
-                && $this->isParameterizedOrIgnored($node);
+            && $this->isReturnTypeBoolean($node)
+            && $this->isParameterizedOrIgnored($node);
     }
 
     /**
@@ -78,6 +78,7 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
     private function isReturnTypeBoolean(MethodNode $node)
     {
         $comment = $node->getDocComment();
+
         return (preg_match('(\*\s*@return\s+bool(ean)?\s)i', $comment) > 0);
     }
 
@@ -93,6 +94,7 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
         if ($this->getBooleanProperty('checkParameterizedMethods')) {
             return $node->getParameterCount() === 0;
         }
+
         return true;
     }
 }

--- a/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
@@ -53,7 +53,7 @@ class ShortMethodName extends AbstractRule implements MethodAware, FunctionAware
             array(
                 $node->getParentName(),
                 $node->getName(),
-                $threshold
+                $threshold,
             )
         );
     }

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -52,6 +52,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
 
         if ($node->getType() === 'class') {
             $this->applyClass($node);
+
             return;
         }
 
@@ -171,9 +172,9 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
     private function isNameAllowedInContext(AbstractNode $node)
     {
         return $this->isChildOf($node, 'CatchStatement')
-                || $this->isChildOf($node, 'ForInit')
-                || $this->isChildOf($node, 'ForeachStatement')
-                || $this->isChildOf($node, 'MemberPrimaryPrefix');
+            || $this->isChildOf($node, 'ForInit')
+            || $this->isChildOf($node, 'ForeachStatement')
+            || $this->isChildOf($node, 'MemberPrimaryPrefix');
     }
 
     /**
@@ -193,6 +194,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
             }
             $parent = $parent->getParent();
         }
+
         return false;
     }
 

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -80,6 +80,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
         if ($node instanceof MethodNode) {
             return $node->isAbstract();
         }
+
         return false;
     }
 
@@ -95,29 +96,32 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
         if ($node instanceof MethodNode) {
             return preg_match('/\@inheritdoc/i', $node->getDocComment());
         }
+
         return false;
     }
 
     /**
      * Returns <b>true</b> when the given node is a magic method signature
+     *
      * @param AbstractNode $node
      * @return boolean
      */
     private function isMagicMethod(AbstractNode $node)
     {
         static $names = array(
-                'call',
-                'callStatic',
-                'get',
-                'set',
-                'isset',
-                'unset',
-                'set_state'
+            'call',
+            'callStatic',
+            'get',
+            'set',
+            'isset',
+            'unset',
+            'set_state',
         );
 
         if ($node instanceof MethodNode) {
             return preg_match('/\__(?:' . implode("|", $names) . ')/i', $node->getName());
         }
+
         return false;
     }
 
@@ -134,6 +138,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
         if ($node instanceof MethodNode) {
             return !$node->isDeclaration();
         }
+
         return false;
     }
 
@@ -188,7 +193,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
             }
         }
     }
-    
+
     /**
      * Removes all the compound variables from a given node
      *

--- a/src/main/php/PHPMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateField.php
@@ -160,9 +160,10 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
             }
             $parent = $parent->getParent();
             if (is_null($parent)) {
-                   return false;
+                return false;
             }
         }
+
         return true;
     }
 

--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -113,6 +113,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
                 unset($methods[strtolower($postfix->getImage())]);
             }
         }
+
         return $methods;
     }
 

--- a/src/main/php/PHPMD/RuleSet.php
+++ b/src/main/php/PHPMD/RuleSet.php
@@ -190,6 +190,7 @@ class RuleSet implements \IteratorAggregate
                 return $rule;
             }
         }
+
         return null;
     }
 

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -109,6 +109,7 @@ class RuleSetFactory
 
             $ruleSetFileName = strtok(',');
         }
+
         return $ruleSets;
     }
 
@@ -121,6 +122,7 @@ class RuleSetFactory
     public function createSingleRuleSet($ruleSetOrFileName)
     {
         $fileName = $this->createRuleSetFileName($ruleSetOrFileName);
+
         return $this->parseRuleSetNode($fileName);
     }
 
@@ -173,6 +175,7 @@ class RuleSetFactory
                 }
             }
         }
+
         return $ruleSets;
     }
 
@@ -243,10 +246,12 @@ class RuleSetFactory
     {
         if (substr($node['ref'], -3, 3) === 'xml') {
             $this->parseRuleSetReferenceNode($ruleSet, $node);
+
             return;
         }
         if ('' === (string)$node['ref']) {
             $this->parseSingleRuleNode($ruleSet, $node);
+
             return;
         }
         $this->parseRuleReferenceNode($ruleSet, $node);
@@ -302,6 +307,7 @@ class RuleSetFactory
                 return false;
             }
         }
+
         return true;
     }
 
@@ -492,6 +498,7 @@ class RuleSetFactory
         if (isset($propertyNode->value)) {
             return (string)$propertyNode->value;
         }
+
         return (string)$propertyNode['value'];
     }
 
@@ -530,6 +537,7 @@ class RuleSetFactory
 
             return $excludes;
         }
+
         return null;
     }
 

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -30,8 +30,8 @@ class Command
      * Exit codes used by the phpmd command line tool.
      */
     const EXIT_SUCCESS = 0,
-          EXIT_EXCEPTION = 1,
-          EXIT_VIOLATION = 2;
+        EXIT_EXCEPTION = 1,
+        EXIT_VIOLATION = 2;
 
     /**
      * This method creates a PHPMD instance and configures this object based
@@ -53,6 +53,7 @@ class Command
     {
         if ($opts->hasVersion()) {
             fwrite(STDOUT, sprintf('PHPMD %s', $this->getVersion()) . PHP_EOL);
+
             return self::EXIT_SUCCESS;
         }
 
@@ -83,7 +84,7 @@ class Command
         $phpmd->setOptions(
             array_filter(
                 array(
-                    'coverage' => $opts->getCoverageReport()
+                    'coverage' => $opts->getCoverageReport(),
                 )
             )
         );
@@ -108,6 +109,7 @@ class Command
         if ($phpmd->hasViolations() && !$opts->ignoreViolationsOnExit()) {
             return self::EXIT_VIOLATION;
         }
+
         return self::EXIT_SUCCESS;
     }
 
@@ -125,6 +127,7 @@ class Command
             $data = @parse_ini_file($build);
             $version = $data['project.version'];
         }
+
         return $version;
     }
 

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -503,7 +503,7 @@ class CommandLineOptions
             '--suffixes: comma-separated string of valid source code ' .
             'filename extensions, e.g. php,phtml' . \PHP_EOL .
             '--exclude: comma-separated string of patterns that are used to ' .
-            'ignore directories. Use asterisks to exclude by pattern. '.
+            'ignore directories. Use asterisks to exclude by pattern. ' .
             'For example *src/foo/*.php or *src/foo/*' . \PHP_EOL .
             '--strict: also report those nodes with a @SuppressWarnings ' .
             'annotation' . \PHP_EOL .
@@ -518,7 +518,7 @@ class CommandLineOptions
      */
     protected function getListOfAvailableRenderers()
     {
-        $renderersDirPathName=__DIR__.'/../Renderer';
+        $renderersDirPathName = __DIR__ . '/../Renderer';
         $renderers = array();
 
         foreach (scandir($renderersDirPathName) as $rendererFileName) {

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -41,6 +41,7 @@ class StreamWriter extends AbstractWriter
     {
         if (is_resource($streamResourceOrUri) === true) {
             $this->stream = $streamResourceOrUri;
+
             return;
         }
         $dirName = dirname($streamResourceOrUri);

--- a/src/test/php/PHPMD/AbstractStaticTest.php
+++ b/src/test/php/PHPMD/AbstractStaticTest.php
@@ -116,7 +116,7 @@ abstract class AbstractStaticTest extends PHPUnit_Framework_TestCase
     /**
      * Asserts the actual xml output matches against the expected file.
      *
-     * @param string $actualOutput     Generated xml output.
+     * @param string $actualOutput Generated xml output.
      * @param string $expectedFileName File with expected xml result.
      * @return void
      */
@@ -148,7 +148,7 @@ abstract class AbstractStaticTest extends PHPUnit_Framework_TestCase
     /**
      * Asserts the actual JSON output matches against the expected file.
      *
-     * @param string $actualOutput     Generated JSON output.
+     * @param string $actualOutput Generated JSON output.
      * @param string $expectedFileName File with expected JSON result.
      *
      * @return void

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -310,7 +310,12 @@ abstract class AbstractTest extends AbstractStaticTest
      */
     protected function createFunctionMock($metric = null, $value = null)
     {
-        return $this->createFunctionOrMethodMock('PHPMD\\Node\\FunctionNode', new ASTFunction('fooBar'), $metric, $value);
+        return $this->createFunctionOrMethodMock(
+            'PHPMD\\Node\\FunctionNode',
+            new ASTFunction('fooBar'),
+            $metric,
+            $value
+        );
     }
 
     /**

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -605,7 +605,7 @@ abstract class AbstractTest extends AbstractStaticTest
         $tokenizer = new PHPTokenizerInternal();
         $tokenizer->setSourceFile($sourceFile);
 
-        $builder =  new PHPBuilder();
+        $builder = new PHPBuilder();
 
         $parser = new PHPParserGeneric(
             $tokenizer,

--- a/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
+++ b/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
@@ -75,9 +75,10 @@ class CommandLineInputFileOptionTest extends AbstractTest
                 '--reportfile',
                 $reportfile,
                 '--inputfile',
-                $inputfile
+                $inputfile,
             )
         );
+
         return file_get_contents($reportfile);
     }
 }

--- a/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
@@ -44,7 +44,7 @@ class CouplingBetweenObjectsIntegrationTest extends AbstractTest
                 'text',
                 'design',
                 '--reportfile',
-                $file
+                $file,
             )
         );
 

--- a/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
@@ -44,7 +44,7 @@ class GotoStatementIntegrationTest extends AbstractTest
                 'text',
                 'design',
                 '--reportfile',
-                $file
+                $file,
             )
         );
 

--- a/src/test/php/PHPMD/Node/InterfaceNodeTest.php
+++ b/src/test/php/PHPMD/Node/InterfaceNodeTest.php
@@ -23,6 +23,7 @@ use PHPMD\AbstractTest;
 
 /**
  * Test case for the interface node implementation.
+ *
  * @covers \PHPMD\Node\InterfaceNode
  * @covers \PHPMD\Node\AbstractTypeNode
  */

--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -39,7 +39,7 @@ class MethodNodeTest extends AbstractTest
     {
         $method = $this->getMockFromBuilder(
             $this->getMockBuilder('PDepend\\Source\\AST\\ASTMethod')
-            ->setConstructorArgs(array(null))
+                ->setConstructorArgs(array(null))
         );
         $method->expects($this->once())
             ->method('getStartLine');

--- a/src/test/php/PHPMD/ParserTest.php
+++ b/src/test/php/PHPMD/ParserTest.php
@@ -137,7 +137,7 @@ class ParserTest extends AbstractTest
         $pdepend->expects($this->once())
             ->method('getExceptions')
             ->will($this->returnValue(array(
-                new InvalidStateException(42, __FILE__, 'foo')
+                new InvalidStateException(42, __FILE__, 'foo'),
             )));
 
         $parser = new Parser($pdepend);

--- a/src/test/php/PHPMD/ProcessingErrorTest.php
+++ b/src/test/php/PHPMD/ProcessingErrorTest.php
@@ -62,17 +62,17 @@ class ProcessingErrorTest extends AbstractTest
         return array(
             array(
                 'The parser has reached an invalid state near line "42" in file ' .
-                '"/tmp/foo.php". Please check the following conditions: message'
+                '"/tmp/foo.php". Please check the following conditions: message',
             ),
             array(
-                'Unexpected token: >, line: 42, col: 23, file: /tmp/foo.php.'
+                'Unexpected token: >, line: 42, col: 23, file: /tmp/foo.php.',
             ),
             array(
-                'Unexpected end of token stream in file: /tmp/foo.php.'
+                'Unexpected end of token stream in file: /tmp/foo.php.',
             ),
             array(
-                'Missing default value on line: 42, col: 23, file: /tmp/foo.php.'
-            )
+                'Missing default value on line: 42, col: 23, file: /tmp/foo.php.',
+            ),
         );
     }
 }

--- a/src/test/php/PHPMD/Regression/AbstractTest.php
+++ b/src/test/php/PHPMD/Regression/AbstractTest.php
@@ -40,6 +40,7 @@ abstract class AbstractTest extends \PHPMD\AbstractTest
         if ($localPath === '') {
             $localPath = $trace[1]['function'] . '.php';
         }
+
         return parent::createFileUri('Regression/' . $ticket . '/' . $localPath);
     }
 }

--- a/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -60,6 +60,5 @@ class HTMLRendererTest extends AbstractTest
             "~.*<section class='prb' id='p-(\d+)'> <header> <h3> <a href='#p-\d+' class='indx'>.*~",
             $writer->getData()
         );
-
     }
 }

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -68,9 +68,11 @@ class ReportTest extends AbstractTest
 
         $actual = array();
         foreach ($report->getRuleViolations() as $violation) {
-            $actual[] = array($violation->getFileName(),
-                              $violation->getBeginLine(),
-                              $violation->getEndLine());
+            $actual[] = array(
+                $violation->getFileName(),
+                $violation->getBeginLine(),
+                $violation->getEndLine(),
+            );
         }
 
         $expected = array(

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -219,6 +219,7 @@ class CamelCaseMethodNameTest extends AbstractTest
     protected function getMethod()
     {
         $methods = $this->getClass()->getMethods();
+
         return reset($methods);
     }
 }

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
@@ -28,6 +28,7 @@ class CamelCaseParameterNameTest extends AbstractTest
 {
     /**
      * Tests that the rule does apply for an invalid parameter name
+     *
      * @return void
      */
     public function testRuleDoesApplyForInparameterNameWithUnderscore()

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
@@ -28,6 +28,7 @@ class CamelCaseVariableNameTest extends AbstractTest
 {
     /**
      * Tests that the rule does apply for an invalid variable name
+     *
      * @return void
      */
     public function testRuleDoesApplyForInvariableNameWithUnderscore()

--- a/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -163,7 +163,7 @@ class TooManyMethodsTest extends AbstractTest
     /**
      * Creates a prepared class node mock
      *
-     * @param integer  $numberOfMethods
+     * @param integer $numberOfMethods
      * @param string[] $methodNames
      * @return \PHPMD\Node\ClassNode
      */
@@ -176,6 +176,7 @@ class TooManyMethodsTest extends AbstractTest
                 ->method('getMethodNames')
                 ->will($this->returnValue($methodNames));
         }
+
         return $class;
     }
 }

--- a/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -190,6 +190,7 @@ class TooManyPublicMethodsTest extends AbstractTest
     {
         $astMethod = new ASTMethod($methodName);
         $astMethod->setModifiers(State::IS_PUBLIC);
+
         return new MethodNode($astMethod);
     }
 
@@ -199,6 +200,7 @@ class TooManyPublicMethodsTest extends AbstractTest
     private function createPrivateMethod($methodName)
     {
         $astMethod = new ASTMethod($methodName);
+
         return new MethodNode($astMethod);
     }
 }

--- a/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
@@ -143,6 +143,7 @@ class BooleanGetMethodNameTest extends AbstractTest
     protected function getMethod()
     {
         $methods = $this->getClass()->getMethods();
+
         return reset($methods);
     }
 }

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -741,6 +741,7 @@ class RuleSetFactoryTest extends AbstractTest
         $args = func_get_args();
 
         $factory = new RuleSetFactory();
+
         return $factory->createRuleSets(join(',', $args));
     }
 

--- a/src/test/php/PHPMD/RuleSetTest.php
+++ b/src/test/php/PHPMD/RuleSetTest.php
@@ -91,7 +91,8 @@ class RuleSetTest extends AbstractTest
     {
         $ruleSet = new RuleSet();
 
-        for ($i = 0; $i < func_num_args(); ++$i) {
+        $funcNumArgs = func_num_args();
+        for ($i = 0; $i < $funcNumArgs; ++$i) {
             $ruleSet->addRule(new RuleStub(func_get_arg($i)));
         }
 

--- a/src/test/php/PHPMD/RuleSetTest.php
+++ b/src/test/php/PHPMD/RuleSetTest.php
@@ -91,9 +91,8 @@ class RuleSetTest extends AbstractTest
     {
         $ruleSet = new RuleSet();
 
-        $funcNumArgs = func_num_args();
-        for ($i = 0; $i < $funcNumArgs; ++$i) {
-            $ruleSet->addRule(new RuleStub(func_get_arg($i)));
+        foreach (func_get_args() as $name) {
+            $ruleSet->addRule(new RuleStub($name));
         }
 
         return $ruleSet;

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -336,7 +336,7 @@ class CommandLineOptionsTest extends AbstractTest
                 'text',
                 'codesize',
                 '--coverage',
-                __METHOD__
+                __METHOD__,
             )
         );
 
@@ -395,7 +395,7 @@ class CommandLineOptionsTest extends AbstractTest
     {
         return array(
             array(''),
-            array('PHPMD\\Test\\Renderer\\NotExistsRenderer')
+            array('PHPMD\\Test\\Renderer\\NotExistsRenderer'),
         );
     }
 
@@ -430,7 +430,7 @@ class CommandLineOptionsTest extends AbstractTest
     {
         return array(
             array('extensions', 'suffixes'),
-            array('ignore', 'exclude')
+            array('ignore', 'exclude'),
         );
     }
 
@@ -453,15 +453,15 @@ class CommandLineOptionsTest extends AbstractTest
         return array(
             array(
                 array('--reportfile-xml', __FILE__),
-                array('xml' => __FILE__)
+                array('xml' => __FILE__),
             ),
             array(
                 array('--reportfile-html', __FILE__),
-                array('html' => __FILE__)
+                array('html' => __FILE__),
             ),
             array(
                 array('--reportfile-text', __FILE__),
-                array('text' => __FILE__)
+                array('text' => __FILE__),
             ),
             array(
                 array(
@@ -472,7 +472,7 @@ class CommandLineOptionsTest extends AbstractTest
                     '--reportfile-html',
                     __FILE__,
                 ),
-                array('text' => __FILE__, 'xml' => __FILE__, 'html' => __FILE__)
+                array('text' => __FILE__, 'xml' => __FILE__, 'html' => __FILE__),
             ),
         );
     }

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -79,25 +79,25 @@ class CommandTest extends AbstractTest
         return array(
             array(
                 'source/source_without_violations.php',
-                Command::EXIT_SUCCESS
+                Command::EXIT_SUCCESS,
             ),
             array(
                 'source/source_with_npath_violation.php',
-                Command::EXIT_VIOLATION
+                Command::EXIT_VIOLATION,
             ),
             array(
                 'source/source_with_npath_violation.php',
                 Command::EXIT_SUCCESS,
-                array('--ignore-violations-on-exit')
+                array('--ignore-violations-on-exit'),
             ),
             array(
                 'source/ccn_suppress_function.php',
                 Command::EXIT_VIOLATION,
-                array('--strict')
+                array('--strict'),
             ),
             array(
                 'source/ccn_suppress_function.php',
-                Command::EXIT_SUCCESS
+                Command::EXIT_SUCCESS,
             ),
         );
     }
@@ -177,7 +177,7 @@ class CommandTest extends AbstractTest
                 __FILE__,
                 self::createFileUri('source/source_with_npath_violation.php'),
                 "''",
-                'naming'
+                'naming',
             )
         );
 
@@ -196,7 +196,7 @@ class CommandTest extends AbstractTest
         Command::main(
             array(
                 __FILE__,
-                '--version'
+                '--version',
             )
         );
 

--- a/src/test/resources/files/Integration/CommandLineInputFileOption/Class1.php
+++ b/src/test/resources/files/Integration/CommandLineInputFileOption/Class1.php
@@ -15,7 +15,8 @@
  * @link http://phpmd.org/
  */
 
-class Class1 {
+class Class1
+{
     function foo()
     {
         $foo = 42;

--- a/src/test/resources/files/Integration/CommandLineInputFileOption/Class2.php
+++ b/src/test/resources/files/Integration/CommandLineInputFileOption/Class2.php
@@ -15,8 +15,10 @@
  * @link http://phpmd.org/
  */
 
-class Class2 {
-    function foo($foo) {
+class Class2
+{
+    function foo($foo)
+    {
         return ($foo * 42);
     }
 }

--- a/src/test/resources/files/Integration/CommandLineInputFileOption/Class3.php
+++ b/src/test/resources/files/Integration/CommandLineInputFileOption/Class3.php
@@ -15,7 +15,8 @@
  * @link http://phpmd.org/
  */
 
-class Class3 {
+class Class3
+{
     public function bar()
     {
         $bar = 23;

--- a/src/test/resources/files/Integration/GotoStatementIntegration/testReportContainsGotoStatementWarning.php
+++ b/src/test/resources/files/Integration/GotoStatementIntegration/testReportContainsGotoStatementWarning.php
@@ -18,7 +18,7 @@
 function testReportContainsGotoStatementWarning()
 {
     LABEL:
-        echo 'You goto ' . __LINE__;
+    echo 'You goto ' . __LINE__;
 
     if (time() % 42 === 23) {
         goto LABEL;

--- a/src/test/resources/files/Node/ClassNode/testGetConstantCount.php
+++ b/src/test/resources/files/Node/ClassNode/testGetConstantCount.php
@@ -18,6 +18,6 @@
 class testGetConstantCount
 {
     const PDEPEND = 42,
-          PHPMD = 23,
-          TEST = 17;
+        PHPMD = 23,
+        TEST = 17;
 }

--- a/src/test/resources/files/Node/InterfaceNode/testGetConstantCount.php
+++ b/src/test/resources/files/Node/InterfaceNode/testGetConstantCount.php
@@ -18,6 +18,6 @@
 interface testGetConstantCount
 {
     const PDEPEND = 42,
-          PHPMD = 23,
-          TEST = 17;
+        PHPMD = 23,
+        TEST = 17;
 }

--- a/src/test/resources/files/Node/MethodNode/testGetParentTypeReturnsClassForClassMethod.php
+++ b/src/test/resources/files/Node/MethodNode/testGetParentTypeReturnsClassForClassMethod.php
@@ -22,6 +22,7 @@ class testGetParentTypeReturnsClassForClassMethodClass
 
     }
 }
+
 class testGetParentTypeReturnsClassForClassMethodClass
 {
     public function testGetParentTypeReturnsClassForClassMethod()

--- a/src/test/resources/files/Node/MethodNode/testGetParentTypeReturnsInterfaceForInterfaceMethod.php
+++ b/src/test/resources/files/Node/MethodNode/testGetParentTypeReturnsInterfaceForInterfaceMethod.php
@@ -19,6 +19,7 @@ interface testGetParentTypeReturnsInterfaceForInterfaceMethodInterface
 {
     function testGetParentTypeReturnsInterfaceForInterfaceMethod();
 }
+
 interface testGetParentTypeReturnsInterfaceForInterfaceMethodInterface
 {
     function testGetParentTypeReturnsInterfaceForInterfaceMethod();

--- a/src/test/resources/files/Node/MethodNode/testHasSuppressWarningsDelegatesToParentClassMethod.php
+++ b/src/test/resources/files/Node/MethodNode/testHasSuppressWarningsDelegatesToParentClassMethod.php
@@ -20,7 +20,9 @@
  */
 class testHasSuppressWarningsDelegatesToParentClassMethodClass
 {
-    public function testHasSuppressWarningsDelegatesToParentClassMethod() {}
+    public function testHasSuppressWarningsDelegatesToParentClassMethod()
+    {
+    }
 }
 
 /**
@@ -28,5 +30,7 @@ class testHasSuppressWarningsDelegatesToParentClassMethodClass
  */
 class testHasSuppressWarningsDelegatesToParentClassMethodClass
 {
-    public function testHasSuppressWarningsDelegatesToParentClassMethod() {}
+    public function testHasSuppressWarningsDelegatesToParentClassMethod()
+    {
+    }
 }

--- a/src/test/resources/files/Regression/001/source/FooBar.php
+++ b/src/test/resources/files/Regression/001/source/FooBar.php
@@ -18,4 +18,6 @@
 /**
  * @package ticket001
  */
-class FooBarTicket001 {}
+class FooBarTicket001
+{
+}

--- a/src/test/resources/files/Regression/14990109/testRuleDoesNotApplyToFunctionParameterNamedArgv.php
+++ b/src/test/resources/files/Regression/14990109/testRuleDoesNotApplyToFunctionParameterNamedArgv.php
@@ -17,8 +17,7 @@
 
 function testRuleDoesNotApplyToFunctionParameterNamedArgv($argv)
 {
-    foreach ($argv as $arg)
-    {
+    foreach ($argv as $arg) {
         echo $arg;
     }
 }

--- a/src/test/resources/files/Regression/14990109/testRuleDoesNotApplyToMethodParameterNamedArgv.php
+++ b/src/test/resources/files/Regression/14990109/testRuleDoesNotApplyToMethodParameterNamedArgv.php
@@ -19,8 +19,7 @@ class testRuleDoesNotApplyToMethodParameterNamedArgvClass
 {
     public function testRuleDoesNotApplyToMethodParameterNamedArgv($argv)
     {
-        foreach ($argv as $arg)
-        {
+        foreach ($argv as $arg) {
             echo $arg;
         }
     }

--- a/src/test/resources/files/Regression/24975295/testLocalVariableUsedInDoubleQuoteStringGetsNotReported.php
+++ b/src/test/resources/files/Regression/24975295/testLocalVariableUsedInDoubleQuoteStringGetsNotReported.php
@@ -25,7 +25,7 @@ class Bootstrap extends Bootstrap24975295
         $front = $this->getResource('frontController');
         $router = $front->getRouter();
 
-        $route = new Hostname24975295('foo', array('module' => 'default' ));
+        $route = new Hostname24975295('foo', array('module' => 'default'));
         $router
             ->addRoute('default', $route->chain(new Route('x', array('controller' => 'index'))))
             ->addRoute('default', $route->chain(new Route('x', array('controller' => 'index'))))
@@ -94,7 +94,6 @@ class Bootstrap extends Bootstrap24975295
             ->addRoute('default', $route->chain(new Route('x', array('controller' => 'index'))))
             ->addRoute('default', $route->chain(new Route('x', array('controller' => 'index'))))
             ->addRoute('default', $route->chain(new Route('x', array('controller' => 'index'))))
-            ->addRoute('default', $route->chain(new Route('x', array('controller' => 'index'))))
-        ;
+            ->addRoute('default', $route->chain(new Route('x', array('controller' => 'index'))));
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/DuplicatedArrayKey/testRuleAppliesCorrectlyWithNestedArrays.php
+++ b/src/test/resources/files/Rule/CleanCode/DuplicatedArrayKey/testRuleAppliesCorrectlyWithNestedArrays.php
@@ -33,6 +33,6 @@ function testRuleAppliesCorrectlyWithNestedArrays()
         array(
             'foo' => 47,
             'foo' => 49,
-        )
+        ),
     );
 }

--- a/src/test/resources/files/Rule/CleanCode/ElseExpression/testRuleNotAppliesToMethodWithoutElseExpression.php
+++ b/src/test/resources/files/Rule/CleanCode/ElseExpression/testRuleNotAppliesToMethodWithoutElseExpression.php
@@ -20,7 +20,7 @@ class Foo
     function testRuleNotAppliesToMethodWithoutElseExpression()
     {
         if (true) {
-        } else if (true) {
+        } elseif (true) {
         }
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/MissingImport/testRuleAppliesToFunctionWithNotImportedDependencies.php
+++ b/src/test/resources/files/Rule/CleanCode/MissingImport/testRuleAppliesToFunctionWithNotImportedDependencies.php
@@ -17,6 +17,7 @@
 
 namespace PHPMDTest;
 
-function testRuleAppliesToFunctionWithNotImportedDependencies(){
+function testRuleAppliesToFunctionWithNotImportedDependencies()
+{
     $a = new \stdClass();
 }

--- a/src/test/resources/files/Rule/CleanCode/MissingImport/testRuleNotAppliesToFunctionWithOnlyImportedDependencies.php
+++ b/src/test/resources/files/Rule/CleanCode/MissingImport/testRuleNotAppliesToFunctionWithOnlyImportedDependencies.php
@@ -19,6 +19,7 @@ namespace PHPMDTest;
 
 use stdClass;
 
-function testRuleNotAppliesToFunctionWithOnlyImportedDependencies(){
+function testRuleNotAppliesToFunctionWithOnlyImportedDependencies()
+{
     $a = new stdClass();
 }

--- a/src/test/resources/files/Rule/CleanCode/MissingImport/testRuleNotAppliesToFunctionWithoutAnyDependencies.php
+++ b/src/test/resources/files/Rule/CleanCode/MissingImport/testRuleNotAppliesToFunctionWithoutAnyDependencies.php
@@ -17,6 +17,7 @@
 
 namespace PHPMDTest;
 
-function testRuleNotAppliesToFunctionWithoutAnyDependencies(){
+function testRuleNotAppliesToFunctionWithoutAnyDependencies()
+{
     $a = null;
 }

--- a/src/test/resources/files/Rule/CleanCode/StaticAccess/testRuleNotAppliesToStaticMethodAccessWhenExcluded.php
+++ b/src/test/resources/files/Rule/CleanCode/StaticAccess/testRuleNotAppliesToStaticMethodAccessWhenExcluded.php
@@ -20,6 +20,6 @@ class Foo
     public function testRuleNotAppliesToStaticMethodAccessWhenExcluded()
     {
         Excluded1::foo();
-		Excluded2::bar();
+        Excluded2::bar();
     }
 }

--- a/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleAppliesToMethodWithinNamespace.php
+++ b/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleAppliesToMethodWithinNamespace.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Test\Namespace;
+namespace Test\namespace;
 
 /**
  * This file is part of PHP Mess Detector.
@@ -17,9 +17,10 @@ namespace Test\Namespace;
  * @license https://opensource.org/licenses/bsd-license.php BSD License
  * @link http://phpmd.org/
  */
-
-class testRuleAppliesToMethodWithinNamespace {
-    public function __construct($test = 'Test') {
+class testRuleAppliesToMethodWithinNamespace
+{
+    public function __construct($test = 'Test')
+    {
         var_dump($test);
     }
 }

--- a/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleNotAppliesToMethodWithinNamespaceByDefault.php
+++ b/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleNotAppliesToMethodWithinNamespaceByDefault.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Test\Namespace;
+namespace Test\namespace;
 
 /**
  * This file is part of PHP Mess Detector.
@@ -17,9 +17,10 @@ namespace Test\Namespace;
  * @license https://opensource.org/licenses/bsd-license.php BSD License
  * @link http://phpmd.org/
  */
-
-class testRuleNotAppliesToMethodWithinNamespaceByDefault {
-    public function __construct($test = 'Test') {
+class testRuleNotAppliesToMethodWithinNamespaceByDefault
+{
+    public function __construct($test = 'Test')
+    {
         var_dump($test);
     }
 }

--- a/src/test/resources/files/Rule/Design/EmptyCatchBlock/testRuleNotAppliesToCatchBlockWithComments.php
+++ b/src/test/resources/files/Rule/Design/EmptyCatchBlock/testRuleNotAppliesToCatchBlockWithComments.php
@@ -37,7 +37,7 @@ function testRuleNotAppliesToCatchBlockWithComments()
     try {
         // ...
     } catch (Exception $e) {
-        /** /** valid line of code */
+        /** valid line of code */
     }
     try {
         // ...

--- a/src/test/resources/files/Rule/Design/EvalExpression/testRuleAppliesMultipleTimesToFunctionWithEvalExpression.php
+++ b/src/test/resources/files/Rule/Design/EvalExpression/testRuleAppliesMultipleTimesToFunctionWithEvalExpression.php
@@ -19,10 +19,8 @@ function testRuleAppliesMultipleTimesToFunctionWithEvalExpression()
 {
     if (true) {
         eval('$a = 17;');
-    } else {
-        if (time() % 42 === 0) {
-            eval('$a = 23;');
-        }
+    } elseif (time() % 42 === 0) {
+        eval('$a = 23;');
     }
     eval('$a = 42;');
 }

--- a/src/test/resources/files/Rule/Design/EvalExpression/testRuleAppliesMultipleTimesToFunctionWithEvalExpression.php
+++ b/src/test/resources/files/Rule/Design/EvalExpression/testRuleAppliesMultipleTimesToFunctionWithEvalExpression.php
@@ -19,8 +19,10 @@ function testRuleAppliesMultipleTimesToFunctionWithEvalExpression()
 {
     if (true) {
         eval('$a = 17;');
-    } else if (time() % 42 === 0) {
-        eval('$a = 23;');
+    } else {
+        if (time() % 42 === 0) {
+            eval('$a = 23;');
+        }
     }
     eval('$a = 42;');
 }

--- a/src/test/resources/files/Rule/Design/EvalExpression/testRuleAppliesMultipleTimesToMethodWithEvalExpression.php
+++ b/src/test/resources/files/Rule/Design/EvalExpression/testRuleAppliesMultipleTimesToMethodWithEvalExpression.php
@@ -21,10 +21,8 @@ class testRuleAppliesMultipleTimesToMethodWithEvalExpression
     {
         if (true) {
             eval('$a = 17;');
-        } else {
-            if (time() % 42 === 0) {
-                eval('$a = 23;');
-            }
+        } elseif (time() % 42 === 0) {
+            eval('$a = 23;');
         }
         eval('$a = 42;');
     }

--- a/src/test/resources/files/Rule/Design/EvalExpression/testRuleAppliesMultipleTimesToMethodWithEvalExpression.php
+++ b/src/test/resources/files/Rule/Design/EvalExpression/testRuleAppliesMultipleTimesToMethodWithEvalExpression.php
@@ -21,8 +21,10 @@ class testRuleAppliesMultipleTimesToMethodWithEvalExpression
     {
         if (true) {
             eval('$a = 17;');
-        } else if (time() % 42 === 0) {
-            eval('$a = 23;');
+        } else {
+            if (time() % 42 === 0) {
+                eval('$a = 23;');
+            }
         }
         eval('$a = 42;');
     }

--- a/src/test/resources/files/Rule/Design/ExitExpression/testRuleAppliesMultipleTimesToFunctionWithExitExpression.php
+++ b/src/test/resources/files/Rule/Design/ExitExpression/testRuleAppliesMultipleTimesToFunctionWithExitExpression.php
@@ -19,10 +19,8 @@ function testRuleAppliesMultipleTimesToFunctionWithExitExpression()
 {
     if (true) {
         exit(0);
-    } else {
-        if (time() % 42 === 0) {
-            exit(1);
-        }
+    } elseif (time() % 42 === 0) {
+        exit(1);
     }
     exit(2);
 }

--- a/src/test/resources/files/Rule/Design/ExitExpression/testRuleAppliesMultipleTimesToFunctionWithExitExpression.php
+++ b/src/test/resources/files/Rule/Design/ExitExpression/testRuleAppliesMultipleTimesToFunctionWithExitExpression.php
@@ -19,8 +19,10 @@ function testRuleAppliesMultipleTimesToFunctionWithExitExpression()
 {
     if (true) {
         exit(0);
-    } else if (time() % 42 === 0) {
-        exit(1);
+    } else {
+        if (time() % 42 === 0) {
+            exit(1);
+        }
     }
     exit(2);
 }

--- a/src/test/resources/files/Rule/Design/ExitExpression/testRuleAppliesMultipleTimesToMethodWithExitExpression.php
+++ b/src/test/resources/files/Rule/Design/ExitExpression/testRuleAppliesMultipleTimesToMethodWithExitExpression.php
@@ -21,8 +21,10 @@ class testRuleAppliesMultipleTimesToMethodWithExitExpression
     {
         if (true) {
             exit(0);
-        } else if (time() % 42 === 0) {
-            exit(1);
+        } else {
+            if (time() % 42 === 0) {
+                exit(1);
+            }
         }
         exit(2);
     }

--- a/src/test/resources/files/Rule/Design/ExitExpression/testRuleAppliesMultipleTimesToMethodWithExitExpression.php
+++ b/src/test/resources/files/Rule/Design/ExitExpression/testRuleAppliesMultipleTimesToMethodWithExitExpression.php
@@ -21,10 +21,8 @@ class testRuleAppliesMultipleTimesToMethodWithExitExpression
     {
         if (true) {
             exit(0);
-        } else {
-            if (time() % 42 === 0) {
-                exit(1);
-            }
+        } elseif (time() % 42 === 0) {
+            exit(1);
         }
         exit(2);
     }

--- a/src/test/resources/files/Rule/Design/GotoStatement/testRuleAppliesToFunctionWithGotoStatement.php
+++ b/src/test/resources/files/Rule/Design/GotoStatement/testRuleAppliesToFunctionWithGotoStatement.php
@@ -18,7 +18,7 @@
 function testRuleAppliesToFunctionWithGotoStatement()
 {
     LABEL:
-        echo 'FOOBAR';
+    echo 'FOOBAR';
 
     if (time() % 23 === 42) {
         goto LABEL;

--- a/src/test/resources/files/Rule/Design/GotoStatement/testRuleAppliesToMethodWithGotoStatement.php
+++ b/src/test/resources/files/Rule/Design/GotoStatement/testRuleAppliesToMethodWithGotoStatement.php
@@ -20,7 +20,7 @@ class testRuleAppliesToMethodWithGotoStatementClass
     public function testRuleAppliesToMethodWithGotoStatement()
     {
         LABEL:
-            echo 'YES';
+        echo 'YES';
 
         if (time() % 42 === 0) {
             goto LABEL;

--- a/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleAppliesToMethodStartingWithGetAndReturningBool.php
+++ b/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleAppliesToMethodStartingWithGetAndReturningBool.php
@@ -20,5 +20,7 @@ class testRuleAppliesToMethodStartingWithGetAndReturningBool
     /**
      * @return Bool
      */
-    public function getBaz() {}
+    public function getBaz()
+    {
+    }
 }

--- a/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleIgnoresParametersWhenNotExplicitConfigured.php
+++ b/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleIgnoresParametersWhenNotExplicitConfigured.php
@@ -20,5 +20,7 @@ class testRuleIgnoresParametersWhenNotExplicitConfigured
     /**
      * @return boolean
      */
-    function getBaz($foo) {}
+    function getBaz($foo)
+    {
+    }
 }

--- a/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleNotAppliesToMethodStartingWithHas.php
+++ b/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleNotAppliesToMethodStartingWithHas.php
@@ -20,5 +20,7 @@ class testRuleNotAppliesToMethodStartingWithHas
     /**
      * @return boolean
      */
-    function hasX() {}
+    function hasX()
+    {
+    }
 }

--- a/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleNotAppliesToMethodStartingWithIs.php
+++ b/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleNotAppliesToMethodStartingWithIs.php
@@ -20,5 +20,7 @@ class testRuleNotAppliesToMethodStartingWithIs
     /**
      * @return boolean
      */
-    function isBaz() {}
+    function isBaz()
+    {
+    }
 }

--- a/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleNotAppliesToMethodWithReturnTypeNotBoolean.php
+++ b/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleNotAppliesToMethodWithReturnTypeNotBoolean.php
@@ -20,5 +20,7 @@ class testRuleNotAppliesToMethodWithReturnTypeNotBoolean
     /**
      * @return array(boolean)
      */
-    function getFooBar() {}
+    function getFooBar()
+    {
+    }
 }

--- a/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleNotAppliesWhenParametersAreExplicitEnabled.php
+++ b/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleNotAppliesWhenParametersAreExplicitEnabled.php
@@ -20,5 +20,7 @@ class testRuleNotAppliesWhenParametersAreExplicitEnabled
     /**
      * @return boolean
      */
-    public function getBaz($foo) {}
+    public function getBaz($foo)
+    {
+    }
 }

--- a/src/test/resources/files/Rule/Naming/ConstantNamingConventions/testRuleAppliesToClassConstantWithLowerCaseCharacters.php
+++ b/src/test/resources/files/Rule/Naming/ConstantNamingConventions/testRuleAppliesToClassConstantWithLowerCaseCharacters.php
@@ -18,6 +18,7 @@
 class testRuleAppliesToClassConstantWithLowerCaseCharacters
 {
     const T_FOO = 42;
+
     const T_Bar = 23,
-          t_baz = 17;
+        t_baz = 17;
 }

--- a/src/test/resources/files/Rule/Naming/ConstantNamingConventions/testRuleNotAppliesToClassConstantWithUpperCaseCharacters.php
+++ b/src/test/resources/files/Rule/Naming/ConstantNamingConventions/testRuleNotAppliesToClassConstantWithUpperCaseCharacters.php
@@ -17,7 +17,7 @@
 
 class testRuleNotAppliesToClassConstantWithUpperCaseCharacters
 {
-    const T_FOO =42,
-          T_BAR = 23,
-          T_BAZ = 17;
+    const T_FOO = 42,
+        T_BAR = 23,
+        T_BAZ = 17;
 }

--- a/src/test/resources/files/Rule/Naming/ShortVariable/testRuleAppliesToFieldAndParameterWithNameShorterThanThreshold.php
+++ b/src/test/resources/files/Rule/Naming/ShortVariable/testRuleAppliesToFieldAndParameterWithNameShorterThanThreshold.php
@@ -19,5 +19,7 @@ class testRuleAppliesToFieldAndParameterWithNameShorterThanThreshold
 {
     protected $_x;
 
-    public function testRuleAppliesToFieldAndParameterWithNameShorterThanThreshold($x) {}
+    public function testRuleAppliesToFieldAndParameterWithNameShorterThanThreshold($x)
+    {
+    }
 }

--- a/src/test/resources/files/Rule/Naming/ShortVariable/testRuleAppliesToMethodParameterWithNameShorterThanThreshold.php
+++ b/src/test/resources/files/Rule/Naming/ShortVariable/testRuleAppliesToMethodParameterWithNameShorterThanThreshold.php
@@ -17,5 +17,7 @@
 
 class testRuleAppliesToMethodParameterWithNameShorterThanThreshold
 {
-    public function testRuleAppliesToMethodParameterWithNameShorterThanThreshold($fo) {}
+    public function testRuleAppliesToMethodParameterWithNameShorterThanThreshold($fo)
+    {
+    }
 }

--- a/src/test/resources/files/Rule/Naming/ShortVariable/testRuleNotAppliesToMethodParameterWithNameLongerThanThreshold.php
+++ b/src/test/resources/files/Rule/Naming/ShortVariable/testRuleNotAppliesToMethodParameterWithNameLongerThanThreshold.php
@@ -17,5 +17,7 @@
 
 class testRuleNotAppliesToMethodParameterWithNameLongerThanThreshold
 {
-    function testRuleNotAppliesToMethodParameterWithNameLongerThanThreshold($foo) {}
+    function testRuleNotAppliesToMethodParameterWithNameLongerThanThreshold($foo)
+    {
+    }
 }

--- a/src/test/resources/files/Rule/Naming/ShortVariable/testRuleNotAppliesToShortVariableNameInCatchStatement.php
+++ b/src/test/resources/files/Rule/Naming/ShortVariable/testRuleNotAppliesToShortVariableNameInCatchStatement.php
@@ -19,5 +19,6 @@ function testRuleNotAppliesToShortVariableNameInCatchStatement()
 {
     try {
         foo();
-    } catch (Exception $e) {}
+    } catch (Exception $e) {
+    }
 }

--- a/src/test/resources/files/Rule/UnusedFormalParameter/testRuleDoesNotApplyToInnerFunctionDeclaration.php
+++ b/src/test/resources/files/Rule/UnusedFormalParameter/testRuleDoesNotApplyToInnerFunctionDeclaration.php
@@ -23,5 +23,6 @@ function testRuleDoesNotApplyToInnerFunctionDeclaration($x, $y, $z)
         $c
     ) {
     }
+
     return ($x + $y + $z);
 }

--- a/src/test/resources/files/Rule/UnusedLocalVariable/testCompactFunctionRuleWorksCaseInsensitive.php
+++ b/src/test/resources/files/Rule/UnusedLocalVariable/testCompactFunctionRuleWorksCaseInsensitive.php
@@ -19,7 +19,9 @@ class testCompactFunctionRuleWorksCaseInsensitive
 {
     public function testCompactFunctionRuleWorksCaseInsensitive()
     {
-        $foo = 1; $bar = 2; $baz = 0;
+        $foo = 1;
+        $bar = 2;
+        $baz = 0;
 
         return Compact('foo', 'bar', 'baz');
     }

--- a/src/test/resources/files/Rule/UnusedLocalVariable/testNamespacedCompactFunctionRuleWorksCaseInsensitive.php
+++ b/src/test/resources/files/Rule/UnusedLocalVariable/testNamespacedCompactFunctionRuleWorksCaseInsensitive.php
@@ -21,7 +21,9 @@ class testNamespacedCompactFunctionRuleWorksCaseInsensitive
 {
     public function testNamespacedCompactFunctionRuleWorksCaseInsensitive()
     {
-        $foo = 1; $bar = 2; $baz = 0;
+        $foo = 1;
+        $bar = 2;
+        $baz = 0;
 
         return Compact('foo', 'bar', 'baz');
     }

--- a/src/test/resources/files/Rule/UnusedLocalVariable/testRuleAppliesToLocalVariableWithSameNameAsStaticArrayProperty.php
+++ b/src/test/resources/files/Rule/UnusedLocalVariable/testRuleAppliesToLocalVariableWithSameNameAsStaticArrayProperty.php
@@ -17,11 +17,12 @@
 
 class testRuleAppliesToLocalVariableWithSameNameAsStaticArrayProperty
 {
-    protected $foo = array(array(1=>42));
+    protected $foo = array(array(1 => 42));
 
     public function testRuleAppliesToLocalVariableWithSameNameAsStaticArrayProperty()
     {
         $foo = 23;
+
         return self::$foo[0][1];
     }
 }

--- a/src/test/resources/files/Rule/UnusedLocalVariable/testRuleAppliesToLocalVariableWithSameNameAsStaticProperty.php
+++ b/src/test/resources/files/Rule/UnusedLocalVariable/testRuleAppliesToLocalVariableWithSameNameAsStaticProperty.php
@@ -18,6 +18,7 @@
 class testRuleAppliesToLocalVariableWithSameNameAsStaticProperty
 {
     protected $foo = 42;
+
     function testRuleAppliesToLocalVariableWithSameNameAsStaticProperty()
     {
         $foo = 23;

--- a/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesApplyToCompoundVariableInString.php
+++ b/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesApplyToCompoundVariableInString.php
@@ -20,6 +20,7 @@ class testRuleDoesApplyToCompoundVariableInString
     public function testRuleDoesApplyToCompoundVariableInString()
     {
         $bar = 'foo';
+
         return "${bar}_me";
     }
 }

--- a/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotAppliesToWhitelistedUnusedLocaleVariable.php
+++ b/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotAppliesToWhitelistedUnusedLocaleVariable.php
@@ -1,4 +1,5 @@
 <?php
+
 class testRuleDoesNotAppliesToWhitelistedUnusedLocaleVariable
 {
     function testRuleDoesNotAppliesToWhitelistedUnusedLocaleVariable()

--- a/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToCompactFunction.php
+++ b/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToCompactFunction.php
@@ -20,6 +20,7 @@ class testRuleDoesNotApplyToCompactFunction
     public function testRuleDoesNotApplyToCompactFunction()
     {
         $key = 'ok';
+
         return compact('key');
     }
 }

--- a/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToLocalVariableUsedInCompoundVariable.php
+++ b/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToLocalVariableUsedInCompoundVariable.php
@@ -22,6 +22,7 @@ class testRuleDoesNotApplyToLocalVariableUsedInCompoundVariable
     public function testRuleDoesNotApplyToLocalVariableUsedInCompoundVariable()
     {
         $bar = 'foo';
+
         return self::${$bar};
     }
 }

--- a/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToNamespacedCompactFunction.php
+++ b/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToNamespacedCompactFunction.php
@@ -22,6 +22,7 @@ class testRuleDoesNotApplyToNamespacedCompactFunction
     public function testRuleDoesNotApplyToNamespacedCompactFunction()
     {
         $key = 'ok';
+
         return compact('key');
     }
 }

--- a/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToUnusedForeachKeyWhenWhitelisted.php
+++ b/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToUnusedForeachKeyWhenWhitelisted.php
@@ -1,4 +1,5 @@
 <?php
+
 class testRuleDoesNotApplyToUnusedForeachKeyWhenWhitelisted
 {
     public function testRuleDoesNotApplyToUnusedForeachKeyWhenWhitelisted()

--- a/src/test/resources/files/Rule/UnusedLocalVariable/testRuleStillAppliesWhenSomeUnusedLocaleAreWhitelisted.php
+++ b/src/test/resources/files/Rule/UnusedLocalVariable/testRuleStillAppliesWhenSomeUnusedLocaleAreWhitelisted.php
@@ -1,4 +1,5 @@
 <?php
+
 class testRuleStillAppliesWhenSomeUnusedLocaleAreWhitelisted
 {
     function testRuleStillAppliesWhenSomeUnusedLocaleAreWhitelisted()

--- a/src/test/resources/files/Rule/UnusedPrivateField/testRuleAppliesWhenLocalVariableIsUsedInStaticMemberPrefix.php
+++ b/src/test/resources/files/Rule/UnusedPrivateField/testRuleAppliesWhenLocalVariableIsUsedInStaticMemberPrefix.php
@@ -18,6 +18,7 @@
 class testRuleAppliesWhenLocalVariableIsUsedInStaticMemberPrefix
 {
     private static $_foo = 23;
+
     public static $foo = 17;
 
     public function bar()

--- a/src/test/resources/files/Rule/UnusedPrivateField/testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnDifferentClass.php
+++ b/src/test/resources/files/Rule/UnusedPrivateField/testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnDifferentClass.php
@@ -19,7 +19,7 @@ class testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnDifferentClass
 {
     private $foo = 23;
 
-    public function  __construct()
+    public function __construct()
     {
         FooBar::$foo = 23;
     }

--- a/src/test/resources/files/Rule/UnusedPrivateField/testRuleDoesNotApplyToSelfAccessedPrivateField.php
+++ b/src/test/resources/files/Rule/UnusedPrivateField/testRuleDoesNotApplyToSelfAccessedPrivateField.php
@@ -19,7 +19,7 @@ class testRuleDoesNotApplyToSelfAccessedPrivateField
 {
     private static $_foo = 42;
 
-    public function  __construct()
+    public function __construct()
     {
         self::$_foo = 23;
     }

--- a/src/test/resources/files/Rule/UnusedPrivateField/testRuleDoesNotApplyToStaticAccessedPrivateField.php
+++ b/src/test/resources/files/Rule/UnusedPrivateField/testRuleDoesNotApplyToStaticAccessedPrivateField.php
@@ -19,7 +19,7 @@ class testRuleDoesNotApplyToStaticAccessedPrivateField
 {
     private static $_foo = 23;
 
-    public function  __construct()
+    public function __construct()
     {
         static::$_foo = 42;
     }

--- a/src/test/resources/files/Rule/UnusedPrivateMethod/testRuleAppliesToParentReferencedUnusedPrivateMethod.php
+++ b/src/test/resources/files/Rule/UnusedPrivateMethod/testRuleAppliesToParentReferencedUnusedPrivateMethod.php
@@ -22,7 +22,7 @@ class testRuleAppliesToParentReferencedUnusedPrivateMethod extends stdClass
 
     }
 
-    public function  __construct()
+    public function __construct()
     {
         parent::foo();
     }

--- a/src/test/resources/files/Rule/UnusedPrivateMethod/testRuleDoesNotApplyToPrivateCloneMethod.php
+++ b/src/test/resources/files/Rule/UnusedPrivateMethod/testRuleDoesNotApplyToPrivateCloneMethod.php
@@ -17,7 +17,7 @@
 
 class testRuleDoesNotApplyToPrivateCloneMethod
 {
-    private function  __clone()
+    private function __clone()
     {
 
     }

--- a/src/test/resources/files/classes/does_not_follow_psr0.class.php
+++ b/src/test/resources/files/classes/does_not_follow_psr0.class.php
@@ -20,18 +20,21 @@
  *
  * @author Gerrit Addiks <gerrit@addiks.de>
  */
-class some_class_that_does_not_follow_psr0 extends \PHPMD\AbstractRule{
+class some_class_that_does_not_follow_psr0 extends \PHPMD\AbstractRule
+{
 
     /**
      * A method that returns foo, bar and baz.
      *
      * @return string
      */
-    public function getFooBarBaz(){
+    public function getFooBarBaz()
+    {
         return array('foo', 'bar', 'baz');
     }
 
-    public function apply(\PHPMD\AbstractNode $node){
+    public function apply(\PHPMD\AbstractNode $node)
+    {
 
     }
 

--- a/src/test/resources/files/pmd/single-directory.xml
+++ b/src/test/resources/files/pmd/single-directory.xml
@@ -11,10 +11,10 @@
     </violation>
   </file>
   <file name="#{rootDirectory}_DS_source_DS_source_with_npath_violation.php">
-    <violation beginline="22" endline="33" rule="CyclomaticComplexity" ruleset="Code Size Rules" package="+global" externalInfoUrl="https://phpmd.org/rules/codesize.html#cyclomaticcomplexity" class="NPathClass" method="doSomething" priority="3">
+    <violation beginline="23" endline="43" rule="CyclomaticComplexity" ruleset="Code Size Rules" package="+global" externalInfoUrl="https://phpmd.org/rules/codesize.html#cyclomaticcomplexity" class="NPathClass" method="doSomething" priority="3">
       The method doSomething() has a Cyclomatic Complexity of 25. The configured cyclomatic complexity threshold is 10.
     </violation>
-    <violation beginline="22" endline="33" rule="NPathComplexity" ruleset="Code Size Rules" package="+global" externalInfoUrl="https://phpmd.org/rules/codesize.html#npathcomplexity" class="NPathClass" method="doSomething" priority="3">
+    <violation beginline="23" endline="43" rule="NPathComplexity" ruleset="Code Size Rules" package="+global" externalInfoUrl="https://phpmd.org/rules/codesize.html#npathcomplexity" class="NPathClass" method="doSomething" priority="3">
       The method doSomething() has an NPath complexity of 50000. The configured NPath complexity threshold is 50.
     </violation>
   </file>

--- a/src/test/resources/files/source/source_with_npath_violation.php
+++ b/src/test/resources/files/source/source_with_npath_violation.php
@@ -18,18 +18,28 @@
 /**
  * Simple test class
  */
-class NPathClass {
+class NPathClass
+{
     function doSomething()
     {
-        if (true) {}
-        if (true) {}
-        if (true) {}
-        if (true) {}
-        if (true && true && true && true) {}
-        if (true && true && true && true) {}
-        if (true && true && true && true) {}
-        if (true && true && true && true) {}
-        if (true && true && true && true) {}
+        if (true) {
+        }
+        if (true) {
+        }
+        if (true) {
+        }
+        if (true) {
+        }
+        if (true && true && true && true) {
+        }
+        if (true && true && true && true) {
+        }
+        if (true && true && true && true) {
+        }
+        if (true && true && true && true) {
+        }
+        if (true && true && true && true) {
+        }
     }
 }
 

--- a/src/test/resources/files/source/source_without_violations.php
+++ b/src/test/resources/files/source/source_without_violations.php
@@ -25,6 +25,7 @@ class SourceWithoutViolations
         if (time() % 42 === 0) {
             return 'foo';
         }
+
         return 'bar';
     }
 }

--- a/src/test/resources/files/sourceExcluded/source_with_npath_violation.php
+++ b/src/test/resources/files/sourceExcluded/source_with_npath_violation.php
@@ -18,18 +18,28 @@
 /**
  * Simple test class
  */
-class NPathClass {
+class NPathClass
+{
     function doSomething()
     {
-        if (true) {}
-        if (true) {}
-        if (true) {}
-        if (true) {}
-        if (true && true && true && true) {}
-        if (true && true && true && true) {}
-        if (true && true && true && true) {}
-        if (true && true && true && true) {}
-        if (true && true && true && true) {}
+        if (true) {
+        }
+        if (true) {
+        }
+        if (true) {
+        }
+        if (true) {
+        }
+        if (true && true && true && true) {
+        }
+        if (true && true && true && true) {
+        }
+        if (true && true && true && true) {
+        }
+        if (true && true && true && true) {
+        }
+        if (true && true && true && true) {
+        }
     }
 }
 


### PR DESCRIPTION
Type: refactoring (cleanup)
Issue: Resolves none
Breaking change: no

I executed the ``Reformat code`` functionality of PhpStorm 2020.1 on our bin, source & tests folders.

The very most of them are totally trivial stuff like:
- missing white lines,
- too few or too much whitte space,
- braces on new line or line before
- trailing commas
- indentation
- and previously undetected PSR-2 violations

Since PHPMD doesn't care about codestyle in the sense of formatting, these changes do not affect the tests.
I only had to adjust one test case as the violating lines in the test file changed due to the reformatting.

I hope we can merge this quickly, so new PRs can base upon this and won't have merge conflicts.

LTGM :money_mouth_face: 