### PR TITLE
Update CONTRIBUTING to point out to the correct coding standard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ if you have found a bug or have an idea for a feature
 There are a few guidelines that we need contributors to follow, so that we have a
 chance of keeping on top of things.
 
-* The code must follow the [PSR-2 coding standard](http://www.php-fig.org/psr/psr-2/).
+* The code must follow the [coding standard](https://github.com/phpmd/phpmd/blob/master/phpcs.xml.dist), that is based on [PSR-2 coding standard](http://www.php-fig.org/psr/psr-2/) with additional rules.
 * All code changes should be covered by unit tests
 
 Issues
@@ -26,15 +26,15 @@ Issues
 Coding Standard
 ---------------
 
-Make sure your code changes comply with the PSR-2 coding standard by
+Make sure your code changes comply with the [coding standard](https://github.com/phpmd/phpmd/blob/master/phpcs.xml.dist) by
 using [PHP Codesniffer](https://github.com/squizlabs/PHP_CodeSniffer)
 from within your PHPMD folder:
 
-    vendor/bin/phpcs -p --extensions=php --standard=PSR2 src > phpcs.txt
+    vendor/bin/phpcs -p --extensions=php src > phpcs.txt
 
 Linux / OS X users may extend this command to exclude files, that are not part of a commit:
 
-    vendor/bin/phpcs -p --extensions=php --standard=PSR2 --ignore=src/tests/resources $(git ls-files -om --exclude-standard | grep '\.php$') > phpcs.txt
+    vendor/bin/phpcs -p --extensions=php --ignore=src/tests/resources $(git ls-files -om --exclude-standard | grep '\.php$') > phpcs.txt
 
 Check the ``phpcs.txt`` once it finished.
 


### PR DESCRIPTION
Type: documentation update  
Issue: -
Breaking change: no

I found out that we have a new coding standard but the CONTRIBUTING.md still say we use the PSR-2, this PR is to fix that.