### PR TITLE
recognize compact variables with double quotes

### DIFF
--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -200,7 +200,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      */
     protected function collectLiteral(ASTNode $node)
     {
-        $variable = '$' . trim($node->getImage(), '\'');
+        $variable = '$' . trim($node->getImage(), '\'\"');
 
         if (!isset($this->images[$variable])) {
             $this->images[$variable] = array();

--- a/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
@@ -638,6 +638,28 @@ class UnusedLocalVariableTest extends AbstractTest
     }
 
     /**
+     * testRuleDoesNotApplyToCompactWithDoubleQuotesFunction
+     *
+     * <code>
+     * class Foo {
+     *     public function bar() {
+     *         $key = "ok";
+     *         return compact("key");
+     *     }
+     * }
+     * </code>
+     *
+     * @return void
+     */
+    public function testRuleDoesNotApplyToCompactWithDoubleQuotesFunction()
+    {
+        $rule = new UnusedLocalVariable();
+        $rule->addProperty('allow-unused-foreach-variables', 'false');
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getMethod());
+    }
+
+    /**
      * @test
      * @return void
      * @since 2.0.0

--- a/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToCompactWithDoubleQuotesFunction.php
+++ b/src/test/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToCompactWithDoubleQuotesFunction.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyToCompactWithDoubleQuotesFunction
+{
+    public function testRuleDoesNotApplyToCompactWithDoubleQuotesFunction()
+    {
+        $key = 'ok';
+
+        return compact("key");
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: Resolves #557 
Breaking change: yes/no (if yes explain why)

Fix UnusedLocalVariable to detect variables written in double quotes
The fix is easy as `trim` function can accept a character mask , so I added `"` instead of `'` only