### PR TITLE
Revert "Disallow capital letter at the beginning in CamelCasePropertyName rule"

### DIFF
--- a/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
@@ -40,9 +40,9 @@ class CamelCasePropertyName extends AbstractRule implements ClassAware
     {
         $allowUnderscore = $this->getBooleanProperty('allow-underscore');
 
-        $pattern = '/^\$[a-z][a-zA-Z0-9]*$/';
+        $pattern = '/^\$[a-zA-Z][a-zA-Z0-9]*$/';
         if ($allowUnderscore === true) {
-            $pattern = '/^\$[_]?[a-z][a-zA-Z0-9]*$/';
+            $pattern = '/^\$[_]?[a-zA-Z][a-zA-Z0-9]*$/';
         }
 
         foreach ($node->getProperties() as $property) {

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
@@ -42,15 +42,15 @@ class CamelCasePropertyNameTest extends AbstractTest
     }
 
     /**
-     * Tests that the rule does apply for a property name
+     * Tests that the rule does NOT apply for an property name
      * starting with a capital.
      *
      * @return void
      */
-    public function testRuleDoesApplyForPropertyNameWithCapital()
+    public function testRuleDoesNotApplyForPropertyNameWithCapital()
     {
         // Test property name with capital at the beginning
-        $report = $this->getReportWithOneViolation();
+        $report = $this->getReportWithNoViolation();
 
         $rule = new CamelCasePropertyName();
         $rule->setReport($report);

--- a/src/test/resources/files/Rule/Controversial/CamelCasePropertyName/testRuleDoesNotApplyForPropertyNameWithCapital.php
+++ b/src/test/resources/files/Rule/Controversial/CamelCasePropertyName/testRuleDoesNotApplyForPropertyNameWithCapital.php
@@ -15,7 +15,7 @@
  * @link http://phpmd.org/
  */
 
-class testRuleDoesApplyForPropertyNameWithCapital
+class testRuleDoesNotApplyForPropertyNameWithCapital
 {
-    public $NotValidPropertyName;
+    public $AlsoValidPropertyName;
 }


### PR DESCRIPTION
Reverts phpmd/phpmd#833

Sorry, forgot that this was a BC break. My bad.