### PR TITLE
Fix test methods with number after underscore

### DIFF
--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -74,7 +74,7 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
     protected function isValid($methodName)
     {
         if ($this->getBooleanProperty('allow-underscore-test') && strpos($methodName, 'test') === 0) {
-            return preg_match('/^test[a-zA-Z0-9]*(_[a-z][a-zA-Z0-9]*)*$/', $methodName);
+            return preg_match('/^test[a-zA-Z0-9]*(_[a-z0-9][a-zA-Z0-9]*)*$/', $methodName);
         }
 
         if ($this->getBooleanProperty('allow-underscore')) {

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -228,6 +228,18 @@ class CamelCaseMethodNameTest extends AbstractTest
         $rule->apply($method);
     }
 
+    public function testRuleDoesNotApplyToTestMethodWithUnderscoreFollowedByNumber()
+    {
+        $method = $this->getMethod();
+        $report = $this->getReportWithNoViolation();
+
+        $rule = new CamelCaseMethodName();
+        $rule->setReport($report);
+        $rule->addProperty('allow-underscore', 'false');
+        $rule->addProperty('allow-underscore-test', 'true');
+        $rule->apply($method);
+    }
+
     /**
      * Returns the first method found in a source file related to the calling
      * test method.

--- a/src/test/resources/files/Rule/Controversial/CamelCaseMethodName/testRuleDoesNotApplyToTestMethodWithUnderscoreFollowedByNumber.php
+++ b/src/test/resources/files/Rule/Controversial/CamelCaseMethodName/testRuleDoesNotApplyToTestMethodWithUnderscoreFollowedByNumber.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyToTestMethodWithUnderscoreFollowedByNumber
+{
+    public function test_method_1()
+    {
+
+    }
+}


### PR DESCRIPTION
Type: bugfix
Breaking change: no

Methods like `test_if_something_is_ok` are currently allowed see https://github.com/phpmd/phpmd/pull/852 
I encounter an issue with methods as example like `test_stub_response_1`

This fixes the issue that numbers aren't allowed after the underscore in test methods.

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
  
 ## Adding a New Rule

- Add the new rule to the matching rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new rule, e.g. ``src/site/rst/rules/naming.rst``
- Implement the new rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new rule in the rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new rule *should* apply
-- Cover the case when the new rule *should not* apply
-- Cover edge cases of the new rule

## Adding a New Rule Property

- Add the new property to rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new property, e.g. ``src/site/rst/rules/naming.rst``
- Implement new property in rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new property in rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new property is not set and the rule *should not* apply
-- Cover the case when the new property is not set and the rule *should* apply
-- Cover case when the new property is set and the rule *should not* apply
-- Cover case when the new property is set and the rule *should* apply
-- Cover edge cases of the new property, if any
-->
