### PR TITLE
Added option --update-baseline to update an existing phpmd.baseline.xml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,6 +227,7 @@ By default PHPMD will look next to ``phpmd.xml`` for ``phpmd.baseline.xml``. To 
   ~ $ phpmd /path/to/source text phpmd.xml --baseline-file /path/to/source/phpmd.baseline.xml
 
 To clean up an existing baseline file and *only remove* no longer existing violations::
+
   ~ $ phpmd /path/to/source text phpmd.xml --update-baseline
 
 PHPMD for enterprise

--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ Command line options
   - ``--generate-baseline`` - will generate a ``phpmd.baseline.xml`` for existing violations
     next to the ruleset definition file.
 
-  - ``--update-baseline`` - will remove all violations from an existing phpmd.baseline.xml
+  - ``--update-baseline`` - will remove all violations from an existing ``phpmd.baseline.xml``
     that no longer exist. New violations will _not_ be added.
 
   - ``--baseline-file`` - the filepath to a custom baseline xml file. The filepath

--- a/README.rst
+++ b/README.rst
@@ -132,8 +132,11 @@ Command line options
   - ``--ignore-violations-on-exit`` - will exit with a zero code, even if any
     violations are found.
 
-  - ``--generate-baseline`` - will generate a phpmd.baseline.xml for existing violations
+  - ``--generate-baseline`` - will generate a ``phpmd.baseline.xml`` for existing violations
     next to the ruleset definition file.
+
+  - ``--update-baseline`` - will remove all violations from an existing phpmd.baseline.xml
+    that no longer exist. New violations will _not_ be added.
 
   - ``--baseline-file`` - the filepath to a custom baseline xml file. The filepath
     of all baselined files must be relative to this file location.
@@ -211,7 +214,7 @@ Baseline
 
 For existing projects a violation baseline can be generated. All violations in this baseline will be ignored in further inspections.
 
-The recommended approach would be a ``phpmd.xml`` in the root of the project. To generate the phpmd.baseline.xml next to it::
+The recommended approach would be a ``phpmd.xml`` in the root of the project. To generate the ``phpmd.baseline.xml`` next to it::
 
   ~ $ phpmd /path/to/source text phpmd.xml --generate-baseline
 
@@ -222,6 +225,9 @@ To specify a custom baseline filepath for export::
 By default PHPMD will look next to ``phpmd.xml`` for ``phpmd.baseline.xml``. To overwrite this behaviour::
 
   ~ $ phpmd /path/to/source text phpmd.xml --baseline-file /path/to/source/phpmd.baseline.xml
+
+To clean up an existing baseline file and *only remove* no longer existing violations::
+  ~ $ phpmd /path/to/source text phpmd.xml --update-baseline
 
 PHPMD for enterprise
 --------------------

--- a/src/main/php/PHPMD/Baseline/BaselineMode.php
+++ b/src/main/php/PHPMD/Baseline/BaselineMode.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PHPMD\Baseline;
+
+class BaselineMode
+{
+    /**
+     * Do not generate or update any baseline file
+     */
+    const NONE = 'none';
+
+    /**
+     * Generate a baseline file for _all_ current violations
+     */
+    const GENERATE = 'generate';
+
+    /**
+     * Remove any non existing violations from the baseline file. Do not baseline any new violations.
+     */
+    const UPDATE = 'update';
+}

--- a/src/main/php/PHPMD/Baseline/BaselineValidator.php
+++ b/src/main/php/PHPMD/Baseline/BaselineValidator.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace PHPMD\Baseline;
+
+use PHPMD\RuleViolation;
+
+class BaselineValidator
+{
+    /** @var string */
+    private $baselineMode;
+
+    /** @var BaselineSet */
+    private $baselineSet;
+
+    /**
+     * @param string $baselineMode
+     */
+    public function __construct(BaselineSet $baselineSet, $baselineMode)
+    {
+        $this->baselineMode = $baselineMode;
+        $this->baselineSet  = $baselineSet;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isBaselined(RuleViolation $violation)
+    {
+        $contains = $this->baselineSet->contains(
+            $violation->getFileName(),
+            get_class($violation->getRule()),
+            $violation->getMethodName()
+        );
+
+        // regular baseline: violations is baselined if it is in the BaselineSet
+        if ($this->baselineMode === BaselineMode::NONE) {
+            return $contains;
+        }
+
+        // update baseline: violation _can_ be baselined if it was already in the BaselineSet
+        if ($this->baselineMode === BaselineMode::UPDATE) {
+            return $contains === false;
+        }
+
+        return false;
+    }
+}

--- a/src/main/php/PHPMD/Baseline/BaselineValidator.php
+++ b/src/main/php/PHPMD/Baseline/BaselineValidator.php
@@ -27,8 +27,8 @@ class BaselineValidator
     public function isBaselined(RuleViolation $violation)
     {
         $contains = $this->baselineSet->contains(
-            $violation->getFileName(),
             get_class($violation->getRule()),
+            $violation->getFileName(),
             $violation->getMethodName()
         );
 

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -17,8 +17,6 @@
 
 namespace PHPMD;
 
-use PHPMD\Baseline\BaselineSet;
-
 /**
  * This is the main facade of the PHP PMD application
  */

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -216,7 +216,7 @@ class PHPMD
      * @param string $ruleSets
      * @param \PHPMD\AbstractRenderer[] $renderers
      * @param \PHPMD\RuleSetFactory $ruleSetFactory
-     * @param \PHPMD\Baseline\BaselineSet|null $baseline
+     * @param \PHPMD\Report $report
      * @return void
      */
     public function processFiles(
@@ -224,15 +224,12 @@ class PHPMD
         $ruleSets,
         array $renderers,
         RuleSetFactory $ruleSetFactory,
-        BaselineSet $baseline = null
+        Report $report
     ) {
-
         // Merge parsed excludes
         $this->addIgnorePatterns($ruleSetFactory->getIgnorePattern($ruleSets));
 
         $this->input = $inputPath;
-
-        $report = new Report($baseline);
 
         $factory = new ParserFactory();
         $parser = $factory->create($this);

--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -17,7 +17,6 @@
 
 namespace PHPMD;
 
-use PHPMD\Baseline\BaselineSet;
 use PHPMD\Baseline\BaselineValidator;
 
 /**

--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -18,6 +18,7 @@
 namespace PHPMD;
 
 use PHPMD\Baseline\BaselineSet;
+use PHPMD\Baseline\BaselineValidator;
 
 /**
  * The report class collects all found violations and further information about
@@ -54,12 +55,12 @@ class Report
      */
     private $errors = array();
 
-    /** @var BaselineSet|null */
-    private $baseline;
+    /** @var BaselineValidator|null */
+    private $baselineValidator;
 
-    public function __construct(BaselineSet $baseline = null)
+    public function __construct(BaselineValidator $baselineValidator = null)
     {
-        $this->baseline = $baseline;
+        $this->baselineValidator = $baselineValidator;
     }
 
     /**
@@ -70,12 +71,11 @@ class Report
      */
     public function addRuleViolation(RuleViolation $violation)
     {
-        $fileName = $violation->getFileName();
-        $ruleName = get_class($violation->getRule());
-        if ($this->baseline !== null && $this->baseline->contains($ruleName, $fileName, $violation->getMethodName())) {
+        if ($this->baselineValidator !== null && $this->baselineValidator->isBaselined($violation)) {
             return;
         }
 
+        $fileName = $violation->getFileName();
         if (!isset($this->ruleViolations[$fileName])) {
             $this->ruleViolations[$fileName] = array();
         }

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -18,6 +18,7 @@
 namespace PHPMD\TextUI;
 
 use PHPMD\Baseline\BaselineFileFinder;
+use PHPMD\Baseline\BaselineMode;
 use PHPMD\Baseline\BaselineSetFactory;
 use PHPMD\PHPMD;
 use PHPMD\Renderer\RendererFactory;
@@ -82,7 +83,7 @@ class Command
         // Configure baseline violations
         $baseline = null;
         $finder   = new BaselineFileFinder($opts);
-        if ($opts->generateBaseline()) {
+        if ($opts->generateBaseline() === BaselineMode::GENERATE) {
             // overwrite any renderer with the baseline renderer
             $renderers = array(RendererFactory::createBaselineRenderer(new StreamWriter($finder->notNull()->find())));
         } else {

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -22,6 +22,7 @@ use PHPMD\Baseline\BaselineMode;
 use PHPMD\Baseline\BaselineSetFactory;
 use PHPMD\PHPMD;
 use PHPMD\Renderer\RendererFactory;
+use PHPMD\Report;
 use PHPMD\RuleSetFactory;
 use PHPMD\Utility\Paths;
 use PHPMD\Writer\StreamWriter;
@@ -125,14 +126,16 @@ class Command
             $opts->getRuleSets(),
             $renderers,
             $ruleSetFactory,
-            $baseline
+            new Report($baseline)
         );
 
         if ($phpmd->hasErrors() && !$opts->ignoreErrorsOnExit()) {
             return self::EXIT_ERROR;
         }
 
-        if ($phpmd->hasViolations() && !$opts->ignoreViolationsOnExit() && !$opts->generateBaseline()) {
+        if ($phpmd->hasViolations()
+            && !$opts->ignoreViolationsOnExit()
+            && $opts->generateBaseline() === BaselineMode::NONE) {
             return self::EXIT_VIOLATION;
         }
 

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -20,6 +20,7 @@ namespace PHPMD\TextUI;
 use PHPMD\Baseline\BaselineFileFinder;
 use PHPMD\Baseline\BaselineMode;
 use PHPMD\Baseline\BaselineSetFactory;
+use PHPMD\Baseline\BaselineValidator;
 use PHPMD\PHPMD;
 use PHPMD\Renderer\RendererFactory;
 use PHPMD\Report;
@@ -82,16 +83,22 @@ class Command
         }
 
         // Configure baseline violations
-        $baseline = null;
+        $report   = null;
         $finder   = new BaselineFileFinder($opts);
         if ($opts->generateBaseline() === BaselineMode::GENERATE) {
             // overwrite any renderer with the baseline renderer
             $renderers = array(RendererFactory::createBaselineRenderer(new StreamWriter($finder->notNull()->find())));
+        } elseif ($opts->generateBaseline() === BaselineMode::UPDATE) {
+            $baselineFile = $finder->notNull()->existingFile()->find();
+            $baseline     = BaselineSetFactory::fromFile(Paths::getRealPath($baselineFile));
+            $renderers    = array(RendererFactory::createBaselineRenderer(new StreamWriter($baselineFile)));
+            $report       = new Report(new BaselineValidator($baseline, BaselineMode::UPDATE));
         } else {
             // try to locate a baseline file and read it
             $baselineFile = $finder->existingFile()->find();
             if ($baselineFile !== null) {
                 $baseline = BaselineSetFactory::fromFile(Paths::getRealPath($baselineFile));
+                $report   = new Report(new BaselineValidator($baseline, BaselineMode::NONE));
             }
         }
 
@@ -126,7 +133,7 @@ class Command
             $opts->getRuleSets(),
             $renderers,
             $ruleSetFactory,
-            new Report($baseline)
+            $report !== null ? $report : new Report()
         );
 
         if ($phpmd->hasErrors() && !$opts->ignoreErrorsOnExit()) {

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\TextUI;
 
+use PHPMD\Baseline\BaselineMode;
 use PHPMD\Renderer\AnsiRenderer;
 use PHPMD\Renderer\GitHubRenderer;
 use PHPMD\Renderer\HTMLRenderer;
@@ -149,9 +150,9 @@ class CommandLineOptions
 
     /**
      * Should PHPMD baseline the existing violations and write them to the $baselineFile
-     * @var bool
+     * @var string allowed modes: NONE, GENERATE or UPDATE
      */
-    protected $generateBaseline = false;
+    protected $generateBaseline = BaselineMode::NONE;
 
     /**
      * The baseline source file to read the baseline violations from.
@@ -225,7 +226,10 @@ class CommandLineOptions
                     $this->strict = false;
                     break;
                 case '--generate-baseline':
-                    $this->generateBaseline = true;
+                    $this->generateBaseline = BaselineMode::GENERATE;
+                    break;
+                case '--update-baseline':
+                    $this->generateBaseline = BaselineMode::UPDATE;
                     break;
                 case '--baseline-file':
                     $this->baselineFile = array_shift($args);
@@ -387,7 +391,7 @@ class CommandLineOptions
     /**
      * Should the current violations be baselined
      *
-     * @return bool
+     * @return string
      */
     public function generateBaseline()
     {
@@ -585,6 +589,7 @@ class CommandLineOptions
             'even if any violations are found' . \PHP_EOL .
             '--generate-baseline: will generate a phpmd.baseline.xml next ' .
             'to the first ruleset file location' . \PHP_EOL .
+            '--update-baseline: will remove any non-existing violations from the phpmd.baseline.xml' . \PHP_EOL .
             '--baseline-file: a custom location of the baseline file' . \PHP_EOL;
     }
 

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -149,4 +149,5 @@ By default PHPMD will look next to ``phpmd.xml`` for ``phpmd.baseline.xml``. To 
   ~ $ phpmd /path/to/source text phpmd.xml --baseline-file /path/to/source/phpmd.baseline.xml
 
 To clean up an existing baseline file and *only remove* no longer existing violations::
+
   ~ $ phpmd /path/to/source text phpmd.xml --update-baseline

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -126,7 +126,7 @@ At the moment PHPMD comes with the following five renderers:
 
 - *xml*, which formats the report as XML.
 - *text*, simple textual format.
-- *ansi*, colorful, formated text for the command line.
+- *ansi*, colorful, formatted text for the command line.
 - *html*, single HTML file with possible problems.
 - *json*, formats JSON report.
 - *github*, a format that GitHub Actions understands (see `CI Integration </documentation/ci-integration.html#github-actions>`_).

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -64,8 +64,11 @@ Command line options
   - ``--ignore-violations-on-exit`` - will exit with a zero code, even if any
     violations are found.
 
-  - ``--generate-baseline`` - will generate a phpmd.baseline.xml for existing violations
+  - ``--generate-baseline`` - will generate a ``phpmd.baseline.xml`` for existing violations
     next to the ruleset definition file.
+
+  - ``--update-baseline`` - will remove all violations from an existing phpmd.baseline.xml
+    that no longer exist. New violations will _not_ be added.
 
   - ``--baseline-file`` - the filepath to a custom baseline xml file. The filepath
     of all baselined files must be relative to this file location.
@@ -144,3 +147,6 @@ To specify a custom baseline filepath for export::
 By default PHPMD will look next to ``phpmd.xml`` for ``phpmd.baseline.xml``. To overwrite this behaviour::
 
   ~ $ phpmd /path/to/source text phpmd.xml --baseline-file /path/to/source/phpmd.baseline.xml
+
+To clean up an existing baseline file and *only remove* no longer existing violations::
+  ~ $ phpmd /path/to/source text phpmd.xml --update-baseline

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -67,7 +67,7 @@ Command line options
   - ``--generate-baseline`` - will generate a ``phpmd.baseline.xml`` for existing violations
     next to the ruleset definition file.
 
-  - ``--update-baseline`` - will remove all violations from an existing phpmd.baseline.xml
+  - ``--update-baseline`` - will remove all violations from an existing ``phpmd.baseline.xml``
     that no longer exist. New violations will _not_ be added.
 
   - ``--baseline-file`` - the filepath to a custom baseline xml file. The filepath

--- a/src/test/php/PHPMD/AbstractStaticTest.php
+++ b/src/test/php/PHPMD/AbstractStaticTest.php
@@ -237,11 +237,17 @@ abstract class AbstractStaticTest extends PHPUnit_Framework_TestCase
     /**
      * Creates a file uri for a temporary test file.
      *
+     * @param string|null $fileName
      * @return string
      */
-    protected static function createTempFileUri()
+    protected static function createTempFileUri($fileName = null)
     {
-        return (self::$tempFiles[] = tempnam(sys_get_temp_dir(), 'phpmd.'));
+        if ($fileName !== null) {
+            $filePath = sys_get_temp_dir() . '/' . $fileName;
+        } else {
+            $filePath = tempnam(sys_get_temp_dir(), 'phpmd.');
+        }
+        return (self::$tempFiles[] = $filePath);
     }
 
     /**

--- a/src/test/php/PHPMD/AbstractStaticTest.php
+++ b/src/test/php/PHPMD/AbstractStaticTest.php
@@ -66,6 +66,8 @@ abstract class AbstractStaticTest extends PHPUnit_Framework_TestCase
      */
     protected static function cleanupTempFiles()
     {
+        // cleanup any open resources on temp files
+        gc_collect_cycles();
         foreach (self::$tempFiles as $tempFile) {
             unlink($tempFile);
         }

--- a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -8,6 +8,7 @@ use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * @coversDefaultClass \PHPMD\Baseline\BaselineValidator
+ * @covers ::__construct
  */
 class BaselineValidatorTest extends TestCase
 {

--- a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -2,15 +2,15 @@
 
 namespace PHPMD\Baseline;
 
+use PHPMD\AbstractTest;
 use PHPMD\RuleViolation;
-use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * @coversDefaultClass \PHPMD\Baseline\BaselineValidator
  * @covers ::__construct
  */
-class BaselineValidatorTest extends TestCase
+class BaselineValidatorTest extends AbstractTest
 {
     /** @var BaselineSet|PHPUnit_Framework_MockObject_MockObject */
     private $baselineSet;
@@ -21,18 +21,18 @@ class BaselineValidatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $rule            = $this->getMockBuilder('\PHPMD\Rule')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->violation = $this->getMockBuilder('\PHPMD\RuleViolation')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $rule            = $this->getMockFromBuilder(
+            $this->getMockBuilder('\PHPMD\Rule')->disableOriginalConstructor()
+        );
+        $this->violation = $this->getMockFromBuilder(
+            $this->getMockBuilder('\PHPMD\RuleViolation')->disableOriginalConstructor()
+        );
         $this->violation
             ->method('getRule')
             ->willReturn($rule);
-        $this->baselineSet = $this->getMockBuilder('\PHPMD\Baseline\BaselineSet')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->baselineSet = $this->getMockFromBuilder(
+            $this->getMockBuilder('\PHPMD\Baseline\BaselineSet')->disableOriginalConstructor()
+        );
     }
 
     /**

--- a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace PHPMD\Baseline;
+
+use PHPMD\RuleViolation;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
+
+class BaselineValidatorTest extends TestCase
+{
+    /** @var BaselineSet|PHPUnit_Framework_MockObject_MockObject */
+    private $baselineSet;
+
+    /** @var RuleViolation|PHPUnit_Framework_MockObject_MockObject */
+    private $violation;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $rule            = $this->getMockBuilder('\PHPMD\Rule')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->violation = $this->getMockBuilder('\PHPMD\RuleViolation')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->violation
+            ->method('getRule')
+            ->willReturn($rule);
+        $this->baselineSet = $this->getMockBuilder('\PHPMD\Baseline\BaselineSet')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * @covers ::isBaselined
+     * @dataProvider dataProvider
+     * @param bool   $contains
+     * @param string $baselineMode
+     * @param bool   $isBaselined
+     */
+    public function testIsBaselined($contains, $baselineMode, $isBaselined)
+    {
+        $this->baselineSet->method('contains')->willReturn($contains);
+        $validator = new BaselineValidator($this->baselineSet, $baselineMode);
+        static::assertSame($isBaselined, $validator->isBaselined($this->violation));
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProvider()
+    {
+        return array(
+            'contains: true, mode: none'      => array(true, BaselineMode::NONE, true),
+            'contains: false, mode: none'     => array(false, BaselineMode::NONE, false),
+            'contains: true, mode: update'    => array(true, BaselineMode::UPDATE, false),
+            'contains: false, mode: update'   => array(false, BaselineMode::UPDATE, true),
+            'contains: true, mode: generate'  => array(true, BaselineMode::GENERATE, false),
+            'contains: false, mode: generate' => array(false, BaselineMode::GENERATE, false),
+        );
+    }
+}

--- a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -6,6 +6,9 @@ use PHPMD\RuleViolation;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * @coversDefaultClass \PHPMD\Baseline\BaselineValidator
+ */
 class BaselineValidatorTest extends TestCase
 {
     /** @var BaselineSet|PHPUnit_Framework_MockObject_MockObject */

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -49,7 +49,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/ccn_function.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new Report()
         );
 
         $this->assertXmlEquals($writer->getData(), 'pmd/default-xml.xml');
@@ -74,7 +75,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new Report()
         );
 
         $this->assertXmlEquals($writer->getData(), 'pmd/single-directory.xml');
@@ -99,7 +101,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/ccn_function.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new Report()
         );
 
         $this->assertXmlEquals($writer->getData(), 'pmd/single-file.xml');
@@ -144,7 +147,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/source_without_violations.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new Report()
         );
 
         $this->assertFalse($phpmd->hasErrors());
@@ -168,7 +172,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/source_with_npath_violation.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new Report()
         );
 
         $this->assertFalse($phpmd->hasErrors());
@@ -197,7 +202,7 @@ class PHPMDTest extends AbstractTest
             'pmd-refset1',
             array($renderer),
             new RuleSetFactory(),
-            $baselineSet
+            new Report($baselineSet)
         );
 
         static::assertFalse($phpmd->hasViolations());
@@ -220,7 +225,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('source/source_with_parse_error.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new Report()
         );
 
         $this->assertTrue($phpmd->hasErrors());
@@ -243,7 +249,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('sourceExcluded/'),
             'pmd-refset1',
             array(),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new Report()
         );
 
         $this->assertFalse($phpmd->hasErrors());
@@ -254,7 +261,8 @@ class PHPMDTest extends AbstractTest
             self::createFileUri('sourceExcluded/'),
             'exclude-pattern',
             array(),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new Report()
         );
 
         $this->assertFalse($phpmd->hasErrors());

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -17,7 +17,9 @@
 
 namespace PHPMD;
 
+use PHPMD\Baseline\BaselineMode;
 use PHPMD\Baseline\BaselineSet;
+use PHPMD\Baseline\BaselineValidator;
 use PHPMD\Renderer\XMLRenderer;
 use PHPMD\Stubs\WriterStub;
 use PHPUnit_Framework_MockObject_MockObject;
@@ -202,7 +204,7 @@ class PHPMDTest extends AbstractTest
             'pmd-refset1',
             array($renderer),
             new RuleSetFactory(),
-            new Report($baselineSet)
+            new Report(new BaselineValidator($baselineSet, BaselineMode::NONE))
         );
 
         static::assertFalse($phpmd->hasViolations());

--- a/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
+++ b/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
@@ -19,6 +19,7 @@ namespace PHPMD\Regression;
 
 use PHPMD\PHPMD;
 use PHPMD\Renderer\XMLRenderer;
+use PHPMD\Report;
 use PHPMD\RuleSetFactory;
 use PHPMD\Stubs\WriterStub;
 
@@ -46,7 +47,8 @@ class AcceptsFilesAndDirectoriesAsInputTicket001Test extends AbstractTest
             self::createFileUri('source'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new Report()
         );
     }
 
@@ -67,7 +69,8 @@ class AcceptsFilesAndDirectoriesAsInputTicket001Test extends AbstractTest
             self::createFileUri('source/FooBar.php'),
             'pmd-refset1',
             array($renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new Report()
         );
     }
 }

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
@@ -87,7 +87,8 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
             __DIR__ . '/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php',
             'codesize',
             array($this->renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new Report()
         );
     }
 
@@ -127,7 +128,8 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
             __DIR__ . '/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php',
             'codesize',
             array($this->renderer),
-            new RuleSetFactory()
+            new RuleSetFactory(),
+            new Report()
         );
     }
 }

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
@@ -19,6 +19,7 @@ namespace PHPMD\Regression;
 
 use PHPMD\PHPMD;
 use PHPMD\Renderer\TextRenderer;
+use PHPMD\Report;
 use PHPMD\RuleSetFactory;
 use PHPMD\Writer\StreamWriter;
 
@@ -49,6 +50,6 @@ class MaximumNestingLevelTicket24975295Test extends AbstractTest
         $factory = new RuleSetFactory();
 
         $phpmd = new PHPMD();
-        $phpmd->processFiles($inputs, $rules, $renderes, $factory);
+        $phpmd->processFiles($inputs, $rules, $renderes, $factory, new Report());
     }
 }

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -18,6 +18,7 @@
 namespace PHPMD\TextUI;
 
 use PHPMD\AbstractTest;
+use PHPMD\Baseline\BaselineMode;
 use PHPMD\Rule;
 
 /**
@@ -348,7 +349,7 @@ class CommandLineOptionsTest extends AbstractTest
     {
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
-        static::assertFalse($opts->generateBaseline());
+        static::assertSame(BaselineMode::NONE, $opts->generateBaseline());
     }
 
     /**
@@ -358,7 +359,17 @@ class CommandLineOptionsTest extends AbstractTest
     {
         $args = array(__FILE__, __FILE__, 'text', 'codesize', '--generate-baseline');
         $opts = new CommandLineOptions($args);
-        static::assertTrue($opts->generateBaseline());
+        static::assertSame(BaselineMode::GENERATE, $opts->generateBaseline());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCliOptionUpdateBaselineShouldBeSet()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'codesize', '--update-baseline');
+        $opts = new CommandLineOptions($args);
+        static::assertSame(BaselineMode::UPDATE, $opts->generateBaseline());
     }
 
     /**

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -243,29 +243,37 @@ class CommandTest extends AbstractTest
         static::assertContains($uri, file_get_contents($temp));
     }
 
+    /**
+     * Testcase:
+     * - Class has existing ShortVariable and new BooleanGetMethodName violations
+     * - Baseline has ShortVariable and LongClassName baseline violations
+     * Expect in baseline:
+     * - LongClassName violation should be removed
+     * - ShortVariable violation should still exist
+     * - BooleanGetMethodName shouldn't be added
+     */
     public function testMainUpdateBaseline()
     {
-        $sourceFile   = realpath(static::createResourceUriForTest('UpdateBaseline/ClassWithMultipleViolations.php'));
-        $baselineFile = realpath(static::createResourceUriForTest('UpdateBaseline/phpmd.baseline.xml'));
-
-        $temp     = self::createTempFileUri();
-        copy($baselineFile, $temp);
+        $sourceTemp   = self::createTempFileUri('ClassWithMultipleViolations.php');
+        $baselineTemp = self::createTempFileUri();
+        copy(static::createResourceUriForTest('UpdateBaseline/ClassWithMultipleViolations.php'), $sourceTemp);
+        copy(static::createResourceUriForTest('UpdateBaseline/phpmd.baseline.xml'), $baselineTemp);
 
         $exitCode = Command::main(array(
             __FILE__,
-            str_replace("\\", "/", $sourceFile),
+            $sourceTemp,
             'text',
             'naming',
             '--update-baseline',
             '--baseline-file',
-            $baselineFile,
+            $baselineTemp,
         ));
 
-        $output = file_get_contents($temp);
-
         static::assertSame(Command::EXIT_SUCCESS, $exitCode);
-        static::assertFileExists($temp);
-        //static::assertContains($uri, file_get_contents($temp));
+        static::assertXmlStringEqualsXmlString(
+            file_get_contents(static::createResourceUriForTest('UpdateBaseline/expected.baseline.xml')),
+            file_get_contents($baselineTemp)
+        );
     }
 
     public function testMainBaselineViolationShouldBeIgnored()

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -243,6 +243,31 @@ class CommandTest extends AbstractTest
         static::assertContains($uri, file_get_contents($temp));
     }
 
+    public function testMainUpdateBaseline()
+    {
+        $sourceFile   = realpath(static::createResourceUriForTest('UpdateBaseline/ClassWithMultipleViolations.php'));
+        $baselineFile = realpath(static::createResourceUriForTest('UpdateBaseline/phpmd.baseline.xml'));
+
+        $temp     = self::createTempFileUri();
+        copy($baselineFile, $temp);
+
+        $exitCode = Command::main(array(
+            __FILE__,
+            str_replace("\\", "/", $sourceFile),
+            'text',
+            'naming',
+            '--update-baseline',
+            '--baseline-file',
+            $baselineFile,
+        ));
+
+        $output = file_get_contents($temp);
+
+        static::assertSame(Command::EXIT_SUCCESS, $exitCode);
+        static::assertFileExists($temp);
+        //static::assertContains($uri, file_get_contents($temp));
+    }
+
     public function testMainBaselineViolationShouldBeIgnored()
     {
         $sourceFile   = realpath(static::createResourceUriForTest('Baseline/ClassWithShortVariable.php'));

--- a/src/test/resources/files/TextUI/Command/UpdateBaseline/ClassWithMultipleViolations.php
+++ b/src/test/resources/files/TextUI/Command/UpdateBaseline/ClassWithMultipleViolations.php
@@ -1,0 +1,17 @@
+<?php
+
+class ClassWithMultipleViolations
+{
+    public function method($a)
+    {
+        return $a;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getValue()
+    {
+        return true;
+    }
+}

--- a/src/test/resources/files/TextUI/Command/UpdateBaseline/expected.baseline.xml
+++ b/src/test/resources/files/TextUI/Command/UpdateBaseline/expected.baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<phpmd-baseline>
+  <violation rule="PHPMD\Rule\Naming\ShortVariable" file="ClassWithMultipleViolations.php"/>
+</phpmd-baseline>

--- a/src/test/resources/files/TextUI/Command/UpdateBaseline/phpmd.baseline.xml
+++ b/src/test/resources/files/TextUI/Command/UpdateBaseline/phpmd.baseline.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<phpmd-baseline>
+  <violation rule="PHPMD\Rule\Naming\LongClassName" file="ClassWithMultipleViolations.php"/>
+  <violation rule="PHPMD\Rule\Naming\ShortVariable" file="ClassWithMultipleViolations.php"/>
+</phpmd-baseline>


### PR DESCRIPTION
Type: feature
Issue: -
Breaking change: no

Adds a `--update-baseline` cli option to clean up an existing `phpmd.baseline.xml`. This option removes violations that no longer exist in the codebase. No new violations will be added. Similar to `--generate-baseline` it can be combined with `--baseline-file`

**Added/changed**
- Added cli option `--update-baseline` to CommandLineOptions
- Added class `BaselineMode`. Contains NONE, GENERATE, UPDATE consts
- Added class `BaselineValidator` which contains the logic if an entry should be added to the Report based on the `BaselineMode`.
- Moved Report class creation outside PHMD, to be able to pass the BaselineValidator.
- Added coverage for all the new files, and the files I changed.
- Updated documentation to include the new cli parameter and baseline explanation.

Extra: as I ran into it myself, Ive fixed the `Resource temporary unavailable` error in `AbstractTest::cleanupTempFiles`
AppVeyor now passes: https://ci.appveyor.com/project/phpmd/phpmd/builds/38669510
