### PR TITLE
Simplify the allow-underscore RegExps

### DIFF
--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -74,11 +74,11 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
     protected function isValid($methodName)
     {
         if ($this->getBooleanProperty('allow-underscore-test') && strpos($methodName, 'test') === 0) {
-            return preg_match('/^test[a-zA-Z0-9]*([_][a-z][a-zA-Z0-9]*)?$/', $methodName);
+            return preg_match('/^test[a-zA-Z0-9]*(_[a-z][a-zA-Z0-9]*)?$/', $methodName);
         }
 
         if ($this->getBooleanProperty('allow-underscore')) {
-            return preg_match('/^[_]?[a-z][a-zA-Z0-9]*$/', $methodName);
+            return preg_match('/^_?[a-z][a-zA-Z0-9]*$/', $methodName);
         }
 
         return preg_match('/^[a-z][a-zA-Z0-9]*$/', $methodName);


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Classes of one char can simply be replaced with the char itself in regular expressions.

Moved in https://github.com/phpmd/phpmd/pull/852/files#diff-4716980b01ddc239233e94630c8adf66aa26966554eb7441eccc5a79653bf00c