### PR TITLE
Add GitHub renderer for GitHub Actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -193,6 +193,7 @@ At the moment PHPMD comes with the following renderers:
 - *html*, single HTML file with possible problems.
 - *json*, formats JSON report.
 - *ansi*, a command line friendly format.
+- *github*, a format that GitHub Actions understands.
 
 PHPMD for enterprise
 --------------------

--- a/src/main/php/PHPMD/Renderer/GitHubRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitHubRenderer.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Lukas Bestle <project-phpmd@lukasbestle.com>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Renderer;
+
+use PHPMD\AbstractRenderer;
+use PHPMD\Report;
+
+/**
+ * This renderer outputs all violations in a format that GitHub Actions
+ * understands to display and highlight as problems.
+ */
+class GitHubRenderer extends AbstractRenderer
+{
+
+    /**
+     * This method will be called when the engine has finished the source analysis
+     * phase.
+     *
+     * @param \PHPMD\Report $report
+     * @return void
+     */
+    public function renderReport(Report $report)
+    {
+        $writer = $this->getWriter();
+
+        foreach ($report->getRuleViolations() as $violation) {
+            $writer->write('::warning file=');
+            $writer->write($violation->getFileName());
+            $writer->write(',line=');
+            $writer->write($violation->getBeginLine());
+            $writer->write('::');
+            $writer->write($violation->getDescription());
+            $writer->write(PHP_EOL);
+        }
+
+        foreach ($report->getErrors() as $error) {
+            $writer->write('::error file=');
+            $writer->write($error->getFile());
+            $writer->write('::');
+            $writer->write($error->getMessage());
+            $writer->write(PHP_EOL);
+        }
+    }
+}

--- a/src/main/php/PHPMD/Renderer/GitHubRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitHubRenderer.php
@@ -26,7 +26,6 @@ use PHPMD\Report;
  */
 class GitHubRenderer extends AbstractRenderer
 {
-
     /**
      * This method will be called when the engine has finished the source analysis
      * phase.

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -18,6 +18,7 @@
 namespace PHPMD\TextUI;
 
 use PHPMD\Renderer\AnsiRenderer;
+use PHPMD\Renderer\GitHubRenderer;
 use PHPMD\Renderer\HTMLRenderer;
 use PHPMD\Renderer\JSONRenderer;
 use PHPMD\Renderer\TextRenderer;
@@ -394,6 +395,8 @@ class CommandLineOptions
                 return $this->createJsonRenderer();
             case 'ansi':
                 return $this->createAnsiRenderer();
+            case 'github':
+                return $this->createGitHubRenderer();
             default:
                 return $this->createCustomRenderer();
         }
@@ -421,6 +424,14 @@ class CommandLineOptions
     protected function createAnsiRenderer()
     {
         return new AnsiRenderer();
+    }
+
+    /**
+     * @return \PHPMD\Renderer\GitHubRenderer
+     */
+    protected function createGitHubRenderer()
+    {
+        return new GitHubRenderer();
     }
 
     /**

--- a/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Lukas Bestle <project-phpmd@lukasbestle.com>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Renderer;
+
+use PHPMD\AbstractTest;
+use PHPMD\ProcessingError;
+use PHPMD\Stubs\WriterStub;
+
+/**
+ * Test case for the GitHub renderer implementation.
+ *
+ * @covers \PHPMD\Renderer\GitHubRenderer
+ */
+class GitHubRendererTest extends AbstractTest
+{
+    /**
+     * testRendererCreatesExpectedNumberOfTextEntries
+     *
+     * @return void
+     */
+    public function testRendererCreatesExpectedNumberOfTextEntries()
+    {
+        // Create a writer instance.
+        $writer = new WriterStub();
+
+        $violations = array(
+            $this->getRuleViolationMock('/bar.php', 1),
+            $this->getRuleViolationMock('/foo.php', 2),
+            $this->getRuleViolationMock('/foo.php', 3),
+        );
+
+        $report = $this->getReportWithNoViolation();
+        $report->expects($this->once())
+            ->method('getRuleViolations')
+            ->will($this->returnValue(new \ArrayIterator($violations)));
+        $report->expects($this->once())
+            ->method('getErrors')
+            ->will($this->returnValue(new \ArrayIterator(array())));
+
+        $renderer = new GitHubRenderer();
+        $renderer->setWriter($writer);
+
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        $this->assertEquals(
+            "::warning file=/bar.php,line=1::Test description" . PHP_EOL .
+            "::warning file=/foo.php,line=2::Test description" . PHP_EOL .
+            "::warning file=/foo.php,line=3::Test description" . PHP_EOL,
+            $writer->getData()
+        );
+    }
+
+    /**
+     * testRendererAddsProcessingErrorsToTextReport
+     *
+     * @return void
+     */
+    public function testRendererAddsProcessingErrorsToTextReport()
+    {
+        // Create a writer instance.
+        $writer = new WriterStub();
+
+        $errors = array(
+            new ProcessingError('Failed for file "/tmp/foo.php".'),
+            new ProcessingError('Failed for file "/tmp/bar.php".'),
+            new ProcessingError('Failed for file "/tmp/baz.php".'),
+        );
+
+        $report = $this->getReportWithNoViolation();
+        $report->expects($this->once())
+            ->method('getRuleViolations')
+            ->will($this->returnValue(new \ArrayIterator(array())));
+        $report->expects($this->once())
+            ->method('getErrors')
+            ->will($this->returnValue(new \ArrayIterator($errors)));
+
+        $renderer = new GitHubRenderer();
+        $renderer->setWriter($writer);
+
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        $this->assertEquals(
+            "::error file=/tmp/foo.php::Failed for file \"/tmp/foo.php\"." . PHP_EOL .
+            "::error file=/tmp/bar.php::Failed for file \"/tmp/bar.php\"." . PHP_EOL .
+            "::error file=/tmp/baz.php::Failed for file \"/tmp/baz.php\"." . PHP_EOL,
+            $writer->getData()
+        );
+    }
+}

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -236,7 +236,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertContains('Available formats: ansi, html, json, text, xml.', $opts->usage());
+        $this->assertContains('Available formats: ansi, github, html, json, text, xml.', $opts->usage());
     }
 
     /**


### PR DESCRIPTION
Type: feature
Breaking change: no

## About this PR

GitHub Actions can automatically consume and display analyzer warnings and errors right next to the source code. This simple renderer adds support for that to PHPMD.

This feature is inspired by Psalm, which already features an output option for GitHub Actions (a `github` "report" as they call it).

## Example use-case

You can see this PR in action in this quick and dirty example workflow run:

- [Workflow overview](https://github.com/lukasbestle/phpmd/actions/runs/458144760)
- [Code comments in the commit view](https://github.com/lukasbestle/phpmd/commit/1d14adf7682d5e88f6cedb0dfbc42d829a774e1d#diff-ba03783ef53129fbd47621bdd6b5e34a2cc90f66078ff20a27cda2b3365f8e76)
- [Log output](https://github.com/lukasbestle/phpmd/runs/1637499129?check_suite_focus=true)

---

Please check this points before submitting your PR.
- [x] Add test to cover the changes you made on the code.
- [x] If you add a new feature please update the documentation in the same PR.