### PR TITLE
Fix DevelopmentCodeFragment

### DIFF
--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -45,7 +45,7 @@ class DevelopmentCodeFragment extends AbstractRule implements MethodAware, Funct
         $namespace = $node->getNamespaceName();
         foreach ($node->findChildrenOfType('FunctionPostfix') as $postfix) {
             $fragment = $postfix->getImage();
-            if ($ignoreNS) {
+            if ($ignoreNS || !function_exists($fragment)) {
                 $fragment = str_replace("{$namespace}\\", "", $fragment);
             }
             $fragment = strtolower($fragment);

--- a/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -163,11 +163,23 @@ class DevelopmentCodeFragmentTest extends AbstractTest
     }
 
     /**
-     * testRuleNotAppliesToMethodWithinNamespaceByDefault
+     * testRuleAppliesToMethodWithinNamespaceByDefault
      *
      * @return void
      */
-    public function testRuleNotAppliesToMethodWithinNamespaceByDefault()
+    public function testRuleAppliesToMethodWithinNamespaceByDefault()
+    {
+        $rule = $this->getRule();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getClass());
+    }
+
+    /**
+     * testRuleNotAppliesToMethodWithinNamespaceByDefaultWhenFunctionExistsInNamespace
+     *
+     * @return void
+     */
+    public function testRuleNotAppliesToMethodWithinNamespaceByDefaultWhenFunctionExistsInNamespace()
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleAppliesToMethodWithinNamespaceByDefault.php
+++ b/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleAppliesToMethodWithinNamespaceByDefault.php
@@ -17,7 +17,7 @@ namespace Test\namespace;
  * @license https://opensource.org/licenses/bsd-license.php BSD License
  * @link http://phpmd.org/
  */
-class testRuleNotAppliesToMethodWithinNamespaceByDefault
+class testRuleAppliesToMethodWithinNamespaceByDefault
 {
     public function __construct($test = 'Test')
     {

--- a/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleNotAppliesToMethodWithinNamespaceByDefaultWhenFunctionExistsInNamespace.php
+++ b/src/test/resources/files/Rule/Design/DevelopmentCodeFragment/testRuleNotAppliesToMethodWithinNamespaceByDefaultWhenFunctionExistsInNamespace.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Test\namespace;
+
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+class testRuleNotAppliesToMethodWithinNamespaceByDefaultWhenFunctionExistsInNamespace
+{
+    public function __construct($test = 'Test')
+    {
+        var_dump($test);
+    }
+}
+
+function var_dump($argument) {
+
+}


### PR DESCRIPTION
Type: (bugfix)  
Issue: Resolves #949 
Breaking change: no

This PR checks if a development function exists in the current namespace.
