### PR TITLE
Allow install composer/xdebug-handler 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "php": ">=5.3.9",
     "pdepend/pdepend": "^2.10.2",
     "ext-xml": "*",
-    "composer/xdebug-handler": "^1.0 || ^2.0"
+    "composer/xdebug-handler": "^1.0 || ^2.0 || ^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8.36 || ^5.7.27",


### PR DESCRIPTION
Type: feature
Breaking change: no

This allows to install [`composer/xdebug-handler` 3](https://github.com/composer/xdebug-handler/blob/main/CHANGELOG.md#300---2021-12-23) which should be fine since its usage remains the same:

https://github.com/phpmd/phpmd/blob/9e531d61b088339078f7e5cce5390e2beeb8e810/src/bin/phpmd#L29-L32