### PR TITLE
Update docs: filename/directory in CLI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,11 +16,11 @@ https://phpmd.org
 .. image:: https://ci.appveyor.com/api/projects/status/pc08owbun2y00kwk?svg=true
    :target: https://ci.appveyor.com/project/phpmd/phpmd
    :alt: AppVeyor Build Status
-   
-.. image:: https://codecov.io/gh/phpmd/phpmd/branch/master/graph/badge.svg?token=XrBrvTLJeE 
+
+.. image:: https://codecov.io/gh/phpmd/phpmd/branch/master/graph/badge.svg?token=XrBrvTLJeE
    :target: https://codecov.io/gh/phpmd/phpmd
    :alt: Codecov Status
- 
+
 .. image:: https://scrutinizer-ci.com/g/phpmd/phpmd/badges/build.png?b=master
    :target: https://scrutinizer-ci.com/g/phpmd/phpmd/build-status/master
    :alt: Scrutinizer Build Status
@@ -49,7 +49,7 @@ See https://phpmd.org/download/index.html
 Command line usage
 ------------------
 
-Type ``phpmd [filename|directory] [report format] [ruleset file]``, i.e: ::
+Type ``phpmd [filename|directory[,filename|directory[,...]]] [report format] [ruleset file]``, i.e: ::
 
   mapi@arwen ~ $ phpmd php/PDepend/DbusUI/ xml rulesets.xml
 
@@ -95,8 +95,8 @@ The xml report would like like this:
     </file>
   </pmd>
 
-You can pass a file name or a directory name containing PHP source
-code to PHPMD.
+You can pass a comma-separated string with list of file names
+or a directory names, containing PHP source code to PHPMD.
 
 The `PHPMD Phar distribution`__ includes the rule set files inside
 its archive, even if the "rulesets/codesize.xml" parameter above looks

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -2,7 +2,7 @@
 Command line usage
 ==================
 
-Type phpmd [filename|directory] [report format] [ruleset file], i.e: ::
+Type phpmd [filename|directory[,filename|directory[,...]]] [report format] [ruleset file], i.e: ::
 
   mapi@arwen ~ $ phpmd PHP/Depend/DbusUI/ xml rulesets/codesize.xml
   <?xml version="1.0" encoding="UTF-8" ?>
@@ -20,8 +20,8 @@ Type phpmd [filename|directory] [report format] [ruleset file], i.e: ::
     </file>
   </pmd>
 
-You can pass a file name or a directory name containing PHP source
-code to PHPMD.
+You can pass a comma-separated string with list of file names
+or a directory names, containing PHP source code to PHPMD.
 
 The PHPMD Phar distribution includes the rule set files inside
 its archive, even if the "rulesets/codesize.xml" parameter above looks


### PR DESCRIPTION
**Type:** documentation update
**Issue:** Resolves #989
**Breaking change:** no

Documentation update regarding filename/directory in PHPMD command line.
