### PR TITLE
Allow PHPMD to run on PHP 8.0

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -42,6 +42,10 @@ jobs:
           coverage: none
           tools: composer:v2
 
+      - name: Patch for Backward Compatibility
+        if: matrix.php <= 7.1
+        run: patch --strip 1 < src/test/resources/files/php-7.1.patch
+
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
+        php: [5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - dependency-version: prefer-lowest
@@ -26,6 +26,8 @@ jobs:
             php: 7.3
           - dependency-version: prefer-lowest
             php: 7.4
+          - dependency-version: prefer-lowest
+            php: 8.0
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/phpunit_coverage.yml
+++ b/.github/workflows/phpunit_coverage.yml
@@ -33,6 +33,10 @@ jobs:
           coverage: none
           tools: composer:v2
 
+      - name: Patch for Backward Compatibility
+        if: matrix.php <= 7.1
+        run: patch --strip 1 < src/test/resources/files/php-7.1.patch
+
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .abc
 .idea
 .sonar
+.phpunit.result.cache
 .project
 .buildpath
 .settings

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "composer/xdebug-handler": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.36 || ^5.7.27",
+    "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^8.5.12",
     "squizlabs/php_codesniffer": "^2.0",
     "mikey179/vfsstream": "^1.6.4",
     "gregwar/rst": "^1.0",

--- a/src/test/php/PHPMD/AbstractStaticTest.php
+++ b/src/test/php/PHPMD/AbstractStaticTest.php
@@ -194,7 +194,7 @@ abstract class AbstractStaticTest extends PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$filesDirectory = realpath(__DIR__ . '/../../resources/files');
 

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -765,4 +765,11 @@ abstract class AbstractTest extends AbstractStaticTest
 
         $this->assertInternalType($expected, $actual, $message);
     }
+
+    public function expectNotToPerformAssertionsBackwards()
+    {
+        if (version_compare(Version::id(), '8.0.0', '>=')) {
+            $this->expectNotToPerformAssertions();
+        }
+    }
 }

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -731,4 +731,15 @@ abstract class AbstractTest extends AbstractStaticTest
 
         $this->setExpectedException($exception, $message, $code);
     }
+
+    public function assertContainsBackwards($needle, $haystack, $message = '')
+    {
+        if (version_compare(Version::id(), '8.0.0', '>=')) {
+            $this->assertStringContainsString($needle, $haystack, $message);
+
+            return;
+        }
+
+        $this->assertContains($needle, $haystack, $message);
+    }
 }

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -742,4 +742,15 @@ abstract class AbstractTest extends AbstractStaticTest
 
         $this->assertContains($needle, $haystack, $message);
     }
+
+    public function assertNotContainsBackwards($needle, $haystack, $message = '')
+    {
+        if (version_compare(Version::id(), '8.0.0', '>=')) {
+            $this->assertStringNotContainsString($needle, $haystack, $message);
+
+            return;
+        }
+
+        $this->assertNotContains($needle, $haystack, $message);
+    }
 }

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -104,7 +104,7 @@ abstract class AbstractTest extends AbstractStaticTest
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         static::returnToOriginalWorkingDirectory();
         static::cleanupTempFiles();

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -753,4 +753,16 @@ abstract class AbstractTest extends AbstractStaticTest
 
         $this->assertNotContains($needle, $haystack, $message);
     }
+
+    public function assertInternalTypeBackwards($expected, $actual, $message = '')
+    {
+        if (version_compare(Version::id(), '8.0.0', '>=')) {
+            $method = 'assertIs' . ucfirst($expected);
+            $this->$method($actual, $message);
+
+            return;
+        }
+
+        $this->assertInternalType($expected, $actual, $message);
+    }
 }

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -37,6 +37,7 @@ use PHPMD\Stubs\RuleStub;
 use PHPUnit_Framework_ExpectationFailedException;
 use PHPUnit_Framework_MockObject_MockBuilder;
 use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Runner_Version as Version;
 use ReflectionProperty;
 use Traversable;
 
@@ -710,5 +711,24 @@ abstract class AbstractTest extends AbstractStaticTest
         $parser->parse();
 
         return $builder->getNamespaces()->current();
+    }
+
+    public function setExpectedException($exception, $message = '', $code = null)
+    {
+        if (version_compare(Version::id(), '8.0.0', '>=')) {
+            $this->expectException($exception);
+
+            if ($message) {
+                $this->expectExceptionMessage($message);
+            }
+
+            if ($code) {
+                $this->expectExceptionCode($code);
+            }
+
+            return;
+        }
+
+        parent::setExpectedException($exception, $message, $code);
     }
 }

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -713,7 +713,7 @@ abstract class AbstractTest extends AbstractStaticTest
         return $builder->getNamespaces()->current();
     }
 
-    public function setExpectedException($exception, $message = '', $code = null)
+    public function setExpectedExceptionBackwards($exception, $message = null, $code = null)
     {
         if (version_compare(Version::id(), '8.0.0', '>=')) {
             $this->expectException($exception);
@@ -729,6 +729,6 @@ abstract class AbstractTest extends AbstractStaticTest
             return;
         }
 
-        parent::setExpectedException($exception, $message, $code);
+        $this->setExpectedException($exception, $message, $code);
     }
 }

--- a/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
@@ -66,11 +66,14 @@ class BaselineFileFinderTest extends AbstractTest
      * @covers ::find
      * @covers ::tryFind
      * @covers ::notNull
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unable to find the baseline file
      */
     public function testShouldThrowExceptionWhenFileIsNull()
     {
+        $this->setExpectedExceptionBackwards(
+            'RuntimeException',
+            'Unable to find the baseline file'
+        );
+
         $args   = array('script', 'source', 'xml', static::createResourceUriForTest('testB/phpmd.xml'));
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
         static::assertNull($finder->existingFile()->notNull()->find());

--- a/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
@@ -41,41 +41,53 @@ class BaselineSetFactoryTest extends AbstractTest
 
     /**
      * @covers ::fromFile
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unable to locate the baseline file at
      */
     public function testFromFileShouldThrowExceptionForMissingFile()
     {
+        $this->setExpectedExceptionBackwards(
+            'RuntimeException',
+            'Unable to locate the baseline file at'
+        );
+
         BaselineSetFactory::fromFile('foobar.xml');
     }
 
     /**
      * @covers ::fromFile
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unable to read xml from
      */
     public function testFromFileShouldThrowExceptionForOnInvalidXML()
     {
+        $this->setExpectedExceptionBackwards(
+            'RuntimeException',
+            'Unable to read xml from'
+        );
+
         BaselineSetFactory::fromFile(static::createResourceUriForTest('invalid-baseline.xml'));
     }
 
     /**
      * @covers ::fromFile
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Missing `rule` attribute in `violation`
      */
     public function testFromFileViolationMissingRuleShouldThrowException()
     {
+        $this->setExpectedExceptionBackwards(
+            'RuntimeException',
+            'Missing `rule` attribute in `violation`'
+        );
+
         BaselineSetFactory::fromFile(static::createResourceUriForTest('missing-rule-baseline.xml'));
     }
 
     /**
      * @covers ::fromFile
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Missing `file` attribute in `violation` in
      */
     public function testFromFileViolationMissingFileShouldThrowException()
     {
+        $this->setExpectedExceptionBackwards(
+            'RuntimeException',
+            'Missing `file` attribute in `violation` in'
+        );
+
         BaselineSetFactory::fromFile(static::createResourceUriForTest('missing-file-baseline.xml'));
     }
 }

--- a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -18,7 +18,7 @@ class BaselineValidatorTest extends AbstractTest
     /** @var RuleViolation|PHPUnit_Framework_MockObject_MockObject */
     private $violation;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $rule            = $this->getMockFromBuilder(

--- a/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
+++ b/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
@@ -49,7 +49,7 @@ class CommandLineInputFileOptionTest extends AbstractTest
      */
     public function testReportNotContainsRuleViolationWarningForFileNotInList()
     {
-        self::assertNotContains(
+        $this->assertNotContainsBackwards(
             "Avoid unused local variables such as '\$bar'.",
             self::runCommandLine()
         );

--- a/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
+++ b/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
@@ -35,7 +35,7 @@ class CommandLineInputFileOptionTest extends AbstractTest
      */
     public function testReportContainsExpectedRuleViolationWarning()
     {
-        self::assertContains(
+        $this->assertContainsBackwards(
             "Avoid unused local variables such as '\$foo'.",
             self::runCommandLine()
         );

--- a/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
@@ -48,7 +48,7 @@ class CouplingBetweenObjectsIntegrationTest extends AbstractTest
             )
         );
 
-        self::assertContains(
+        $this->assertContainsBackwards(
             'has a coupling between objects value of 14. ' .
             'Consider to reduce the number of dependencies under 13.',
             file_get_contents($file)

--- a/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
@@ -48,6 +48,6 @@ class GotoStatementIntegrationTest extends AbstractTest
             )
         );
 
-        self::assertContains('utilizes a goto statement.', file_get_contents($file));
+        $this->assertContainsBackwards('utilizes a goto statement.', file_get_contents($file));
     }
 }

--- a/src/test/php/PHPMD/Node/FunctionTest.php
+++ b/src/test/php/PHPMD/Node/FunctionTest.php
@@ -50,10 +50,11 @@ class FunctionTest extends AbstractTest
      * testMagicCallThrowsExceptionWhenNoMatchingMethodExists
      *
      * @return void
-     * @expectedException BadMethodCallException
      */
     public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists()
     {
+        $this->setExpectedExceptionBackwards('BadMethodCallException');
+
         $node = new FunctionNode(new ASTFunction(null));
         $node->getFooBar();
     }

--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -52,10 +52,11 @@ class MethodNodeTest extends AbstractTest
      * testMagicCallThrowsExceptionWhenNoMatchingMethodExists
      *
      * @return void
-     * @expectedException \BadMethodCallException
      */
     public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists()
     {
+        $this->setExpectedExceptionBackwards('BadMethodCallException');
+
         $node = new MethodNode(new ASTMethod(null));
         $node->getFooBar();
     }

--- a/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
+++ b/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001Test.php
@@ -37,6 +37,8 @@ class AcceptsFilesAndDirectoriesAsInputTicket001Test extends AbstractTest
      */
     public function testCliAcceptsDirectoryAsInput()
     {
+        $this->expectNotToPerformAssertionsBackwards();
+
         self::changeWorkingDirectory();
 
         $renderer = new XMLRenderer();
@@ -59,6 +61,8 @@ class AcceptsFilesAndDirectoriesAsInputTicket001Test extends AbstractTest
      */
     public function testCliAcceptsSingleFileAsInput()
     {
+        $this->expectNotToPerformAssertionsBackwards();
+
         self::changeWorkingDirectory();
 
         $renderer = new XMLRenderer();

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
@@ -41,7 +41,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
     /**
      * Sets up the renderer mock
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->renderer = $this->getMockFromBuilder(
             $this->getMockBuilder('PHPMD\Renderer\TextRenderer')

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295Test.php
@@ -41,6 +41,8 @@ class MaximumNestingLevelTicket24975295Test extends AbstractTest
      */
     public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported()
     {
+        $this->expectNotToPerformAssertionsBackwards();
+
         $renderer = new TextRenderer();
         $renderer->setWriter(new StreamWriter(self::createTempFileUri()));
 

--- a/src/test/php/PHPMD/Renderer/RendererFactoryTest.php
+++ b/src/test/php/PHPMD/Renderer/RendererFactoryTest.php
@@ -24,11 +24,14 @@ class RendererFactoryTest extends AbstractTest
 
     /**
      * @covers ::createBaselineRenderer
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Unable to determine the realpath for
      */
     public function testCreateBaselineRendererThrowsExceptionForInvalidStream()
     {
+        $this->setExpectedExceptionBackwards(
+            'RuntimeException',
+            'Unable to determine the realpath for'
+        );
+
         $writer = new StreamWriter(STDOUT);
         RendererFactory::createBaselineRenderer($writer);
     }

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -69,7 +69,7 @@ class RuleSetFactoryTest extends AbstractTest
     public function testCreateRuleSetsReturnsArray()
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
-        $this->assertInternalType('array', $ruleSets);
+        $this->assertInternalTypeBackwards('array', $ruleSets);
     }
 
     /**
@@ -185,7 +185,7 @@ class RuleSetFactoryTest extends AbstractTest
         self::changeWorkingDirectory();
 
         $ruleSets = $this->createRuleSetsFromFiles('rulesets/set1.xml');
-        $this->assertInternalType('array', $ruleSets);
+        $this->assertInternalTypeBackwards('array', $ruleSets);
     }
 
     /**

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -43,7 +43,7 @@ class RuleSetFactoryTest extends AbstractTest
         $factory = new RuleSetFactory();
         $ruleSet = $factory->createSingleRuleSet('codesize');
 
-        $this->assertContains('The Code Size Ruleset', $ruleSet->getDescription());
+        $this->assertContainsBackwards('The Code Size Ruleset', $ruleSet->getDescription());
     }
 
     /**

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -18,6 +18,7 @@
 namespace PHPMD;
 
 use org\bovigo\vfs\vfsStream;
+use ReflectionProperty;
 
 /**
  * Test case for the rule set factory class.
@@ -642,7 +643,9 @@ class RuleSetFactoryTest extends AbstractTest
 
         $ruleSets = $factory->createRuleSets($fileName);
 
-        $this->assertAttributeEquals(true, 'strict', $ruleSets[0]);
+        $property = new ReflectionProperty($ruleSets[0], 'strict');
+        $property->setAccessible(true);
+        $this->assertTrue($property->getValue($ruleSets[0]));
     }
 
     /**

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -563,7 +563,7 @@ class RuleSetFactoryTest extends AbstractTest
     {
         $factory = new RuleSetFactory();
 
-        $this->setExpectedException(
+        $this->setExpectedExceptionBackwards(
             'PHPMD\\RuleSetNotFoundException',
             'Cannot find specified rule-set "foo-bar-ruleset-23".'
         );
@@ -583,7 +583,7 @@ class RuleSetFactoryTest extends AbstractTest
         $fileName = self::createFileUri('rulesets/set-class-file-not-found.xml');
         $factory = new RuleSetFactory();
 
-        $this->setExpectedException(
+        $this->setExpectedExceptionBackwards(
             'PHPMD\\RuleClassFileNotFoundException',
             'Cannot load source file for class: PHPMD\\Stubs\\ClassFileNotFoundRule'
         );
@@ -603,7 +603,7 @@ class RuleSetFactoryTest extends AbstractTest
         $fileName = self::createFileUri('rulesets/set-class-not-found.xml');
         $factory = new RuleSetFactory();
 
-        $this->setExpectedException(
+        $this->setExpectedExceptionBackwards(
             'PHPMD\\RuleClassNotFoundException',
             'Cannot find rule class: PHPMD\\Stubs\\ClassNotFoundRule'
         );
@@ -617,10 +617,11 @@ class RuleSetFactoryTest extends AbstractTest
      *
      * @return void
      * @covers \PHPMD\RuleClassNotFoundException
-     * @expectedException \RuntimeException
      */
     public function testCreateRuleSetsThrowsExpectedExceptionForInvalidXmlFile()
     {
+        $this->setExpectedExceptionBackwards('RuntimeException');
+
         $fileName = self::createFileUri('rulesets/set-invalid-xml.xml');
 
         $factory = new RuleSetFactory();

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -123,12 +123,13 @@ class RuleTest extends AbstractTest
      * testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
-     * @expectedException \OutOfBoundsException
      * @covers ::getIntProperty
      * @covers ::getProperty
      */
     public function testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
+        $this->setExpectedExceptionBackwards('OutOfBoundsException');
+
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->getIntProperty(__FUNCTION__);
@@ -153,12 +154,13 @@ class RuleTest extends AbstractTest
      * testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
-     * @expectedException \OutOfBoundsException
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
     public function testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
+        $this->setExpectedExceptionBackwards('OutOfBoundsException');
+
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->getBooleanProperty(__FUNCTION__);
@@ -168,12 +170,13 @@ class RuleTest extends AbstractTest
      * testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
-     * @expectedException \OutOfBoundsException
      * @covers ::getStringProperty
      * @covers ::getProperty
      */
     public function testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
+        $this->setExpectedExceptionBackwards('OutOfBoundsException');
+
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
         $rule->getStringProperty(__FUNCTION__);

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -226,7 +226,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertContains('--ignore-errors-on-exit:', $opts->usage());
+        $this->assertContainsBackwards('--ignore-errors-on-exit:', $opts->usage());
     }
 
     /**
@@ -265,7 +265,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertContains('--ignore-violations-on-exit:', $opts->usage());
+        $this->assertContainsBackwards('--ignore-violations-on-exit:', $opts->usage());
     }
 
     /**
@@ -278,7 +278,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertContains(
+        $this->assertContainsBackwards(
             'Available formats: ansi, baseline, github, html, json, sarif, text, xml.',
             $opts->usage()
         );
@@ -294,7 +294,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertContains('--strict:', $opts->usage());
+        $this->assertContainsBackwards('--strict:', $opts->usage());
     }
 
     /**
@@ -509,7 +509,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize', sprintf('--%s', $deprecatedName), 42);
         new CommandLineOptions($args);
 
-        $this->assertContains(
+        $this->assertContainsBackwards(
             sprintf(
                 'The --%s option is deprecated, please use --%s instead.',
                 $deprecatedName,

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -36,7 +36,7 @@ class CommandLineOptionsTest extends AbstractTest
     /**
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (is_resource($this->stderrStreamFilter)) {
             stream_filter_remove($this->stderrStreamFilter);

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -93,10 +93,11 @@ class CommandLineOptionsTest extends AbstractTest
      *
      * @return void
      * @since 1.1.0
-     * @expectedException \InvalidArgumentException
      */
     public function testThrowsExpectedExceptionWhenRequiredArgumentsNotSet()
     {
+        $this->setExpectedExceptionBackwards('InvalidArgumentException');
+
         $args = array(__FILE__, 'text', 'design');
         new CommandLineOptions($args);
     }
@@ -154,10 +155,11 @@ class CommandLineOptionsTest extends AbstractTest
      *
      * @return void
      * @since 1.1.0
-     * @expectedException \InvalidArgumentException
      */
     public function testThrowsExpectedExceptionWhenInputFileNotExists()
     {
+        $this->setExpectedExceptionBackwards('InvalidArgumentException');
+
         $args = array('foo.php', 'text', 'design', '--inputfile', 'inputfail.txt');
         new CommandLineOptions($args);
     }
@@ -470,12 +472,13 @@ class CommandLineOptionsTest extends AbstractTest
     /**
      * @param string $reportFormat
      * @return void
-     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessageRegExp (^Can\'t )
      * @dataProvider dataProviderCreateRendererThrowsException
      */
     public function testCreateRendererThrowsException($reportFormat)
     {
+        $this->setExpectedExceptionBackwards('InvalidArgumentException');
+
         $args = array(__FILE__, __FILE__, $reportFormat, 'codesize');
         $opts = new CommandLineOptions($args);
         $opts->createRenderer();

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -243,7 +243,7 @@ class CommandTest extends AbstractTest
 
         static::assertSame(Command::EXIT_SUCCESS, $exitCode);
         static::assertFileExists($temp);
-        static::assertContains($uri, file_get_contents($temp));
+        $this->assertContainsBackwards($uri, file_get_contents($temp));
     }
 
     /**
@@ -310,7 +310,7 @@ class CommandTest extends AbstractTest
             )
         );
 
-        $this->assertContains(
+        $this->assertContainsBackwards(
             'Can\'t find the custom report class: ',
             StreamFilter::$streamHandle
         );

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -34,7 +34,7 @@ class CommandTest extends AbstractTest
     /**
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (is_resource($this->stderrStreamFilter)) {
             stream_filter_remove($this->stderrStreamFilter);

--- a/src/test/php/PHPMD/Utility/PathsTest.php
+++ b/src/test/php/PHPMD/Utility/PathsTest.php
@@ -60,10 +60,11 @@ class PathsTest extends AbstractTest
 
     /**
      * @covers ::getAbsolutePath
-     * @expectedException RuntimeException
      */
     public function testGetAbsolutePathShouldReturnNullForIrregularStream()
     {
+        $this->setExpectedExceptionBackwards('RuntimeException');
+
         Paths::getAbsolutePath(fopen('php://stdout', 'wb'));
     }
 
@@ -87,10 +88,11 @@ class PathsTest extends AbstractTest
 
     /**
      * @covers ::getRealPath
-     * @expectedException RuntimeException
      */
     public function testGetRealPathShouldThrowExceptionOnFailure()
     {
+        $this->setExpectedExceptionBackwards('RuntimeException');
+
         Paths::getRealPath('unknown/path');
     }
 }

--- a/src/test/php/PHPMD/Utility/StringsTest.php
+++ b/src/test/php/PHPMD/Utility/StringsTest.php
@@ -90,12 +90,12 @@ class StringsTest extends AbstractTest
     /**
      * Tests the splitToList() method with an empty separator
      *
-     * @expectedException \InvalidArgumentException
-     *
      * @return void
      */
     public function testSplitToListEmptySeparatorThrowsException()
     {
+        $this->setExpectedExceptionBackwards('InvalidArgumentException');
+
         Strings::splitToList('UnitTest', '');
     }
 

--- a/src/test/php/bootstrap.php
+++ b/src/test/php/bootstrap.php
@@ -20,6 +20,7 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 if (class_exists('PHPUnit\Framework\TestCase') && ! class_exists('PHPUnit_Framework_TestCase')) {
     class_alias('PHPUnit\Framework\MockObject\MockBuilder', 'PHPUnit_Framework_MockObject_MockBuilder');
     class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
+    class_alias('PHPUnit\Runner\Version', 'PHPUnit_Runner_Version');
 }
 
 spl_autoload_register(

--- a/src/test/php/bootstrap.php
+++ b/src/test/php/bootstrap.php
@@ -17,6 +17,10 @@
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
+if (class_exists('PHPUnit\Framework\TestCase') && ! class_exists('PHPUnit_Framework_TestCase')) {
+    class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
+}
+
 spl_autoload_register(
     function ($class) {
         $file = __DIR__ . '/' . strtr($class, '\\', '/') . '.php';

--- a/src/test/php/bootstrap.php
+++ b/src/test/php/bootstrap.php
@@ -18,6 +18,7 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
 if (class_exists('PHPUnit\Framework\TestCase') && ! class_exists('PHPUnit_Framework_TestCase')) {
+    class_alias('PHPUnit\Framework\MockObject\MockBuilder', 'PHPUnit_Framework_MockObject_MockBuilder');
     class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
 }
 

--- a/src/test/resources/files/php-7.1.patch
+++ b/src/test/resources/files/php-7.1.patch
@@ -1,0 +1,78 @@
+diff --git a/src/test/php/PHPMD/AbstractStaticTest.php b/src/test/php/PHPMD/AbstractStaticTest.php
+index 2fbb98b6..31991f54 100644
+--- a/src/test/php/PHPMD/AbstractStaticTest.php
++++ b/src/test/php/PHPMD/AbstractStaticTest.php
+@@ -194,7 +194,7 @@ abstract class AbstractStaticTest extends PHPUnit_Framework_TestCase
+      *
+      * @return void
+      */
+-    public static function setUpBeforeClass(): void
++    public static function setUpBeforeClass()
+     {
+         self::$filesDirectory = realpath(__DIR__ . '/../../resources/files');
+ 
+diff --git a/src/test/php/PHPMD/AbstractTest.php b/src/test/php/PHPMD/AbstractTest.php
+index 2ed18f3f..3a2f7c7c 100644
+--- a/src/test/php/PHPMD/AbstractTest.php
++++ b/src/test/php/PHPMD/AbstractTest.php
+@@ -104,7 +104,7 @@ abstract class AbstractTest extends AbstractStaticTest
+      *
+      * @return void
+      */
+-    protected function tearDown(): void
++    protected function tearDown()
+     {
+         static::returnToOriginalWorkingDirectory();
+         static::cleanupTempFiles();
+diff --git a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+index 53b0de84..12caac3b 100644
+--- a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
++++ b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+@@ -18,7 +18,7 @@ class BaselineValidatorTest extends AbstractTest
+     /** @var RuleViolation|PHPUnit_Framework_MockObject_MockObject */
+     private $violation;
+ 
+-    protected function setUp(): void
++    protected function setUp()
+     {
+         parent::setUp();
+         $rule            = $this->getMockFromBuilder(
+diff --git a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
+index 53c23b18..5c2ccf14 100644
+--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
++++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest.php
+@@ -41,7 +41,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsTest extends AbstractTe
+     /**
+      * Sets up the renderer mock
+      */
+-    public function setUp(): void
++    public function setUp()
+     {
+         $this->renderer = $this->getMockFromBuilder(
+             $this->getMockBuilder('PHPMD\Renderer\TextRenderer')
+diff --git a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+index 3da8e9f4..619b18e4 100644
+--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
++++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+@@ -36,7 +36,7 @@ class CommandLineOptionsTest extends AbstractTest
+     /**
+      * @return void
+      */
+-    protected function tearDown(): void
++    protected function tearDown()
+     {
+         if (is_resource($this->stderrStreamFilter)) {
+             stream_filter_remove($this->stderrStreamFilter);
+diff --git a/src/test/php/PHPMD/TextUI/CommandTest.php b/src/test/php/PHPMD/TextUI/CommandTest.php
+index 990b7dff..7cb4e117 100644
+--- a/src/test/php/PHPMD/TextUI/CommandTest.php
++++ b/src/test/php/PHPMD/TextUI/CommandTest.php
+@@ -34,7 +34,7 @@ class CommandTest extends AbstractTest
+     /**
+      * @return void
+      */
+-    protected function tearDown(): void
++    protected function tearDown()
+     {
+         if (is_resource($this->stderrStreamFilter)) {
+             stream_filter_remove($this->stderrStreamFilter);


### PR DESCRIPTION
Type: feature
Breaking change: no

This PR updates Composer PHP requirement to 8.0 and fixes warnings when using this version.