### PR TITLE
Don't call preg_match_all on null

### DIFF
--- a/src/main/php/PHPMD/Node/Annotations.php
+++ b/src/main/php/PHPMD/Node/Annotations.php
@@ -45,7 +45,12 @@ class Annotations
      */
     public function __construct(\PHPMD\AbstractNode $node)
     {
-        preg_match_all($this->regexp, $node->getDocComment(), $matches);
+        $comment = $node->getDocComment();
+        if ($comment === null) {
+            return;
+        }
+
+        preg_match_all($this->regexp, $comment, $matches);
         foreach (array_keys($matches[0]) as $i) {
             $name = $matches[1][$i];
             $value = trim($matches[2][$i], '" ');


### PR DESCRIPTION
Type: bugfix  
Issue: n/a
Breaking change: no

This PR fixes a deprecation message with PHP 8.1:
```
Deprecated: preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated in vendor/phpmd/phpmd/src/main/php/PHPMD/Node/Annotations.php on line 48
```

This could be also seen as a micro-optimization since it avoids unnecessary calls to `preg_match_call`.

This case is already covered by a test: `testCollectionReturnsFalseWhenNoAnnotationExists`