### PR TITLE
fix: global import from an array value

### DIFF
--- a/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
@@ -89,6 +89,6 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
      */
     protected function isGlobalNamespace(ASTNode $classNode)
     {
-        return !strpos($classNode->getImage(), '\\', 1);
+        return $classNode->getImage() !== '' && !strpos($classNode->getImage(), '\\', 1);
     }
 }

--- a/src/test/resources/files/Rule/CleanCode/MissingImport/testRuleAppliesToFunctionWithNotImportedDependencies.php
+++ b/src/test/resources/files/Rule/CleanCode/MissingImport/testRuleAppliesToFunctionWithNotImportedDependencies.php
@@ -20,4 +20,8 @@ namespace PHPMDTest;
 function testRuleAppliesToFunctionWithNotImportedDependencies()
 {
     $a = new \stdClass();
+
+    // Using an array value as a classname can break the code, as the node will not be an ASTClass*
+    $classes = array('\stdClass');
+    $b = new $classes[0];
 }


### PR DESCRIPTION
Type: bugfix
Breaking change: no 

This PR fixes a PHP issue when running the following code with the `MissingImport`'s `ignore-global` option enabled:

```php
$classes = ['\stdClass'];
$b = new $classes[0];
```

The error:

```
ValueError: strpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack)

src/main/php/PHPMD/Rule/CleanCode/MissingImport.php:92
```

The reason:

In this case, the current ASTNode will be a `PDepend\Source\AST\ASTArrayIndexExpression`, and `$classNode->getImage()` will return an empty string 