### PR TITLE
Change exit code on processing errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,8 @@ Command line options
 
   - ``--strict`` - Also report those nodes with a @SuppressWarnings annotation.
 
+  - ``--ignore-errors-on-exit`` - will exit with a zero code, even on error.
+
   - ``--ignore-violations-on-exit`` - will exit with a zero code, even if any
     violations are found.
 
@@ -170,18 +172,21 @@ to create one output for certain parts of your code ::
 Exit codes
 ----------
 
-PHPMD's command line tool currently defines three different exit codes.
+PHPMD's command line tool currently defines four different exit codes.
 
 - *0*, This exit code indicates that everything worked as expected. This means
   there was no error/exception and PHPMD hasn't detected any rule violation
   in the code under test.
-- *1*, This exit code indicates that an error/exception occured which has
+- *1*, This exit code indicates that an exception occurred which has
   interrupted PHPMD during execution.
 - *2*, This exit code means that PHPMD has processed the code under test
-  without the occurence of an error/exception, but it has detected rule
+  without the occurrence of an error/exception, but it has detected rule
   violations in the analyzed source code. You can also prevent this behaviour
   with the ``--ignore-violations-on-exit`` flag, which will result to a *0*
   even if any violations are found.
+- *3*, This exit code means that one or multiple files under test could not
+   be processed because of an error. There may also be violations in other
+   files that could be processed correctly.
 
 Renderers
 ---------

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -28,6 +28,15 @@ class PHPMD
     const VERSION = '@package_version@';
 
     /**
+     * This property will be set to <b>true</b> when an error
+     * was found in the processed source code.
+     *
+     * @var boolean
+     * @since 2.10.0
+     */
+    private $errors = false;
+
+    /**
      * List of valid file extensions for analyzed files.
      *
      * @var array(string)
@@ -49,7 +58,7 @@ class PHPMD
     private $input;
 
     /**
-     * This property will be set to <b>true</b> when an error or a violation
+     * This property will be set to <b>true</b> when a violation
      * was found in the processed source code.
      *
      * @var boolean
@@ -64,6 +73,18 @@ class PHPMD
      * @since 1.2.0
      */
     private $options = array();
+
+    /**
+     * This method will return <b>true</b> when the processed source code
+     * contains errors.
+     *
+     * @return boolean
+     * @since 2.10.0
+     */
+    public function hasErrors()
+    {
+        return $this->errors;
+    }
 
     /**
      * This method will return <b>true</b> when the processed source code
@@ -232,6 +253,7 @@ class PHPMD
             $renderer->end();
         }
 
+        $this->errors = $report->hasErrors();
         $this->violations = !$report->isEmpty();
     }
 }

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -31,7 +31,8 @@ class Command
      */
     const EXIT_SUCCESS = 0,
         EXIT_EXCEPTION = 1,
-        EXIT_VIOLATION = 2;
+        EXIT_VIOLATION = 2,
+        EXIT_ERROR = 3;
 
     /**
      * This method creates a PHPMD instance and configures this object based
@@ -40,10 +41,11 @@ class Command
      * The return value of this method can be used as an exit code. A value
      * equal to <b>EXIT_SUCCESS</b> means that no violations or errors were
      * found in the analyzed code. Otherwise this method will return a value
-     * equal to <b>EXIT_VIOLATION</b>.
+     * equal to <b>EXIT_VIOLATION</b> or <b>EXIT_ERROR</b> respectively.
      *
-     * The use of flag <b>--ignore-violations-on-exit</b> will result to a
-     * <b>EXIT_SUCCESS</b> even if any violation is found.
+     * The use of the flags <b>--ignore-violations-on-exit</b> and
+     * <b>--ignore-errors-on-exit</b> will result to a <b>EXIT_SUCCESS</b>
+     * even if any violation or error is found.
      *
      * @param \PHPMD\TextUI\CommandLineOptions $opts
      * @param \PHPMD\RuleSetFactory $ruleSetFactory
@@ -105,6 +107,10 @@ class Command
             $renderers,
             $ruleSetFactory
         );
+
+        if ($phpmd->hasErrors() && !$opts->ignoreErrorsOnExit()) {
+            return self::EXIT_ERROR;
+        }
 
         if ($phpmd->hasViolations() && !$opts->ignoreViolationsOnExit()) {
             return self::EXIT_VIOLATION;

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -126,6 +126,14 @@ class CommandLineOptions
     protected $strict = false;
 
     /**
+     * Should PHPMD exit without error code even if error is found?
+     *
+     * @var boolean
+     * @since 2.10.0
+     */
+    protected $ignoreErrorsOnExit = false;
+
+    /**
      * Should PHPMD exit without error code even if violation is found?
      *
      * @var boolean
@@ -202,6 +210,9 @@ class CommandLineOptions
                     break;
                 case '--not-strict':
                     $this->strict = false;
+                    break;
+                case '--ignore-errors-on-exit':
+                    $this->ignoreErrorsOnExit = true;
                     break;
                 case '--ignore-violations-on-exit':
                     $this->ignoreViolationsOnExit = true;
@@ -352,6 +363,17 @@ class CommandLineOptions
     public function hasStrict()
     {
         return $this->strict;
+    }
+
+    /**
+     * Was the <b>--ignore-errors-on-exit</b> passed to PHPMD's command line interface?
+     *
+     * @return boolean
+     * @since 2.10.0
+     */
+    public function ignoreErrorsOnExit()
+    {
+        return $this->ignoreErrorsOnExit;
     }
 
     /**
@@ -518,6 +540,8 @@ class CommandLineOptions
             'For example *src/foo/*.php or *src/foo/*' . \PHP_EOL .
             '--strict: also report those nodes with a @SuppressWarnings ' .
             'annotation' . \PHP_EOL .
+            '--ignore-errors-on-exit: will exit with a zero code, ' .
+            'even on error' . \PHP_EOL .
             '--ignore-violations-on-exit: will exit with a zero code, ' .
             'even if any violations are found' . \PHP_EOL;
     }

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -59,6 +59,8 @@ Command line options
 
   - ``--not-strict`` - Does not report those nodes with a @SuppressWarnings annotation.
 
+  - ``--ignore-errors-on-exit`` - will exit with a zero code, even on error.
+
   - ``--ignore-violations-on-exit`` - will exit with a zero code, even if any
     violations are found.
 
@@ -92,18 +94,21 @@ that will check the source code.
 Exit codes
 ==========
 
-PHPMD's command line tool currently defines three different exit codes.
+PHPMD's command line tool currently defines four different exit codes.
 
 - *0*, This exit code indicates that everything worked as expected. This means
   there was no error/exception and PHPMD hasn't detected any rule violation
   in the code under test.
-- *1*, This exit code indicates that an error/exception occurred which has
+- *1*, This exit code indicates that an exception occurred which has
   interrupted PHPMD during execution.
 - *2*, This exit code means that PHPMD has processed the code under test
   without the occurrence of an error/exception, but it has detected rule
   violations in the analyzed source code. You can also prevent this behaviour
   with the ``--ignore-violations-on-exit`` flag, which will result to a *0*
   even if any violations are found.
+- *3*, This exit code means that one or multiple files under test could not
+   be processed because of an error. There may also be violations in other
+   files that could be processed correctly.
 
 Renderers
 =========

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -104,6 +104,17 @@ class PHPMDTest extends AbstractTest
     }
 
     /**
+     * testHasErrorsReturnsFalseByDefault
+     *
+     * @return void
+     */
+    public function testHasErrorsReturnsFalseByDefault()
+    {
+        $phpmd = new PHPMD();
+        $this->assertFalse($phpmd->hasErrors());
+    }
+
+    /**
      * testHasViolationsReturnsFalseByDefault
      *
      * @return void
@@ -134,6 +145,7 @@ class PHPMDTest extends AbstractTest
             new RuleSetFactory()
         );
 
+        $this->assertFalse($phpmd->hasErrors());
         $this->assertFalse($phpmd->hasViolations());
     }
 
@@ -157,7 +169,32 @@ class PHPMDTest extends AbstractTest
             new RuleSetFactory()
         );
 
+        $this->assertFalse($phpmd->hasErrors());
         $this->assertTrue($phpmd->hasViolations());
+    }
+
+    /**
+     * testHasErrorsReturnsTrueForSourceWithError
+     *
+     * @return void
+     */
+    public function testHasErrorsReturnsTrueForSourceWithError()
+    {
+        self::changeWorkingDirectory();
+
+        $renderer = new XMLRenderer();
+        $renderer->setWriter(new WriterStub());
+
+        $phpmd = new PHPMD();
+        $phpmd->processFiles(
+            self::createFileUri('source/source_with_parse_error.php'),
+            'pmd-refset1',
+            array($renderer),
+            new RuleSetFactory()
+        );
+
+        $this->assertTrue($phpmd->hasErrors());
+        $this->assertFalse($phpmd->hasViolations());
     }
 
     /**
@@ -179,6 +216,7 @@ class PHPMDTest extends AbstractTest
             new RuleSetFactory()
         );
 
+        $this->assertFalse($phpmd->hasErrors());
         $this->assertTrue($phpmd->hasViolations());
 
         // Process with exclusions, should result in no violations.
@@ -189,6 +227,7 @@ class PHPMDTest extends AbstractTest
             new RuleSetFactory()
         );
 
+        $this->assertFalse($phpmd->hasErrors());
         $this->assertFalse($phpmd->hasViolations());
     }
 }

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -188,6 +188,45 @@ class CommandLineOptionsTest extends AbstractTest
     }
 
     /**
+     * Tests if ignoreErrorsOnExit returns false by default
+     *
+     * @return void
+     */
+    public function testIgnoreErrorsOnExitReturnsFalseByDefault()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'unusedcode');
+        $opts = new CommandLineOptions($args);
+
+        self::assertFalse($opts->ignoreErrorsOnExit());
+    }
+
+    /**
+     * Tests if CLI options accepts ignoreErrorsOnExit argument
+     *
+     * @return void
+     */
+    public function testCliOptionsAcceptsIgnoreErrorsOnExitArgument()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'unusedcode', '--ignore-errors-on-exit');
+        $opts = new CommandLineOptions($args);
+
+        self::assertTrue($opts->ignoreErrorsOnExit());
+    }
+
+    /**
+     * Tests if CLI usage contains ignoreErrorsOnExit option
+     *
+     * @return void
+     */
+    public function testCliUsageContainsIgnoreErrorsOnExitOption()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'codesize');
+        $opts = new CommandLineOptions($args);
+
+        $this->assertContains('--ignore-errors-on-exit:', $opts->usage());
+    }
+
+    /**
      * Tests if ignoreViolationsOnExit returns false by default
      *
      * @return void

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -91,6 +91,44 @@ class CommandTest extends AbstractTest
                 array('--ignore-violations-on-exit'),
             ),
             array(
+                'source/source_with_npath_violation.php',
+                Command::EXIT_VIOLATION,
+                array('--ignore-errors-on-exit'),
+            ),
+            array(
+                'source/source_with_parse_error.php',
+                Command::EXIT_ERROR,
+            ),
+            array(
+                'source/source_with_parse_error.php',
+                Command::EXIT_ERROR,
+                array('--ignore-violations-on-exit'),
+            ),
+            array(
+                'source/source_with_parse_error.php',
+                Command::EXIT_SUCCESS,
+                array('--ignore-errors-on-exit'),
+            ),
+            array(
+                'source',
+                Command::EXIT_ERROR,
+            ),
+            array(
+                'source',
+                Command::EXIT_ERROR,
+                array('--ignore-violations-on-exit'),
+            ),
+            array(
+                'source',
+                Command::EXIT_VIOLATION,
+                array('--ignore-errors-on-exit'),
+            ),
+            array(
+                'source',
+                Command::EXIT_SUCCESS,
+                array('--ignore-errors-on-exit', '--ignore-violations-on-exit'),
+            ),
+            array(
                 'source/ccn_suppress_function.php',
                 Command::EXIT_VIOLATION,
                 array('--strict'),
@@ -182,7 +220,7 @@ class CommandTest extends AbstractTest
     {
         return array(
             array('--suffixes', '.class.php'),
-            array('--exclude', 'ccn_,npath_'),
+            array('--exclude', 'ccn_,npath_,parse_error'),
         );
     }
 

--- a/src/test/resources/files/pmd/single-directory.xml
+++ b/src/test/resources/files/pmd/single-directory.xml
@@ -18,4 +18,5 @@
       The method doSomething() has an NPath complexity of 50000. The configured NPath complexity threshold is 50.
     </violation>
   </file>
+  <error filename="#{rootDirectory}_DS_source_DS_source_with_parse_error.php" msg="Unexpected end of token stream in file: #{rootDirectory}_DS_source_DS_source_with_parse_error.php."/>
 </pmd>

--- a/src/test/resources/files/source/source_with_parse_error.php
+++ b/src/test/resources/files/source/source_with_parse_error.php
@@ -1,0 +1,3 @@
+<?php
+
+function test () {


### PR DESCRIPTION
Type: bugfix & feature
Issue: Resolves #514
Breaking change: no

PHPMD now exits with a new exit code `3` if a processing error occurred. This makes it possible to spot configuration issues in CI environments because the PHPMD run no longer succeeds even though it couldn't actually parse any files (for example in the case of https://github.com/phpmd/phpmd/issues/853).

If both violations and errors are present, the errors are more important than the violations, so the exit code `3` is used.

To silence the exit code, there is also a new `--ignore-errors-on-exit` flag that works just like `--ignore-violations-on-exit`. Both flags can be combined.