### PR TITLE
Catch DevelopmentCodeFragment with fully qualified functions

### DIFF
--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -49,6 +49,7 @@ class DevelopmentCodeFragment extends AbstractRule implements MethodAware, Funct
                 $fragment = str_replace("{$namespace}\\", "", $fragment);
             }
             $fragment = strtolower($fragment);
+            $fragment = trim($fragment, "\.");
             if (false === in_array($fragment, $this->getSuspectImages())) {
                 continue;
             }

--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -49,7 +49,7 @@ class DevelopmentCodeFragment extends AbstractRule implements MethodAware, Funct
                 $fragment = str_replace("{$namespace}\\", "", $fragment);
             }
             $fragment = strtolower($fragment);
-            $fragment = trim($fragment, "\.");
+            $fragment = trim($fragment, "\\");
             if (false === in_array($fragment, $this->getSuspectImages())) {
                 continue;
             }

--- a/src/main/resources/rulesets/design.xml
+++ b/src/main/resources/rulesets/design.xml
@@ -205,7 +205,7 @@ just forgotten.
         </description>
         <priority>2</priority>
         <properties>
-            <property name="unwanted-functions" value="\var_dump,var_dump,\print_r,print_r,\debug_zval_dump,debug_zval_dump,\debug_print_backtrace,debug_print_backtrace" description="Comma separated list of suspect function images." />
+            <property name="unwanted-functions" value="var_dump,print_r,debug_zval_dump,debug_print_backtrace" description="Comma separated list of suspect function images." />
             <property name="ignore-namespaces" value="false" description="Ignore namespaces when looking for dev. fragments" />
         </properties>
         <example>

--- a/src/main/resources/rulesets/design.xml
+++ b/src/main/resources/rulesets/design.xml
@@ -205,7 +205,7 @@ just forgotten.
         </description>
         <priority>2</priority>
         <properties>
-            <property name="unwanted-functions" value="var_dump,print_r,debug_zval_dump,debug_print_backtrace" description="Comma separated list of suspect function images." />
+            <property name="unwanted-functions" value="\var_dump,var_dump,\print_r,print_r,\debug_zval_dump,debug_zval_dump,\debug_print_backtrace,debug_print_backtrace" description="Comma separated list of suspect function images." />
             <property name="ignore-namespaces" value="false" description="Ignore namespaces when looking for dev. fragments" />
         </properties>
         <example>

--- a/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -134,7 +134,7 @@ class DevelopmentCodeFragmentTest extends AbstractTest
     private function getRule()
     {
         $rule = new DevelopmentCodeFragment();
-        $rule->addProperty('unwanted-functions', 'var_dump,print_r,debug_zval_dump,debug_print_backtrace');
+        $rule->addProperty('unwanted-functions', '\var_dump,var_dump,\print_r,print_r,\debug_zval_dump,debug_zval_dump,\debug_print_backtrace,debug_print_backtrace');
         $rule->addProperty('ignore-namespaces', 'false');
 
         return $rule;

--- a/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -134,7 +134,7 @@ class DevelopmentCodeFragmentTest extends AbstractTest
     private function getRule()
     {
         $rule = new DevelopmentCodeFragment();
-        $rule->addProperty('unwanted-functions', '\var_dump,var_dump,\print_r,print_r,\debug_zval_dump,debug_zval_dump,\debug_print_backtrace,debug_print_backtrace');
+        $rule->addProperty('unwanted-functions', 'var_dump,print_r,debug_zval_dump,debug_print_backtrace');
         $rule->addProperty('ignore-namespaces', 'false');
 
         return $rule;

--- a/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -66,6 +66,30 @@ class DevelopmentCodeFragmentTest extends AbstractTest
     }
 
     /**
+     * testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall
+     *
+     * @return void
+     */
+    public function testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall()
+    {
+        $rule = $this->getRule();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getMethod());
+    }
+
+    /**
+     * testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall
+     *
+     * @return void
+     */
+    public function testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall()
+    {
+        $rule = $this->getRule();
+        $rule->setReport($this->getReportMock(3));
+        $rule->apply($this->getMethod());
+    }
+
+    /**
      * testRuleNotAppliesToFunctionWithoutSuspectFunctionCall
      *
      * @return void
@@ -95,6 +119,30 @@ class DevelopmentCodeFragmentTest extends AbstractTest
      * @return void
      */
     public function testRuleAppliesToFunctionWithMultipleSuspectFunctionCall()
+    {
+        $rule = $this->getRule();
+        $rule->setReport($this->getReportMock(3));
+        $rule->apply($this->getFunction());
+    }
+
+    /**
+     * testRuleAppliesToFunctionWithSuspectFullyQualifiedFunctionCall
+     *
+     * @return void
+     */
+    public function testRuleAppliesToFunctionWithSuspectFullyQualifiedFunctionCall()
+    {
+        $rule = $this->getRule();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getFunction());
+    }
+
+    /**
+     * testRuleAppliesToFunctionWithMultipleSuspectFullyQualifiedFunctionCall
+     *
+     * @return void
+     */
+    public function testRuleAppliesToFunctionWithMultipleSuspectFullyQualifiedFunctionCall()
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportMock(3));

--- a/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleAppliesToFunctionWithMultipleSuspectFullyQualifiedFunctionCall.php
+++ b/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleAppliesToFunctionWithMultipleSuspectFullyQualifiedFunctionCall.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+function testRuleAppliesToFunctionWithMultipleSuspectFullyQualifiedFunctionCall()
+{
+    \var_dump(__FUNCTION__);
+    \debug_print_backtrace();
+    \debug_zval_dump($GLOBALS);
+}

--- a/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleAppliesToFunctionWithSuspectFullyQualifiedFunctionCall.php
+++ b/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleAppliesToFunctionWithSuspectFullyQualifiedFunctionCall.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+function testRuleAppliesToFunctionWithSuspectFullyQualifiedFunctionCall()
+{
+    \print_r(__FUNCTION__);
+}

--- a/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall.php
+++ b/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class class_testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall
+{
+    public function testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall()
+    {
+        \var_dump(__FUNCTION__);
+        \print_r(__METHOD__);
+        \debug_zval_dump($this);
+    }
+}

--- a/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall.php
+++ b/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class class_testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall
+{
+    public function testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall()
+    {
+        \var_dump(__METHOD__);
+    }
+}


### PR DESCRIPTION
Fixes issue #846 by adding functions like \print_r to the unwanted functions list.

Type: bugfix
Issue: Resolves #846 
Breaking change: No

My PR resolves #846 by adding the functions with a slash in front of them in the development code fragment rule.
<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
  
 ## Adding a New Rule

- Add the new rule to the matching rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new rule, e.g. ``src/site/rst/rules/naming.rst``
- Implement the new rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new rule in the rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new rule *should* apply
-- Cover the case when the new rule *should not* apply
-- Cover edge cases of the new rule

## Adding a New Rule Property

- Add the new property to rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new property, e.g. ``src/site/rst/rules/naming.rst``
- Implement new property in rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new property in rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new property is not set and the rule *should not* apply
-- Cover the case when the new property is not set and the rule *should* apply
-- Cover case when the new property is set and the rule *should not* apply
-- Cover case when the new property is set and the rule *should* apply
-- Cover edge cases of the new property, if any
-->
