### PR TITLE
Fix #884 Avoid unused parameters on PHP 8: Constructor property

### DIFF
--- a/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -503,4 +503,26 @@ class UnusedFormalParameterTest extends AbstractTest
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
+
+    /**
+     * testRuleDoesNotApplyToPropertyPromotionParameters
+     *
+     * <code>
+     * class Foo {
+     *     public function __construct(private string $foo) {}
+     * }
+     * </code>
+     *
+     * @return void
+     */
+    public function testRuleDoesNotApplyToPropertyPromotionParameters()
+    {
+        $methods = array_filter($this->getClass()->getMethods(), function ($method) {
+            return $method->getImage() === '__construct';
+        });
+
+        $rule = new UnusedFormalParameter();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($methods[0]);
+    }
 }

--- a/src/test/resources/files/Rule/UnusedFormalParameter/testRuleDoesNotApplyToPropertyPromotionParameters.php
+++ b/src/test/resources/files/Rule/UnusedFormalParameter/testRuleDoesNotApplyToPropertyPromotionParameters.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyToPropertyPromotionParameters
+{
+    function __construct(private string $foo) {}
+}


### PR DESCRIPTION
Type: bugfix
Issue: Resolves #884 
Breaking change: no

Don't apply UnusedFormalParameter to property promotion parameters