### PR TITLE
Fix multiple underscores in method name when allow-underscore-test is…

### DIFF
--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -74,7 +74,7 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
     protected function isValid($methodName)
     {
         if ($this->getBooleanProperty('allow-underscore-test') && strpos($methodName, 'test') === 0) {
-            return preg_match('/^test[a-zA-Z0-9]*([_][a-z][a-zA-Z0-9]*)?$/', $methodName);
+            return preg_match('/^test[a-zA-Z0-9]*([_][a-z][a-zA-Z0-9]*)*?$/', $methodName);
         }
 
         if ($this->getBooleanProperty('allow-underscore')) {

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -78,7 +78,7 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
         }
 
         if ($this->getBooleanProperty('allow-underscore')) {
-            return preg_match('/^[_]?[a-z][a-zA-Z0-9]*$/', $methodName);
+            return preg_match('/^_?[a-z][a-zA-Z0-9]*$/', $methodName);
         }
 
         return preg_match('/^[a-z][a-zA-Z0-9]*$/', $methodName);

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -74,7 +74,7 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
     protected function isValid($methodName)
     {
         if ($this->getBooleanProperty('allow-underscore-test') && strpos($methodName, 'test') === 0) {
-            return preg_match('/^test[a-zA-Z0-9]*([_][a-z][a-zA-Z0-9]*)*?$/', $methodName);
+            return preg_match('/^test[a-zA-Z0-9]*(_[a-z][a-zA-Z0-9]*)*$/', $methodName);
         }
 
         if ($this->getBooleanProperty('allow-underscore')) {

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -175,12 +175,30 @@ class CamelCaseMethodNameTest extends AbstractTest
     }
 
     /**
-     * Tests that the rule does apply for a test method name
-     * with multiple underscores even when one is allowed.
+     * Tests that the rule does not apply for a valid test method name
+     * with multiple underscores in different positions when an single underscore is allowed.
      *
      * @return void
      */
-    public function testRuleAppliesToTestMethodWithTwoUnderscoresEvenWhenOneIsAllowed()
+    public function testRuleDoesNotApplyForTestMethodWithMultipleUnderscoresWhenAllowed()
+    {
+        $method = $this->getMethod();
+        $report = $this->getReportWithNoViolation();
+
+        $rule = new CamelCaseMethodName();
+        $rule->setReport($report);
+        $rule->addProperty('allow-underscore', 'false');
+        $rule->addProperty('allow-underscore-test', 'true');
+        $rule->apply($method);
+    }
+
+    /**
+     * Tests that the rule does apply for a test method name
+     * with multiple consecutive underscores even when underscores are allowed.
+     *
+     * @return void
+     */
+    public function testRuleAppliesToTestMethodWithTwoConsecutiveUnderscoresWhenAllowed()
     {
         $method = $this->getMethod();
         $report = $this->getReportWithOneViolation();

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -158,7 +158,7 @@ class CamelCaseMethodNameTest extends AbstractTest
 
     /**
      * Tests that the rule does not apply for a valid test method name
-     * with an underscore when an single underscore is allowed.
+     * with an underscore when underscores are allowed.
      *
      * @return void
      */
@@ -176,7 +176,7 @@ class CamelCaseMethodNameTest extends AbstractTest
 
     /**
      * Tests that the rule does not apply for a valid test method name
-     * with multiple underscores in different positions when an single underscore is allowed.
+     * with multiple underscores in different positions when underscores are allowed.
      *
      * @return void
      */
@@ -194,7 +194,7 @@ class CamelCaseMethodNameTest extends AbstractTest
 
     /**
      * Tests that the rule does apply for a test method name
-     * with multiple consecutive underscores even when underscores are allowed.
+     * with consecutive underscores even when underscores are allowed.
      *
      * @return void
      */

--- a/src/test/resources/files/Rule/Controversial/CamelCaseMethodName/testRuleAppliesToTestMethodWithTwoConsecutiveUnderscoresWhenAllowed.php
+++ b/src/test/resources/files/Rule/Controversial/CamelCaseMethodName/testRuleAppliesToTestMethodWithTwoConsecutiveUnderscoresWhenAllowed.php
@@ -15,9 +15,9 @@
  * @link http://phpmd.org/
  */
 
-class testRuleAppliesToTestMethodWithTwoUnderscoresEvenWhenOneIsAllowed
+class testRuleAppliesToTestMethodWithTwoConsecutiveUnderscoresWhenAllowed
 {
-    public function testGivenSomeValue_expectSome_niceResult()
+    public function testGivenSomeValue_expectSome__niceResult()
     {
 
     }

--- a/src/test/resources/files/Rule/Controversial/CamelCaseMethodName/testRuleDoesNotApplyForTestMethodWithMultipleUnderscoresWhenAllowed.php
+++ b/src/test/resources/files/Rule/Controversial/CamelCaseMethodName/testRuleDoesNotApplyForTestMethodWithMultipleUnderscoresWhenAllowed.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyForTestMethodWithMultipleUnderscoresWhenAllowed
+{
+    public function testGivenSomeValue_expect_some_result()
+    {
+
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: Resolves #851 
Breaking change: no

This PR adds an extra test to allow methods like `test_some_action_i_do` currently only a single underscore is allowed. 
There was one test that tested methods with multiple underscores which is modified to test 2 consecutive underscores which shouldn't be allowed. 

 