### PR TITLE
Add missing github & gitlab reportfile options

### DIFF
--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -245,12 +245,14 @@ class CommandLineOptions
                     $this->ignoreViolationsOnExit = true;
                     break;
                 case '--reportfile-checkstyle':
+                case '--reportfile-github':
+                case '--reportfile-gitlab':
                 case '--reportfile-html':
                 case '--reportfile-json':
                 case '--reportfile-sarif':
                 case '--reportfile-text':
                 case '--reportfile-xml':
-                    preg_match('(^\-\-reportfile\-(checkstyle|html|json|sarif|text|xml)$)', $arg, $match);
+                    preg_match('(^\-\-reportfile\-(checkstyle|github|gitlab|html|json|sarif|text|xml)$)', $arg, $match);
                     $this->reportFiles[$match[1]] = array_shift($args);
                     break;
                 default:

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -582,7 +582,7 @@ class CommandLineOptionsTest extends AbstractTest
                     'xml' => __FILE__,
                     'html' => __FILE__,
                     'github' => __FILE__,
-                    'gitlab' => __FILE__
+                    'gitlab' => __FILE__,
                 ),
             ),
         );

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -557,6 +557,14 @@ class CommandLineOptionsTest extends AbstractTest
                 array('text' => __FILE__),
             ),
             array(
+                array('--reportfile-github', __FILE__),
+                array('github' => __FILE__),
+            ),
+            array(
+                array('--reportfile-gitlab', __FILE__),
+                array('gitlab' => __FILE__),
+            ),
+            array(
                 array(
                     '--reportfile-text',
                     __FILE__,
@@ -564,8 +572,18 @@ class CommandLineOptionsTest extends AbstractTest
                     __FILE__,
                     '--reportfile-html',
                     __FILE__,
+                    '--reportfile-github',
+                    __FILE__,
+                    '--reportfile-gitlab',
+                    __FILE__,
                 ),
-                array('text' => __FILE__, 'xml' => __FILE__, 'html' => __FILE__),
+                array(
+                    'text' => __FILE__,
+                    'xml' => __FILE__,
+                    'html' => __FILE__,
+                    'github' => __FILE__,
+                    'gitlab' => __FILE__
+                ),
             ),
         );
     }


### PR DESCRIPTION
Type: bugfix / feature
Fix #977
Breaking change: no 

The new supported reports for gitlab and github are missing from the `--reportfile-` Command line option. I found this issue when I wanted to report using ansi in the command line and export a report file for gitlab's CI. This is useful for end-users as the CI shows a nice report using `ansi` and the artifact generated by the --reportfile can be parsed by Github/Gitlab

This MR fixes the missing --report-file option for both gitlab and github.

**Before MR:**
```
phpmd app,tests ansi ./phpmd-ruleset.xml --reportfile-github report-github.json --reportfile-gitlab report-gitlab.json
```
No report-github.json or report-gitlab.json was created.

**After MR:**
```
phpmd app,tests ansi ./phpmd-ruleset.xml --reportfile-github report-github.json --reportfile-gitlab report-gitlab.json
```
report-gitlab.json is created with `gitlab` as report render.
report-github.json is created with `github` as report render.

