### PR TITLE
Change the naming error where possible

### DIFF
--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -65,11 +65,11 @@ class ParserFactory
     {
         $application = new Application();
 
-        $currentWorkingDirectory = getcwd();
-        if (file_exists($currentWorkingDirectory . self::PDEPEND_CONFIG_FILE_NAME)) {
-            $application->setConfigurationFile($currentWorkingDirectory . self::PDEPEND_CONFIG_FILE_NAME);
-        } elseif (file_exists($currentWorkingDirectory . self::PDEPEND_CONFIG_FILE_NAME_DIST)) {
-            $application->setConfigurationFile($currentWorkingDirectory . self::PDEPEND_CONFIG_FILE_NAME_DIST);
+        $workingDirectory = getcwd();
+        if (file_exists($workingDirectory . self::PDEPEND_CONFIG_FILE_NAME)) {
+            $application->setConfigurationFile($workingDirectory . self::PDEPEND_CONFIG_FILE_NAME);
+        } elseif (file_exists($workingDirectory . self::PDEPEND_CONFIG_FILE_NAME_DIST)) {
+            $application->setConfigurationFile($workingDirectory . self::PDEPEND_CONFIG_FILE_NAME_DIST);
         }
 
         return $application->getEngine();

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -318,13 +318,13 @@ class HTMLRenderer extends AbstractRenderer
      */
     public function renderReport(Report $report)
     {
-        $w = $this->getWriter();
+        $writer = $this->getWriter();
 
         $index = 0;
         $violations = $report->getRuleViolations();
 
         $count = count($violations);
-        $w->write(sprintf('<h3>%d problems found</h3>', $count));
+        $writer->write(sprintf('<h3>%d problems found</h3>', $count));
 
         // If no problems were found, don't bother with rendering anything else.
         if (!$count) {
@@ -332,7 +332,7 @@ class HTMLRenderer extends AbstractRenderer
         }
 
         // Render summary tables.
-        $w->write("<h2>Summary</h2>");
+        $writer->write("<h2>Summary</h2>");
         $categorized = self::sumUpViolations($violations);
         $this->writeTable('By priority', 'Priority', $categorized[self::CATEGORY_PRIORITY]);
         $this->writeTable('By namespace', 'PHP Namespace', $categorized[self::CATEGORY_NAMESPACE]);
@@ -340,8 +340,8 @@ class HTMLRenderer extends AbstractRenderer
         $this->writeTable('By name', 'Rule name', $categorized[self::CATEGORY_RULE]);
 
         // Render details of each violation and place the "Details" display toggle.
-        $w->write("<h2 style='page-break-before: always'>Details</h2>");
-        $w->write("
+        $writer->write("<h2 style='page-break-before: always'>Details</h2>");
+        $writer->write("
             <a
                 id='details-link'
                 class='info-lnk blck'
@@ -350,7 +350,7 @@ class HTMLRenderer extends AbstractRenderer
             >
             Show details &#x25BC;
         </a>");
-        $w->write("<div id='details-wrapper' class='hidden'>");
+        $writer->write("<div id='details-wrapper' class='hidden'>");
 
         foreach ($violations as $violation) {
             // This is going to be used as ID in HTML (deep anchoring).
@@ -401,7 +401,7 @@ class HTMLRenderer extends AbstractRenderer
 
             // Remove unnecessary tab/space characters at the line beginnings.
             $html = self::reduceWhitespace($html);
-            $w->write(sprintf($html, $excerptHtml));
+            $writer->write(sprintf($html, $excerptHtml));
         }
     }
 
@@ -458,8 +458,8 @@ class HTMLRenderer extends AbstractRenderer
         // Compile final regex, if not done already.
         if (!self::$compiledHighlightRegex) {
             $prepared = self::$descHighlightRules;
-            array_walk($prepared, function (&$v, $k) {
-                $v = "(?<{$k}>{$v['regex']})";
+            array_walk($prepared, function (&$value, $key) {
+                $value = "(?<{$key}>{$value['regex']})";
             });
 
             self::$compiledHighlightRegex = "#(" . implode('|', $prepared) . ")#";
@@ -467,13 +467,13 @@ class HTMLRenderer extends AbstractRenderer
 
         $rules = self::$descHighlightRules;
 
-        return preg_replace_callback(self::$compiledHighlightRegex, function ($x) use ($rules) {
+        return preg_replace_callback(self::$compiledHighlightRegex, function ($matches) use ($rules) {
             // Extract currently matched specification of highlighting (Match groups
             // are named and we can find out which is not empty.).
-            $definition = array_keys(array_intersect_key($rules, array_filter($x)));
+            $definition = array_keys(array_intersect_key($rules, array_filter($matches)));
             $definition = reset($definition);
 
-            return "<span class='hlt-info {$definition}'>{$x[0]}</span>";
+            return "<span class='hlt-info {$definition}'>{$matches[0]}</span>";
         }, $message);
     }
 
@@ -549,8 +549,8 @@ class HTMLRenderer extends AbstractRenderer
             // We use "ref" reference to make things somewhat easier to read.
             // Also, using a reference to non-existing array index doesn't throw a notice.
 
-            if ($ns = $v->getNamespaceName()) {
-                $ref = &$result[self::CATEGORY_NAMESPACE][$ns];
+            if ($namespaceName = $v->getNamespaceName()) {
+                $ref = &$result[self::CATEGORY_NAMESPACE][$namespaceName];
                 $ref = isset($ref) ? $ref + 1 : 1;
             }
 


### PR DESCRIPTION
Type: Refactoring , follow our own naming rules
Issue: Part of #812
Breaking change: no

Errors left that I think is a BC break if we change it.
1. src/main/php/PHPMD/Renderer/HTMLRenderer.php:64  Avoid excessively long variable names like $compiledHighlightRegex. Keep variable name length under 20.
2. src/main/php/PHPMD/Rule.php:189  The 'getBooleanProperty()' method which returns a boolean should be named 'is...()' or 'has...()'

For the second point it is possible to create a new function and deprecate the old one.
