### PR TITLE
Added ability to baseline existing violations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,15 +211,15 @@ Baseline
 
 For existing projects a violation baseline can be generated. All violations in this baseline will be ignored in further inspections.
 
-To create generate ``phpmd.baseline.xml`` next to ``phpmd.xml``:
+To create generate ``phpmd.baseline.xml`` next to ``phpmd.xml``::
 
   ~ $ phpmd /path/to/source text phpmd.xml --generate-baseline
 
-To specify a custom baseline filepath for export:
+To specify a custom baseline filepath for export::
 
   ~ $ phpmd /path/to/source text phpmd.xml --generate-baseline --baseline-file /path/to/source/phpmd.baseline.xml
 
-By default PHPMD will look next to ``phpmd.xml`` for ``phpmd.baseline.xml``. To overwrite this behaviour:
+By default PHPMD will look next to ``phpmd.xml`` for ``phpmd.baseline.xml``. To overwrite this behaviour::
 
   ~ $ phpmd /path/to/source text phpmd.xml --baseline-file /path/to/source/phpmd.baseline.xml
 

--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,12 @@ Command line options
   - ``--ignore-violations-on-exit`` - will exit with a zero code, even if any
     violations are found.
 
+  - ``--generate-baseline`` - will generate a phpmd.baseline.xml for existing violations
+    next to the ruleset definition file.
+
+  - ``--baseline-file`` - the filepath to a custom baseline xml file. The filepath
+    of all baselined files must be relative to this file location.
+
   An example command line: ::
 
     phpmd PHP/Depend/DbusUI xml codesize --reportfile phpmd.xml --suffixes php,phtml
@@ -199,6 +205,23 @@ At the moment PHPMD comes with the following renderers:
 - *json*, formats JSON report.
 - *ansi*, a command line friendly format.
 - *github*, a format that GitHub Actions understands.
+
+Baseline
+--------
+
+For existing projects a violation baseline can be generated. All violations in this baseline will be ignored in further inspections.
+
+To create generate ``phpmd.baseline.xml`` next to ``phpmd.xml``:
+
+  ~ $ phpmd /path/to/source text phpmd.xml --generate-baseline
+
+To specify a custom baseline filepath for export:
+
+  ~ $ phpmd /path/to/source text phpmd.xml --generate-baseline --baseline-file /path/to/source/phpmd.baseline.xml
+
+By default PHPMD will look next to ``phpmd.xml`` for ``phpmd.baseline.xml``. To overwrite this behaviour:
+
+  ~ $ phpmd /path/to/source text phpmd.xml --baseline-file /path/to/source/phpmd.baseline.xml
 
 PHPMD for enterprise
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -211,7 +211,7 @@ Baseline
 
 For existing projects a violation baseline can be generated. All violations in this baseline will be ignored in further inspections.
 
-To create generate ``phpmd.baseline.xml`` next to ``phpmd.xml``::
+The recommended approach would be a ``phpmd.xml`` in the root of the project. To generate the phpmd.baseline.xml next to it::
 
   ~ $ phpmd /path/to/source text phpmd.xml --generate-baseline
 

--- a/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
+++ b/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace PHPMD\Baseline;
+
+use PHPMD\TextUI\CommandLineOptions;
+use RuntimeException;
+
+class BaselineFileFinder
+{
+    const DEFAULT_FILENAME = 'phpmd.baseline.xml';
+
+    /** @var CommandLineOptions */
+    private $options;
+
+    public function __construct(CommandLineOptions $options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * Try to find the violation baseline file
+     *
+     * @param bool $shouldExist if true, the baseline filepath should point to an existing file
+     * @return string|null
+     * @throws RuntimeException
+     */
+    public function find($shouldExist)
+    {
+        // read baseline file from cli arguments
+        $file = $this->options->baselineFile();
+        if ($file !== null) {
+            return $file;
+        }
+
+        // find baseline file next to the (first) ruleset
+        $ruleSets = explode(',', $this->options->getRuleSets());
+        $rulePath = realpath($ruleSets[0]);
+        if ($rulePath === false) {
+            return null;
+        }
+
+        $baselinePath = dirname($rulePath) . '/' . self::DEFAULT_FILENAME;
+        if ($shouldExist === true && file_exists($baselinePath) === false) {
+            return null;
+        }
+
+        return $baselinePath;
+    }
+}

--- a/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
+++ b/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
@@ -29,7 +29,11 @@ class BaselineFileFinder
         // read baseline file from cli arguments
         $file = $this->options->baselineFile();
         if ($file !== null) {
-            return $file;
+            $absoluteFilePath = realpath($file);
+            if ($absoluteFilePath === false) {
+                throw new RuntimeException('Unknown baseline file at: ' . $file);
+            }
+            return $absoluteFilePath;
         }
 
         // find baseline file next to the (first) ruleset
@@ -39,6 +43,7 @@ class BaselineFileFinder
             return null;
         }
 
+        // create file path and check for existence
         $baselinePath = dirname($rulePath) . '/' . self::DEFAULT_FILENAME;
         if ($shouldExist === true && file_exists($baselinePath) === false) {
             return null;

--- a/src/main/php/PHPMD/Baseline/BaselineSet.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSet.php
@@ -13,11 +13,12 @@ class BaselineSet
     }
 
     /**
-     * @param string $ruleName
-     * @param string $fileName
+     * @param string      $ruleName
+     * @param string      $fileName
+     * @param string|null $methodName
      * @return bool
      */
-    public function contains($ruleName, $fileName)
+    public function contains($ruleName, $fileName, $methodName)
     {
         if (isset($this->violations[$ruleName]) === false) {
             return false;
@@ -27,7 +28,7 @@ class BaselineSet
         $fileName = str_replace('\\', '/', $fileName);
 
         foreach ($this->violations[$ruleName] as $baseline) {
-            if ($baseline->getFileName() === $fileName) {
+            if ($baseline->getFileName() === $fileName && $baseline->getMethodName() === $methodName) {
                 return true;
             }
         }

--- a/src/main/php/PHPMD/Baseline/BaselineSet.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSet.php
@@ -14,17 +14,17 @@ class BaselineSet
 
     /**
      * @param string $ruleName
-     * @param string $filename
+     * @param string $fileName
      * @return bool
      */
-    public function contains($ruleName, $filename)
+    public function contains($ruleName, $fileName)
     {
         if (isset($this->violations[$ruleName]) === false) {
             return false;
         }
 
         foreach ($this->violations[$ruleName] as $baseline) {
-            if ($baseline->getFilename() === $filename) {
+            if ($baseline->getFileName() === $fileName) {
                 return true;
             }
         }

--- a/src/main/php/PHPMD/Baseline/BaselineSet.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSet.php
@@ -23,6 +23,7 @@ class BaselineSet
             return false;
         }
 
+        // normalize slashes in file name
         $fileName = str_replace('\\', '/', $fileName);
 
         foreach ($this->violations[$ruleName] as $baseline) {

--- a/src/main/php/PHPMD/Baseline/BaselineSet.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSet.php
@@ -4,11 +4,31 @@ namespace PHPMD\Baseline;
 
 class BaselineSet
 {
-    /** @var ViolationBaseline[] */
+    /** @var array<string, ViolationBaseline[]> */
     private $violations = array();
 
     public function addEntry(ViolationBaseline $entry)
     {
-        $this->violations[] = $entry;
+        $this->violations[$entry->getRuleName()][] = $entry;
+    }
+
+    /**
+     * @param string $ruleName
+     * @param string $filename
+     * @return bool
+     */
+    public function contains($ruleName, $filename)
+    {
+        if (isset($this->violations[$ruleName]) === false) {
+            return false;
+        }
+
+        foreach ($this->violations[$ruleName] as $baseline) {
+            if ($baseline->getFilename() === $filename) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/main/php/PHPMD/Baseline/BaselineSet.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSet.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PHPMD\Baseline;
+
+class BaselineSet
+{
+    /** @var ViolationBaseline[] */
+    private $violations = array();
+
+    public function addEntry(ViolationBaseline $entry)
+    {
+        $this->violations[] = $entry;
+    }
+}

--- a/src/main/php/PHPMD/Baseline/BaselineSet.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSet.php
@@ -23,6 +23,8 @@ class BaselineSet
             return false;
         }
 
+        $fileName = str_replace('\\', '/', $fileName);
+
         foreach ($this->violations[$ruleName] as $baseline) {
             if ($baseline->getFileName() === $fileName) {
                 return true;

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -16,7 +16,7 @@ class BaselineSetFactory
     public function fromFile($baseDir, $fileName)
     {
         if (file_exists($fileName) === false) {
-            throw new RuntimeException('Unknown file: ' . $fileName);
+            throw new RuntimeException('Unable to locate the baseline file at: ' . $fileName);
         }
 
         $xml = @simplexml_load_string(file_get_contents($fileName));

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -13,7 +13,7 @@ class BaselineSetFactory
      * @return BaselineSet
      * @throws RuntimeException
      */
-    public function fromFile($baseDir, $fileName)
+    public static function fromFile($baseDir, $fileName)
     {
         if (file_exists($fileName) === false) {
             throw new RuntimeException('Unable to locate the baseline file at: ' . $fileName);

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -9,6 +9,7 @@ class BaselineSetFactory
     /**
      * @param string $filename
      * @return BaselineSet
+     * @throws RuntimeException
      */
     public function fromFile($filename)
     {

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -26,7 +26,7 @@ class BaselineSetFactory
             throw new RuntimeException('Unable to read xml from: ' . $fileName);
         }
 
-        $baseDir     = dirname($fileName);
+        $basePath    = dirname($fileName);
         $baselineSet = new BaselineSet();
 
         foreach ($xml->children() as $node) {
@@ -42,14 +42,14 @@ class BaselineSetFactory
                 throw new RuntimeException('Missing `file` attribute in `violation` in ' . $fileName);
             }
 
-            $filePath   = Paths::concat($baseDir, (string)$node['file']);
+            $ruleName   = (string)$node['rule'];
+            $filePath   = Paths::concat($basePath, (string)$node['file']);
             $methodName = null;
             if (isset($node['method']) === true && ((string)$node['method']) !== '') {
                 $methodName = (string)($node['method']);
             }
 
-            $violation = new ViolationBaseline((string)$node['rule'], $filePath, $methodName);
-            $baselineSet->addEntry($violation);
+            $baselineSet->addEntry(new ViolationBaseline($ruleName, $filePath, $methodName));
         }
 
         return $baselineSet;

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -8,6 +8,9 @@ use RuntimeException;
 class BaselineSetFactory
 {
     /**
+     * Read the baseline violations from the given filename path. Append the baseDir to all the filepaths within
+     * the baseline file.
+     *
      * @param string $baseDir
      * @param string $fileName
      * @return BaselineSet
@@ -39,7 +42,13 @@ class BaselineSetFactory
                 throw new RuntimeException('Missing `file` attribute in `violation` in ' . $fileName);
             }
 
-            $violation = new ViolationBaseline((string)$node['rule'], Paths::concat($baseDir, (string)$node['file']));
+            $filePath   = Paths::concat($baseDir, (string)$node['file']);
+            $methodName = null;
+            if (isset($node['method']) === true && ((string)$node['method']) !== '') {
+                $methodName = (string)($node['method']);
+            }
+
+            $violation = new ViolationBaseline((string)$node['rule'], $filePath, $methodName);
             $baselineSet->addEntry($violation);
         }
 

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -11,12 +11,11 @@ class BaselineSetFactory
      * Read the baseline violations from the given filename path. Append the baseDir to all the filepaths within
      * the baseline file.
      *
-     * @param string $baseDir
      * @param string $fileName
      * @return BaselineSet
      * @throws RuntimeException
      */
-    public static function fromFile($baseDir, $fileName)
+    public static function fromFile($fileName)
     {
         if (file_exists($fileName) === false) {
             throw new RuntimeException('Unable to locate the baseline file at: ' . $fileName);
@@ -27,6 +26,7 @@ class BaselineSetFactory
             throw new RuntimeException('Unable to read xml from: ' . $fileName);
         }
 
+        $baseDir     = dirname($fileName);
         $baselineSet = new BaselineSet();
 
         foreach ($xml->children() as $node) {

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PHPMD\Baseline;
+
+use RuntimeException;
+
+class BaselineSetFactory
+{
+    /**
+     * @param string $filename
+     * @return BaselineSet
+     */
+    public function fromFile($filename)
+    {
+        $libxml = libxml_use_internal_errors(true);
+        $xml    = simplexml_load_string(file_get_contents($filename));
+        if ($xml === false) {
+            libxml_use_internal_errors($libxml);
+            throw new RuntimeException(trim(libxml_get_last_error()->message));
+        }
+
+        $baselineSet = new BaselineSet();
+
+        foreach ($xml->children() as $node) {
+            if ($node->getName() !== 'violation') {
+                continue;
+            }
+            $baselineSet->addEntry(new ViolationBaseline((string)$node->rule, (string)$node->filename));
+        }
+
+        return $baselineSet;
+    }
+}

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -2,24 +2,26 @@
 
 namespace PHPMD\Baseline;
 
+use PHPMD\Utility\Paths;
 use RuntimeException;
 
 class BaselineSetFactory
 {
     /**
-     * @param string $filename
+     * @param string $baseDir
+     * @param string $fileName
      * @return BaselineSet
      * @throws RuntimeException
      */
-    public function fromFile($filename)
+    public function fromFile($baseDir, $fileName)
     {
-        if (file_exists($filename) === false) {
-            throw new RuntimeException('Unknown file: ' . $filename);
+        if (file_exists($fileName) === false) {
+            throw new RuntimeException('Unknown file: ' . $fileName);
         }
 
-        $xml = @simplexml_load_string(file_get_contents($filename));
+        $xml = @simplexml_load_string(file_get_contents($fileName));
         if ($xml === false) {
-            throw new RuntimeException('Unable to read xml from: ' . $filename);
+            throw new RuntimeException('Unable to read xml from: ' . $fileName);
         }
 
         $baselineSet = new BaselineSet();
@@ -30,14 +32,15 @@ class BaselineSetFactory
             }
 
             if (isset($node['rule']) === false) {
-                throw new RuntimeException('Missing `rule` attribute in `violation` in ' . $filename);
+                throw new RuntimeException('Missing `rule` attribute in `violation` in ' . $fileName);
             }
 
             if (isset($node['file']) === false) {
-                throw new RuntimeException('Missing `file` attribute in `violation` in ' . $filename);
+                throw new RuntimeException('Missing `file` attribute in `violation` in ' . $fileName);
             }
 
-            $baselineSet->addEntry(new ViolationBaseline((string)$node['rule'], (string)$node['file']));
+            $violation = new ViolationBaseline((string)$node['rule'], Paths::concat($baseDir, (string)$node['file']));
+            $baselineSet->addEntry($violation);
         }
 
         return $baselineSet;

--- a/src/main/php/PHPMD/Baseline/ViolationBaseline.php
+++ b/src/main/php/PHPMD/Baseline/ViolationBaseline.php
@@ -10,14 +10,19 @@ class ViolationBaseline
     /** @var string */
     private $fileName;
 
+    /** @var string|null */
+    private $methodName;
+
     /**
-     * @param string $ruleName
-     * @param string $fileName
+     * @param string      $ruleName
+     * @param string      $fileName
+     * @param string|null $methodName
      */
-    public function __construct($ruleName, $fileName)
+    public function __construct($ruleName, $fileName, $methodName)
     {
-        $this->ruleName = $ruleName;
-        $this->fileName = $fileName;
+        $this->ruleName   = $ruleName;
+        $this->fileName   = $fileName;
+        $this->methodName = $methodName;
     }
 
     /**
@@ -34,5 +39,13 @@ class ViolationBaseline
     public function getFileName()
     {
         return $this->fileName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMethodName()
+    {
+        return $this->methodName;
     }
 }

--- a/src/main/php/PHPMD/Baseline/ViolationBaseline.php
+++ b/src/main/php/PHPMD/Baseline/ViolationBaseline.php
@@ -8,16 +8,16 @@ class ViolationBaseline
     private $ruleName;
 
     /** @var string */
-    private $filename;
+    private $fileName;
 
     /**
      * @param string $ruleName
-     * @param string $filename
+     * @param string $fileName
      */
-    public function __construct($ruleName, $filename)
+    public function __construct($ruleName, $fileName)
     {
         $this->ruleName = $ruleName;
-        $this->filename = $filename;
+        $this->fileName = $fileName;
     }
 
     /**
@@ -31,8 +31,8 @@ class ViolationBaseline
     /**
      * @return string
      */
-    public function getFilename()
+    public function getFileName()
     {
-        return $this->filename;
+        return $this->fileName;
     }
 }

--- a/src/main/php/PHPMD/Baseline/ViolationBaseline.php
+++ b/src/main/php/PHPMD/Baseline/ViolationBaseline.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PHPMD\Baseline;
+
+class ViolationBaseline
+{
+    /** @var string */
+    private $ruleName;
+
+    /** @var string */
+    private $filename;
+
+    /**
+     * @param string $ruleName
+     * @param string $filename
+     */
+    public function __construct($ruleName, $filename)
+    {
+        $this->ruleName = $ruleName;
+        $this->filename = $filename;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRuleName()
+    {
+        return $this->ruleName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilename()
+    {
+        return $this->filename;
+    }
+}

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -17,6 +17,8 @@
 
 namespace PHPMD;
 
+use PHPMD\Baseline\BaselineSet;
+
 /**
  * This is the main facade of the PHP PMD application
  */
@@ -214,13 +216,15 @@ class PHPMD
      * @param string $ruleSets
      * @param \PHPMD\AbstractRenderer[] $renderers
      * @param \PHPMD\RuleSetFactory $ruleSetFactory
+     * @param \PHPMD\Baseline\BaselineSet $baseline
      * @return void
      */
     public function processFiles(
         $inputPath,
         $ruleSets,
         array $renderers,
-        RuleSetFactory $ruleSetFactory
+        RuleSetFactory $ruleSetFactory,
+        BaselineSet $baseline
     ) {
 
         // Merge parsed excludes
@@ -228,7 +232,7 @@ class PHPMD
 
         $this->input = $inputPath;
 
-        $report = new Report();
+        $report = new Report($baseline);
 
         $factory = new ParserFactory();
         $parser = $factory->create($this);

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -216,7 +216,7 @@ class PHPMD
      * @param string $ruleSets
      * @param \PHPMD\AbstractRenderer[] $renderers
      * @param \PHPMD\RuleSetFactory $ruleSetFactory
-     * @param \PHPMD\Baseline\BaselineSet $baseline
+     * @param \PHPMD\Baseline\BaselineSet|null $baseline
      * @return void
      */
     public function processFiles(
@@ -224,7 +224,7 @@ class PHPMD
         $ruleSets,
         array $renderers,
         RuleSetFactory $ruleSetFactory,
-        BaselineSet $baseline
+        BaselineSet $baseline = null
     ) {
 
         // Merge parsed excludes

--- a/src/main/php/PHPMD/Renderer/BaselineRenderer.php
+++ b/src/main/php/PHPMD/Renderer/BaselineRenderer.php
@@ -5,24 +5,18 @@ namespace PHPMD\Renderer;
 use PHPMD\AbstractRenderer;
 use PHPMD\Report;
 use PHPMD\Utility\Paths;
-use PHPMD\Writer\StreamWriter;
-use RuntimeException;
 
 class BaselineRenderer extends AbstractRenderer
 {
     /** @var string */
     private $basePath;
 
-    public function __construct(StreamWriter $writer)
+    /**
+     * @param string $basePath
+     */
+    public function __construct($basePath)
     {
-        $this->setWriter($writer);
-
-        // determine basedir based on output filepath
-        $absolutePath = Paths::getAbsolutePath($writer->getStream());
-        if ($absolutePath === null) {
-            throw new RuntimeException('Failed to determine absolute path for baseline file');
-        }
-        $this->basePath = dirname($absolutePath);
+        $this->basePath = $basePath;
     }
 
     public function renderReport(Report $report)

--- a/src/main/php/PHPMD/Renderer/BaselineRenderer.php
+++ b/src/main/php/PHPMD/Renderer/BaselineRenderer.php
@@ -21,7 +21,7 @@ class BaselineRenderer extends AbstractRenderer
 
     public function renderReport(Report $report)
     {
-        // keep track of which violations already have been written
+        // keep track of which violations have been written, to avoid duplicates in the baseline
         $registered = array();
 
         $writer = $this->getWriter();

--- a/src/main/php/PHPMD/Renderer/BaselineRenderer.php
+++ b/src/main/php/PHPMD/Renderer/BaselineRenderer.php
@@ -5,18 +5,24 @@ namespace PHPMD\Renderer;
 use PHPMD\AbstractRenderer;
 use PHPMD\Report;
 use PHPMD\Utility\Paths;
+use PHPMD\Writer\StreamWriter;
+use RuntimeException;
 
 class BaselineRenderer extends AbstractRenderer
 {
     /** @var string */
-    private $baseDir;
+    private $basePath;
 
-    /**
-     * @param string $baseDir
-     */
-    public function __construct($baseDir)
+    public function __construct(StreamWriter $writer)
     {
-        $this->baseDir = $baseDir;
+        $this->setWriter($writer);
+
+        // determine basedir based on output filepath
+        $absolutePath = Paths::getAbsolutePath($writer->getStream());
+        if ($absolutePath === null) {
+            throw new RuntimeException('Failed to determine absolute path for baseline file');
+        }
+        $this->basePath = dirname($absolutePath);
     }
 
     public function renderReport(Report $report)
@@ -32,7 +38,7 @@ class BaselineRenderer extends AbstractRenderer
             $xmlTag = sprintf(
                 '  <violation rule="%s" file="%s"/>' . PHP_EOL,
                 get_class($rule),
-                Paths::getRelativePath($this->baseDir, $filepath)
+                Paths::getRelativePath($this->basePath, $filepath)
             );
             $writer->write($xmlTag);
         }

--- a/src/main/php/PHPMD/Renderer/BaselineRenderer.php
+++ b/src/main/php/PHPMD/Renderer/BaselineRenderer.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace PHPMD\Renderer;
+
+use PHPMD\AbstractRenderer;
+use PHPMD\Report;
+
+class BaselineRenderer extends AbstractRenderer
+{
+    /** @var string */
+    private $baseDir;
+
+    /**
+     * @param string $baseDir
+     */
+    public function __construct($baseDir)
+    {
+        $this->baseDir = rtrim(str_replace("\\", "/", $baseDir), '/') . '/';
+    }
+
+    public function renderReport(Report $report)
+    {
+        $writer = $this->getWriter();
+        $writer->write('<?xml version="1.0"?>' . PHP_EOL);
+        $writer->write('<phpmd-baseline>' . PHP_EOL);
+
+        foreach ($report->getRuleViolations() as $violation) {
+            $rule     = $violation->getRule();
+            $filepath = $violation->getFileName();
+
+            $xmlTag = sprintf(
+                '  <violation rule="%s" file="%s"/>' . PHP_EOL,
+                get_class($rule),
+                $this->getRelativePath($filepath)
+            );
+            $writer->write($xmlTag);
+        }
+
+        $writer->write('</phpmd-baseline>' . PHP_EOL);
+    }
+
+    /**
+     * Transform the given absolute path to the relative path within the input path
+     *
+     * @param string $filepath
+     * @return string
+     */
+    private function getRelativePath($filepath)
+    {
+        // transform all slashes to forward slashes
+        $filepath = str_replace("\\", "/", $filepath);
+
+        // subtract base dir from filepath if there's a match
+        if (stripos($filepath, $this->baseDir) === 0) {
+            $filepath = substr($filepath, strlen($this->baseDir));
+        }
+
+        return $filepath;
+    }
+}

--- a/src/main/php/PHPMD/Renderer/BaselineRenderer.php
+++ b/src/main/php/PHPMD/Renderer/BaselineRenderer.php
@@ -4,6 +4,7 @@ namespace PHPMD\Renderer;
 
 use PHPMD\AbstractRenderer;
 use PHPMD\Report;
+use PHPMD\Utility\Paths;
 
 class BaselineRenderer extends AbstractRenderer
 {
@@ -15,7 +16,7 @@ class BaselineRenderer extends AbstractRenderer
      */
     public function __construct($baseDir)
     {
-        $this->baseDir = rtrim(str_replace("\\", "/", $baseDir), '/') . '/';
+        $this->baseDir = $baseDir;
     }
 
     public function renderReport(Report $report)
@@ -31,30 +32,11 @@ class BaselineRenderer extends AbstractRenderer
             $xmlTag = sprintf(
                 '  <violation rule="%s" file="%s"/>' . PHP_EOL,
                 get_class($rule),
-                $this->getRelativePath($filepath)
+                Paths::getRelativePath($this->baseDir, $filepath)
             );
             $writer->write($xmlTag);
         }
 
         $writer->write('</phpmd-baseline>' . PHP_EOL);
-    }
-
-    /**
-     * Transform the given absolute path to the relative path within the input path
-     *
-     * @param string $filepath
-     * @return string
-     */
-    private function getRelativePath($filepath)
-    {
-        // transform all slashes to forward slashes
-        $filepath = str_replace("\\", "/", $filepath);
-
-        // subtract base dir from filepath if there's a match
-        if (stripos($filepath, $this->baseDir) === 0) {
-            $filepath = substr($filepath, strlen($this->baseDir));
-        }
-
-        return $filepath;
     }
 }

--- a/src/main/php/PHPMD/Renderer/RendererFactory.php
+++ b/src/main/php/PHPMD/Renderer/RendererFactory.php
@@ -16,10 +16,7 @@ class RendererFactory
     {
         // determine basedir based on output filepath
         $absolutePath = Paths::getAbsolutePath($writer->getStream());
-        if ($absolutePath === null) {
-            throw new RuntimeException('Failed to determine absolute path for baseline file');
-        }
-        $renderer = new BaselineRenderer(dirname($absolutePath));
+        $renderer     = new BaselineRenderer(dirname($absolutePath));
         $renderer->setWriter($writer);
 
         return $renderer;

--- a/src/main/php/PHPMD/Renderer/RendererFactory.php
+++ b/src/main/php/PHPMD/Renderer/RendererFactory.php
@@ -10,6 +10,7 @@ class RendererFactory
 {
     /**
      * @return BaselineRenderer
+     * @throws RuntimeException
      */
     public static function createBaselineRenderer(StreamWriter $writer)
     {

--- a/src/main/php/PHPMD/Renderer/RendererFactory.php
+++ b/src/main/php/PHPMD/Renderer/RendererFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PHPMD\Renderer;
+
+use PHPMD\Utility\Paths;
+use PHPMD\Writer\StreamWriter;
+use RuntimeException;
+
+class RendererFactory
+{
+    /**
+     * @return BaselineRenderer
+     */
+    public static function createBaselineRenderer(StreamWriter $writer)
+    {
+        // determine basedir based on output filepath
+        $absolutePath = Paths::getAbsolutePath($writer->getStream());
+        if ($absolutePath === null) {
+            throw new RuntimeException('Failed to determine absolute path for baseline file');
+        }
+        $renderer = new BaselineRenderer(dirname($absolutePath));
+        $renderer->setWriter($writer);
+
+        return $renderer;
+    }
+}

--- a/src/main/php/PHPMD/Renderer/RendererFactory.php
+++ b/src/main/php/PHPMD/Renderer/RendererFactory.php
@@ -14,7 +14,7 @@ class RendererFactory
      */
     public static function createBaselineRenderer(StreamWriter $writer)
     {
-        // determine basedir based on output filepath
+        // determine basedir based on stream output filepath
         $absolutePath = Paths::getAbsolutePath($writer->getStream());
         $renderer     = new BaselineRenderer(dirname($absolutePath));
         $renderer->setWriter($writer);

--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -72,7 +72,7 @@ class Report
     {
         $fileName = $violation->getFileName();
         $ruleName = get_class($violation->getRule());
-        if ($this->baseline !== null && $this->baseline->contains($ruleName, $fileName)) {
+        if ($this->baseline !== null && $this->baseline->contains($ruleName, $fileName, $violation->getMethodName())) {
             return;
         }
 

--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -17,6 +17,8 @@
 
 namespace PHPMD;
 
+use PHPMD\Baseline\BaselineSet;
+
 /**
  * The report class collects all found violations and further information about
  * a PHPMD run.
@@ -52,6 +54,14 @@ class Report
      */
     private $errors = array();
 
+    /** @var BaselineSet|null */
+    private $baseline;
+
+    public function __construct(BaselineSet $baseline = null)
+    {
+        $this->baseline = $baseline;
+    }
+
     /**
      * Adds a rule violation to this report.
      *
@@ -61,6 +71,11 @@ class Report
     public function addRuleViolation(RuleViolation $violation)
     {
         $fileName = $violation->getFileName();
+        $ruleName = get_class($violation->getRule());
+        if ($this->baseline !== null && $this->baseline->contains($ruleName, $fileName)) {
+            return;
+        }
+
         if (!isset($this->ruleViolations[$fileName])) {
             $this->ruleViolations[$fileName] = array();
         }

--- a/src/main/php/PHPMD/RuleViolation.php
+++ b/src/main/php/PHPMD/RuleViolation.php
@@ -66,7 +66,7 @@ class RuleViolation
      * The name of a method or <b>null</b> when this violation has no method
      * context.
      *
-     * @var string
+     * @var string|null
      */
     private $methodName = null;
 
@@ -188,7 +188,7 @@ class RuleViolation
      * Returns the name of a method or <b>null</b> when this violation has no
      * method context.
      *
-     * @return string
+     * @return string|null
      */
     public function getMethodName()
     {

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -18,13 +18,11 @@
 namespace PHPMD\TextUI;
 
 use PHPMD\Baseline\BaselineFileFinder;
-use PHPMD\Baseline\BaselineSet;
 use PHPMD\Baseline\BaselineSetFactory;
 use PHPMD\PHPMD;
-use PHPMD\Renderer\BaselineRenderer;
+use PHPMD\Renderer\RendererFactory;
 use PHPMD\RuleSetFactory;
 use PHPMD\Writer\StreamWriter;
-use RuntimeException;
 
 /**
  * This class provides a command line interface for PHPMD
@@ -85,7 +83,7 @@ class Command
         $finder   = new BaselineFileFinder($opts);
         if ($opts->generateBaseline()) {
             // overwrite any renderer with the baseline renderer
-            $renderers = array(new BaselineRenderer(new StreamWriter($finder->notNull()->find())));
+            $renderers = array(RendererFactory::createBaselineRenderer(new StreamWriter($finder->notNull()->find())));
         } else {
             // try to locate a baseline file and read it
             $baselineFile = $finder->existingFile()->find();

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -104,13 +104,8 @@ class Command
             // try to read baseline
             $baselineFile = $finder->find(true);
             if ($baselineFile !== null) {
-                $baseDir = $opts->baselineBasedir();
-                if ($baseDir === null) {
-                    $baseDir = dirname($baselineFile);
-                }
-
                 $baselineFactory = new BaselineSetFactory();
-                $baseline        = $baselineFactory->fromFile($baseDir, $baselineFile);
+                $baseline        = $baselineFactory->fromFile(dirname($baselineFile), $baselineFile);
             }
         }
 

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\TextUI;
 
+use PHPMD\Baseline\BaselineSet;
 use PHPMD\PHPMD;
 use PHPMD\Renderer\BaselineRenderer;
 use PHPMD\RuleSetFactory;
@@ -113,7 +114,8 @@ class Command
             $opts->getInputPath(),
             $opts->getRuleSets(),
             $renderers,
-            $ruleSetFactory
+            $ruleSetFactory,
+            new BaselineSet()
         );
 
         if ($phpmd->hasErrors() && !$opts->ignoreErrorsOnExit()) {

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -130,7 +130,7 @@ class Command
             return self::EXIT_ERROR;
         }
 
-        if ($phpmd->hasViolations() && !$opts->ignoreViolationsOnExit()) {
+        if ($phpmd->hasViolations() && !$opts->ignoreViolationsOnExit() && !$opts->generateBaseline()) {
             return self::EXIT_VIOLATION;
         }
 

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -82,30 +82,15 @@ class Command
 
         // Configure baseline violations
         $baseline = null;
-        $finder = new BaselineFileFinder($opts);
+        $finder   = new BaselineFileFinder($opts);
         if ($opts->generateBaseline()) {
-            // overwrite renderers when generate-baseline is requested
-            $baselineFile = $finder->find(false);
-            if ($baselineFile === null) {
-                $message = 'Unable to determine the location of the baseline file. ';
-                $message .= ' Specify the path via --baseline-file';
-                throw new RuntimeException($message);
-            }
-
-            $baseDir = $opts->baselineBasedir();
-            if ($baseDir === null) {
-                $baseDir = dirname($baselineFile);
-            }
-
-            $renderer = new BaselineRenderer($baseDir);
-            $renderer->setWriter(new StreamWriter($baselineFile));
-            $renderers = array($renderer);
+            // overwrite any renderer with the baseline renderer
+            $renderers = array(new BaselineRenderer(new StreamWriter($finder->notNull()->find())));
         } else {
-            // try to read baseline
-            $baselineFile = $finder->find(true);
+            // try to locate a baseline file and read it
+            $baselineFile = $finder->existingFile()->find();
             if ($baselineFile !== null) {
-                $baselineFactory = new BaselineSetFactory();
-                $baseline        = $baselineFactory->fromFile(dirname($baselineFile), $baselineFile);
+                $baseline = BaselineSetFactory::fromFile(dirname($baselineFile), $baselineFile);
             }
         }
 

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -18,6 +18,7 @@
 namespace PHPMD\TextUI;
 
 use PHPMD\PHPMD;
+use PHPMD\Renderer\BaselineRenderer;
 use PHPMD\RuleSetFactory;
 use PHPMD\Writer\StreamWriter;
 
@@ -73,6 +74,13 @@ class Command
             $reportRenderer->setWriter(new StreamWriter($reportFile));
 
             $renderers[] = $reportRenderer;
+        }
+
+        // overwrite renderers when generate-baseline is requested
+        if ($opts->generateBaseline() !== null) {
+            $renderer = new BaselineRenderer($opts->baselineBasedir());
+            $renderer->setWriter(new StreamWriter($opts->generateBaseline()));
+            $renderers = array($renderer);
         }
 
         // Configure a rule set factory

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -9,10 +9,10 @@
  * For full copyright and license information, please see the LICENSE file.
  * Redistributions of files must retain the above copyright notice.
  *
- * @author Manuel Pichler <mapi@phpmd.org>
+ * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
- * @license https://opensource.org/licenses/bsd-license.php BSD License
- * @link http://phpmd.org/
+ * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ * @link      http://phpmd.org/
  */
 
 namespace PHPMD\TextUI;
@@ -22,6 +22,7 @@ use PHPMD\Baseline\BaselineSetFactory;
 use PHPMD\PHPMD;
 use PHPMD\Renderer\RendererFactory;
 use PHPMD\RuleSetFactory;
+use PHPMD\Utility\Paths;
 use PHPMD\Writer\StreamWriter;
 
 /**
@@ -51,7 +52,7 @@ class Command
      * even if any violation or error is found.
      *
      * @param \PHPMD\TextUI\CommandLineOptions $opts
-     * @param \PHPMD\RuleSetFactory $ruleSetFactory
+     * @param \PHPMD\RuleSetFactory            $ruleSetFactory
      * @return integer
      */
     public function run(CommandLineOptions $opts, RuleSetFactory $ruleSetFactory)
@@ -88,7 +89,7 @@ class Command
             // try to locate a baseline file and read it
             $baselineFile = $finder->existingFile()->find();
             if ($baselineFile !== null) {
-                $baseline = BaselineSetFactory::fromFile(dirname($baselineFile), $baselineFile);
+                $baseline = BaselineSetFactory::fromFile(Paths::getRealPath($baselineFile));
             }
         }
 
@@ -148,7 +149,7 @@ class Command
 
         $version = '@package_version@';
         if (file_exists($build)) {
-            $data = @parse_ini_file($build);
+            $data    = @parse_ini_file($build);
             $version = $data['project.version'];
         }
 
@@ -166,8 +167,8 @@ class Command
     {
         try {
             $ruleSetFactory = new RuleSetFactory();
-            $options = new CommandLineOptions($args, $ruleSetFactory->listAvailableRuleSets());
-            $command = new Command();
+            $options        = new CommandLineOptions($args, $ruleSetFactory->listAvailableRuleSets());
+            $command        = new Command();
 
             $exitCode = $command->run($options, $ruleSetFactory);
         } catch (\Exception $e) {

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -148,16 +148,10 @@ class CommandLineOptions
     protected $availableRuleSets = array();
 
     /**
-     * Should PHPMD baseline the existing violations and write them to the baseline xml file
+     * Should PHPMD baseline the existing violations and write them to the $baselineFile
      * @var bool
      */
     protected $generateBaseline = false;
-
-    /**
-     * The relative directory of the baseline files. Defaults to the (first) ruleset file
-     * @var string|null
-     */
-    protected $baselineBasedir;
 
     /**
      * The baseline source file to read the baseline violations from.
@@ -235,9 +229,6 @@ class CommandLineOptions
                     break;
                 case '--baseline-file':
                     $this->baselineFile = array_shift($args);
-                    break;
-                case '--baseline-basedir':
-                    $this->baselineBasedir = array_shift($args);
                     break;
                 case '--ignore-errors-on-exit':
                     $this->ignoreErrorsOnExit = true;
@@ -401,16 +392,6 @@ class CommandLineOptions
     public function generateBaseline()
     {
         return $this->generateBaseline;
-    }
-
-    /**
-     * Get the baseline base directory to which the absolute filepaths will be set relative to.
-     *
-     * @return string|null
-     */
-    public function baselineBasedir()
-    {
-        return $this->baselineBasedir;
     }
 
     /**
@@ -601,7 +582,10 @@ class CommandLineOptions
             '--ignore-errors-on-exit: will exit with a zero code, ' .
             'even on error' . \PHP_EOL .
             '--ignore-violations-on-exit: will exit with a zero code, ' .
-            'even if any violations are found' . \PHP_EOL;
+            'even if any violations are found' . \PHP_EOL .
+            '--generate-baseline: will generate a phpmd.baseline.xml next ' .
+            'to the first ruleset file location' . \PHP_EOL .
+            '--baseline-file: a custom location of the baseline file' . \PHP_EOL;
     }
 
     /**

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -148,18 +148,23 @@ class CommandLineOptions
     protected $availableRuleSets = array();
 
     /**
-     * Should PHPMD baseline the existing violations. Either contains the filepath to write the baseline to
-     * or null if no baseline should be generated
-     *
-     * @var string|null
+     * Should PHPMD baseline the existing violations and write them to the baseline xml file
+     * @var bool
      */
-    protected $generateBaseline;
+    protected $generateBaseline = false;
 
     /**
-     * The directory to base the baseline filepath on
+     * The relative directory of the baseline files. Defaults to the (first) ruleset file
      * @var string|null
      */
     protected $baselineBasedir;
+
+    /**
+     * The baseline source file to read the baseline violations from.
+     * Defaults to the path of the (first) ruleset file as phpmd.baseline.xml
+     * @var string|null
+     */
+    protected $baselineFile;
 
     /**
      * Constructs a new command line options instance.
@@ -226,11 +231,10 @@ class CommandLineOptions
                     $this->strict = false;
                     break;
                 case '--generate-baseline':
-                    if (isset($args[0]) && strpos($args[0], '--') !== 0) {
-                        $this->generateBaseline = array_shift($args);
-                    } else {
-                        $this->generateBaseline = getcwd() . '/phpmd.baseline.xml';
-                    }
+                    $this->generateBaseline = true;
+                    break;
+                case '--baseline-file':
+                    $this->baselineFile = array_shift($args);
                     break;
                 case '--baseline-basedir':
                     $this->baselineBasedir = array_shift($args);
@@ -392,7 +396,7 @@ class CommandLineOptions
     /**
      * Should the current violations be baselined
      *
-     * @return string|null
+     * @return bool
      */
     public function generateBaseline()
     {
@@ -406,12 +410,17 @@ class CommandLineOptions
      */
     public function baselineBasedir()
     {
-        if ($this->baselineBasedir === null) {
-            $baselineFilepath = $this->generateBaseline();
-            return $baselineFilepath === null ? null : dirname($baselineFilepath);
-        }
-
         return $this->baselineBasedir;
+    }
+
+    /**
+     * The filepath of the baseline violations xml
+     *
+     * @return string|null
+     */
+    public function baselineFile()
+    {
+        return $this->baselineFile;
     }
 
     /**

--- a/src/main/php/PHPMD/Utility/Paths.php
+++ b/src/main/php/PHPMD/Utility/Paths.php
@@ -17,4 +17,25 @@ class Paths
         $pathB = ltrim(str_replace('\\', '/', $pathB), '/');
         return $pathA . '/' . $pathB;
     }
+
+    /**
+     * Transform the given absolute path to the relative path within based on the base path.
+     *
+     * @param string $basePath
+     * @param string $filePath
+     * @return string
+     */
+    public static function getRelativePath($basePath, $filePath)
+    {
+        // normalize slashes and ensure base path ends with slash
+        $basePath = rtrim(str_replace('\\', '/', $basePath), '/') . '/';
+        $filePath = str_replace('\\', '/', $filePath);
+
+        // subtract base dir from filepath if there's a match
+        if (stripos($filePath, $basePath) === 0) {
+            $filePath = substr($filePath, strlen($basePath));
+        }
+
+        return $filePath;
+    }
 }

--- a/src/main/php/PHPMD/Utility/Paths.php
+++ b/src/main/php/PHPMD/Utility/Paths.php
@@ -38,4 +38,24 @@ class Paths
 
         return $filePath;
     }
+
+    /**
+     * Derive the absolute path from the given resource
+     * @param resource $resource
+     * @return string
+     */
+    public static function getAbsolutePath($resource)
+    {
+        $metaData = stream_get_meta_data($resource);
+        if (isset($metaData['uri']) === false) {
+            return null;
+        }
+
+        $absolutePath = realpath($metaData['uri']);
+        if ($absolutePath === false) {
+            return null;
+        }
+
+        return $absolutePath;
+    }
 }

--- a/src/main/php/PHPMD/Utility/Paths.php
+++ b/src/main/php/PHPMD/Utility/Paths.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PHPMD\Utility;
+
+class Paths
+{
+    /**
+     * Append $pathB to $pathA and apply the correct amount of slashes between them
+     *
+     * @param string $pathA
+     * @param string $pathB
+     * @return string
+     */
+    public static function concat($pathA, $pathB)
+    {
+        $pathA = rtrim(str_replace('\\', '/', $pathA), '/');
+        $pathB = ltrim(str_replace('\\', '/', $pathB), '/');
+        return $pathA . '/' . $pathB;
+    }
+}

--- a/src/main/php/PHPMD/Utility/Paths.php
+++ b/src/main/php/PHPMD/Utility/Paths.php
@@ -2,6 +2,8 @@
 
 namespace PHPMD\Utility;
 
+use RuntimeException;
+
 class Paths
 {
     /**
@@ -43,13 +45,25 @@ class Paths
      * Derive the absolute path from the given resource
      * @param resource $resource
      * @return string
+     * @throws RuntimeException
      */
     public static function getAbsolutePath($resource)
     {
-        $metaData     = stream_get_meta_data($resource);
-        $absolutePath = realpath($metaData['uri']);
+        $metaData = stream_get_meta_data($resource);
+        return self::getRealPath($metaData['uri']);
+    }
+
+    /**
+     * Get the realpath of the given path or exception on failure
+     * @param string $path
+     * @return string
+     * @throws RuntimeException
+     */
+    public static function getRealPath($path)
+    {
+        $absolutePath = realpath($path);
         if ($absolutePath === false) {
-            return null;
+            throw new RuntimeException('Unable to determine the realpath for: ' . $path);
         }
 
         return $absolutePath;

--- a/src/main/php/PHPMD/Utility/Paths.php
+++ b/src/main/php/PHPMD/Utility/Paths.php
@@ -46,11 +46,7 @@ class Paths
      */
     public static function getAbsolutePath($resource)
     {
-        $metaData = stream_get_meta_data($resource);
-        if (isset($metaData['uri']) === false) {
-            return null;
-        }
-
+        $metaData     = stream_get_meta_data($resource);
         $absolutePath = realpath($metaData['uri']);
         if ($absolutePath === false) {
             return null;

--- a/src/main/php/PHPMD/Utility/Paths.php
+++ b/src/main/php/PHPMD/Utility/Paths.php
@@ -21,7 +21,7 @@ class Paths
     }
 
     /**
-     * Transform the given absolute path to the relative path within based on the base path.
+     * Transform the given absolute path to the relative path based on the given base path.
      *
      * @param string $basePath
      * @param string $filePath

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -77,4 +77,12 @@ class StreamWriter extends AbstractWriter
     {
         fwrite($this->stream, $data);
     }
+
+    /**
+     * @return resource
+     */
+    public function getStream()
+    {
+        return $this->stream;
+    }
 }

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -133,7 +133,7 @@ Baseline
 
 For existing projects a violation baseline can be generated. All violations in this baseline will be ignored in further inspections.
 
-To create generate ``phpmd.baseline.xml`` next to ``phpmd.xml``::
+The recommended approach would be a ``phpmd.xml`` in the root of the project. To generate the phpmd.baseline.xml next to it::
 
   ~ $ phpmd /path/to/source text phpmd.xml --generate-baseline
 

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -133,14 +133,14 @@ Baseline
 
 For existing projects a violation baseline can be generated. All violations in this baseline will be ignored in further inspections.
 
-To create generate ``phpmd.baseline.xml`` next to ``phpmd.xml``:
+To create generate ``phpmd.baseline.xml`` next to ``phpmd.xml``::
 
   ~ $ phpmd /path/to/source text phpmd.xml --generate-baseline
 
-To specify a custom baseline filepath for export:
+To specify a custom baseline filepath for export::
 
   ~ $ phpmd /path/to/source text phpmd.xml --generate-baseline --baseline-file /path/to/source/phpmd.baseline.xml
 
-By default PHPMD will look next to ``phpmd.xml`` for ``phpmd.baseline.xml``. To overwrite this behaviour:
+By default PHPMD will look next to ``phpmd.xml`` for ``phpmd.baseline.xml``. To overwrite this behaviour::
 
   ~ $ phpmd /path/to/source text phpmd.xml --baseline-file /path/to/source/phpmd.baseline.xml

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -64,6 +64,12 @@ Command line options
   - ``--ignore-violations-on-exit`` - will exit with a zero code, even if any
     violations are found.
 
+  - ``--generate-baseline`` - will generate a phpmd.baseline.xml for existing violations
+    next to the ruleset definition file.
+
+  - ``--baseline-file`` - the filepath to a custom baseline xml file. The filepath
+    of all baselined files must be relative to this file location.
+
   An example command line: ::
 
     phpmd PHP/Depend/DbusUI xml codesize --reportfile phpmd.xml --suffixes php,phtml
@@ -121,3 +127,20 @@ At the moment PHPMD comes with the following five renderers:
 - *html*, single HTML file with possible problems.
 - *json*, formats JSON report.
 - *github*, a format that GitHub Actions understands (see `CI Integration </documentation/ci-integration.html#github-actions>`_).
+
+Baseline
+=========
+
+For existing projects a violation baseline can be generated. All violations in this baseline will be ignored in further inspections.
+
+To create generate ``phpmd.baseline.xml`` next to ``phpmd.xml``:
+
+  ~ $ phpmd /path/to/source text phpmd.xml --generate-baseline
+
+To specify a custom baseline filepath for export:
+
+  ~ $ phpmd /path/to/source text phpmd.xml --generate-baseline --baseline-file /path/to/source/phpmd.baseline.xml
+
+By default PHPMD will look next to ``phpmd.xml`` for ``phpmd.baseline.xml``. To overwrite this behaviour:
+
+  ~ $ phpmd /path/to/source text phpmd.xml --baseline-file /path/to/source/phpmd.baseline.xml

--- a/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace PHPMD\Baseline;
+
+use PHPMD\AbstractTest;
+use PHPMD\TextUI\CommandLineOptions;
+
+/**
+ * @coversDefaultClass \PHPMD\Baseline\BaselineFileFinder
+ * @covers ::__construct
+ */
+class BaselineFileFinderTest extends AbstractTest
+{
+    /**
+     * @covers ::find
+     * @covers ::tryFind
+     */
+    public function testShouldFindFileFromCLI()
+    {
+        $args   = array('script', 'source', 'xml', 'phpmd.xml', '--baseline-file', 'foobar.txt');
+        $finder = new BaselineFileFinder(new CommandLineOptions($args));
+        static::assertSame('foobar.txt', $finder->find());
+    }
+
+    /**
+     * @covers ::find
+     * @covers ::tryFind
+     * @covers ::existingFile
+     */
+    public function testShouldFindExistingFileNearRuleSet()
+    {
+        $args   = array('script', 'source', 'xml', static::createResourceUriForTest('testA/phpmd.xml'));
+        $finder = new BaselineFileFinder(new CommandLineOptions($args));
+        static::assertSame(
+            realpath(static::createResourceUriForTest('testA/phpmd.baseline.xml')),
+            $finder->existingFile()->find()
+        );
+    }
+
+    /**
+     * @covers ::find
+     * @covers ::tryFind
+     */
+    public function testShouldReturnNullForNonExistingRuleSet()
+    {
+        $args   = array('script', 'source', 'xml', static::createResourceUriForTest('phpmd.xml'));
+        $finder = new BaselineFileFinder(new CommandLineOptions($args));
+        static::assertNull($finder->find());
+    }
+
+    /**
+     * @covers ::find
+     * @covers ::tryFind
+     * @covers ::existingFile
+     */
+    public function testShouldOnlyFindExistingFile()
+    {
+        $args   = array('script', 'source', 'xml', static::createResourceUriForTest('testB/phpmd.xml'));
+        $finder = new BaselineFileFinder(new CommandLineOptions($args));
+        static::assertNull($finder->existingFile()->find());
+    }
+
+    /**
+     * @covers ::find
+     * @covers ::tryFind
+     * @covers ::notNull
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unable to find the baseline file
+     */
+    public function testShouldThrowExceptionWhenFileIsNull()
+    {
+        $args   = array('script', 'source', 'xml', static::createResourceUriForTest('testB/phpmd.xml'));
+        $finder = new BaselineFileFinder(new CommandLineOptions($args));
+        static::assertNull($finder->existingFile()->notNull()->find());
+    }
+}

--- a/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace PHPMD\Baseline;
+
+use PHPMD\AbstractTest;
+
+/**
+ * @coversDefaultClass \PHPMD\Baseline\BaselineSetFactory
+ */
+class BaselineSetFactoryTest extends AbstractTest
+{
+    /**
+     * @covers ::fromFile
+     */
+    public function testFromFileShouldSucceed()
+    {
+        $filename = static::createResourceUriForTest('baseline.xml');
+
+        $factory = new BaselineSetFactory();
+        $set     = $factory->fromFile($filename);
+
+        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', 'src/foo/bar'));
+        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', 'src/foo/bar'));
+    }
+
+    /**
+     * @covers ::fromFile
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unknown file
+     */
+    public function testFromFileShouldThrowExceptionForMissingFile()
+    {
+        $factory = new BaselineSetFactory();
+        $factory->fromFile('foobar.xml');
+    }
+
+    /**
+     * @covers ::fromFile
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unable to read xml from
+     */
+    public function testFromFileShouldThrowExceptionForOnInvalidXML()
+    {
+        $factory = new BaselineSetFactory();
+        $factory->fromFile(static::createResourceUriForTest('invalid-baseline.xml'));
+    }
+
+    /**
+     * @covers ::fromFile
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Missing `rule` attribute in `violation`
+     */
+    public function testFromFileViolationMissingRuleShouldThrowException()
+    {
+        $factory = new BaselineSetFactory();
+        $factory->fromFile(static::createResourceUriForTest('missing-rule-baseline.xml'));
+    }
+
+    /**
+     * @covers ::fromFile
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Missing `file` attribute in `violation` in
+     */
+    public function testFromFileViolationMissingFileShouldThrowException()
+    {
+        $factory = new BaselineSetFactory();
+        $factory->fromFile(static::createResourceUriForTest('missing-file-baseline.xml'));
+    }
+}

--- a/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
@@ -15,10 +15,13 @@ class BaselineSetFactoryTest extends AbstractTest
     public function testFromFileShouldSucceed()
     {
         $filename = static::createResourceUriForTest('baseline.xml');
-        $set      = BaselineSetFactory::fromFile('/home', $filename);
+        $baseDir  = dirname($filename);
+        $set      = BaselineSetFactory::fromFile($filename);
 
-        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', '/home/src/foo/bar', null));
-        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', '/home/src/foo/bar', 'myMethod'));
+        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', $baseDir . '/src/foo/bar', null));
+        static::assertTrue(
+            $set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', $baseDir . '/src/foo/bar', 'myMethod')
+        );
     }
 
     /**
@@ -27,10 +30,13 @@ class BaselineSetFactoryTest extends AbstractTest
     public function testFromFileShouldSucceedWithBackAndForwardSlashes()
     {
         $filename = static::createResourceUriForTest('baseline.xml');
-        $set      = BaselineSetFactory::fromFile('/home\\', $filename);
+        $baseDir  = dirname($filename);
+        $set      = BaselineSetFactory::fromFile($filename);
 
-        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', '/home/src\\foo/bar', null));
-        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', '/home/src\\foo/bar', 'myMethod'));
+        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', $baseDir . '/src\\foo/bar', null));
+        static::assertTrue(
+            $set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', $baseDir . '/src\\foo/bar', 'myMethod')
+        );
     }
 
     /**
@@ -40,7 +46,7 @@ class BaselineSetFactoryTest extends AbstractTest
      */
     public function testFromFileShouldThrowExceptionForMissingFile()
     {
-        BaselineSetFactory::fromFile('foo', 'foobar.xml');
+        BaselineSetFactory::fromFile('foobar.xml');
     }
 
     /**
@@ -50,7 +56,7 @@ class BaselineSetFactoryTest extends AbstractTest
      */
     public function testFromFileShouldThrowExceptionForOnInvalidXML()
     {
-        BaselineSetFactory::fromFile('foo', static::createResourceUriForTest('invalid-baseline.xml'));
+        BaselineSetFactory::fromFile(static::createResourceUriForTest('invalid-baseline.xml'));
     }
 
     /**
@@ -60,7 +66,7 @@ class BaselineSetFactoryTest extends AbstractTest
      */
     public function testFromFileViolationMissingRuleShouldThrowException()
     {
-        BaselineSetFactory::fromFile('foo', static::createResourceUriForTest('missing-rule-baseline.xml'));
+        BaselineSetFactory::fromFile(static::createResourceUriForTest('missing-rule-baseline.xml'));
     }
 
     /**
@@ -70,6 +76,6 @@ class BaselineSetFactoryTest extends AbstractTest
      */
     public function testFromFileViolationMissingFileShouldThrowException()
     {
-        BaselineSetFactory::fromFile('foo', static::createResourceUriForTest('missing-file-baseline.xml'));
+        BaselineSetFactory::fromFile(static::createResourceUriForTest('missing-file-baseline.xml'));
     }
 }

--- a/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
@@ -17,8 +17,8 @@ class BaselineSetFactoryTest extends AbstractTest
         $filename = static::createResourceUriForTest('baseline.xml');
         $set      = BaselineSetFactory::fromFile('/home', $filename);
 
-        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', '/home/src/foo/bar'));
-        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', '/home/src/foo/bar'));
+        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', '/home/src/foo/bar', null));
+        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', '/home/src/foo/bar', 'myMethod'));
     }
 
     /**
@@ -29,8 +29,8 @@ class BaselineSetFactoryTest extends AbstractTest
         $filename = static::createResourceUriForTest('baseline.xml');
         $set      = BaselineSetFactory::fromFile('/home\\', $filename);
 
-        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', '/home/src\\foo/bar'));
-        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', '/home/src\\foo/bar'));
+        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', '/home/src\\foo/bar', null));
+        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', '/home/src\\foo/bar', 'myMethod'));
     }
 
     /**

--- a/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
@@ -15,23 +15,32 @@ class BaselineSetFactoryTest extends AbstractTest
     public function testFromFileShouldSucceed()
     {
         $filename = static::createResourceUriForTest('baseline.xml');
+        $set      = BaselineSetFactory::fromFile('/home', $filename);
 
-        $factory = new BaselineSetFactory();
-        $set     = $factory->fromFile($filename);
+        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', '/home/src/foo/bar'));
+        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', '/home/src/foo/bar'));
+    }
 
-        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', 'src/foo/bar'));
-        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', 'src/foo/bar'));
+    /**
+     * @covers ::fromFile
+     */
+    public function testFromFileShouldSucceedWithBackAndForwardSlashes()
+    {
+        $filename = static::createResourceUriForTest('baseline.xml');
+        $set      = BaselineSetFactory::fromFile('/home\\', $filename);
+
+        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', '/home/src\\foo/bar'));
+        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', '/home/src\\foo/bar'));
     }
 
     /**
      * @covers ::fromFile
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unknown file
+     * @expectedExceptionMessage Unable to locate the baseline file at
      */
     public function testFromFileShouldThrowExceptionForMissingFile()
     {
-        $factory = new BaselineSetFactory();
-        $factory->fromFile('foobar.xml');
+        BaselineSetFactory::fromFile('foo', 'foobar.xml');
     }
 
     /**
@@ -41,8 +50,7 @@ class BaselineSetFactoryTest extends AbstractTest
      */
     public function testFromFileShouldThrowExceptionForOnInvalidXML()
     {
-        $factory = new BaselineSetFactory();
-        $factory->fromFile(static::createResourceUriForTest('invalid-baseline.xml'));
+        BaselineSetFactory::fromFile('foo', static::createResourceUriForTest('invalid-baseline.xml'));
     }
 
     /**
@@ -52,8 +60,7 @@ class BaselineSetFactoryTest extends AbstractTest
      */
     public function testFromFileViolationMissingRuleShouldThrowException()
     {
-        $factory = new BaselineSetFactory();
-        $factory->fromFile(static::createResourceUriForTest('missing-rule-baseline.xml'));
+        BaselineSetFactory::fromFile('foo', static::createResourceUriForTest('missing-rule-baseline.xml'));
     }
 
     /**
@@ -63,7 +70,6 @@ class BaselineSetFactoryTest extends AbstractTest
      */
     public function testFromFileViolationMissingFileShouldThrowException()
     {
-        $factory = new BaselineSetFactory();
-        $factory->fromFile(static::createResourceUriForTest('missing-file-baseline.xml'));
+        BaselineSetFactory::fromFile('foo', static::createResourceUriForTest('missing-file-baseline.xml'));
     }
 }

--- a/src/test/php/PHPMD/Baseline/BaselineSetTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PHPMD\Baseline;
+
+use PHPMD\AbstractTest;
+
+/**
+ * @coversDefaultClass \PHPMD\Baseline\BaselineSet
+ */
+class BaselineSetTest extends AbstractTest
+{
+    /**
+     * @covers ::addEntry
+     * @covers ::contains
+     */
+    public function testSetContainsEntry()
+    {
+        $set = new BaselineSet();
+        $set->addEntry(new ViolationBaseline('rule', 'foobar'));
+
+        static::assertTrue($set->contains('rule', 'foobar'));
+    }
+
+    /**
+     * @covers ::addEntry
+     * @covers ::contains
+     */
+    public function testShouldFindEntryForIdenticalRules()
+    {
+        $set = new BaselineSet();
+        $set->addEntry(new ViolationBaseline('rule', 'foo'));
+        $set->addEntry(new ViolationBaseline('rule', 'bar'));
+
+        static::assertTrue($set->contains('rule', 'foo'));
+        static::assertTrue($set->contains('rule', 'bar'));
+        static::assertFalse($set->contains('rule', 'unknown'));
+    }
+
+    /**
+     * @covers ::addEntry
+     * @covers ::contains
+     */
+    public function testShouldNotFindEntryForNonExistingRule()
+    {
+        $set = new BaselineSet();
+        $set->addEntry(new ViolationBaseline('rule', 'foo'));
+
+        static::assertFalse($set->contains('unknown', 'foo'));
+    }
+}

--- a/src/test/php/PHPMD/Baseline/BaselineSetTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetTest.php
@@ -13,12 +13,24 @@ class BaselineSetTest extends AbstractTest
      * @covers ::addEntry
      * @covers ::contains
      */
-    public function testSetContainsEntry()
+    public function testSetContainsEntryWithoutMethodName()
     {
         $set = new BaselineSet();
-        $set->addEntry(new ViolationBaseline('rule', 'foobar'));
+        $set->addEntry(new ViolationBaseline('rule', 'foobar', null));
 
-        static::assertTrue($set->contains('rule', 'foobar'));
+        static::assertTrue($set->contains('rule', 'foobar', null));
+    }
+
+    /**
+     * @covers ::addEntry
+     * @covers ::contains
+     */
+    public function testSetContainsEntryWithMethodName()
+    {
+        $set = new BaselineSet();
+        $set->addEntry(new ViolationBaseline('rule', 'foobar', 'method'));
+
+        static::assertTrue($set->contains('rule', 'foobar', 'method'));
     }
 
     /**
@@ -28,12 +40,14 @@ class BaselineSetTest extends AbstractTest
     public function testShouldFindEntryForIdenticalRules()
     {
         $set = new BaselineSet();
-        $set->addEntry(new ViolationBaseline('rule', 'foo'));
-        $set->addEntry(new ViolationBaseline('rule', 'bar'));
+        $set->addEntry(new ViolationBaseline('rule', 'foo', null));
+        $set->addEntry(new ViolationBaseline('rule', 'bar', null));
+        $set->addEntry(new ViolationBaseline('rule', 'bar', 'method'));
 
-        static::assertTrue($set->contains('rule', 'foo'));
-        static::assertTrue($set->contains('rule', 'bar'));
-        static::assertFalse($set->contains('rule', 'unknown'));
+        static::assertTrue($set->contains('rule', 'foo', null));
+        static::assertTrue($set->contains('rule', 'bar', null));
+        static::assertTrue($set->contains('rule', 'bar', 'method'));
+        static::assertFalse($set->contains('rule', 'unknown', null));
     }
 
     /**
@@ -43,8 +57,20 @@ class BaselineSetTest extends AbstractTest
     public function testShouldNotFindEntryForNonExistingRule()
     {
         $set = new BaselineSet();
-        $set->addEntry(new ViolationBaseline('rule', 'foo'));
+        $set->addEntry(new ViolationBaseline('rule', 'foo', null));
 
-        static::assertFalse($set->contains('unknown', 'foo'));
+        static::assertFalse($set->contains('unknown', 'foo', null));
+    }
+
+    /**
+     * @covers ::addEntry
+     * @covers ::contains
+     */
+    public function testShouldNotFindEntryForNonExistingMethod()
+    {
+        $set = new BaselineSet();
+        $set->addEntry(new ViolationBaseline('rule', 'foo', 'method'));
+
+        static::assertFalse($set->contains('rule', 'foo', 'unknown'));
     }
 }

--- a/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
+++ b/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
@@ -13,11 +13,23 @@ class ViolationBaselineTest extends TestCase
      * @covers ::__construct
      * @covers ::getRuleName
      * @covers ::getFileName
+     * @covers ::getMethodName
      */
-    public function testAccessors()
+    public function testAccessorsWithoutMethod()
     {
-        $violation = new ViolationBaseline('rule', 'foobar');
+        $violation = new ViolationBaseline('rule', 'foobar', null);
         static::assertSame('rule', $violation->getRuleName());
         static::assertSame('foobar', $violation->getFileName());
+        static::assertNull($violation->getMethodName());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getMethodName
+     */
+    public function testAccessorsWithMethod()
+    {
+        $violation = new ViolationBaseline('rule', 'foobar', 'method');
+        static::assertSame('method', $violation->getMethodName());
     }
 }

--- a/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
+++ b/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
@@ -12,12 +12,12 @@ class ViolationBaselineTest extends TestCase
     /**
      * @covers ::__construct
      * @covers ::getRuleName
-     * @covers ::getFilename
+     * @covers ::getFileName
      */
     public function testAccessors()
     {
         $violation = new ViolationBaseline('rule', 'foobar');
         static::assertSame('rule', $violation->getRuleName());
-        static::assertSame('foobar', $violation->getFilename());
+        static::assertSame('foobar', $violation->getFileName());
     }
 }

--- a/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
+++ b/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PHPMD\Baseline;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \PHPMD\Baseline\ViolationBaseline
+ */
+class ViolationBaselineTest extends TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::getRuleName
+     * @covers ::getFilename
+     */
+    public function testAccessors()
+    {
+        $violation = new ViolationBaseline('rule', 'foobar');
+        static::assertSame('rule', $violation->getRuleName());
+        static::assertSame('foobar', $violation->getFilename());
+    }
+}

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -17,7 +17,6 @@
 
 namespace PHPMD;
 
-use PHPMD\Baseline\BaselineSet;
 use PHPMD\Renderer\XMLRenderer;
 use PHPMD\Stubs\WriterStub;
 
@@ -48,8 +47,7 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/ccn_function.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory(),
-            new BaselineSet()
+            new RuleSetFactory()
         );
 
         $this->assertXmlEquals($writer->getData(), 'pmd/default-xml.xml');
@@ -74,8 +72,7 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory(),
-            new BaselineSet()
+            new RuleSetFactory()
         );
 
         $this->assertXmlEquals($writer->getData(), 'pmd/single-directory.xml');
@@ -100,8 +97,7 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/ccn_function.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory(),
-            new BaselineSet()
+            new RuleSetFactory()
         );
 
         $this->assertXmlEquals($writer->getData(), 'pmd/single-file.xml');
@@ -146,8 +142,7 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/source_without_violations.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory(),
-            new BaselineSet()
+            new RuleSetFactory()
         );
 
         $this->assertFalse($phpmd->hasErrors());
@@ -171,8 +166,7 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/source_with_npath_violation.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory(),
-            new BaselineSet()
+            new RuleSetFactory()
         );
 
         $this->assertFalse($phpmd->hasErrors());
@@ -196,8 +190,7 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/source_with_parse_error.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory(),
-            new BaselineSet()
+            new RuleSetFactory()
         );
 
         $this->assertTrue($phpmd->hasErrors());
@@ -220,8 +213,7 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('sourceExcluded/'),
             'pmd-refset1',
             array(),
-            new RuleSetFactory(),
-            new BaselineSet()
+            new RuleSetFactory()
         );
 
         $this->assertFalse($phpmd->hasErrors());
@@ -232,8 +224,7 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('sourceExcluded/'),
             'exclude-pattern',
             array(),
-            new RuleSetFactory(),
-            new BaselineSet()
+            new RuleSetFactory()
         );
 
         $this->assertFalse($phpmd->hasErrors());

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD;
 
+use PHPMD\Baseline\BaselineSet;
 use PHPMD\Renderer\XMLRenderer;
 use PHPMD\Stubs\WriterStub;
 
@@ -47,7 +48,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/ccn_function.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new BaselineSet()
         );
 
         $this->assertXmlEquals($writer->getData(), 'pmd/default-xml.xml');
@@ -72,7 +74,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new BaselineSet()
         );
 
         $this->assertXmlEquals($writer->getData(), 'pmd/single-directory.xml');
@@ -97,7 +100,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/ccn_function.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new BaselineSet()
         );
 
         $this->assertXmlEquals($writer->getData(), 'pmd/single-file.xml');
@@ -142,7 +146,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/source_without_violations.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new BaselineSet()
         );
 
         $this->assertFalse($phpmd->hasErrors());
@@ -166,7 +171,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/source_with_npath_violation.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new BaselineSet()
         );
 
         $this->assertFalse($phpmd->hasErrors());
@@ -190,7 +196,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/source_with_parse_error.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new BaselineSet()
         );
 
         $this->assertTrue($phpmd->hasErrors());
@@ -213,7 +220,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('sourceExcluded/'),
             'pmd-refset1',
             array(),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new BaselineSet()
         );
 
         $this->assertFalse($phpmd->hasErrors());
@@ -224,7 +232,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('sourceExcluded/'),
             'exclude-pattern',
             array(),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new BaselineSet()
         );
 
         $this->assertFalse($phpmd->hasErrors());

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -174,6 +174,31 @@ class PHPMDTest extends AbstractTest
     }
 
     /**
+     * @return void
+     */
+    public function testHasViolationsReturnsFalseWhenViolationIsBaselined()
+    {
+        self::changeWorkingDirectory();
+
+        $baselineSet = $this->createMock('\PHPMD\Baseline\BaselineSet');
+        $baselineSet->expects(static::exactly(2))->method('contains')->willReturn(true);
+
+        $renderer = new XMLRenderer();
+        $renderer->setWriter(new WriterStub());
+
+        $phpmd = new PHPMD();
+        $phpmd->processFiles(
+            self::createFileUri('source/source_with_npath_violation.php'),
+            'pmd-refset1',
+            array($renderer),
+            new RuleSetFactory(),
+            $baselineSet
+        );
+
+        static::assertFalse($phpmd->hasViolations());
+    }
+
+    /**
      * testHasErrorsReturnsTrueForSourceWithError
      *
      * @return void

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -183,7 +183,7 @@ class PHPMDTest extends AbstractTest
         $baselineSet = $this->getMockBuilder('\PHPMD\Baseline\BaselineSet')
             ->disableOriginalConstructor()
             ->getMock();
-        $baselineSet->method('contains')->willReturn(true);
+        $baselineSet->expects(static::exactly(2))->method('contains')->willReturn(true);
 
         $renderer = new XMLRenderer();
         $renderer->setWriter(new WriterStub());

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -180,7 +180,9 @@ class PHPMDTest extends AbstractTest
     {
         self::changeWorkingDirectory();
 
-        $baselineSet = $this->createMock('\PHPMD\Baseline\BaselineSet');
+        $baselineSet = $this->getMockBuilder('\PHPMD\Baseline\BaselineSet')
+            ->disableOriginalConstructor()
+            ->getMock();
         $baselineSet->expects(static::exactly(2))->method('contains')->willReturn(true);
 
         $renderer = new XMLRenderer();

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -183,7 +183,7 @@ class PHPMDTest extends AbstractTest
         $baselineSet = $this->getMockBuilder('\PHPMD\Baseline\BaselineSet')
             ->disableOriginalConstructor()
             ->getMock();
-        $baselineSet->expects(static::exactly(2))->method('contains')->willReturn(true);
+        $baselineSet->method('contains')->willReturn(true);
 
         $renderer = new XMLRenderer();
         $renderer->setWriter(new WriterStub());

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -9,16 +9,18 @@
  * For full copyright and license information, please see the LICENSE file.
  * Redistributions of files must retain the above copyright notice.
  *
- * @author Manuel Pichler <mapi@phpmd.org>
+ * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
- * @license https://opensource.org/licenses/bsd-license.php BSD License
- * @link http://phpmd.org/
+ * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ * @link      http://phpmd.org/
  */
 
 namespace PHPMD;
 
+use PHPMD\Baseline\BaselineSet;
 use PHPMD\Renderer\XMLRenderer;
 use PHPMD\Stubs\WriterStub;
+use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * Test case for the main PHPMD class.
@@ -180,9 +182,10 @@ class PHPMDTest extends AbstractTest
     {
         self::changeWorkingDirectory();
 
-        $baselineSet = $this->getMockBuilder('\PHPMD\Baseline\BaselineSet')
-            ->disableOriginalConstructor()
-            ->getMock();
+        /** @var BaselineSet|PHPUnit_Framework_MockObject_MockObject $baselineSet */
+        $baselineSet = $this->getMockFromBuilder(
+            $this->getMockBuilder('\PHPMD\Baseline\BaselineSet')->disableOriginalConstructor()
+        );
         $baselineSet->expects(static::exactly(2))->method('contains')->willReturn(true);
 
         $renderer = new XMLRenderer();

--- a/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
+++ b/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Regression;
 
+use PHPMD\Baseline\BaselineSet;
 use PHPMD\PHPMD;
 use PHPMD\Renderer\XMLRenderer;
 use PHPMD\RuleSetFactory;
@@ -46,7 +47,8 @@ class AcceptsFilesAndDirectoriesAsInputTicket001Test extends AbstractTest
             self::createFileUri('source'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new BaselineSet()
         );
     }
 
@@ -67,7 +69,8 @@ class AcceptsFilesAndDirectoriesAsInputTicket001Test extends AbstractTest
             self::createFileUri('source/FooBar.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new BaselineSet()
         );
     }
 }

--- a/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
+++ b/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
@@ -17,7 +17,6 @@
 
 namespace PHPMD\Regression;
 
-use PHPMD\Baseline\BaselineSet;
 use PHPMD\PHPMD;
 use PHPMD\Renderer\XMLRenderer;
 use PHPMD\RuleSetFactory;
@@ -47,8 +46,7 @@ class AcceptsFilesAndDirectoriesAsInputTicket001Test extends AbstractTest
             self::createFileUri('source'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory(),
-            new BaselineSet()
+            new RuleSetFactory()
         );
     }
 
@@ -69,8 +67,7 @@ class AcceptsFilesAndDirectoriesAsInputTicket001Test extends AbstractTest
             self::createFileUri('source/FooBar.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory(),
-            new BaselineSet()
+            new RuleSetFactory()
         );
     }
 }

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
@@ -17,7 +17,6 @@
 
 namespace PHPMD\Regression;
 
-use PHPMD\Baseline\BaselineSet;
 use PHPMD\PHPMD;
 use PHPMD\Report;
 use PHPMD\RuleSetFactory;
@@ -88,8 +87,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
             __DIR__ . '/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php',
             'codesize',
             array($this->renderer),
-            new RuleSetFactory(),
-            new BaselineSet()
+            new RuleSetFactory()
         );
     }
 
@@ -129,8 +127,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
             __DIR__ . '/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php',
             'codesize',
             array($this->renderer),
-            new RuleSetFactory(),
-            new BaselineSet()
+            new RuleSetFactory()
         );
     }
 }

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Regression;
 
+use PHPMD\Baseline\BaselineSet;
 use PHPMD\PHPMD;
 use PHPMD\Report;
 use PHPMD\RuleSetFactory;
@@ -87,7 +88,8 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
             __DIR__ . '/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php',
             'codesize',
             array($this->renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new BaselineSet()
         );
     }
 
@@ -127,7 +129,8 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
             __DIR__ . '/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php',
             'codesize',
             array($this->renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new BaselineSet()
         );
     }
 }

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Regression;
 
+use PHPMD\Baseline\BaselineSet;
 use PHPMD\PHPMD;
 use PHPMD\Renderer\TextRenderer;
 use PHPMD\RuleSetFactory;
@@ -49,6 +50,6 @@ class MaximumNestingLevelTicket24975295Test extends AbstractTest
         $factory = new RuleSetFactory();
 
         $phpmd = new PHPMD();
-        $phpmd->processFiles($inputs, $rules, $renderes, $factory);
+        $phpmd->processFiles($inputs, $rules, $renderes, $factory, new BaselineSet());
     }
 }

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
@@ -17,7 +17,6 @@
 
 namespace PHPMD\Regression;
 
-use PHPMD\Baseline\BaselineSet;
 use PHPMD\PHPMD;
 use PHPMD\Renderer\TextRenderer;
 use PHPMD\RuleSetFactory;
@@ -50,6 +49,6 @@ class MaximumNestingLevelTicket24975295Test extends AbstractTest
         $factory = new RuleSetFactory();
 
         $phpmd = new PHPMD();
-        $phpmd->processFiles($inputs, $rules, $renderes, $factory, new BaselineSet());
+        $phpmd->processFiles($inputs, $rules, $renderes, $factory);
     }
 }

--- a/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace PHPMD\Renderer;
+
+use ArrayIterator;
+use PHPMD\AbstractTest;
+use PHPMD\Stubs\WriterStub;
+
+/**
+ * @coversDefaultClass \PHPMD\Renderer\BaselineRenderer
+ * @covers ::__construct
+ */
+class BaselineRendererTest extends AbstractTest
+{
+    /**
+     * @covers ::renderReport
+     */
+    public function testRenderReport()
+    {
+        $writer     = new WriterStub();
+        $violations = array(
+            $this->getRuleViolationMock('/src/php/bar.php'),
+            $this->getRuleViolationMock('/src/php/foo.php'),
+        );
+
+        $report = $this->getReportWithNoViolation();
+        $report->expects(static::once())
+            ->method('getRuleViolations')
+            ->willReturn(new ArrayIterator($violations));
+
+        $renderer = new BaselineRenderer('/src');
+        $renderer->setWriter($writer);
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        static::assertXmlEquals(
+            $writer->getData(),
+            'renderer/baseline_renderer_expected1.xml'
+        );
+    }
+
+    /**
+     * @covers ::renderReport
+     */
+    public function testRenderEmptyReport()
+    {
+        $writer = new WriterStub();
+        $report = $this->getReportWithNoViolation();
+        $report->expects(static::once())
+            ->method('getRuleViolations')
+            ->willReturn(new ArrayIterator(array()));
+
+        $renderer = new BaselineRenderer('/src');
+        $renderer->setWriter($writer);
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        static::assertXmlEquals(
+            $writer->getData(),
+            'renderer/baseline_renderer_expected2.xml'
+        );
+    }
+}

--- a/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
@@ -24,7 +24,8 @@ class BaselineRendererTest extends AbstractTest
         );
 
         $report = $this->getReportWithNoViolation();
-        $report->method('getRuleViolations')
+        $report->expects(static::once())
+            ->method('getRuleViolations')
             ->willReturn(new ArrayIterator($violations));
 
         $renderer = new BaselineRenderer('/src');
@@ -46,7 +47,7 @@ class BaselineRendererTest extends AbstractTest
     {
         $writer        = new WriterStub();
         $violationMock = $this->getRuleViolationMock('/src/php/bar.php');
-        $violationMock->method('getMethodName')->willReturn('foo');
+        $violationMock->expects(static::once())->method('getMethodName')->willReturn('foo');
 
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
@@ -76,7 +77,8 @@ class BaselineRendererTest extends AbstractTest
 
         // add the same violation twice
         $report = $this->getReportWithNoViolation();
-        $report->method('getRuleViolations')
+        $report->expects(static::once())
+            ->method('getRuleViolations')
             ->willReturn(new ArrayIterator(array($violationMock, $violationMock)));
 
         $renderer = new BaselineRenderer('/src');
@@ -98,7 +100,8 @@ class BaselineRendererTest extends AbstractTest
     {
         $writer = new WriterStub();
         $report = $this->getReportWithNoViolation();
-        $report->method('getRuleViolations')
+        $report->expects(static::once())
+            ->method('getRuleViolations')
             ->willReturn(new ArrayIterator(array()));
 
         $renderer = new BaselineRenderer('/src');

--- a/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
@@ -4,7 +4,9 @@ namespace PHPMD\Renderer;
 
 use ArrayIterator;
 use PHPMD\AbstractTest;
+use PHPMD\Report;
 use PHPMD\Stubs\WriterStub;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * @coversDefaultClass \PHPMD\Renderer\BaselineRenderer
@@ -23,6 +25,7 @@ class BaselineRendererTest extends AbstractTest
             $this->getRuleViolationMock('/src/php/foo.php'),
         );
 
+        /** @var Report|MockObject $report */
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
@@ -49,6 +52,7 @@ class BaselineRendererTest extends AbstractTest
         $violationMock = $this->getRuleViolationMock('/src/php/bar.php');
         $violationMock->expects(static::once())->method('getMethodName')->willReturn('foo');
 
+        /** @var Report|MockObject $report */
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
@@ -76,6 +80,7 @@ class BaselineRendererTest extends AbstractTest
         $violationMock->expects(static::exactly(2))->method('getMethodName')->willReturn('foo');
 
         // add the same violation twice
+        /** @var Report|MockObject $report */
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
@@ -104,6 +109,7 @@ class BaselineRendererTest extends AbstractTest
             ->method('getRuleViolations')
             ->willReturn(new ArrayIterator(array()));
 
+        /** @var Report|MockObject $report */
         $renderer = new BaselineRenderer('/src');
         $renderer->setWriter($writer);
         $renderer->start();

--- a/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
@@ -43,6 +43,59 @@ class BaselineRendererTest extends AbstractTest
     /**
      * @covers ::renderReport
      */
+    public function testRenderReportShouldWriteMethodName()
+    {
+        $writer        = new WriterStub();
+        $violationMock = $this->getRuleViolationMock('/src/php/bar.php');
+        $violationMock->expects(static::once())->method('getMethodName')->willReturn('foo');
+
+        $report = $this->getReportWithNoViolation();
+        $report->expects(static::once())
+            ->method('getRuleViolations')
+            ->willReturn(new ArrayIterator(array($violationMock)));
+
+        $renderer = new BaselineRenderer('/src');
+        $renderer->setWriter($writer);
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        static::assertXmlEquals(
+            $writer->getData(),
+            'renderer/baseline_renderer_expected2.xml'
+        );
+    }
+
+    /**
+     * @covers ::renderReport
+     */
+    public function testRenderReportShouldDeduplicateSimilarViolations()
+    {
+        $writer        = new WriterStub();
+        $violationMock = $this->getRuleViolationMock('/src/php/bar.php');
+        $violationMock->expects(static::exactly(2))->method('getMethodName')->willReturn('foo');
+
+        // add the same violation twice
+        $report = $this->getReportWithNoViolation();
+        $report->expects(static::once())
+            ->method('getRuleViolations')
+            ->willReturn(new ArrayIterator(array($violationMock, $violationMock)));
+
+        $renderer = new BaselineRenderer('/src');
+        $renderer->setWriter($writer);
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        static::assertXmlEquals(
+            $writer->getData(),
+            'renderer/baseline_renderer_expected2.xml'
+        );
+    }
+
+    /**
+     * @covers ::renderReport
+     */
     public function testRenderEmptyReport()
     {
         $writer = new WriterStub();
@@ -59,7 +112,7 @@ class BaselineRendererTest extends AbstractTest
 
         static::assertXmlEquals(
             $writer->getData(),
-            'renderer/baseline_renderer_expected2.xml'
+            'renderer/baseline_renderer_expected3.xml'
         );
     }
 }

--- a/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
@@ -24,8 +24,7 @@ class BaselineRendererTest extends AbstractTest
         );
 
         $report = $this->getReportWithNoViolation();
-        $report->expects(static::once())
-            ->method('getRuleViolations')
+        $report->method('getRuleViolations')
             ->willReturn(new ArrayIterator($violations));
 
         $renderer = new BaselineRenderer('/src');
@@ -47,7 +46,7 @@ class BaselineRendererTest extends AbstractTest
     {
         $writer        = new WriterStub();
         $violationMock = $this->getRuleViolationMock('/src/php/bar.php');
-        $violationMock->expects(static::once())->method('getMethodName')->willReturn('foo');
+        $violationMock->method('getMethodName')->willReturn('foo');
 
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
@@ -77,8 +76,7 @@ class BaselineRendererTest extends AbstractTest
 
         // add the same violation twice
         $report = $this->getReportWithNoViolation();
-        $report->expects(static::once())
-            ->method('getRuleViolations')
+        $report->method('getRuleViolations')
             ->willReturn(new ArrayIterator(array($violationMock, $violationMock)));
 
         $renderer = new BaselineRenderer('/src');
@@ -100,8 +98,7 @@ class BaselineRendererTest extends AbstractTest
     {
         $writer = new WriterStub();
         $report = $this->getReportWithNoViolation();
-        $report->expects(static::once())
-            ->method('getRuleViolations')
+        $report->method('getRuleViolations')
             ->willReturn(new ArrayIterator(array()));
 
         $renderer = new BaselineRenderer('/src');

--- a/src/test/php/PHPMD/Renderer/RendererFactoryTest.php
+++ b/src/test/php/PHPMD/Renderer/RendererFactoryTest.php
@@ -25,7 +25,7 @@ class RendererFactoryTest extends AbstractTest
     /**
      * @covers ::createBaselineRenderer
      * @expectedException RuntimeException
-     * @expectedExceptionMessage Failed to determine absolute path for baseline file
+     * @expectedExceptionMessage Unable to determine the realpath for
      */
     public function testCreateBaselineRendererThrowsExceptionForInvalidStream()
     {

--- a/src/test/php/PHPMD/Renderer/RendererFactoryTest.php
+++ b/src/test/php/PHPMD/Renderer/RendererFactoryTest.php
@@ -4,6 +4,7 @@ namespace PHPMD\Renderer;
 
 use PHPMD\AbstractTest;
 use PHPMD\Writer\StreamWriter;
+use RuntimeException;
 
 /**
  * @coversDefaultClass \PHPMD\Renderer\RendererFactory
@@ -23,7 +24,7 @@ class RendererFactoryTest extends AbstractTest
 
     /**
      * @covers ::createBaselineRenderer
-     * @expectedException \RuntimeException
+     * @expectedException RuntimeException
      * @expectedExceptionMessage Failed to determine absolute path for baseline file
      */
     public function testCreateBaselineRendererThrowsExceptionForInvalidStream()

--- a/src/test/php/PHPMD/Renderer/RendererFactoryTest.php
+++ b/src/test/php/PHPMD/Renderer/RendererFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PHPMD\Renderer;
+
+use PHPMD\AbstractTest;
+use PHPMD\Writer\StreamWriter;
+
+/**
+ * @coversDefaultClass \PHPMD\Renderer\RendererFactory
+ */
+class RendererFactoryTest extends AbstractTest
+{
+    /**
+     * @covers ::createBaselineRenderer
+     */
+    public function testCreateBaselineRendererSuccessfully()
+    {
+        $writer = new StreamWriter(tmpfile());
+        $renderer = RendererFactory::createBaselineRenderer($writer);
+
+        static::assertSame($writer, $renderer->getWriter());
+    }
+
+    /**
+     * @covers ::createBaselineRenderer
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Failed to determine absolute path for baseline file
+     */
+    public function testCreateBaselineRendererThrowsExceptionForInvalidStream()
+    {
+        $writer = new StreamWriter(STDOUT);
+        RendererFactory::createBaselineRenderer($writer);
+    }
+}

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -195,9 +195,9 @@ class ReportTest extends AbstractTest
      */
     public function testReportShouldIgnoreBaselineViolation()
     {
-        /** @var RuleViolation|PHPUnit_Framework_MockObject_MockObject $ruleA */
+        /** @var RuleViolation $ruleA */
         $ruleA = $this->getRuleViolationMock('foo.txt');
-        /** @var RuleViolation|PHPUnit_Framework_MockObject_MockObject $ruleB */
+        /** @var RuleViolation $ruleB */
         $ruleB = $this->getRuleViolationMock('bar.txt', 1, 2);
 
         // setup baseline

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -193,7 +193,7 @@ class ReportTest extends AbstractTest
     /**
      * @covers ::addRuleViolation
      */
-    public function testShouldIgnoreBaselineViolation()
+    public function testReportShouldIgnoreBaselineViolation()
     {
         /** @var RuleViolation|PHPUnit_Framework_MockObject_MockObject $ruleA */
         $ruleA = $this->getRuleViolationMock('foo.txt');

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -201,7 +201,7 @@ class ReportTest extends AbstractTest
         $ruleB = $this->getRuleViolationMock('bar.txt', 1, 2);
 
         // setup baseline
-        $violation = new ViolationBaseline(get_class($ruleA->getRule()), 'foo.txt');
+        $violation = new ViolationBaseline(get_class($ruleA->getRule()), 'foo.txt', null);
         $baseline  = new BaselineSet();
         $baseline->addEntry($violation);
 

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -9,13 +9,17 @@
  * For full copyright and license information, please see the LICENSE file.
  * Redistributions of files must retain the above copyright notice.
  *
- * @author Manuel Pichler <mapi@phpmd.org>
+ * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
- * @license https://opensource.org/licenses/bsd-license.php BSD License
- * @link http://phpmd.org/
+ * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ * @link      http://phpmd.org/
  */
 
 namespace PHPMD;
+
+use PHPMD\Baseline\BaselineSet;
+use PHPMD\Baseline\ViolationBaseline;
+use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * Test case for the report class.
@@ -184,5 +188,31 @@ class ReportTest extends AbstractTest
         $report->addError(new ProcessingError('Failing file "/foo.php".'));
 
         $this->assertSame(1, iterator_count($report->getErrors()));
+    }
+
+    /**
+     * @covers ::addRuleViolation
+     */
+    public function testShouldIgnoreBaselineViolation()
+    {
+        /** @var RuleViolation|PHPUnit_Framework_MockObject_MockObject $ruleA */
+        $ruleA = $this->getRuleViolationMock('foo.txt');
+        /** @var RuleViolation|PHPUnit_Framework_MockObject_MockObject $ruleB */
+        $ruleB = $this->getRuleViolationMock('bar.txt', 1, 2);
+
+        // setup baseline
+        $violation = new ViolationBaseline(get_class($ruleA->getRule()), 'foo.txt');
+        $baseline  = new BaselineSet();
+        $baseline->addEntry($violation);
+
+        // setup report
+        $report = new Report($baseline);
+        $report->addRuleViolation($ruleA);
+        $report->addRuleViolation($ruleB);
+
+        // only expect ruleB
+        $violations = $report->getRuleViolations();
+        static::assertCount(1, $violations);
+        static::assertSame($ruleB, $violations[0]);
     }
 }

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -191,7 +191,7 @@ class ReportTest extends AbstractTest
     }
 
     /**
-     * @covers ::addRuleViolation
+     * @return void
      */
     public function testReportShouldIgnoreBaselineViolation()
     {

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -19,7 +19,6 @@ namespace PHPMD;
 
 use PHPMD\Baseline\BaselineSet;
 use PHPMD\Baseline\ViolationBaseline;
-use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * Test case for the report class.

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -344,6 +344,46 @@ class CommandLineOptionsTest extends AbstractTest
     /**
      * @return void
      */
+    public function testCliOptionGenerateBaselineFalseByDefault()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'codesize');
+        $opts = new CommandLineOptions($args);
+        static::assertFalse($opts->generateBaseline());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCliOptionGenerateBaselineShouldBeSet()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'codesize', '--generate-baseline');
+        $opts = new CommandLineOptions($args);
+        static::assertTrue($opts->generateBaseline());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCliOptionBaselineFileShouldBeNullByDefault()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'codesize');
+        $opts = new CommandLineOptions($args);
+        static::assertNull($opts->baselineFile());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCliOptionBaselineFileShouldBeWithFilename()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'codesize', '--baseline-file', 'foobar.txt');
+        $opts = new CommandLineOptions($args);
+        static::assertSame('foobar.txt', $opts->baselineFile());
+    }
+
+    /**
+     * @return void
+     */
     public function testGetMinimumPriorityReturnsLowestValueByDefault()
     {
         $args = array(__FILE__, __FILE__, 'text', 'codesize');

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -275,7 +275,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertContains('Available formats: ansi, github, html, json, text, xml.', $opts->usage());
+        $this->assertContains('Available formats: ansi, baseline, github, html, json, text, xml.', $opts->usage());
     }
 
     /**

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -9,10 +9,10 @@
  * For full copyright and license information, please see the LICENSE file.
  * Redistributions of files must retain the above copyright notice.
  *
- * @author Manuel Pichler <mapi@phpmd.org>
+ * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
- * @license https://opensource.org/licenses/bsd-license.php BSD License
- * @link http://phpmd.org/
+ * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ * @link      http://phpmd.org/
  */
 
 namespace PHPMD\TextUI;
@@ -45,8 +45,8 @@ class CommandTest extends AbstractTest
     }
 
     /**
-     * @param $sourceFile
-     * @param $expectedExitCode
+     * @param            $sourceFile
+     * @param            $expectedExitCode
      * @param array|null $options
      * @return void
      * @dataProvider dataProviderTestMainWithOption
@@ -172,8 +172,8 @@ class CommandTest extends AbstractTest
 
     public function testOutput()
     {
-        $uri = realpath(self::createFileUri('source/source_with_anonymous_class.php'));
-        $temp = self::createTempFileUri();
+        $uri      = realpath(self::createFileUri('source/source_with_anonymous_class.php'));
+        $temp     = self::createTempFileUri();
         $exitCode = Command::main(array(
             __FILE__,
             $uri,
@@ -226,20 +226,21 @@ class CommandTest extends AbstractTest
 
     public function testMainGenerateBaseline()
     {
-        $baselineFile = self::createTempFileUri();
-        $args         = array(
+        $uri      = realpath(self::createFileUri('source/source_with_anonymous_class.php'));
+        $temp     = self::createTempFileUri();
+        $exitCode     = Command::main(array(
             __FILE__,
-            self::createFileUri('source/source_with_npath_violation.php'),
-            'xml',
-            'design',
+            $uri,
+            'text',
+            'naming',
             '--generate-baseline',
             '--baseline-file',
-            $baselineFile
-        );
+            $temp,
+        ));
 
-        $exitCode = Command::main($args);
         static::assertSame(Command::EXIT_SUCCESS, $exitCode);
-        static::assertFileExists($baselineFile);
+        static::assertFileExists($temp);
+        static::assertContains($uri, file_get_contents($temp));
     }
 
     public function testMainWritesExceptionMessageToStderr()
@@ -276,7 +277,7 @@ class CommandTest extends AbstractTest
             )
         );
 
-        $data = @parse_ini_file(__DIR__ . '/../../../../../build.properties');
+        $data    = @parse_ini_file(__DIR__ . '/../../../../../build.properties');
         $version = $data['project.version'];
 
         $this->assertEquals('PHPMD ' . $version, trim(StreamFilter::$streamHandle));

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -228,7 +228,7 @@ class CommandTest extends AbstractTest
     {
         $uri      = realpath(self::createFileUri('source/source_with_anonymous_class.php'));
         $temp     = self::createTempFileUri();
-        $exitCode     = Command::main(array(
+        $exitCode = Command::main(array(
             __FILE__,
             $uri,
             'text',
@@ -241,6 +241,22 @@ class CommandTest extends AbstractTest
         static::assertSame(Command::EXIT_SUCCESS, $exitCode);
         static::assertFileExists($temp);
         static::assertContains($uri, file_get_contents($temp));
+    }
+
+    public function testMainBaselineViolationShouldBeIgnored()
+    {
+        $sourceFile   = realpath(static::createResourceUriForTest('Baseline/ClassWithShortVariable.php'));
+        $baselineFile = realpath(static::createResourceUriForTest('Baseline/phpmd.baseline.xml'));
+        $exitCode     = Command::main(array(
+            __FILE__,
+            $sourceFile,
+            'text',
+            'naming',
+            '--baseline-file',
+            $baselineFile,
+        ));
+
+        static::assertSame(Command::EXIT_SUCCESS, $exitCode);
     }
 
     public function testMainWritesExceptionMessageToStderr()

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -224,6 +224,24 @@ class CommandTest extends AbstractTest
         );
     }
 
+    public function testMainGenerateBaseline()
+    {
+        $baselineFile = self::createTempFileUri();
+        $args         = array(
+            __FILE__,
+            self::createFileUri('source/source_with_npath_violation.php'),
+            'xml',
+            'design',
+            '--generate-baseline',
+            '--baseline-file',
+            $baselineFile
+        );
+
+        $exitCode = Command::main($args);
+        static::assertSame(Command::EXIT_SUCCESS, $exitCode);
+        static::assertFileExists($baselineFile);
+    }
+
     public function testMainWritesExceptionMessageToStderr()
     {
         stream_filter_register('stderr_stream', 'PHPMD\\TextUI\\StreamFilter');

--- a/src/test/php/PHPMD/Utility/PathsTest.php
+++ b/src/test/php/PHPMD/Utility/PathsTest.php
@@ -60,8 +60,17 @@ class PathsTest extends AbstractTest
     /**
      * @covers ::getAbsolutePath
      */
-    public function testGetAbsolutePath()
+    public function testGetAbsolutePathShouldReturnNullForIrregularStream()
     {
+        static::assertNull(Paths::getAbsolutePath(STDOUT));
+    }
 
+    /**
+     * @covers ::getAbsolutePath
+     */
+    public function testGetAbsolutePathShouldReturnPath()
+    {
+        $path = static::createResourceUriForTest('resource.txt');
+        static::assertSame(realpath($path), Paths::getAbsolutePath(fopen($path, 'rb')));
     }
 }

--- a/src/test/php/PHPMD/Utility/PathsTest.php
+++ b/src/test/php/PHPMD/Utility/PathsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace PHPMD\Utility;
+
+use PHPMD\AbstractTest;
+
+/**
+ * @coversDefaultClass \PHPMD\Utility\Paths
+ */
+class PathsTest extends AbstractTest
+{
+    /**
+     * @covers ::concat
+     */
+    public function testConcatShouldConcatTwoPaths()
+    {
+        static::assertSame('/foo/bar', Paths::concat('/foo', '/bar'));
+    }
+
+    /**
+     * @covers ::concat
+     */
+    public function testConcatShouldDeduplicateSlashes()
+    {
+        static::assertSame('/foo/bar', Paths::concat('/foo/', '/bar'));
+    }
+
+    /**
+     * @covers ::concat
+     */
+    public function testConcatShouldForwardAllSlashes()
+    {
+        static::assertSame('/foo/bar/text.txt', Paths::concat('/foo\\', '/bar\\text.txt'));
+    }
+
+    /**
+     * @covers ::getRelativePath
+     */
+    public function testGetRelativePathShouldSubtractBasePath()
+    {
+        static::assertSame('bar/', Paths::getRelativePath('/foo', '/foo/bar/'));
+    }
+
+    /**
+     * @covers ::getRelativePath
+     */
+    public function testGetRelativePathShouldTreatForwardAndBackwardSlashes()
+    {
+        static::assertSame('text.txt', Paths::getRelativePath('\\foo/bar\\', '/foo\\bar/text.txt'));
+    }
+
+    /**
+     * @covers ::getRelativePath
+     */
+    public function testGetRelativePathShouldNotSubtractOnInfixPath()
+    {
+        static::assertSame('/foo/bar/text.txt', Paths::getRelativePath('/bar', '/foo/bar/text.txt'));
+    }
+
+    /**
+     * @covers ::getAbsolutePath
+     */
+    public function testGetAbsolutePath()
+    {
+
+    }
+}

--- a/src/test/php/PHPMD/Utility/PathsTest.php
+++ b/src/test/php/PHPMD/Utility/PathsTest.php
@@ -3,6 +3,7 @@
 namespace PHPMD\Utility;
 
 use PHPMD\AbstractTest;
+use RuntimeException;
 
 /**
  * @coversDefaultClass \PHPMD\Utility\Paths
@@ -59,10 +60,11 @@ class PathsTest extends AbstractTest
 
     /**
      * @covers ::getAbsolutePath
+     * @expectedException RuntimeException
      */
     public function testGetAbsolutePathShouldReturnNullForIrregularStream()
     {
-        static::assertNull(Paths::getAbsolutePath(STDOUT));
+        Paths::getAbsolutePath(STDOUT);
     }
 
     /**
@@ -72,5 +74,23 @@ class PathsTest extends AbstractTest
     {
         $path = static::createResourceUriForTest('resource.txt');
         static::assertSame(realpath($path), Paths::getAbsolutePath(fopen($path, 'rb')));
+    }
+
+    /**
+     * @covers ::getRealPath
+     */
+    public function testGetRealPathShouldReturnTheRealPath()
+    {
+        $path = static::createResourceUriForTest('resource.txt');
+        static::assertSame(realpath($path), Paths::getRealPath($path));
+    }
+
+    /**
+     * @covers ::getRealPath
+     * @expectedException RuntimeException
+     */
+    public function testGetRealPathShouldThrowExceptionOnFailure()
+    {
+        Paths::getRealPath('unknown/path');
     }
 }

--- a/src/test/php/PHPMD/Utility/PathsTest.php
+++ b/src/test/php/PHPMD/Utility/PathsTest.php
@@ -64,7 +64,7 @@ class PathsTest extends AbstractTest
      */
     public function testGetAbsolutePathShouldReturnNullForIrregularStream()
     {
-        Paths::getAbsolutePath(STDOUT);
+        Paths::getAbsolutePath(fopen('php://stdout', 'wb'));
     }
 
     /**

--- a/src/test/php/PHPMD/Writer/StreamWriterTest.php
+++ b/src/test/php/PHPMD/Writer/StreamWriterTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PHPMD\Writer;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \PHPMD\Writer\StreamWriter
+ * @covers ::__construct
+ */
+class StreamWriterTest extends TestCase
+{
+    /**
+     * @covers ::getStream
+     */
+    public function testGetStream()
+    {
+        $writer = new StreamWriter(STDOUT);
+        static::assertSame(STDOUT, $writer->getStream());
+    }
+}

--- a/src/test/resources/files/Baseline/BaselineFileFinder/testA/phpmd.baseline.xml
+++ b/src/test/resources/files/Baseline/BaselineFileFinder/testA/phpmd.baseline.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<phpmd-baseline>
+</phpmd-baseline>

--- a/src/test/resources/files/Baseline/BaselineFileFinder/testA/phpmd.xml
+++ b/src/test/resources/files/Baseline/BaselineFileFinder/testA/phpmd.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<phpmd>
+</phpmd>

--- a/src/test/resources/files/Baseline/BaselineFileFinder/testB/phpmd.xml
+++ b/src/test/resources/files/Baseline/BaselineFileFinder/testB/phpmd.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<phpmd>
+</phpmd>

--- a/src/test/resources/files/Baseline/BaselineSetFactory/baseline.xml
+++ b/src/test/resources/files/Baseline/BaselineSetFactory/baseline.xml
@@ -2,5 +2,5 @@
 <phpmd-baseline>
     <skip/>
     <violation rule="PHPMD\Rule\CleanCode\MissingImport" file="src/foo/bar"/>
-    <violation rule="PHPMD\Rule\CleanCode\UndefinedVariable" file="src/foo/bar"/>
+    <violation rule="PHPMD\Rule\CleanCode\UndefinedVariable" file="src/foo/bar" method="myMethod"/>
 </phpmd-baseline>

--- a/src/test/resources/files/Baseline/BaselineSetFactory/baseline.xml
+++ b/src/test/resources/files/Baseline/BaselineSetFactory/baseline.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <phpmd-baseline>
+    <skip/>
     <violation rule="PHPMD\Rule\CleanCode\MissingImport" file="src/foo/bar"/>
     <violation rule="PHPMD\Rule\CleanCode\UndefinedVariable" file="src/foo/bar"/>
 </phpmd-baseline>

--- a/src/test/resources/files/Baseline/BaselineSetFactory/baseline.xml
+++ b/src/test/resources/files/Baseline/BaselineSetFactory/baseline.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<phpmd-baseline>
+    <violation rule="PHPMD\Rule\CleanCode\MissingImport" file="src/foo/bar"/>
+    <violation rule="PHPMD\Rule\CleanCode\UndefinedVariable" file="src/foo/bar"/>
+</phpmd-baseline>

--- a/src/test/resources/files/Baseline/BaselineSetFactory/invalid-baseline.xml
+++ b/src/test/resources/files/Baseline/BaselineSetFactory/invalid-baseline.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<phpmd-baseline>
+   

--- a/src/test/resources/files/Baseline/BaselineSetFactory/missing-file-baseline.xml
+++ b/src/test/resources/files/Baseline/BaselineSetFactory/missing-file-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<phpmd-baseline>
+    <violation rule="PHPMD\Rule\CleanCode\MissingImport"/>
+</phpmd-baseline>

--- a/src/test/resources/files/Baseline/BaselineSetFactory/missing-rule-baseline.xml
+++ b/src/test/resources/files/Baseline/BaselineSetFactory/missing-rule-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<phpmd-baseline>
+    <violation file="src/foo/bar"/>
+</phpmd-baseline>

--- a/src/test/resources/files/TextUI/Command/Baseline/ClassWithShortVariable.php
+++ b/src/test/resources/files/TextUI/Command/Baseline/ClassWithShortVariable.php
@@ -1,0 +1,9 @@
+<?php
+
+class ClassWithShortVariable
+{
+    public function method($a)
+    {
+        return $a;
+    }
+}

--- a/src/test/resources/files/TextUI/Command/Baseline/phpmd.baseline.xml
+++ b/src/test/resources/files/TextUI/Command/Baseline/phpmd.baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<phpmd-baseline>
+  <violation rule="PHPMD\Rule\Naming\ShortVariable" file="ClassWithShortVariable.php"/>
+</phpmd-baseline>

--- a/src/test/resources/files/renderer/baseline_renderer_expected1.xml
+++ b/src/test/resources/files/renderer/baseline_renderer_expected1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<phpmd-baseline>
+    <violation file="php/bar.php" rule="PHPMD\Stubs\RuleStub"/>
+    <violation file="php/foo.php" rule="PHPMD\Stubs\RuleStub"/>
+</phpmd-baseline>

--- a/src/test/resources/files/renderer/baseline_renderer_expected2.xml
+++ b/src/test/resources/files/renderer/baseline_renderer_expected2.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<phpmd-baseline>
+</phpmd-baseline>

--- a/src/test/resources/files/renderer/baseline_renderer_expected2.xml
+++ b/src/test/resources/files/renderer/baseline_renderer_expected2.xml
@@ -1,3 +1,4 @@
 <?xml version="1.0"?>
 <phpmd-baseline>
+    <violation file="php/bar.php" rule="PHPMD\Stubs\RuleStub" method="foo"/>
 </phpmd-baseline>

--- a/src/test/resources/files/renderer/baseline_renderer_expected3.xml
+++ b/src/test/resources/files/renderer/baseline_renderer_expected3.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<phpmd-baseline>
+</phpmd-baseline>


### PR DESCRIPTION
Type: Feature
Issue: Resolves #871
Breaking change: no

Added the ability to export existing violations to a (default) `phpmd.baseline.xml` file. When PHPMD notices this file all violations that exist within the baseline will not be added to the violations report. Violations are detected based on `filename`, `method` (if present), and the specific `rule`.

### What's been changed?
- Added Baseline classes to model, read and write baseline information.
- Modified `Command`, `CommandLineOptions` and `PHPMD` to inject the baseline checks.
- Added coverage for everything I've changed.
- Updated `README.rst` and `index.rst` documentation with the new cli options. This page: https://phpmd.org/documentation/index.html

### Some design decisions:
- PHPMD by default will look for `phpmd.baseline.xml` next to the (first) ruleset given on the cli. Assumed default usage would be a `phpmd.xml` in the root of a project
- A custom file location can be specified with the `--baseline-file /path/to/file` cli option.
- When adding the cli option `--generate-baseline` the violations will be exported to the baseline xml instead of the default renderer. By adding this flag, the 2nd cli argument will be ignored.
- The location of `phpmd.baseline.xml` will serve as the base path of the baselined files. All source files should be relative to this file. Eg, the expected location of `phpmd.baseline.xml` should be in the root of your project.

### Examples
**Export:**
`phpmd /path/to/source text phpmd.xml --generate-baseline`
Writes baseline `phpmd.baseline.xml` next to `phpmd.xml`

**Check:**
`phpmd /path/to/source text phpmd.xml`
Tries to find `phpmd.baseline.xml` next to `phpmd.xml`

`phpmd /path/to/source text phpmd.xml --baseline-file /path/to/file`
Uses the given baseline filepath. All sources should still be relative to the baseline file.


### Discussion A
I tried to stay close to the phpstan behaviour and what felt for me natural in the usages. It could be argued that the 2nd cli argument should be `baseline`. For example for export it could be:
`phpmd /path/to/source baseline phpmd.xml`

I've chosen the extra `--generate-baseline` flag, as the 2nd argument is for output for external purposes, while the baseline is for internal purposes. What are your thoughts?

### Discussion B
I've chosen to determine the relative path of the violation source paths, to be relative to the baseline file. It felt natural for me to have all the files in the baseline file be relative to the file they are listed in. The downside is that with the `-baseline-line` cli option, you can't randomly choose a file location. Currently it _has_ to be in a parent directory of the sources.

Other options would be to calculate the relative path to the `phpmd.xml`. This is kinda awkward as phpmd accepts multiple rulesets as 3rd argument. Would have to pick the location of the first ruleset

Third option would be to calculate the relative path based on the current working directory. This felt a little too magic for me, as the working directory could be outside the project.

### Future
I read that psalm has an `--update-baseline` option, which will only _remove_ entries from the baseline file, and won't add new ones. I think this will be nice feature for a future PR.