### PR TITLE
Fix remaining deprecation messages

### DIFF
--- a/src/main/php/PHPMD/RuleSet.php
+++ b/src/main/php/PHPMD/RuleSet.php
@@ -263,6 +263,7 @@ class RuleSet implements \IteratorAggregate
      *
      * @return \Iterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->getRules();

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -245,7 +245,7 @@ class RuleSetFactory
      */
     private function parseRuleNode(RuleSet $ruleSet, \SimpleXMLElement $node)
     {
-        if (substr($node['ref'], -3, 3) === 'xml') {
+        if ($node['ref'] !== null && substr($node['ref'], -3, 3) === 'xml') {
             $this->parseRuleSetReferenceNode($ruleSet, $node);
 
             return;


### PR DESCRIPTION
Type: bugfix  
Issue: n/a
Breaking change: no

This PR fixes the remaining deprecation messages we get when running with PHP 8.1:
```
Deprecated:  Return type of PHPMD\RuleSet::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/phpmd/phpmd/src/main/php/PHPMD/RuleSet.php on line 266
```

```
Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/phpmd/phpmd/src/main/php/PHPMD/RuleSetFactory.php on line 248
```