### PR TITLE
BUGFIX: Allow short variable name in catch

### DIFF
--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -171,13 +171,10 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      */
     protected function isNameAllowedInContext(AbstractNode $node)
     {
-        if ($this->isChildOf($node, 'ForeachStatement')) {
-            return $this->isInitializedInLoop($node);
-        }
-
         return $this->isChildOf($node, 'CatchStatement')
             || $this->isChildOf($node, 'ForInit')
-            || $this->isChildOf($node, 'MemberPrimaryPrefix');
+            || $this->isChildOf($node, 'MemberPrimaryPrefix')
+            || ($this->isChildOf($node, 'ForeachStatement') && $this->isInitializedInLoop($node));
     }
 
     /**


### PR DESCRIPTION
Type: bugfix
Issue: Resolves #826
Breaking change: no

#827 would already fix the regression but I wanted to give another, maybe simpler option (behaving like before #807).