### PR TITLE
Short long class name documentation

### DIFF
--- a/src/site/rst/rules/naming.rst
+++ b/src/site/rst/rules/naming.rst
@@ -4,6 +4,63 @@ Naming Rules
 
 The Naming Ruleset contains a collection of rules about names - too long, too short, and so forth.
 
+LongClassName
+=============
+
+Since: PHPMD 2.9
+
+Detects when classes or interfaces are declared with excessively long names.
+
+Example: ::
+
+  class ATooLongClassNameThatHintsAtADesignProblem {
+
+  }
+
+  interface ATooLongInterfaceNameThatHintsAtADesignProblem {
+
+  }
+
+This rule has the following properties:
+
++-----------------------------------+---------------+------------------------------------------------------------+
+| Name                              | Default Value | Description                                                |
++===================================+===============+============================================================+
+| maximum                           | 40            | The class name length reporting threshold.                 |
++-----------------------------------+---------------+------------------------------------------------------------+
+| subtract-suffixes                 |               | Comma-separated list of suffixes that will not count in    |
+|                                   |               | the length of the class name. Only the first matching      |
+|                                   |               | suffix will be subtracted.                                 |
++-----------------------------------+---------------+------------------------------------------------------------+
+
+ShortClassName
+==============
+
+Since: PHPMD 2.9
+
+Detects when classes or interfaces have a very short name.
+
+Example: ::
+
+  class Fo {
+
+  }
+
+  interface Fo {
+
+  }
+
+This rule has the following properties:
+
++-----------------------------------+---------------+------------------------------------------------------------+
+| Name                              | Default Value | Description                                                |
++===================================+===============+============================================================+
+| minimum                           | 3             | The class name length reporting threshold                  |
++-----------------------------------+---------------+------------------------------------------------------------+
+| exceptions                        |               | Comma-separated list of exceptions. Example: Log,URL,FTP   |
++-----------------------------------+---------------+------------------------------------------------------------+
+
+
 ShortVariable
 =============
 
@@ -158,4 +215,4 @@ Remark
   This document is based on a ruleset xml-file, that was taken from the original source of the `PMD`__ project. This means that most parts of the content on this page are the intellectual work of the PMD community and its contributors and not of the PHPMD project.
 
 __ http://pmd.sourceforge.net/
-        
+


### PR DESCRIPTION
Type: documentation update
Breaking change: no

In previous PR for short and long class names rules missed to update `src/site/rst/rules/naming.rst`
This PR solves that.
