### PR TITLE
Fix #815 add rule name in text output

### DIFF
--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -26,6 +26,7 @@ use PHPMD\Report;
  */
 class TextRenderer extends AbstractRenderer
 {
+    protected $columnSpacing = 2;
 
     /**
      * This method will be called when the engine has finished the source analysis
@@ -37,12 +38,26 @@ class TextRenderer extends AbstractRenderer
     public function renderReport(Report $report)
     {
         $writer = $this->getWriter();
+        $longestLocationLength = 0;
+        $longestRuleNameLength = 0;
+        $violations = array();
 
         foreach ($report->getRuleViolations() as $violation) {
-            $writer->write($violation->getFileName());
-            $writer->write(':');
-            $writer->write($violation->getBeginLine());
-            $writer->write("\t");
+            $location = $violation->getFileName().':'.$violation->getBeginLine();
+            $ruleName = $violation->getRule()->getName();
+            $locationLength = mb_strlen($location);
+            $ruleNameLength = mb_strlen($ruleName);
+            $longestLocationLength = max($longestLocationLength, $locationLength);
+            $longestRuleNameLength = max($longestRuleNameLength, $ruleNameLength);
+            $violations[] = array($violation, $location, $ruleName, $locationLength, $ruleNameLength);
+        }
+
+        foreach ($violations as $data) {
+            list($violation, $location, $ruleName, $locationLength, $ruleNameLength) = $data;
+            $writer->write($location);
+            $writer->write(str_repeat(' ', $longestLocationLength + $this->columnSpacing - $locationLength));
+            $writer->write($ruleName);
+            $writer->write(str_repeat(' ', $longestRuleNameLength + $this->columnSpacing - $ruleNameLength));
             $writer->write($violation->getDescription());
             $writer->write(PHP_EOL);
         }

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -17,8 +17,10 @@
 
 namespace PHPMD\Renderer;
 
+use ArrayIterator;
 use PHPMD\AbstractTest;
 use PHPMD\ProcessingError;
+use PHPMD\Stubs\RuleStub;
 use PHPMD\Stubs\WriterStub;
 
 /**
@@ -37,9 +39,12 @@ class TextRendererTest extends AbstractTest
     {
         // Create a writer instance.
         $writer = new WriterStub();
+        $rule = new RuleStub();
+        $rule->setName('LongerNamedRule');
+        $rule->setDescription('An other description for this rule');
 
         $violations = array(
-            $this->getRuleViolationMock('/bar.php', 1),
+            $this->getRuleViolationMock('/bar.php', 1, 42, $rule, $rule->getDescription()),
             $this->getRuleViolationMock('/foo-biz.php', 2),
             $this->getRuleViolationMock('/foo.php', 34),
         );
@@ -47,10 +52,10 @@ class TextRendererTest extends AbstractTest
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator($violations)));
+            ->will($this->returnValue(new ArrayIterator($violations)));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator(array())));
+            ->will($this->returnValue(new ArrayIterator(array())));
 
         $renderer = new TextRenderer();
         $renderer->setWriter($writer);
@@ -60,9 +65,9 @@ class TextRendererTest extends AbstractTest
         $renderer->end();
 
         $this->assertEquals(
-            "/bar.php:1      RuleStub  Test description" . PHP_EOL .
-            "/foo-biz.php:2  RuleStub  Test description" . PHP_EOL .
-            "/foo.php:34     RuleStub  Test description" . PHP_EOL,
+            "/bar.php:1      LongerNamedRule  An other description for this rule" . PHP_EOL .
+            "/foo-biz.php:2  RuleStub         Test description" . PHP_EOL .
+            "/foo.php:34     RuleStub         Test description" . PHP_EOL,
             $writer->getData()
         );
     }
@@ -86,10 +91,10 @@ class TextRendererTest extends AbstractTest
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator(array())));
+            ->will($this->returnValue(new ArrayIterator(array())));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator($errors)));
+            ->will($this->returnValue(new ArrayIterator($errors)));
 
         $renderer = new TextRenderer();
         $renderer->setWriter($writer);

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -40,8 +40,8 @@ class TextRendererTest extends AbstractTest
 
         $violations = array(
             $this->getRuleViolationMock('/bar.php', 1),
-            $this->getRuleViolationMock('/foo.php', 2),
-            $this->getRuleViolationMock('/foo.php', 3),
+            $this->getRuleViolationMock('/foo-biz.php', 2),
+            $this->getRuleViolationMock('/foo.php', 34),
         );
 
         $report = $this->getReportWithNoViolation();
@@ -60,9 +60,9 @@ class TextRendererTest extends AbstractTest
         $renderer->end();
 
         $this->assertEquals(
-            "/bar.php:1\tTest description" . PHP_EOL .
-            "/foo.php:2\tTest description" . PHP_EOL .
-            "/foo.php:3\tTest description" . PHP_EOL,
+            "/bar.php:1      RuleStub  Test description" . PHP_EOL .
+            "/foo-biz.php:2  RuleStub  Test description" . PHP_EOL .
+            "/foo.php:34     RuleStub  Test description" . PHP_EOL,
             $writer->getData()
         );
     }

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -192,7 +192,8 @@ class CommandTest extends AbstractTest
 
         $this->assertSame(Command::EXIT_VIOLATION, $exitCode);
         $this->assertSame(
-            "$uri:8  ShortVariable  Avoid variables with short names like \$a. Configured minimum length is 3." . PHP_EOL,
+            "$uri:8  ShortVariable  Avoid variables with short names like \$a. " .
+            'Configured minimum length is 3.' . PHP_EOL,
             file_get_contents($temp)
         );
     }

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -192,7 +192,7 @@ class CommandTest extends AbstractTest
 
         $this->assertSame(Command::EXIT_VIOLATION, $exitCode);
         $this->assertSame(
-            "$uri:8	Avoid variables with short names like \$a. Configured minimum length is 3." . PHP_EOL,
+            "$uri:8  ShortVariable  Avoid variables with short names like \$a. Configured minimum length is 3." . PHP_EOL,
             file_get_contents($temp)
         );
     }


### PR DESCRIPTION
Type: feature
Issue: Resolves #815
Breaking change: yes

Changes:
- Add the rule name in the text renderer output between the location (file path + line) and the description of each rule violation.
- Align columns of the text renderer output (with at least 2 spaces between columnts).

Considering that this text output could be parsed splitting with `\t` those kind of parsing will fail at the next version due to:
- new number of columns: 2 => 3
- gluing is now using only spaces to fix the columns alignment

If you need to parse the PHPMD text output to extract the summary data, here is how to achieve it after this PR is merged:
```php
$data = array_map(function ($line) {
    $object = new stdClass();
    [$object->location, $object->rule, $object->description] = preg_split('/\s{2,}/', trim($line), 3);

    return $object;
}, explode("\n", trim($output)));
```