### PR TITLE
Fix PHP 8 deprecation notices on the fly for phar build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,6 +19,7 @@
 
 /src/test         export-ignore
 /src/site         export-ignore
+/src/phar         export-ignore
 /vendor/squizlabs export-ignore
 .gitattributes    export-ignore
 .github           export-ignore

--- a/.github/workflows/generate_phar.yml
+++ b/.github/workflows/generate_phar.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Git submodules
         run: git submodule update --init
 
+      - name: Fix PHP compatibility
+        run: php src/phar/compatibility.php
+
       - name: Ant
         run: ant package -D-phar:filename=./phpmd.phar && ./phpmd.phar --version
 

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -141,6 +141,28 @@ abstract class AbstractNode
     }
 
     /**
+     * List all first-level children of the nodes of the given type found in any depth of
+     * the current node.
+     *
+     * @param string $type The searched child type.
+     * @return ASTNode[]
+     */
+    public function findChildrenWithParentType($type)
+    {
+        $children = $this->node->findChildrenOfType('PDepend\Source\AST\AST' . $type);
+
+        $nodes = array();
+
+        foreach ($children as $child) {
+            foreach ($child->getChildren() as $subChild) {
+                $nodes[] = $subChild;
+            }
+        }
+
+        return $nodes;
+    }
+
+    /**
      * Searches recursive for all children of this node that are of variable.
      *
      * @return ASTVariable[]

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -163,11 +163,15 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
         foreach ($node->findChildrenWithParentType('ForeachStatement') as $child) {
             if ($child instanceof ASTVariable) {
                 $this->addVariableDefinition($child);
-            } elseif ($child instanceof ASTUnaryExpression) {
-                foreach ($child->getChildren() as $refChildren) {
-                    if ($refChildren instanceof ASTVariable) {
-                        $this->addVariableDefinition($refChildren);
-                    }
+            }
+
+            if (!($child instanceof ASTUnaryExpression)) {
+                continue;
+            }
+
+            foreach ($child->getChildren() as $refChildren) {
+                if ($refChildren instanceof ASTVariable) {
+                    $this->addVariableDefinition($refChildren);
                 }
             }
         }

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -119,12 +119,8 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectGlobalStatements(AbstractNode $node)
     {
-        $globalStatements = $node->findChildrenOfType('GlobalStatement');
-
-        foreach ($globalStatements as $globalStatement) {
-            foreach ($globalStatement->getChildren() as $variable) {
-                $this->addVariableDefinition($variable);
-            }
+        foreach ($node->findChildrenWithParentType('GlobalStatement') as $variable) {
+            $this->addVariableDefinition($variable);
         }
     }
 
@@ -136,13 +132,9 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectExceptionCatches(AbstractCallableNode $node)
     {
-        $catchStatements = $node->findChildrenOfType('CatchStatement');
-
-        foreach ($catchStatements as $catchStatement) {
-            foreach ($catchStatement->getChildren() as $children) {
-                if ($children instanceof ASTVariable) {
-                    $this->addVariableDefinition($children);
-                }
+        foreach ($node->findChildrenWithParentType('CatchStatement') as $child) {
+            if ($child instanceof ASTVariable) {
+                $this->addVariableDefinition($child);
             }
         }
     }
@@ -155,12 +147,8 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectListExpressions(AbstractCallableNode $node)
     {
-        $lists = $node->findChildrenOfType('ListExpression');
-
-        foreach ($lists as $listExpression) {
-            foreach ($listExpression->getChildren() as $variable) {
-                $this->addVariableDefinition($variable);
-            }
+        foreach ($node->findChildrenWithParentType('ListExpression') as $variable) {
+            $this->addVariableDefinition($variable);
         }
     }
 
@@ -172,17 +160,13 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectForeachStatements(AbstractCallableNode $node)
     {
-        $foreachStatements = $node->findChildrenOfType('ForeachStatement');
-
-        foreach ($foreachStatements as $foreachStatement) {
-            foreach ($foreachStatement->getChildren() as $children) {
-                if ($children instanceof ASTVariable) {
-                    $this->addVariableDefinition($children);
-                } elseif ($children instanceof ASTUnaryExpression) {
-                    foreach ($children->getChildren() as $refChildren) {
-                        if ($refChildren instanceof ASTVariable) {
-                            $this->addVariableDefinition($refChildren);
-                        }
+        foreach ($node->findChildrenWithParentType('ForeachStatement') as $child) {
+            if ($child instanceof ASTVariable) {
+                $this->addVariableDefinition($child);
+            } elseif ($child instanceof ASTUnaryExpression) {
+                foreach ($child->getChildren() as $refChildren) {
+                    if ($refChildren instanceof ASTVariable) {
+                        $this->addVariableDefinition($refChildren);
                     }
                 }
             }
@@ -273,13 +257,9 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectPropertyPostfix(AbstractNode $node)
     {
-        $properties = $node->findChildrenOfType('PropertyPostfix');
-
-        foreach ($properties as $property) {
-            foreach ($property->getChildren() as $children) {
-                if ($children instanceof ASTVariable) {
-                    $this->addVariableDefinition($children);
-                }
+        foreach ($node->findChildrenWithParentType('PropertyPostfix') as $child) {
+            if ($child instanceof ASTVariable) {
+                $this->addVariableDefinition($child);
             }
         }
     }

--- a/src/phar/compatibility.php
+++ b/src/phar/compatibility.php
@@ -1,0 +1,24 @@
+<?php
+
+function replaceInFiles(array $files, array $replacements)
+{
+    foreach ($files as $file) {
+        $oldContent = file_get_contents($file);
+        $newContent = strtr($oldContent, $replacements);
+
+        if ($oldContent !== $newContent) {
+            file_put_contents($file, $newContent);
+        }
+    }
+}
+
+// Mute PHP 8 deprecation notices
+replaceInFiles(
+    array(
+        __DIR__ . '/../../vendor/symfony/config/Util/XmlUtils.php',
+        __DIR__ . '/../../vendor/symfony/dependency-injection/Loader/XmlFileLoader.php',
+    ),
+    array(
+        ' libxml_disable_entity_loader(' => ' @libxml_disable_entity_loader(',
+    )
+);


### PR DESCRIPTION
Type: feature
Issue: Resolves #881
Breaking change: no

While checking PHAR generation, the hook ensuring our own code pass some rules, it failed on `UndefinedVariable` which has complexity > 50. So in order to keep the complexity below and have the PHAR generation still working without increasing the threshold, I also took the opportunity to dedupe some code in `UndefinedVariable` class.