### PR TITLE
Fix #714 static:: and self:: properties access

### DIFF
--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -224,7 +224,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      *
      * @return \PDepend\Source\AST\ASTArtifact|\PDepend\Source\AST\ASTNode
      */
-    private function getNode($node)
+    protected function getNode($node)
     {
         if ($node instanceof ASTNode) {
             return $node->getNode();

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -34,6 +34,11 @@ use PHPMD\Node\ASTNode;
 abstract class AbstractLocalVariable extends AbstractRule
 {
     /**
+     * @var array Self reference class names.
+     */
+    protected $selfReferences = array('self', 'static');
+
+    /**
      * PHP super globals that are available in all php scopes, so that they
      * can never be unused local variables.
      *

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -17,6 +17,11 @@
 
 namespace PHPMD\Rule;
 
+use PDepend\Source\AST\ASTArrayIndexExpression;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTPropertyPostfix;
+use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
@@ -165,5 +170,61 @@ abstract class AbstractLocalVariable extends AbstractRule
         $parts = explode('\\', trim($node->getImage(), '\\'));
 
         return (0 === strcasecmp(array_pop($parts), $name));
+    }
+
+    /**
+     * Get the image of the given variable node.
+     *
+     * Prefix self:: and static:: properties with "::".
+     *
+     * @param ASTVariable|ASTPropertyPostfix|ASTVariableDeclarator $variable
+     *
+     * @return string
+     */
+    protected function getVariableImage($variable)
+    {
+        $image = $variable->getImage();
+
+        if ($image === '::') {
+            return $image.$variable->getChild(1)->getImage();
+        }
+
+        $base = $variable;
+        $parent = $this->getNode($variable->getParent());
+
+        while ($parent && $parent instanceof ASTArrayIndexExpression && $parent->getChild(0) === $base->getNode()) {
+            $base = $parent;
+            $parent = $this->getNode($base->getParent());
+        }
+
+        if ($parent && $parent instanceof ASTPropertyPostfix) {
+            $parent = $parent->getParent();
+
+            if ($parent instanceof ASTMemberPrimaryPrefix &&
+                in_array($parent->getChild(0)->getImage(), $this->selfReferences)
+            ) {
+                return "::$image";
+            }
+        }
+
+        return $image;
+    }
+
+    /**
+     * Return the PDepend node of ASTNode PHPMD node.
+     *
+     * Or return the input as is if it's not an ASTNode PHPMD node.
+     *
+     * @param mixed $node
+     *
+     * @return \PDepend\Source\AST\ASTArtifact|\PDepend\Source\AST\ASTNode
+     */
+    private function getNode($node)
+    {
+        if ($node instanceof ASTNode) {
+            return $node->getNode();
+        }
+
+        return $node;
     }
 }

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -183,7 +183,6 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Prefix self:: and static:: properties with "::".
      *
      * @param ASTVariable|ASTPropertyPostfix|ASTVariableDeclarator $variable
-     *
      * @return string
      */
     protected function getVariableImage($variable)
@@ -221,7 +220,6 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Or return the input as is if it's not an ASTNode PHPMD node.
      *
      * @param mixed $node
-     *
      * @return \PDepend\Source\AST\ASTArtifact|\PDepend\Source\AST\ASTNode
      */
     protected function getNode($node)

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -38,11 +38,6 @@ use PHPMD\Rule\MethodAware;
 class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, MethodAware
 {
     /**
-     * @var array Self reference class names.
-     */
-    protected $selfReferences = array('self', 'static');
-
-    /**
      * Found variable images within a single method or function.
      *
      * @var array(string)

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -18,8 +18,6 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PDepend\Source\AST\ASTArray;
-use PDepend\Source\AST\ASTArrayIndexExpression;
-use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTPropertyPostfix;
 use PDepend\Source\AST\ASTUnaryExpression;
 use PDepend\Source\AST\ASTVariable;
@@ -278,62 +276,6 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
         if (!isset($this->images[$image])) {
             $this->images[$image] = $variable;
         }
-    }
-
-    /**
-     * Return the PDepend node of ASTNode PHPMD node.
-     *
-     * Or return the input as is if it's not an ASTNode PHPMD node.
-     *
-     * @param mixed $node
-     *
-     * @return \PDepend\Source\AST\ASTArtifact|\PDepend\Source\AST\ASTNode
-     */
-    private function getNode($node)
-    {
-        if ($node instanceof ASTNode) {
-            return $node->getNode();
-        }
-
-        return $node;
-    }
-
-    /**
-     * Get the image of the given variable node.
-     *
-     * Prefix self:: and static:: properties with "::".
-     *
-     * @param ASTVariable|ASTPropertyPostfix|ASTVariableDeclarator $variable
-     *
-     * @return string
-     */
-    private function getVariableImage($variable)
-    {
-        $image = $variable->getImage();
-
-        if ($image === '::') {
-            return $image.$variable->getChild(1)->getImage();
-        }
-
-        $base = $variable;
-        $parent = $this->getNode($variable->getParent());
-
-        while ($parent && $parent instanceof ASTArrayIndexExpression && $parent->getChild(0) === $base->getNode()) {
-            $base = $parent;
-            $parent = $this->getNode($base->getParent());
-        }
-
-        if ($parent && $parent instanceof ASTPropertyPostfix) {
-            $parent = $parent->getParent();
-
-            if ($parent instanceof ASTMemberPrimaryPrefix &&
-                in_array($parent->getChild(0)->getImage(), $this->selfReferences)
-            ) {
-                return "::$image";
-            }
-        }
-
-        return $image;
     }
 
     /**

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleAppliesToStaticProperties.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleAppliesToStaticProperties.php
@@ -15,17 +15,10 @@
  * @link http://phpmd.org/
  */
 
-class testRuleDoesNotApplyToStaticProperties
+class testRuleAppliesToStaticProperties
 {
-    protected $foo = [];
-    protected static $array = [];
-
-    function testRuleDoesNotApplyToStaticProperties($key)
+    function testRuleAppliesToStaticProperties($key)
     {
-        if (isset(static::$array[$key])) {
-            return static::$array[$key];
-        }
-
-        return $key;
+        return static::$array[$key];
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToStaticProperties.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToStaticProperties.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyToStaticProperties
+{
+    protected static $array = [];
+
+    function testRuleDoesNotApplyToStaticProperties($key)
+    {
+        if (isset(static::$array[$key])) {
+            return static::$array[$key];
+        }
+
+        return static::$array[$key] = $key;
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix #714
Breaking change: no

Handle properly undefined properties in code like:
```php
<?php

class Test
{
    private static $foo = [
        'bar' => 'biz',
    ];

    public static function getFoo()
    {
        return self::$foo['bar'];
    }
}
```

- [x] Refactor UndefinedVariable which became too complex.