### PR TITLE
Optimize UnusedFormalParameter

### DIFF
--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -43,12 +43,20 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      */
     public function apply(AbstractNode $node)
     {
-        if ($this->isAbstractMethod($node) ||
-            // Magic methods should be ignored as invalid declarations are picked up by PHP.
-            $this->isMagicMethod($node) ||
-            $this->isInheritedSignature($node) ||
-            $this->isNotDeclaration($node)
-        ) {
+        if ($this->isAbstractMethod($node)) {
+            return;
+        }
+
+        // Magic methods should be ignored as invalid declarations are picked up by PHP.
+        if ($this->isMagicMethod($node)) {
+            return;
+        }
+
+        if ($this->isInheritedSignature($node)) {
+            return;
+        }
+
+        if ($this->isNotDeclaration($node)) {
             return;
         }
 

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -109,11 +109,14 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      */
     private function isMagicMethod(AbstractNode $node)
     {
-        if ($node instanceof MethodNode) {
-            static $magicMethodRegExp = null;
+        if (!($node instanceof MethodNode)) {
+            return false;
+        }
 
-            if ($magicMethodRegExp === null) {
-                $magicMethodRegExp = '/__(?:' . implode("|", array(
+        static $magicMethodRegExp = null;
+
+        if ($magicMethodRegExp === null) {
+            $magicMethodRegExp = '/__(?:' . implode("|", array(
                     'call',
                     'callStatic',
                     'get',
@@ -122,12 +125,9 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
                     'unset',
                     'set_state',
                 )) . ')/i';
-            }
-
-            return preg_match($magicMethodRegExp, $node->getName()) === 1;
         }
 
-        return false;
+        return preg_match($magicMethodRegExp, $node->getName()) === 1;
     }
 
     /**


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Optimizations:
- `isInheritedSignature()` and `isMagicMethod()` were marked `@return bool` but actually returned the result of `preg_match()` so `1|0|false`, they now really return `true|false`
- in `isMagicMethod()` `$names` were instanciated even if not used (when `$node instanceof MethodNode` is false) and the RegExp string was recomposed each time. Now the whole RegExp string is composed only once and only if actually used.
- code style