### PR TITLE
Fix PHP 8.1 deprecation messages

### DIFF
--- a/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
@@ -78,6 +78,9 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
     protected function isReturnTypeBoolean(MethodNode $node)
     {
         $comment = $node->getDocComment();
+        if ($comment === null) {
+            return false;
+        }
 
         return (preg_match('(\*\s*@return\s+bool(ean)?\s)i', $comment) > 0);
     }

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -95,8 +95,8 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      */
     protected function isInheritedSignature(AbstractNode $node)
     {
-        if ($node instanceof MethodNode && $node->getDocComment() !== null) {
-            return preg_match('/@inheritdoc/i', $node->getDocComment()) === 1;
+        if ($node instanceof MethodNode && ($comment = $node->getDocComment()) !== null) {
+            return preg_match('/@inheritdoc/i', $comment) === 1;
         }
 
         return false;

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -95,7 +95,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      */
     protected function isInheritedSignature(AbstractNode $node)
     {
-        if ($node instanceof MethodNode) {
+        if ($node instanceof MethodNode && $node->getDocComment() !== null) {
             return preg_match('/@inheritdoc/i', $node->getDocComment()) === 1;
         }
 

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -95,8 +95,10 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      */
     protected function isInheritedSignature(AbstractNode $node)
     {
-        if ($node instanceof MethodNode && ($comment = $node->getDocComment()) !== null) {
-            return preg_match('/@inheritdoc/i', $comment) === 1;
+        if ($node instanceof MethodNode) {
+            $comment = $node->getDocComment();
+
+            return $comment && preg_match('/@inheritdoc/i', $comment);
         }
 
         return false;

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -368,7 +368,7 @@ class RuleSetFactory
 
         $rule->setRuleSetName($ruleSet->getName());
 
-        if (trim($ruleNode['since']) !== '') {
+        if (isset($ruleNode['since']) && trim($ruleNode['since']) !== '') {
             $rule->setSince((string)$ruleNode['since']);
         }
 
@@ -411,13 +411,13 @@ class RuleSetFactory
         $ruleSetRef = $ruleSetFactory->createSingleRuleSet($fileName);
         $rule = $ruleSetRef->getRuleByName($ruleName);
 
-        if (trim($ruleNode['name']) !== '') {
+        if (isset($ruleNode['name']) && trim($ruleNode['name']) !== '') {
             $rule->setName((string)$ruleNode['name']);
         }
-        if (trim($ruleNode['message']) !== '') {
+        if (isset($ruleNode['message']) && trim($ruleNode['message']) !== '') {
             $rule->setMessage((string)$ruleNode['message']);
         }
-        if (trim($ruleNode['externalInfoUrl']) !== '') {
+        if (isset($ruleNode['externalInfoUrl']) && trim($ruleNode['externalInfoUrl']) !== '') {
             $rule->setExternalInfoUrl((string)$ruleNode['externalInfoUrl']);
         }
 


### PR DESCRIPTION
Type: bugfix
Breaking change: no

Fix following deprecation messages (running with PHP8.1)
```
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /path/to/vendor/phpmd/phpmd/src/main/php/PHPMD/RuleSetFactory.php on line 414

Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /path/to/vendor/phpmd/phpmd/src/main/php/PHPMD/RuleSetFactory.php on line 417

Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /path/to/vendor/phpmd/phpmd/src/main/php/PHPMD/RuleSetFactory.php on line 420
```

```
Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /path/to/vendor/phpmd/phpmd/src/main/php/PHPMD/Rule/UnusedFormalParameter.php on line 99
```

```
Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /path/to/vendor/phpmd/phpmd/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php on line 82
```