### PR TITLE
Add Gitlab renderer for Gitlab CI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,6 +213,7 @@ At the moment PHPMD comes with the following renderers:
 - *json*, formats JSON report.
 - *ansi*, a command line friendly format.
 - *github*, a format that GitHub Actions understands.
+- *gitlab*, a format that GitLab CI understands.
 - *sarif*, the Static Analysis Results Interchange Format.
 - *checkstyle*, language and tool agnostic XML format
 

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -41,7 +41,7 @@ class GitLabRenderer extends AbstractRenderer
 
 
     /**
-     * Add violations, if any, to the report data
+     * Add violations, if any, to GitLab Code Quality report format
      *
      * @param Report $report The report with potential violations.
      *
@@ -83,7 +83,7 @@ class GitLabRenderer extends AbstractRenderer
     }
 
     /**
-     * Add errors, if any, to the report data
+     * Add errors, if any, to GitLab Code Quality report format
      *
      * @param Report $report The report with potential errors.
      * @param array  $data   The report output to add the errors to.

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -49,11 +49,11 @@ class GitLabRenderer extends AbstractRenderer
      */
     protected function addViolationsToReport(Report $report)
     {
-        $violationResult = array();
+        $data = array();
 
         /** @var RuleViolation $violation */
         foreach ($report->getRuleViolations() as $violation) {
-            $violationResult[] = array(
+            $violationResult = array(
                 'type' => 'issue',
                 'categories' =>
                     array(
@@ -62,7 +62,7 @@ class GitLabRenderer extends AbstractRenderer
                     ),
                 'check_name' => $violation->getRule()->getName(),
                 'fingerprint' => $violation->getFileName().':'.$violation->getBeginLine().':'.$violation->getRule(
-                    )->getName(),
+                )->getName(),
                 'description' => $violation->getDescription(),
                 'severity' => 'minor',
                 'location' =>
@@ -75,9 +75,9 @@ class GitLabRenderer extends AbstractRenderer
                             ),
                     ),
             );
-        }
 
-        $data[] = $violationResult;
+            $data[] = $violationResult;
+        }
 
         return $data;
     }
@@ -95,7 +95,7 @@ class GitLabRenderer extends AbstractRenderer
         $errors = $report->getErrors();
         if ($errors) {
             foreach ($errors as $error) {
-                $data[] = array(
+                $errorResult = array(
                     'description' => $error->getMessage(),
                     'fingerprint' => $error->getFile().':0:MajorErrorInFile',
                     'severity' => 'major',
@@ -108,6 +108,8 @@ class GitLabRenderer extends AbstractRenderer
                                 ),
                         ),
                 );
+
+                $data[] = $errorResult;
             }
         }
 

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author    Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ * @link      http://phpmd.org/
+ */
+
+namespace PHPMD\Renderer;
+
+use PHPMD\AbstractRenderer;
+use PHPMD\Report;
+use PHPMD\RuleViolation;
+
+/**
+ * This class will render a GitLab compatible JSON report.
+ */
+class GitLabRenderer extends AbstractRenderer
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function renderReport(Report $report)
+    {
+        $data = $this->addViolationsToReport($report);
+        $data = $this->addErrorsToReport($report, $data);
+        $jsonData = $this->encodeReport($data);
+
+        $writer = $this->getWriter();
+        $writer->write($jsonData.PHP_EOL);
+    }
+
+
+    /**
+     * Add violations, if any, to the report data
+     *
+     * @param Report $report The report with potential violations.
+     *
+     * @return array The report output with violations, if any.
+     */
+    protected function addViolationsToReport(Report $report)
+    {
+        $violationResult = array();
+
+        /** @var RuleViolation $violation */
+        foreach ($report->getRuleViolations() as $violation) {
+            $violationResult[] = array(
+                'type' => 'issue',
+                'categories' =>
+                    array(
+                        'Style',
+                        'PHP',
+                    ),
+                'check_name' => $violation->getRule()->getName(),
+                'fingerprint' => $violation->getFileName().':'.$violation->getBeginLine().':'.$violation->getRule(
+                    )->getName(),
+                'description' => $violation->getDescription(),
+                'severity' => 'minor',
+                'location' =>
+                    array(
+                        'path' => $violation->getFileName(),
+                        'lines' =>
+                            array(
+                                'begin' => $violation->getBeginLine(),
+                                'end' => $violation->getEndLine(),
+                            ),
+                    ),
+            );
+        }
+
+        $data[] = $violationResult;
+
+        return $data;
+    }
+
+    /**
+     * Add errors, if any, to the report data
+     *
+     * @param Report $report The report with potential errors.
+     * @param array  $data   The report output to add the errors to.
+     *
+     * @return array The report output with errors, if any.
+     */
+    protected function addErrorsToReport(Report $report, array $data)
+    {
+        $errors = $report->getErrors();
+        if ($errors) {
+            foreach ($errors as $error) {
+                $data[] = array(
+                    'description' => $error->getMessage(),
+                    'fingerprint' => $error->getFile().':0:MajorErrorInFile',
+                    'severity' => 'major',
+                    'location' =>
+                        array(
+                            'path' => $error->getFile(),
+                            'lines' =>
+                                array(
+                                    'begin' => 0,
+                                ),
+                        ),
+                );
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Encode report data to the JSON representation string
+     *
+     * @param array $data The report data
+     *
+     * @return string
+     */
+    private function encodeReport($data)
+    {
+        $encodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP |
+            (defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0);
+
+        return json_encode($data, $encodeOptions);
+    }
+}

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -21,6 +21,7 @@ use InvalidArgumentException;
 use PHPMD\Baseline\BaselineMode;
 use PHPMD\Renderer\AnsiRenderer;
 use PHPMD\Renderer\GitHubRenderer;
+use PHPMD\Renderer\GitLabRenderer;
 use PHPMD\Renderer\HTMLRenderer;
 use PHPMD\Renderer\JSONRenderer;
 use PHPMD\Renderer\SARIFRenderer;
@@ -459,6 +460,8 @@ class CommandLineOptions
                 return $this->createAnsiRenderer();
             case 'checkstyle':
                 return $this->createCheckStyleRenderer();
+            case 'gitlab':
+                return $this->createGitLabRenderer();
             case 'github':
                 return $this->createGitHubRenderer();
             case 'html':
@@ -498,6 +501,14 @@ class CommandLineOptions
     protected function createAnsiRenderer()
     {
         return new AnsiRenderer();
+    }
+
+    /**
+     * @return \PHPMD\Renderer\GitLabRenderer
+     */
+    protected function createGitLabRenderer()
+    {
+        return new GitLabRenderer();
     }
 
     /**

--- a/src/site/rst/documentation/ci-integration.rst
+++ b/src/site/rst/documentation/ci-integration.rst
@@ -12,9 +12,9 @@ GitHub Actions is supported out of the box with its own PHPMD renderer called ``
 A simple GitHub Actions workflow could look like this: ::
 
   name: CI
-  
+
   on: push
-  
+
   jobs:
     phpmd:
       name: PHPMD
@@ -22,14 +22,31 @@ A simple GitHub Actions workflow could look like this: ::
       steps:
         - name: Checkout
           uses: actions/checkout@v2
-  
+
         - name: Setup PHP environment
           uses: shivammathur/setup-php@v2
           with:
             coverage: none
             tools: phpmd
-  
+
         - name: Run PHPMD
           run: phpmd . github phpmd.ruleset.xml --exclude 'tests/*,vendor/*'
 
 This assumes that you have a `custom rule set </documentation/creating-a-ruleset.html>`_ in the file ``phpmd.ruleset.xml``. Alternatively, you can of course list the rule sets manually.
+
+GitLab Code Quality Reporting
+=========
+
+GitLab Code Quality reporting is supported out of the box with its own PHPMD renderer called ``gitlab``. You can read the GitLab docs about this topic `here </https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html>`_.
+
+A simple GitLab Code Quality report workflow could look like this: ::
+
+  mess_detection:
+      image: ubuntu-latest
+      stage: quality
+      script:
+        - phpmd . gitlab phpmd.ruleset.xml > phpmd-report.json
+      artifacts:
+        reports:
+          codequality: phpmd-report.json
+

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -130,6 +130,7 @@ At the moment PHPMD comes with the following five renderers:
 - *ansi*, colorful, formatted text for the command line.
 - *html*, single HTML file with possible problems.
 - *json*, formats JSON report.
+- *gitlab*, a format that GitLab CI understands.
 - *github*, a format that GitHub Actions understands (see `CI Integration </documentation/ci-integration.html#github-actions>`_).
 
 Some more formats can be obtained by conversion such as:

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -123,7 +123,7 @@ PHPMD's command line tool currently defines four different exit codes.
 Renderers
 =========
 
-At the moment PHPMD comes with the following five renderers:
+At the moment PHPMD comes with the following renderers:
 
 - *xml*, which formats the report as XML.
 - *text*, simple textual format.

--- a/src/test/php/PHPMD/Renderer/GitLabRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/GitLabRendererTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Renderer;
+
+use PHPMD\AbstractTest;
+use PHPMD\ProcessingError;
+use PHPMD\Stubs\WriterStub;
+
+/**
+ * Test case for the JSON renderer implementation.
+ *
+ * @covers \PHPMD\Renderer\GitLabRenderer
+ */
+class GitLabRendererTest extends AbstractTest
+{
+    /**
+     * testRendererCreatesExpectedNumberOfGitLabElements
+     *
+     * @return void
+     */
+    public function testRendererCreatesExpectedNumberOfGitLabElements()
+    {
+        $writer = new WriterStub();
+
+        $violations = array(
+            $this->getRuleViolationMock('/bar.php'),
+            $this->getRuleViolationMock('/foo.php'),
+            $this->getRuleViolationMock('/bar.php'), // TODO Set with description "foo <?php bar".
+        );
+
+        $report = $this->getReportWithNoViolation();
+        $report->expects($this->once())
+            ->method('getRuleViolations')
+            ->will($this->returnValue(new \ArrayIterator($violations)));
+        $report->expects($this->once())
+            ->method('getErrors')
+            ->will($this->returnValue(new \ArrayIterator(array())));
+
+        $renderer = new GitLabRenderer();
+        $renderer->setWriter($writer);
+
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        $this->assertJsonEquals(
+            $writer->getData(),
+            'renderer/gitlab_renderer_expected.json'
+        );
+    }
+
+    /**
+     * testRendererAddsProcessingErrorsToGitLabReport
+     *
+     * @return void
+     */
+    public function testRendererAddsProcessingErrorsToGitLabReport()
+    {
+        $writer = new WriterStub();
+
+        $processingErrors = array(
+            new ProcessingError('Failed for file "/tmp/foo.php".'),
+            new ProcessingError('Failed for file "/tmp/bar.php".'),
+            new ProcessingError('Failed for file "/tmp/baz.php".'),
+            new ProcessingError('Cannot read file "/tmp/foo.php". Permission denied.'),
+        );
+
+        $report = $this->getReportWithNoViolation();
+        $report->expects($this->once())
+            ->method('getRuleViolations')
+            ->will($this->returnValue(new \ArrayIterator(array())));
+        $report->expects($this->once())
+            ->method('getErrors')
+            ->will($this->returnValue(new \ArrayIterator($processingErrors)));
+
+        $renderer = new GitLabRenderer();
+        $renderer->setWriter($writer);
+
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        $this->assertJsonEquals(
+            $writer->getData(),
+            'renderer/gitlab_renderer_processing_errors.json'
+        );
+    }
+}

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -277,7 +277,7 @@ class CommandLineOptionsTest extends AbstractTest
         $opts = new CommandLineOptions($args);
 
         $this->assertContains(
-            'Available formats: ansi, baseline, checkstyle, github, html, json, sarif, text, xml.',
+            'Available formats: ansi, baseline, checkstyle, github, gitlab, html, json, sarif, text, xml.',
             $opts->usage()
         );
     }

--- a/src/test/resources/files/renderer/gitlab_renderer_expected.json
+++ b/src/test/resources/files/renderer/gitlab_renderer_expected.json
@@ -1,0 +1,56 @@
+[
+  {
+    "type": "issue",
+    "categories": [
+      "Style",
+      "PHP"
+    ],
+    "check_name": "RuleStub",
+    "fingerprint": "\/bar.php:23:RuleStub",
+    "description": "Test description",
+    "severity": "minor",
+    "location": {
+      "path": "\/bar.php",
+      "lines": {
+        "begin": 23,
+        "end": 42
+      }
+    }
+  },
+  {
+    "type": "issue",
+    "categories": [
+      "Style",
+      "PHP"
+    ],
+    "check_name": "RuleStub",
+    "fingerprint": "\/bar.php:23:RuleStub",
+    "description": "Test description",
+    "severity": "minor",
+    "location": {
+      "path": "\/bar.php",
+      "lines": {
+        "begin": 23,
+        "end": 42
+      }
+    }
+  },
+  {
+    "type": "issue",
+    "categories": [
+      "Style",
+      "PHP"
+    ],
+    "check_name": "RuleStub",
+    "fingerprint": "\/foo.php:23:RuleStub",
+    "description": "Test description",
+    "severity": "minor",
+    "location": {
+      "path": "\/foo.php",
+      "lines": {
+        "begin": 23,
+        "end": 42
+      }
+    }
+  }
+]

--- a/src/test/resources/files/renderer/gitlab_renderer_expected.json
+++ b/src/test/resources/files/renderer/gitlab_renderer_expected.json
@@ -24,11 +24,11 @@
       "PHP"
     ],
     "check_name": "RuleStub",
-    "fingerprint": "\/bar.php:23:RuleStub",
+    "fingerprint": "\/foo.php:23:RuleStub",
     "description": "Test description",
     "severity": "minor",
     "location": {
-      "path": "\/bar.php",
+      "path": "\/foo.php",
       "lines": {
         "begin": 23,
         "end": 42
@@ -42,11 +42,11 @@
       "PHP"
     ],
     "check_name": "RuleStub",
-    "fingerprint": "\/foo.php:23:RuleStub",
+    "fingerprint": "\/bar.php:23:RuleStub",
     "description": "Test description",
     "severity": "minor",
     "location": {
-      "path": "\/foo.php",
+      "path": "\/bar.php",
       "lines": {
         "begin": 23,
         "end": 42

--- a/src/test/resources/files/renderer/gitlab_renderer_processing_errors.json
+++ b/src/test/resources/files/renderer/gitlab_renderer_processing_errors.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "Failed for file \u0022\/tmp\/foo.php\u0022.",
+    "fingerprint": "/tmp/foo.php:0:MajorErrorInFile",
+    "severity": "major",
+    "location": {
+      "path": "/tmp/foo.php",
+      "lines": {
+        "begin": 0
+      }
+    }
+  }
+]

--- a/src/test/resources/files/renderer/gitlab_renderer_processing_errors.json
+++ b/src/test/resources/files/renderer/gitlab_renderer_processing_errors.json
@@ -1,10 +1,43 @@
 [
   {
     "description": "Failed for file \u0022\/tmp\/foo.php\u0022.",
-    "fingerprint": "/tmp/foo.php:0:MajorErrorInFile",
+    "fingerprint": "\/tmp\/foo.php:0:MajorErrorInFile",
     "severity": "major",
     "location": {
-      "path": "/tmp/foo.php",
+      "path": "\/tmp\/foo.php",
+      "lines": {
+        "begin": 0
+      }
+    }
+  },
+  {
+    "description": "Failed for file \u0022\/tmp\/bar.php\u0022.",
+    "fingerprint": "\/tmp\/bar.php:0:MajorErrorInFile",
+    "severity": "major",
+    "location": {
+      "path": "\/tmp\/bar.php",
+      "lines": {
+        "begin": 0
+      }
+    }
+  },
+  {
+    "description": "Failed for file \u0022\/tmp\/baz.php\u0022.",
+    "fingerprint": "\/tmp\/baz.php:0:MajorErrorInFile",
+    "severity": "major",
+    "location": {
+      "path": "\/tmp\/baz.php",
+      "lines": {
+        "begin": 0
+      }
+    }
+  },
+  {
+    "description": "Cannot read file \u0022\/tmp\/foo.php\u0022. Permission denied.",
+    "fingerprint": "\/tmp\/foo.php:0:MajorErrorInFile",
+    "severity": "major",
+    "location": {
+      "path": "\/tmp\/foo.php",
       "lines": {
         "begin": 0
       }


### PR DESCRIPTION
Type: feature
Issue: Resolves #955 (Add Gitlab renderer for Gitlab CI)
Breaking change: no

## Description
There is a Github renderer at the moment, so it only makes sense to also add a Gitlab version. There are some ways to convert the json output, but that also requires additional software to parse the json output and nobody wants that kind of strain on the runners.

As far as i can tell the output should look something like this:

```json
[
  {
    "type": "issue",
    "categories": [
      "Style",
      "PHP"
    ],
    "check_name": "ExcessiveClassComplexity",
    "fingerprint": "/var/www/html/app/SomeFile.php:31:ExcessiveClassComplexity",
    "description": "The class SomeFile has an overall complexity of 51 which is very high. The configured complexity threshold is 50.",
    "severity": "unknown",
    "location": {
      "path": "/var/www/html/app/SomeFile.php",
      "lines": {
        "begin": 31,
        "end": 2772
      }
    }
  },
]
```
