### PR TITLE
Add missing external info URL for UndefinedVariable

### DIFF
--- a/src/main/resources/rulesets/cleancode.xml
+++ b/src/main/resources/rulesets/cleancode.xml
@@ -204,7 +204,7 @@ function make() {
           since="2.8.0"
           message="Avoid using undefined variables such as '{0}' which will lead to PHP notices."
           class="PHPMD\Rule\CleanCode\UndefinedVariable"
-          externalInfoUrl="">
+          externalInfoUrl="https://phpmd.org/rules/cleancode.html#undefinedvariable">
         <description>
             Detects when a variable is used that has not been defined before.
         </description>

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -712,6 +712,39 @@ class RuleSetFactoryTest extends AbstractTest
     }
 
     /**
+     * Checks the ruleset XML files provided with PHPMD all provide externalInfoUrls
+     *
+     * @param string $file The path to the ruleset xml to test
+     * @return void
+     * @dataProvider getDefaultRuleSets
+     */
+    public function testDefaultRuleSetsProvideExternalInfoUrls($file)
+    {
+        $rulesets = $this->createRuleSetsFromFiles($file);
+        $ruleset = $rulesets[0];
+        /** @var Rule $rule */
+        foreach ($ruleset->getRules() as $rule) {
+            $message = sprintf(
+                '%s in rule set %s should provide an externalInfoUrl',
+                $rule->getName(),
+                $ruleset->getName()
+            );
+
+            $this->assertNotEmpty($rule->getExternalInfoUrl(), $message);
+        }
+    }
+
+    /**
+     * Provides an array of the file paths to rule sets provided with PHPMD
+     *
+     * @return array
+     */
+    public function getDefaultRuleSets()
+    {
+        return static::getValuesAsArrays(glob(__DIR__ . '/../../../main/resources/rulesets/*.xml'));
+    }
+
+    /**
      * Invokes the <b>createRuleSets()</b> of the {@link RuleSetFactory}
      * class.
      *
@@ -741,7 +774,7 @@ class RuleSetFactoryTest extends AbstractTest
         $args = func_get_args();
 
         $factory = new RuleSetFactory();
-      
+
         return $factory->createRuleSets(implode(',', $args));
     }
 

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -720,14 +720,14 @@ class RuleSetFactoryTest extends AbstractTest
      */
     public function testDefaultRuleSetsProvideExternalInfoUrls($file)
     {
-        $rulesets = $this->createRuleSetsFromFiles($file);
-        $ruleset = $rulesets[0];
+        $ruleSets = $this->createRuleSetsFromFiles($file);
+        $ruleSet = $ruleSets[0];
         /** @var Rule $rule */
-        foreach ($ruleset->getRules() as $rule) {
+        foreach ($ruleSet->getRules() as $rule) {
             $message = sprintf(
                 '%s in rule set %s should provide an externalInfoUrl',
                 $rule->getName(),
-                $ruleset->getName()
+                $ruleSet->getName()
             );
 
             $this->assertNotEmpty($rule->getExternalInfoUrl(), $message);


### PR DESCRIPTION
Type: documentation update
Issue: Resolves #724
Breaking change: no

- Adds the missing Url as suggested in the linked issue
- Adds a test that all of the rulesets provided with PHPMD provide an external info URL
