### PR TITLE
Improve error message for apply and notApply tests

### DIFF
--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -264,13 +264,13 @@ abstract class AbstractTest extends AbstractStaticTest
      * Return a human-friendly failure message for a given list of violations and the actual/expected counts.
      *
      * @param string $file
-     * @param int $actualInvokes
      * @param int $expectedInvokes
+     * @param int $actualInvokes
      * @param array|iterable|Traversable $violations
      *
      * @return string
      */
-    protected function getViolationFailureMessage($file, $actualInvokes, $expectedInvokes, $violations)
+    protected function getViolationFailureMessage($file, $expectedInvokes, $actualInvokes, $violations)
     {
         return basename($file)." failed:\n".
             "Expected $expectedInvokes violation".($expectedInvokes !== 1 ? 's' : '')."\n".

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -34,6 +34,7 @@ use PHPMD\Node\MethodNode;
 use PHPMD\Node\TraitNode;
 use PHPMD\Rule\Design\TooManyFields;
 use PHPMD\Stubs\RuleStub;
+use PHPUnit_Framework_ExpectationFailedException;
 use PHPUnit_Framework_MockObject_MockBuilder;
 use PHPUnit_Framework_MockObject_MockObject;
 
@@ -239,10 +240,12 @@ abstract class AbstractTest extends AbstractStaticTest
      */
     protected function expectRuleHasViolationsForFile(Rule $rule, $expectedInvokes, $file)
     {
-        $rule->setReport($this->getReportMock($expectedInvokes));
+        $reportMock = $this->getReportMock($expectedInvokes);
+        $rule->setReport($reportMock);
 
         try {
             $rule->apply($this->getNodeForTestFile($file));
+            $reportMock->__phpunit_verify();
         } catch (PHPUnit_Framework_ExpectationFailedException $failedException) {
             throw new PHPUnit_Framework_ExpectationFailedException(
                 basename($file)."\n".


### PR DESCRIPTION
Type: testing feature
Breaking change: no

Before when a violation count error occurred:
```
PHPMD\Report::addRuleViolation(PHPMD\RuleViolation Object (...)) was not expected to be called.
```

Now:
```
testRuleDoesNotApplyToKeyReferencePair.php failed:
Expected 0 violations
But 1 violation raised:
  - line 26 on Variable $fooBar
```