### PR TITLE
Violation baseline appveyor fixes

### DIFF
--- a/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
@@ -31,10 +31,12 @@ class BaselineFileFinderTest extends AbstractTest
     {
         $args   = array('script', 'source', 'xml', static::createResourceUriForTest('testA/phpmd.xml'));
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
-        static::assertSame(
-            realpath(static::createResourceUriForTest('testA/phpmd.baseline.xml')),
-            $finder->existingFile()->find()
-        );
+
+        // ensure consistent slashes
+        $expected = str_replace("\\", "/", realpath(static::createResourceUriForTest('testA/phpmd.baseline.xml')));
+        $actual   = str_replace("\\", "/", $finder->existingFile()->find());
+
+        static::assertSame($expected, $actual);
     }
 
     /**

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -226,7 +226,7 @@ class CommandTest extends AbstractTest
 
     public function testMainGenerateBaseline()
     {
-        $uri      = realpath(self::createFileUri('source/source_with_anonymous_class.php'));
+        $uri      = str_replace("\\", "/", realpath(self::createFileUri('source/source_with_anonymous_class.php')));
         $temp     = self::createTempFileUri();
         $exitCode = Command::main(array(
             __FILE__,


### PR DESCRIPTION
Type: bugfix
Issue: -
Breaking change: no

The AppVeyor build fails on 2 tests of the baseline violations as the environment seems to be Windows.
https://ci.appveyor.com/project/phpmd/phpmd

This PR fixes the differences in slashes for 2 tests.


Remark: AppVeyor is quite out of view that tests are failing. I only noticed it by the appveyor label in the readme on master.