### PR TITLE
Fix #672 Handle passing-by-reference in native PHP functions

### DIFF
--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -87,9 +87,21 @@ abstract class AbstractLocalVariable extends AbstractRule
      * @param \PHPMD\AbstractNode $variable
      * @return boolean
      */
+    protected function isSuperGlobal(AbstractNode $variable)
+    {
+        return isset(self::$superGlobals[$variable->getImage()]);
+    }
+
+    /**
+     * Tests if the given variable does not represent one of the PHP super globals
+     * that are available in scopes.
+     *
+     * @param \PHPMD\AbstractNode $variable
+     * @return boolean
+     */
     protected function isNotSuperGlobal(AbstractNode $variable)
     {
-        return !isset(self::$superGlobals[$variable->getImage()]);
+        return !$this->isSuperGlobal($variable);
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule;
 
+use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTArrayIndexExpression;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTPropertyPostfix;
@@ -25,6 +26,8 @@ use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
+use ReflectionException;
+use ReflectionFunction;
 
 /**
  * Base class for rules that rely on local variables.
@@ -229,5 +232,36 @@ abstract class AbstractLocalVariable extends AbstractRule
         }
 
         return $node;
+    }
+
+    /**
+     * Return true if the given variable is passed by reference in a native PHP function.
+     *
+     * @param ASTVariable|ASTPropertyPostfix|ASTVariableDeclarator $variable
+     * @return bool
+     */
+    protected function isPassedByReference($variable)
+    {
+        $parent = $this->getNode($variable->getParent());
+
+        if ($parent && $parent instanceof ASTArguments) {
+            $argumentPosition = array_search($this->getNode($variable), $parent->getChildren());
+            $function = $this->getNode($parent->getParent());
+            $functionName = $function->getImage();
+
+            try {
+                $reflectionFunction = new ReflectionFunction($functionName);
+                $parameters = $reflectionFunction->getParameters();
+
+                if ($parameters[$argumentPosition]->isPassedByReference()) {
+                    return true;
+                }
+            } catch (ReflectionException $exception) {
+                // @TODO: Find a way to handle user-land functions
+                // @TODO: Find a way to handle methods
+            }
+        }
+
+        return false;
     }
 }

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -73,24 +73,13 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
         }
 
         foreach ($node->findChildrenOfType('Variable') as $variable) {
-            if (!$this->isNotSuperGlobal($variable)) {
+            /** @var ASTVariable $variable */
+
+            if ($this->isSuperGlobal($variable) || $this->isPassedByReference($variable)) {
                 $this->addVariableDefinition($variable);
+            } elseif (!$this->checkVariableDefined($variable, $node)) {
+                $this->addViolation($variable, array($this->getVariableImage($variable)));
             }
-
-            $this->doCheckVariable($variable, $node);
-        }
-    }
-
-    private function doCheckVariable($variable, $node)
-    {
-        if (!$this->checkVariableDefined($variable, $node)) {
-            if ($this->isPassedByReference($variable)) {
-                $this->addVariableDefinition($variable);
-
-                return;
-            }
-
-            $this->addViolation($variable, array($this->getVariableImage($variable)));
         }
     }
 

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -17,7 +17,6 @@
 
 namespace PHPMD\Rule\CleanCode;
 
-use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTArray;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTPropertyPostfix;
@@ -32,8 +31,6 @@ use PHPMD\Node\MethodNode;
 use PHPMD\Rule\AbstractLocalVariable;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
-use ReflectionException;
-use ReflectionFunction;
 
 /**
  * This rule collects all undefined variables within a given function or method
@@ -87,26 +84,10 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
     private function doCheckVariable($variable, $node)
     {
         if (!$this->checkVariableDefined($variable, $node)) {
-            $parent = $this->getNode($variable->getParent());
+            if ($this->isPassedByReference($variable)) {
+                $this->addVariableDefinition($variable);
 
-            if ($parent && $parent instanceof ASTArguments) {
-                $argumentPosition = array_search($this->getNode($variable), $parent->getChildren());
-                $function = $this->getNode($parent->getParent());
-                $functionName = $function->getImage();
-
-                try {
-                    $reflectionFunction = new ReflectionFunction($functionName);
-                    $parameters = $reflectionFunction->getParameters();
-
-                    if ($parameters[$argumentPosition]->isPassedByReference()) {
-                        $this->addVariableDefinition($variable);
-
-                        return;
-                    }
-                } catch (ReflectionException $exception) {
-                    // @TODO: Find a way to handle user-land functions
-                    // @TODO: Find a way to handle methods
-                }
+                return;
             }
 
             $this->addViolation($variable, array($this->getVariableImage($variable)));

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToPassingByReferences.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToPassingByReferences.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyToPassingByReferences
+{
+    function testRuleDoesNotApplyToPassingByReferences($text)
+    {
+        preg_match_all('/./', $text, $matches);
+
+        foreach ($matches[0] as $match) {
+            echo $match . PHP_EOL;
+        }
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix #672 ([confirmed](https://github.com/phpmd/phpmd/issues/672#issuecomment-630027978))
Breaking change: no