### PR TITLE
Remove now superfluous var annotations

### DIFF
--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -205,7 +205,6 @@ class RuleSetFactory
         }
 
         foreach ($xml->children() as $node) {
-            /** @var $node \SimpleXMLElement */
             if ($node->getName() === 'php-includepath') {
                 $includePath = (string)$node;
 
@@ -366,7 +365,6 @@ class RuleSetFactory
         }
 
         foreach ($ruleNode->children() as $node) {
-            /** @var $node \SimpleXMLElement */
             if ($node->getName() === 'description') {
                 $rule->setDescription((string)$node);
             } elseif ($node->getName() === 'example') {
@@ -416,7 +414,6 @@ class RuleSetFactory
         }
 
         foreach ($ruleNode->children() as $node) {
-            /** @var $node \SimpleXMLElement */
             if ($node->getName() === 'description') {
                 $rule->setDescription((string)$node);
             } elseif ($node->getName() === 'example') {
@@ -454,7 +451,6 @@ class RuleSetFactory
     private function parsePropertiesNode(Rule $rule, \SimpleXMLElement $propertiesNode)
     {
         foreach ($propertiesNode->children() as $node) {
-            /** @var $node \SimpleXMLElement */
             if ($node->getName() === 'property') {
                 $this->addProperty($rule, $node);
             }
@@ -522,7 +518,6 @@ class RuleSetFactory
             }
 
             foreach ($xml->children() as $node) {
-                /** @var $node \SimpleXMLElement */
                 if ($node->getName() === 'exclude-pattern') {
                     $excludes[] = '' . $node;
                 }


### PR DESCRIPTION
Type: refactoring
Issue: Resolves none
Breaking change: none

These became unnecessary since some type hints were added and because IDEs gotten smarter.