### PR TITLE
Add dev as keyword to the composer.json file 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "phpmd/phpmd",
   "description": "PHPMD is a spin-off project of PHP Depend and aims to be a PHP equivalent of the well known Java tool PMD.",
   "keywords": [
+    "dev",
     "phpmd",
     "pdepend",
     "pmd",


### PR DESCRIPTION
Add dev as keyword to the composer.json file to suggest to install it as a require-dev package.

See: https://github.com/composer/composer/pull/10960

Type:feature 
Issue: Resolves none
Breaking change: no

With adding dev as keyword composer will suggest it as dev package if someone install it with composer require without --dev.