### PR TITLE
Add missing methods to AbstractTest to handle more various apply/notApply series

### DIFF
--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -187,17 +187,27 @@ abstract class AbstractTest extends AbstractStaticTest
      * Returns the first method as a MethodNode for a given test file.
      *
      * @param string $file
-     * @return MethodNode
+     * @return MethodNode|FunctionNode
      * @since 2.8.3
      */
     protected function getMethodNodeForTestFile($file)
     {
-        return new MethodNode(
+        $source = $this->parseSource($file);
+        $class = $source
+            ->getTypes()
+            ->current();
+        $nodeClassName = 'PHPMD\\Node\\FunctionNode';
+        $getter = 'getFunctions';
+
+        if ($class) {
+            $source = $class;
+            $nodeClassName = 'PHPMD\\Node\\MethodNode';
+            $getter = 'getMethods';
+        }
+
+        return new $nodeClassName(
             $this->getNodeByName(
-                $this->parseSource($file)
-                    ->getTypes()
-                    ->current()
-                    ->getMethods(),
+                $source->$getter(),
                 pathinfo($file, PATHINFO_FILENAME)
             )
         );

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -198,7 +198,7 @@ abstract class AbstractTest extends AbstractStaticTest
     }
 
     /**
-     * Returns the first method or function as a MethodNode for a given test file.
+     * Returns the first method or function node for a given test file.
      *
      * @param string $file
      * @return MethodNode|FunctionNode

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -237,7 +237,17 @@ abstract class AbstractTest extends AbstractStaticTest
     protected function expectRuleHasViolationsForFile(Rule $rule, $expectedInvokes, $file)
     {
         $rule->setReport($this->getReportMock($expectedInvokes));
-        $rule->apply($this->getNodeForTestFile($file));
+
+        try {
+            $rule->apply($this->getNodeForTestFile($file));
+        } catch (PHPUnit_Framework_ExpectationFailedException $failedException) {
+            throw new PHPUnit_Framework_ExpectationFailedException(
+                basename($file)."\n".
+                $failedException->getMessage(),
+                $failedException->getComparisonFailure(),
+                $failedException->getPrevious()
+            );
+        }
     }
 
     /**

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -228,7 +228,10 @@ abstract class AbstractTest extends AbstractStaticTest
     }
 
     /**
-     * Test that a given file trigger N times the given rule.
+     * Assert that a given file trigger N times the given rule.
+     *
+     * Rethrows the PHPUnit ExpectationFailedException with the base name
+     * of the file for better readability.
      *
      * @param Rule $rule Rule to test.
      * @param int $expectedInvokes Count of expected invocations.

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -186,7 +186,7 @@ abstract class AbstractTest extends AbstractStaticTest
     /**
      * Returns the first class found for a given test file.
      *
-     * @return FunctionNode
+     * @return ClassNode
      */
     protected function getClassNodeForTestFile($file)
     {

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -184,13 +184,27 @@ abstract class AbstractTest extends AbstractStaticTest
     }
 
     /**
+     * Returns the first class found for a given test file.
+     *
+     * @return FunctionNode
+     */
+    protected function getClassNodeForTestFile($file)
+    {
+        return new ClassNode(
+            $this->parseSource($file)
+                ->getTypes()
+                ->current()
+        );
+    }
+
+    /**
      * Returns the first method as a MethodNode for a given test file.
      *
      * @param string $file
      * @return MethodNode|FunctionNode
      * @since 2.8.3
      */
-    protected function getMethodNodeForTestFile($file)
+    protected function getNodeForTestFile($file)
     {
         $source = $this->parseSource($file);
         $class = $source
@@ -223,7 +237,7 @@ abstract class AbstractTest extends AbstractStaticTest
     protected function expectRuleHasViolationsForFile(Rule $rule, $expectedInvokes, $file)
     {
         $rule->setReport($this->getReportMock($expectedInvokes));
-        $rule->apply($this->getMethodNodeForTestFile($file));
+        $rule->apply($this->getNodeForTestFile($file));
     }
 
     /**

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -198,7 +198,7 @@ abstract class AbstractTest extends AbstractStaticTest
     }
 
     /**
-     * Returns the first method as a MethodNode for a given test file.
+     * Returns the first method or function as a MethodNode for a given test file.
      *
      * @param string $file
      * @return MethodNode|FunctionNode


### PR DESCRIPTION
Type: refactoring
Breaking change: no

This is the testing changes needed for the tests migrations of:
- MissingImportTest #782 
- UnusedLocalVariableTest #783