### PR TITLE
Prepare a changelog for version 2.9.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,29 @@
+phpmd-2.9.0 (2020/05/25)
+========================
+
+- Added #496: Add rule for PHP's @ operator
+- Added #737: Allowing custom exclusion for StaticAccess by extending the class
+- Added #749: Add allow-underscore option for CamelCaseParameterName & CamelCaseVariableName 
+- Added #747: Long variable subtract suffix
+- Fixed #743: Output for version
+- Fixed #754: Fix #720 undefined variable in foreach when passed by reference
+- Fixed #764: Fix #718 Handle anonymous class in "undefined variable" rule
+- Fixed #770: Fix #769 Handle deconstruction assignation for undefined variable
+- Fixed #781: Fix #714 static:: and self:: properties access
+- Fixed #784: Fix #672 Handle passing-by-reference in native PHP functions
+- Updated different parts of the documentation. #717 #736 #748 
+- Changed: #529 : Replaced HTML renderer with new "pretty HTML" renderer 
+- Changed: Internal code improvement #750 #752 #756 #757 #758 #759 #768 #773 #775 #785 #787
+- Deprecated all the PHPMD exceptions that aren't part of the PHPMD\Exceptions namespace. See #775
+
+### A potential BC change:
+With the clean-up in #768 we have a potential BC break in an unsupported part that we want to give attention for.
+> The class aliases ``PHP_PMD_*`` used for PHPMD 1.x backwards PEAR compatibility were removed. If you happen to still depend on these, please adjust your code like so:
+> 
+> From ``PHP_PMD_[Component]_[Class]'`` to ``PHPMD\[Component]\[Class]``,
+> as in ``PHP_PMD_Renderer_HTMLRenderer'`` to ``PHPMD\Renderer\HTMLRenderer``.
+See #768
+
 phpmd-2.8.2 (2020/02/24)
 ========================
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-phpmd-2.9.0 (2020/07/23)
+phpmd-2.9.0 (2020/09/02)
 ========================
 
 - Added #496: Added rule for PHP's @ operator

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,9 +11,15 @@ phpmd-2.9.0 (2020/05/25)
 - Fixed #770: Fixed #769 Handle deconstruction assignation for undefined variable
 - Fixed #781: Fixed #714 static:: and self:: properties access
 - Fixed #784: Fixed #672 Handle passing-by-reference in native PHP functions
-- Updated different parts of the documentation. #717 #736 #748 
-- Changed: #529 : Replaced HTML renderer with new "pretty HTML" renderer 
-- Changed: Internal code improvement #750 #752 #756 #757 #758 #759 #768 #773 #775 #785 #787
+- Fixed #793: Fixed #580 Raise UnusedFormalParameter instead UnusedLocalVariable for unused closure parameter
+- Fixed #794: Fixed #540 Detect unused variable declared multiple times
+- Fixed #805: Fixed #802 Prevent an error with nested arrays
+- Fixed #807: Fixed #790 Fix for short variables rule inside foreach statements
+- Fixed #809: Fixed #808 Ignore rule path for supression annotation
+- Updated different parts of the documentation. #717 #736 #748 #811
+- Changed: #529 : Replaced HTML renderer with new "pretty HTML" renderer
+- Changed: #806 : Changed #44 Change private methods to protected in rules. Make rules extendable  
+- Changed: Internal code improvement #750 #752 #756 #757 #758 #759 #768 #773 #775 #785 #787 #791 #792
 - Deprecated all the PHPMD exceptions that aren't part of the PHPMD\Exceptions namespace. See #775
 
 ### A potential BC change:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,11 +6,11 @@ phpmd-2.9.0 (2020/05/25)
 - Added #749: Add allow-underscore option for CamelCaseParameterName & CamelCaseVariableName 
 - Added #747: Long variable subtract suffix
 - Fixed #743: Output for version
-- Fixed #754: Fix #720 undefined variable in foreach when passed by reference
-- Fixed #764: Fix #718 Handle anonymous class in "undefined variable" rule
-- Fixed #770: Fix #769 Handle deconstruction assignation for undefined variable
-- Fixed #781: Fix #714 static:: and self:: properties access
-- Fixed #784: Fix #672 Handle passing-by-reference in native PHP functions
+- Fixed #754: Fixed #720 undefined variable in foreach when passed by reference
+- Fixed #764: Fixed #718 Handle anonymous class in "undefined variable" rule
+- Fixed #770: Fixed #769 Handle deconstruction assignation for undefined variable
+- Fixed #781: Fixed #714 static:: and self:: properties access
+- Fixed #784: Fixed #672 Handle passing-by-reference in native PHP functions
 - Updated different parts of the documentation. #717 #736 #748 
 - Changed: #529 : Replaced HTML renderer with new "pretty HTML" renderer 
 - Changed: Internal code improvement #750 #752 #756 #757 #758 #759 #768 #773 #775 #785 #787


### PR DESCRIPTION
Type: documentation update  
Issue: -
Breaking change: no

This PR prepares the release of 2.9.0

If approved I did plan to release a new version on monday after releasing a new version of PDepend
