### PR TITLE
Fix for short variables rule

### DIFF
--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -188,7 +188,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      */
     protected function isInitializedInLoop(AbstractNode $node)
     {
-        $exceptionVariables = [];
+        $exceptionVariables = array();
 
         $parentForeaches = $this->getParentsOfType($node, 'ForeachStatement');
         foreach ($parentForeaches as $foreach) {
@@ -210,7 +210,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      */
     protected function getParentsOfType(AbstractNode $node, $type)
     {
-        $parents = [];
+        $parents = array();
 
         $parent = $node->getParent();
 

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -188,6 +188,10 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      */
     protected function isInitializedInLoop(AbstractNode $node)
     {
+        if (!$this->getBooleanProperty('allow-short-variables-in-loop', true)) {
+            return false;
+        }
+
         $exceptionVariables = array();
 
         $parentForeaches = $this->getParentsOfType($node, 'ForeachStatement');

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -346,8 +346,6 @@ class ShortVariableTest extends AbstractTest
         $rule->apply($this->getClass());
     }
 
-
-
     /**
      * testRuleAppliesToVariablesWithinForeach
      *

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -370,9 +370,9 @@ class ShortVariableTest extends AbstractTest
 
     public function provideClassWithShortForeachVariables()
     {
-        return [
-            [true, 2],
-            [false, 5],
-        ];
+        return array(
+            array(true, 2),
+            array(false, 5),
+        );
     }
 }

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -349,14 +349,16 @@ class ShortVariableTest extends AbstractTest
     /**
      * testRuleAppliesToVariablesWithinForeach
      *
+     * @dataProvider provideClassWithShortForeachVariables
      * @return void
      */
-    public function testRuleAppliesToVariablesWithinForeach()
+    public function testRuleAppliesToVariablesWithinForeach($allowShortVarInLoop, $expectedErrorsCount)
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
         $rule->addProperty('exceptions', '');
-        $rule->setReport($this->getReportMock(2));
+        $rule->addProperty('allow-short-variables-in-loop', $allowShortVarInLoop);
+        $rule->setReport($this->getReportMock($expectedErrorsCount));
 
         $class = $this->getClass();
         $rule->apply($class);
@@ -364,5 +366,13 @@ class ShortVariableTest extends AbstractTest
         foreach ($class->getMethods() as $method) {
             $rule->apply($method);
         }
+    }
+
+    public function provideClassWithShortForeachVariables()
+    {
+        return [
+            [true, 2],
+            [false, 5],
+        ];
     }
 }

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -345,4 +345,26 @@ class ShortVariableTest extends AbstractTest
 
         $rule->apply($this->getClass());
     }
+
+
+
+    /**
+     * testRuleAppliesToVariablesWithinForeach
+     *
+     * @return void
+     */
+    public function testRuleAppliesToVariablesWithinForeach()
+    {
+        $rule = new ShortVariable();
+        $rule->addProperty('minimum', 3);
+        $rule->addProperty('exceptions', '');
+        $rule->setReport($this->getReportMock(2));
+
+        $class = $this->getClass();
+        $rule->apply($class);
+
+        foreach ($class->getMethods() as $method) {
+            $rule->apply($method);
+        }
+    }
 }

--- a/src/test/resources/files/Rule/Naming/ShortVariable/testRuleAppliesToVariablesWithinForeach.php
+++ b/src/test/resources/files/Rule/Naming/ShortVariable/testRuleAppliesToVariablesWithinForeach.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleAppliesToVariablesWithinForeach
+{
+    public function testing()
+    {
+        $abc = 1;
+
+        foreach ([1, 2, 3] as $i) {
+            $a = $i;
+            echo $a;
+            foreach ([4, 5, 6] as $k => $v) {
+                echo $k;
+                echo $v;
+                $x = (string) $k . (string) $v;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Type: **bugfix**
Issue: Resolves #790 
Breaking change: no

The issue says that the PHPMD's ShortVariable rule skips variables inside foreach statements.

The reason for that is that the Rule checks the variable's context and skips it, if the variable has certain parents (https://github.com/phpmd/phpmd/blob/master/src/main/php/PHPMD/Rule/Naming/ShortVariable.php#L172)
I guess, the idea was to skip short variables that were initialized inside loops, like `foreach ($values as $k => $v)`.
But the parents verification used recursion to check ALL parents.

I've refactored the method `isNameAllowedInContext` so that for foreach statement it skips only variables that are the immediate children of this statement.

The issue also expects that variables inside foreach loops are also processed and not skipped. I think the right way to do that is to add a new configuration for the ShortVariable rule, something like "Process variables inside loops" that would be false by default and run those checks only if this config is set to true. This would keep the backward compatibility. Anyway, I think this is more like a new feature and if accepted by you, would rather be made in its own PR.