### PR TITLE
add 2.0 version of the `composer/xdebug-handler`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "php": ">=5.3.9",
     "pdepend/pdepend": "^2.9.1",
     "ext-xml": "*",
-    "composer/xdebug-handler": "^1.0"
+    "composer/xdebug-handler": "^1.0 || ^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8.36 || ^5.7.27",


### PR DESCRIPTION
Type: refactoring
Issue: `phpmd` has conflicts by versions with `infection/infection` which require ^2.0 of `composer/xdebug-handler`
Breaking change: no
