### PR TITLE
#818 Fix passing-by-reference detection

### DIFF
--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -262,7 +262,13 @@ abstract class AbstractLocalVariable extends AbstractRule
         if ($parent && $parent instanceof ASTArguments) {
             $argumentPosition = array_search($this->getNode($variable), $parent->getChildren());
             $function = $this->getNode($parent->getParent());
+            $functionParent = $this->getNode($function->getParent());
             $functionName = $function->getImage();
+
+            if ($functionParent instanceof ASTMemberPrimaryPrefix) {
+                // @TODO: Find a way to handle methods
+                return false;
+            }
 
             try {
                 $reflectionFunction = new ReflectionFunction($functionName);
@@ -273,7 +279,6 @@ abstract class AbstractLocalVariable extends AbstractRule
                 }
             } catch (ReflectionException $exception) {
                 // @TODO: Find a way to handle user-land functions
-                // @TODO: Find a way to handle methods
             }
         }
 

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -253,7 +253,7 @@ abstract class AbstractTest extends AbstractStaticTest
 
         if (!$assertion) {
             throw new PHPUnit_Framework_ExpectationFailedException(
-                $this->getViolationFailureMessage($file, $actualInvokes, $expectedInvokes, $violations)
+                $this->getViolationFailureMessage($file, $expectedInvokes, $actualInvokes, $violations)
             );
         }
 

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleAppliesToExtraParameters.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleAppliesToExtraParameters.php
@@ -15,11 +15,17 @@
  * @link http://phpmd.org/
  */
 
-class testRuleAppliesToUndefinedVariableOnArray
+class testRuleAppliesToExtraParameters
 {
-    function testRuleAppliesToUndefinedVariableOnArrayWithKeys()
+    function testRuleAppliesToExtraParameters()
     {
-        $x = ['a' => 42, 'b' => $y];
-        echo $x;
+        $x = 42;
+
+        $this->foo($x, $y);
+    }
+
+    function foo(&$a)
+    {
+        $a++;
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleAppliesToMethodMatchingFunctionName.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleAppliesToMethodMatchingFunctionName.php
@@ -15,11 +15,15 @@
  * @link http://phpmd.org/
  */
 
-class testRuleAppliesToUndefinedVariableOnArray
+class testRuleAppliesToMethodMatchingFunctionName
 {
-    function testRuleAppliesToUndefinedVariableOnArrayWithKeys()
+    public function testRuleAppliesToMethodMatchingFunctionName()
     {
-        $x = ['a' => 42, 'b' => $y];
-        echo $x;
+        $this->preg_match('a', 'b', $undefined);
+    }
+
+    public function preg_match($a, $b, $c)
+    {
+        // noop
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleAppliesToUndefinedVariableOnArray.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleAppliesToUndefinedVariableOnArray.php
@@ -15,7 +15,7 @@
  * @link http://phpmd.org/
  */
 
-class testRuleAppliesToUndefinedVariableOnArray extends AbstractTest
+class testRuleAppliesToUndefinedVariableOnArray
 {
     function testRuleAppliesToUndefinedVariableOnArray()
     {

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleAppliesToUndefinedVariableWithDefinedVariable.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleAppliesToUndefinedVariableWithDefinedVariable.php
@@ -15,7 +15,7 @@
  * @link http://phpmd.org/
  */
 
-class testRuleAppliesToUndefinedVariableWithDefinedVariable extends AbstractTest
+class testRuleAppliesToUndefinedVariableWithDefinedVariable
 {
     function testRuleAppliesToUndefinedVariableWithDefinedVariable()
     {

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleAppliesToUnknownArguments.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleAppliesToUnknownArguments.php
@@ -15,11 +15,10 @@
  * @link http://phpmd.org/
  */
 
-class testRuleAppliesToUndefinedVariableOnArray
+class testRuleAppliesToUnknownArguments
 {
-    function testRuleAppliesToUndefinedVariableOnArrayWithKeys()
+    function testRuleAppliesToUnknownArguments(UnknownObject $object)
     {
-        $x = ['a' => 42, 'b' => $y];
-        echo $x;
+        $object->foo($a);
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToUnknownMethod.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToUnknownMethod.php
@@ -15,11 +15,10 @@
  * @link http://phpmd.org/
  */
 
-class testRuleAppliesToUndefinedVariableOnArray
+class testRuleDoesNotApplyToUnknownMethod
 {
-    function testRuleAppliesToUndefinedVariableOnArrayWithKeys()
+    function testRuleDoesNotApplyToUnknownMethod(UnknownObject $object)
     {
-        $x = ['a' => 42, 'b' => $y];
-        echo $x;
+        $this->foo($object);
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToUsedProperties.php
+++ b/src/test/resources/files/Rule/CleanCode/UndefinedVariable/testRuleDoesNotApplyToUsedProperties.php
@@ -15,7 +15,7 @@
  * @link http://phpmd.org/
  */
 
-class testRuleDoesNotApplyToUsedProperties extends AbstractTest
+class testRuleDoesNotApplyToUsedProperties
 {
     protected $x = 'abc';
 


### PR DESCRIPTION
Type: bugfix
Related to: #816 #818
Breaking change: no

Observed: Calling `->preg_match()` detect a passing by reference due to `preg_match` name matching.

Expected: Until we can properly extract available methods on an object/class, we should consider by default that there is no passing by reference (for methods: e.g. calles prefixed by `->` or `::`).