### PR TITLE
Add debug information to cache results

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,10 @@ Command line options
 
 - The command line interface also accepts the following optional arguments:
 
+  - ``-v, -vv, -vvv`` - The output verbosity level. Will print more information
+    what is being processed or cached. Will be send to ``STDERR`` to not interfere
+    with report output.
+
   - ``--minimumpriority`` - The rule priority threshold; rules with lower
     priority than they will not be used.
 

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -2,20 +2,20 @@
 
 namespace PHPMD\Cache;
 
+use PHPMD\Console\OutputInterface;
 use PHPMD\RuleSet;
 use PHPMD\TextUI\CommandLineOptions;
-use PHPMD\Utility\Output;
 
 class ResultCacheEngineFactory
 {
-    /** @var Output */
+    /** @var OutputInterface */
     private $output;
     /** @var ResultCacheKeyFactory */
     private $cacheKeyFactory;
     /** @var ResultCacheStateFactory */
     private $cacheStateFactory;
 
-    public function __construct(Output $output, ResultCacheKeyFactory $cacheKeyFactory, ResultCacheStateFactory $cacheStateFactory)
+    public function __construct(OutputInterface $output, ResultCacheKeyFactory $cacheKeyFactory, ResultCacheStateFactory $cacheStateFactory)
     {
         $this->output            = $output;
         $this->cacheKeyFactory   = $cacheKeyFactory;
@@ -30,7 +30,7 @@ class ResultCacheEngineFactory
     public function create($basePath, CommandLineOptions $options, array $ruleSetList)
     {
         if ($options->isCacheEnabled() === false) {
-            $this->output->writeln('Cache is not enabled.', Output::VERBOSITY_VERY_VERBOSE);
+            $this->output->writeln('Cache is not enabled.', OutputInterface::VERBOSITY_VERY_VERBOSE);
             return null;
         }
 
@@ -40,18 +40,24 @@ class ResultCacheEngineFactory
         // load result cache from file
         $state = $this->cacheStateFactory->fromFile($options->cacheFile());
         if ($state === null) {
-            $this->output->writeln('Cache is enabled, but no prior cache-result file exists.', Output::VERBOSITY_VERY_VERBOSE);
+            $this->output->writeln(
+                'Cache is enabled, but no prior cache-result file exists.',
+                OutputInterface::VERBOSITY_VERY_VERBOSE
+            );
         }
 
         // the cache key doesn't match the stored cache key. Invalidate cache
         if ($state !== null && $state->getCacheKey()->isEqualTo($cacheKey) === false) {
-            $this->output->writeln('Cache is enabled, but the cache metadata doesnt match.', Output::VERBOSITY_VERY_VERBOSE);
+            $this->output->writeln(
+                'Cache is enabled, but the cache metadata doesnt match.',
+                OutputInterface::VERBOSITY_VERY_VERBOSE
+            );
             $state = null;
         }
 
         return new ResultCacheEngine(
             new ResultCacheFileFilter($basePath, $options->cacheStrategy(), $cacheKey, $state),
-            new ResultCacheUpdater($basePath),
+            new ResultCacheUpdater($this->output, $basePath),
             new ResultCacheWriter($options->cacheFile())
         );
     }

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -16,9 +16,10 @@ class ResultCacheEngineFactory
     private $cacheStateFactory;
 
     public function __construct(
-        OutputInterface $output,
-        ResultCacheKeyFactory $cacheKeyFactory,
-        ResultCacheStateFactory $cacheStateFactory)
+        OutputInterface         $output,
+        ResultCacheKeyFactory   $cacheKeyFactory,
+        ResultCacheStateFactory $cacheStateFactory
+    )
     {
         $this->output            = $output;
         $this->cacheKeyFactory   = $cacheKeyFactory;

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -15,7 +15,10 @@ class ResultCacheEngineFactory
     /** @var ResultCacheStateFactory */
     private $cacheStateFactory;
 
-    public function __construct(OutputInterface $output, ResultCacheKeyFactory $cacheKeyFactory, ResultCacheStateFactory $cacheStateFactory)
+    public function __construct(
+        OutputInterface $output,
+        ResultCacheKeyFactory $cacheKeyFactory,
+        ResultCacheStateFactory $cacheStateFactory)
     {
         $this->output            = $output;
         $this->cacheKeyFactory   = $cacheKeyFactory;

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -4,16 +4,20 @@ namespace PHPMD\Cache;
 
 use PHPMD\RuleSet;
 use PHPMD\TextUI\CommandLineOptions;
+use PHPMD\Utility\Output;
 
 class ResultCacheEngineFactory
 {
+    /** @var Output */
+    private $output;
     /** @var ResultCacheKeyFactory */
     private $cacheKeyFactory;
     /** @var ResultCacheStateFactory */
     private $cacheStateFactory;
 
-    public function __construct(ResultCacheKeyFactory $cacheKeyFactory, ResultCacheStateFactory $cacheStateFactory)
+    public function __construct(Output $output, ResultCacheKeyFactory $cacheKeyFactory, ResultCacheStateFactory $cacheStateFactory)
     {
+        $this->output            = $output;
         $this->cacheKeyFactory   = $cacheKeyFactory;
         $this->cacheStateFactory = $cacheStateFactory;
     }
@@ -26,6 +30,7 @@ class ResultCacheEngineFactory
     public function create($basePath, CommandLineOptions $options, array $ruleSetList)
     {
         if ($options->isCacheEnabled() === false) {
+            $this->output->writeln('Cache is not enabled.', Output::VERBOSITY_VERY_VERBOSE);
             return null;
         }
 
@@ -34,9 +39,13 @@ class ResultCacheEngineFactory
 
         // load result cache from file
         $state = $this->cacheStateFactory->fromFile($options->cacheFile());
+        if ($state === null) {
+            $this->output->writeln('Cache is enabled, but no prior cache-result file exists.', Output::VERBOSITY_VERY_VERBOSE);
+        }
 
         // the cache key doesn't match the stored cache key. Invalidate cache
         if ($state !== null && $state->getCacheKey()->isEqualTo($cacheKey) === false) {
+            $this->output->writeln('Cache is enabled, but the cache metadata doesnt match.', Output::VERBOSITY_VERY_VERBOSE);
             $state = null;
         }
 

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -30,7 +30,7 @@ class ResultCacheEngineFactory
     public function create($basePath, CommandLineOptions $options, array $ruleSetList)
     {
         if ($options->isCacheEnabled() === false) {
-            $this->output->writeln('Cache is not enabled.', OutputInterface::VERBOSITY_VERY_VERBOSE);
+            $this->output->writeln('ResultCache is not enabled.', OutputInterface::VERBOSITY_VERY_VERBOSE);
             return null;
         }
 
@@ -41,7 +41,7 @@ class ResultCacheEngineFactory
         $state = $this->cacheStateFactory->fromFile($options->cacheFile());
         if ($state === null) {
             $this->output->writeln(
-                'Cache is enabled, but no prior cache-result file exists.',
+                'ResultCache is enabled, but no prior cache-result file exists.',
                 OutputInterface::VERBOSITY_VERY_VERBOSE
             );
         }
@@ -49,10 +49,15 @@ class ResultCacheEngineFactory
         // the cache key doesn't match the stored cache key. Invalidate cache
         if ($state !== null && $state->getCacheKey()->isEqualTo($cacheKey) === false) {
             $this->output->writeln(
-                'Cache is enabled, but the cache metadata doesnt match.',
+                'ResultCache is enabled, but the cache metadata doesn\'t match.',
                 OutputInterface::VERBOSITY_VERY_VERBOSE
             );
             $state = null;
+        } else {
+            $this->output->writeln(
+                'ResultCache is enabled, and read from ' . $options->cacheFile(),
+                OutputInterface::VERBOSITY_VERY_VERBOSE
+            );
         }
 
         return new ResultCacheEngine(

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -56,7 +56,7 @@ class ResultCacheEngineFactory
         }
 
         return new ResultCacheEngine(
-            new ResultCacheFileFilter($basePath, $options->cacheStrategy(), $cacheKey, $state),
+            new ResultCacheFileFilter($this->output, $basePath, $options->cacheStrategy(), $cacheKey, $state),
             new ResultCacheUpdater($this->output, $basePath),
             new ResultCacheWriter($options->cacheFile())
         );

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -19,8 +19,7 @@ class ResultCacheEngineFactory
         OutputInterface         $output,
         ResultCacheKeyFactory   $cacheKeyFactory,
         ResultCacheStateFactory $cacheStateFactory
-    )
-    {
+    ) {
         $this->output            = $output;
         $this->cacheKeyFactory   = $cacheKeyFactory;
         $this->cacheStateFactory = $cacheStateFactory;

--- a/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
@@ -5,6 +5,7 @@ namespace PHPMD\Cache;
 use PDepend\Input\Filter;
 use PHPMD\Cache\Model\ResultCacheKey;
 use PHPMD\Cache\Model\ResultCacheState;
+use PHPMD\Console\OutputInterface;
 use PHPMD\Utility\Paths;
 
 class ResultCacheFileFilter implements Filter
@@ -24,14 +25,18 @@ class ResultCacheFileFilter implements Filter
     /** @var array<string, bool> */
     private $fileIsModified = array();
 
+    /** @var OutputInterface */
+    private $output;
+
 
     /**
      * @param string                $basePath
      * @param string                $strategy
      * @param ResultCacheState|null $state
      */
-    public function __construct($basePath, $strategy, ResultCacheKey $cacheKey, $state)
+    public function __construct(OutputInterface $output, $basePath, $strategy, ResultCacheKey $cacheKey, $state)
     {
+        $this->output   = $output;
         $this->basePath = $basePath;
         $this->strategy = $strategy;
         $this->state    = $state;
@@ -70,6 +75,18 @@ class ResultCacheFileFilter implements Filter
         if ($isModified === false) {
             // File was not modified, transfer previous violations
             $this->newState->setViolations($filePath, $this->state->getViolations($filePath));
+        }
+
+        if ($isModified) {
+            $this->output->writeln(
+                'Cache: ' . $filePath . ' is modified since last run and will be inspected.',
+                OutputInterface::VERBOSITY_DEBUG
+            );
+        } else {
+            $this->output->writeln(
+                'Cache: ' . $filePath . ' is not modified and will not be inspected.',
+                OutputInterface::VERBOSITY_DEBUG
+            );
         }
 
         return $this->fileIsModified[$filePath] = $isModified;

--- a/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
@@ -79,12 +79,12 @@ class ResultCacheFileFilter implements Filter
 
         if ($isModified) {
             $this->output->writeln(
-                'Cache: ' . $filePath . ' is modified since last run and will be inspected.',
+                'Cache: MISS for file ' . $filePath . '.',
                 OutputInterface::VERBOSITY_DEBUG
             );
         } else {
             $this->output->writeln(
-                'Cache: ' . $filePath . ' is not modified and will not be inspected.',
+                'Cache: HIT for file ' . $filePath . '.',
                 OutputInterface::VERBOSITY_DEBUG
             );
         }

--- a/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
@@ -5,18 +5,22 @@ namespace PHPMD\Cache;
 use PHPMD\Cache\Model\ResultCacheState;
 use PHPMD\Report;
 use PHPMD\RuleSet;
+use PHPMD\Utility\Output;
 use PHPMD\Utility\Paths;
 
 class ResultCacheUpdater
 {
+    /** @var Output */
+    private $output;
     /** @var string */
     private $basePath;
 
     /**
      * @param string $basePath
      */
-    public function __construct($basePath)
+    public function __construct(Output $output, $basePath)
     {
+        $this->output   = $output;
         $this->basePath = $basePath;
     }
 
@@ -30,8 +34,11 @@ class ResultCacheUpdater
         $newViolations = $report->getRuleViolations();
 
         // add RuleViolations from the result cache to the report
+        $violationsFromCache = 0;
+
         foreach ($state->getRuleViolations($this->basePath, $ruleSetList) as $ruleViolation) {
             $report->addRuleViolation($ruleViolation);
+            ++$violationsFromCache;
         }
 
         // add violations from the report to the result cache
@@ -39,6 +46,9 @@ class ResultCacheUpdater
             $filePath = Paths::getRelativePath($this->basePath, $violation->getFileName());
             $state->addRuleViolation($filePath, $violation);
         }
+
+        $this->output->writeln('Cache: added ' . count($newViolations) . ' to the result cache.', Output::VERBOSITY_VERY_VERBOSE);
+        $this->output->writeln('Cache: added ' . $violationsFromCache . ' from the result cache to the report.', Output::VERBOSITY_VERY_VERBOSE);
 
         return $state;
     }

--- a/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
@@ -3,14 +3,14 @@
 namespace PHPMD\Cache;
 
 use PHPMD\Cache\Model\ResultCacheState;
+use PHPMD\Console\OutputInterface;
 use PHPMD\Report;
 use PHPMD\RuleSet;
-use PHPMD\Utility\Output;
 use PHPMD\Utility\Paths;
 
 class ResultCacheUpdater
 {
-    /** @var Output */
+    /** @var OutputInterface */
     private $output;
     /** @var string */
     private $basePath;
@@ -18,7 +18,7 @@ class ResultCacheUpdater
     /**
      * @param string $basePath
      */
-    public function __construct(Output $output, $basePath)
+    public function __construct(OutputInterface $output, $basePath)
     {
         $this->output   = $output;
         $this->basePath = $basePath;
@@ -49,11 +49,11 @@ class ResultCacheUpdater
 
         $this->output->writeln(
             'Cache: added ' . count($newViolations) . ' violations to the result cache.',
-            Output::VERBOSITY_VERY_VERBOSE
+            OutputInterface::VERBOSITY_VERY_VERBOSE
         );
         $this->output->writeln(
             'Cache: added ' . $violationsFromCache . ' violations from the result cache to the report.',
-            Output::VERBOSITY_VERY_VERBOSE
+            OutputInterface::VERBOSITY_VERY_VERBOSE
         );
 
         return $state;

--- a/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
@@ -47,8 +47,14 @@ class ResultCacheUpdater
             $state->addRuleViolation($filePath, $violation);
         }
 
-        $this->output->writeln('Cache: added ' . count($newViolations) . ' to the result cache.', Output::VERBOSITY_VERY_VERBOSE);
-        $this->output->writeln('Cache: added ' . $violationsFromCache . ' from the result cache to the report.', Output::VERBOSITY_VERY_VERBOSE);
+        $this->output->writeln(
+            'Cache: added ' . count($newViolations) . ' violations to the result cache.',
+            Output::VERBOSITY_VERY_VERBOSE
+        );
+        $this->output->writeln(
+            'Cache: added ' . $violationsFromCache . ' violations from the result cache to the report.',
+            Output::VERBOSITY_VERY_VERBOSE
+        );
 
         return $state;
     }

--- a/src/main/php/PHPMD/Console/NullOutput.php
+++ b/src/main/php/PHPMD/Console/NullOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PHPMD\Console;
+
+class NullOutput extends Output
+{
+    /**
+     * @inheritDoc
+     */
+    protected function doWrite($message)
+    {
+        // do nothing
+    }
+}

--- a/src/main/php/PHPMD/Console/Output.php
+++ b/src/main/php/PHPMD/Console/Output.php
@@ -1,32 +1,17 @@
 <?php
 
-namespace PHPMD\Utility;
+namespace PHPMD\Console;
 
-/**
- * A basic write-to-stream output class. Follows a partial implementation of Symfony's OutputInterface to allow future drop-in replacement
- * by the Console package.
- */
-class Output
+abstract class Output implements OutputInterface
 {
-    const VERBOSITY_QUIET        = 16;
-    const VERBOSITY_NORMAL       = 32;
-    const VERBOSITY_VERBOSE      = 64;
-    const VERBOSITY_VERY_VERBOSE = 128;
-    const VERBOSITY_DEBUG        = 256;
-
-    /** @var resource */
-    private $stream;
-
     /** @var int */
     private $verbosity;
 
     /**
-     * @param resource $stream
-     * @param int      $verbosity
+     * @param int $verbosity
      */
-    public function __construct($stream, $verbosity = self::VERBOSITY_NORMAL)
+    public function __construct($verbosity = self::VERBOSITY_NORMAL)
     {
-        $this->stream    = $stream;
         $this->verbosity = $verbosity;
     }
 
@@ -55,7 +40,7 @@ class Output
         }
 
         foreach ($messages as $message) {
-            fwrite($this->stream, $message . ($newline ? "\n" : ""));
+            $this->doWrite($message . ($newline ? "\n" : ""));
         }
     }
 
@@ -86,4 +71,10 @@ class Output
     {
         return $this->verbosity;
     }
+
+    /**
+     * @param string $message
+     * @return void
+     */
+    abstract protected function doWrite($message);
 }

--- a/src/main/php/PHPMD/Console/OutputInterface.php
+++ b/src/main/php/PHPMD/Console/OutputInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace PHPMD\Console;
+
+/**
+ * A basic OutputInterface that follows a partial implementation of Symfony's OutputInterface to allow future drop-in replacement
+ * by the Console package.
+ */
+interface OutputInterface
+{
+    const VERBOSITY_QUIET        = 16;
+    const VERBOSITY_NORMAL       = 32;
+    const VERBOSITY_VERBOSE      = 64;
+    const VERBOSITY_VERY_VERBOSE = 128;
+    const VERBOSITY_DEBUG        = 256;
+
+    /**
+     * @param string|string[] $messages
+     * @param bool            $newline
+     * @param int             $options A bitmask of options (one of the VERBOSITY constants),
+     *                                 0 is considered the same as self::VERBOSITY_NORMAL
+     * @return void
+     */
+    public function write($messages, $newline = false, $options = self::VERBOSITY_NORMAL);
+
+    /**
+     * @param string|string[] $messages
+     * @param int             $options A bitmask of options (one of the VERBOSITY constants),
+     *                                 0 is considered the same as self::VERBOSITY_NORMAL
+     * @return void
+     */
+    public function writeln($messages, $options = self::VERBOSITY_NORMAL);
+
+    /**
+     * @param int $level
+     * @return void
+     */
+    public function setVerbosity($level);
+
+    /**
+     * @return int
+     */
+    public function getVerbosity();
+}

--- a/src/main/php/PHPMD/Console/OutputInterface.php
+++ b/src/main/php/PHPMD/Console/OutputInterface.php
@@ -3,8 +3,8 @@
 namespace PHPMD\Console;
 
 /**
- * A basic OutputInterface that follows a partial implementation of Symfony's OutputInterface to allow future drop-in replacement
- * by the Console package.
+ * A basic OutputInterface that follows a partial implementation of Symfony's OutputInterface to allow future drop-in
+ * replacement by the Console package.
  */
 interface OutputInterface
 {

--- a/src/main/php/PHPMD/Console/StreamOutput.php
+++ b/src/main/php/PHPMD/Console/StreamOutput.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PHPMD\Console;
+
+class StreamOutput extends Output
+{
+    /** @var resource */
+    private $stream;
+
+    /**
+     * @param resource $stream
+     */
+    public function __construct($stream, $verbosity = self::VERBOSITY_NORMAL)
+    {
+        parent::__construct($verbosity);
+        $this->stream = $stream;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function doWrite($message)
+    {
+        fwrite($this->stream, $message);
+    }
+}

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -25,7 +25,6 @@ use PHPMD\Cache\ResultCacheEngineFactory;
 use PHPMD\Cache\ResultCacheKeyFactory;
 use PHPMD\Cache\ResultCacheStateFactory;
 use PHPMD\Console\Output;
-use PHPMD\Console\OutputInterface;
 use PHPMD\Console\StreamOutput;
 use PHPMD\PHPMD;
 use PHPMD\Renderer\RendererFactory;
@@ -207,10 +206,7 @@ class Command
         try {
             $ruleSetFactory = new RuleSetFactory();
             $options        = new CommandLineOptions($args, $ruleSetFactory->listAvailableRuleSets());
-            $output         = new StreamOutput(
-                fopen("php://output", 'wb'),
-                $options->isDebug() ? OutputInterface::VERBOSITY_VERY_VERBOSE : OutputInterface::VERBOSITY_NORMAL
-            );
+            $output         = new StreamOutput(fopen("php://output", 'wb'), $options->getVerbosity());
             $command        = new Command($output);
 
             $exitCode = $command->run($options, $ruleSetFactory);

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -206,7 +206,7 @@ class Command
         try {
             $ruleSetFactory = new RuleSetFactory();
             $options        = new CommandLineOptions($args, $ruleSetFactory->listAvailableRuleSets());
-            $output         = new StreamOutput(fopen("php://output", 'wb'), $options->getVerbosity());
+            $output         = new StreamOutput(STDERR, $options->getVerbosity());
             $command        = new Command($output);
 
             $exitCode = $command->run($options, $ruleSetFactory);

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -28,6 +28,7 @@ use PHPMD\PHPMD;
 use PHPMD\Renderer\RendererFactory;
 use PHPMD\Report;
 use PHPMD\RuleSetFactory;
+use PHPMD\Utility\Output;
 use PHPMD\Utility\Paths;
 use PHPMD\Writer\StreamWriter;
 
@@ -43,6 +44,14 @@ class Command
         EXIT_EXCEPTION = 1,
         EXIT_VIOLATION = 2,
         EXIT_ERROR = 3;
+
+    /** @var Output */
+    private $output;
+
+    public function __construct(Output $output)
+    {
+        $this->output = $output;
+    }
 
     /**
      * This method creates a PHPMD instance and configures this object based
@@ -138,6 +147,7 @@ class Command
         // Configure Result Cache Engine
         if ($opts->generateBaseline() === BaselineMode::NONE) {
             $cacheEngineFactory = new ResultCacheEngineFactory(
+                $this->output,
                 new ResultCacheKeyFactory(getcwd(), $baselineFile),
                 new ResultCacheStateFactory()
             );
@@ -195,7 +205,8 @@ class Command
         try {
             $ruleSetFactory = new RuleSetFactory();
             $options        = new CommandLineOptions($args, $ruleSetFactory->listAvailableRuleSets());
-            $command        = new Command();
+            $output         = new Output(fopen("php://output", 'wb'), $options->isDebug() ? Output::VERBOSITY_VERY_VERBOSE : Output::VERBOSITY_NORMAL);
+            $command        = new Command($output);
 
             $exitCode = $command->run($options, $ruleSetFactory);
         } catch (\Exception $e) {

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -24,11 +24,13 @@ use PHPMD\Baseline\BaselineValidator;
 use PHPMD\Cache\ResultCacheEngineFactory;
 use PHPMD\Cache\ResultCacheKeyFactory;
 use PHPMD\Cache\ResultCacheStateFactory;
+use PHPMD\Console\Output;
+use PHPMD\Console\OutputInterface;
+use PHPMD\Console\StreamOutput;
 use PHPMD\PHPMD;
 use PHPMD\Renderer\RendererFactory;
 use PHPMD\Report;
 use PHPMD\RuleSetFactory;
-use PHPMD\Utility\Output;
 use PHPMD\Utility\Paths;
 use PHPMD\Writer\StreamWriter;
 
@@ -205,7 +207,10 @@ class Command
         try {
             $ruleSetFactory = new RuleSetFactory();
             $options        = new CommandLineOptions($args, $ruleSetFactory->listAvailableRuleSets());
-            $output         = new Output(fopen("php://output", 'wb'), $options->isDebug() ? Output::VERBOSITY_VERY_VERBOSE : Output::VERBOSITY_NORMAL);
+            $output         = new StreamOutput(
+                fopen("php://output", 'wb'),
+                $options->isDebug() ? OutputInterface::VERBOSITY_VERY_VERBOSE : OutputInterface::VERBOSITY_NORMAL
+            );
             $command        = new Command($output);
 
             $exitCode = $command->run($options, $ruleSetFactory);

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -432,6 +432,14 @@ class CommandLineOptions
     }
 
     /**
+     * @return bool
+     */
+    public function isDebug()
+    {
+        return $this->debug;
+    }
+
+    /**
      * Should the current violations be baselined
      *
      * @return string

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -20,6 +20,7 @@ namespace PHPMD\TextUI;
 use InvalidArgumentException;
 use PHPMD\Baseline\BaselineMode;
 use PHPMD\Cache\Model\ResultCacheStrategy;
+use PHPMD\Console\OutputInterface;
 use PHPMD\Renderer\AnsiRenderer;
 use PHPMD\Renderer\CheckStyleRenderer;
 use PHPMD\Renderer\GitHubRenderer;
@@ -131,8 +132,8 @@ class CommandLineOptions
      */
     protected $strict = false;
 
-    /** @var bool */
-    protected $debug = false;
+    /** @var int */
+    protected $verbosity = OutputInterface::VERBOSITY_NORMAL;
 
     /**
      * Should PHPMD exit without error code even if error is found?
@@ -204,9 +205,14 @@ class CommandLineOptions
         $arguments = array();
         while (($arg = array_shift($args)) !== null) {
             switch ($arg) {
+                case '-v':
+                    $this->verbosity = OutputInterface::VERBOSITY_VERBOSE;
+                    break;
+                case '-vv':
+                    $this->verbosity = OutputInterface::VERBOSITY_VERY_VERBOSE;
+                    break;
                 case '-vvv':
-                case '--debug':
-                    $this->debug = true;
+                    $this->verbosity = OutputInterface::VERBOSITY_DEBUG;
                     break;
                 case '--min-priority':
                 case '--minimum-priority':
@@ -432,11 +438,11 @@ class CommandLineOptions
     }
 
     /**
-     * @return bool
+     * @return int
      */
-    public function isDebug()
+    public function getVerbosity()
     {
-        return $this->debug;
+        return $this->verbosity;
     }
 
     /**
@@ -688,7 +694,7 @@ class CommandLineOptions
             'Available rulesets: ' . implode(', ', $this->availableRuleSets) . '.' . \PHP_EOL . \PHP_EOL .
             'Optional arguments that may be put after the mandatory arguments:' .
             \PHP_EOL .
-            '-vvv, --debug: Show debug information' . \PHP_EOL .
+            '-v, -vv, -vvv: Show debug information.' . \PHP_EOL .
             '--minimumpriority: rule priority threshold; rules with lower ' .
             'priority than this will not be used' . \PHP_EOL .
             '--reportfile: send report output to a file; default to STDOUT' .

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -131,6 +131,9 @@ class CommandLineOptions
      */
     protected $strict = false;
 
+    /** @var bool */
+    protected $debug = false;
+
     /**
      * Should PHPMD exit without error code even if error is found?
      *
@@ -201,6 +204,10 @@ class CommandLineOptions
         $arguments = array();
         while (($arg = array_shift($args)) !== null) {
             switch ($arg) {
+                case '-vvv':
+                case '--debug':
+                    $this->debug = true;
+                    break;
                 case '--min-priority':
                 case '--minimum-priority':
                 case '--minimumpriority':
@@ -673,6 +680,7 @@ class CommandLineOptions
             'Available rulesets: ' . implode(', ', $this->availableRuleSets) . '.' . \PHP_EOL . \PHP_EOL .
             'Optional arguments that may be put after the mandatory arguments:' .
             \PHP_EOL .
+            '-vvv, --debug: Show debug information' . \PHP_EOL .
             '--minimumpriority: rule priority threshold; rules with lower ' .
             'priority than this will not be used' . \PHP_EOL .
             '--reportfile: send report output to a file; default to STDOUT' .

--- a/src/main/php/PHPMD/Utility/Output.php
+++ b/src/main/php/PHPMD/Utility/Output.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace PHPMD\Utility;
+
+/**
+ * A basic write-to-stream output class. Follows a partial implementation of Symfony's OutputInterface to allow future drop-in replacement
+ * by the Console package.
+ */
+class Output
+{
+    const VERBOSITY_QUIET        = 16;
+    const VERBOSITY_NORMAL       = 32;
+    const VERBOSITY_VERBOSE      = 64;
+    const VERBOSITY_VERY_VERBOSE = 128;
+    const VERBOSITY_DEBUG        = 256;
+
+    /** @var resource */
+    private $stream;
+
+    /** @var int */
+    private $verbosity;
+
+    /**
+     * @param resource $stream
+     * @param int      $verbosity
+     */
+    public function __construct($stream, $verbosity = self::VERBOSITY_NORMAL)
+    {
+        $this->stream    = $stream;
+        $this->verbosity = $verbosity;
+    }
+
+    /**
+     * @param string|string[] $messages
+     * @param bool            $newline
+     * @param int             $options A bitmask of options (one of the VERBOSITY constants),
+     *                                 0 is considered the same as self::VERBOSITY_NORMAL
+     * @return void
+     */
+    public function write($messages, $newline = false, $options = self::VERBOSITY_NORMAL)
+    {
+        if (is_array($messages) === false) {
+            $messages = array($messages);
+        }
+
+        $verbosities = self::VERBOSITY_QUIET
+            | self::VERBOSITY_NORMAL
+            | self::VERBOSITY_VERBOSE
+            | self::VERBOSITY_VERY_VERBOSE
+            | self::VERBOSITY_DEBUG;
+        $verbosity   = $verbosities & $options ?: self::VERBOSITY_NORMAL;
+
+        if ($verbosity > $this->getVerbosity()) {
+            return;
+        }
+
+        foreach ($messages as $message) {
+            fwrite($this->stream, $message . ($newline ? "\n" : ""));
+        }
+    }
+
+    /**
+     * @param string|string[] $messages
+     * @param int             $options A bitmask of options (one of the VERBOSITY constants),
+     *                                 0 is considered the same as self::VERBOSITY_NORMAL
+     * @return void
+     */
+    public function writeln($messages, $options = self::VERBOSITY_NORMAL)
+    {
+        $this->write($messages, true, $options);
+    }
+
+    /**
+     * @param int $level
+     * @return void
+     */
+    public function setVerbosity($level)
+    {
+        $this->verbosity = $level;
+    }
+
+    /**
+     * @return int
+     */
+    public function getVerbosity()
+    {
+        return $this->verbosity;
+    }
+}

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -40,6 +40,10 @@ Command line options
 
 - The command line interface also accepts the following optional arguments:
 
+  - ``-v, -vv, -vvv`` - The output verbosity level. Will print more information
+    what is being processed or cached. Will be send to ``STDERR`` to not interfere
+    with report output.
+
   - ``--minimumpriority`` ``--min-priority`` ``--minimum-priority`` - The rule priority threshold; rules with lower
     priority than they will not be used.
 

--- a/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
@@ -88,7 +88,7 @@ class ResultCacheEngineFactoryTest extends AbstractTest
 
         $this->options->expects(self::once())->method('isCacheEnabled')->willReturn(true);
         $this->options->expects(self::once())->method('hasStrict')->willReturn(true);
-        $this->options->expects(self::exactly(2))->method('cacheFile')->willReturn('/path/to/cache');
+        $this->options->expects(self::exactly(3))->method('cacheFile')->willReturn('/path/to/cache');
 
         $this->keyFactory->expects(self::once())->method('create')->with(true, $ruleSetList)->willReturn($cacheKey);
         $this->stateFactory->expects(self::once())->method('fromFile')->with('/path/to/cache')->willReturn($state);

--- a/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
@@ -5,6 +5,7 @@ namespace PHPMD\Cache;
 use PHPMD\AbstractTest;
 use PHPMD\Cache\Model\ResultCacheKey;
 use PHPMD\Cache\Model\ResultCacheState;
+use PHPMD\Console\NullOutput;
 use PHPMD\RuleSet;
 use PHPMD\TextUI\CommandLineOptions;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
@@ -40,7 +41,7 @@ class ResultCacheEngineFactoryTest extends AbstractTest
             $this->getMockBuilder('\PHPMD\Cache\ResultCacheStateFactory')->disableOriginalConstructor()
         );
 
-        $this->engineFactory = new ResultCacheEngineFactory($this->keyFactory, $this->stateFactory);
+        $this->engineFactory = new ResultCacheEngineFactory(new NullOutput(), $this->keyFactory, $this->stateFactory);
     }
 
     /**

--- a/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
@@ -6,6 +6,7 @@ use PHPMD\AbstractTest;
 use PHPMD\Cache\Model\ResultCacheKey;
 use PHPMD\Cache\Model\ResultCacheState;
 use PHPMD\Cache\Model\ResultCacheStrategy;
+use PHPMD\Console\NullOutput;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
@@ -14,6 +15,8 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  */
 class ResultCacheFileFilterTest extends AbstractTest
 {
+    /** @var NullOutput */
+    private $output;
     /** @var ResultCacheKey&MockObject */
     private $key;
     /** @var ResultCacheState&MockObject */
@@ -21,10 +24,11 @@ class ResultCacheFileFilterTest extends AbstractTest
 
     protected function setUp()
     {
-        $this->key   = $this->getMockFromBuilder(
+        $this->output = new NullOutput();
+        $this->key    = $this->getMockFromBuilder(
             $this->getMockBuilder('\PHPMD\Cache\Model\ResultCacheKey')->disableOriginalConstructor()
         );
-        $this->state = $this->getMockFromBuilder(
+        $this->state  = $this->getMockFromBuilder(
             $this->getMockBuilder('\PHPMD\Cache\Model\ResultCacheState')->disableOriginalConstructor()
         );
     }
@@ -35,7 +39,7 @@ class ResultCacheFileFilterTest extends AbstractTest
      */
     public function testAcceptStrategyContentModified()
     {
-        $filter = new ResultCacheFileFilter(__DIR__, ResultCacheStrategy::CONTENT, $this->key, $this->state);
+        $filter = new ResultCacheFileFilter($this->output, __DIR__, ResultCacheStrategy::CONTENT, $this->key, $this->state);
 
         $this->state->expects(self::once())->method('isFileModified')->willReturn(true);
 
@@ -50,7 +54,7 @@ class ResultCacheFileFilterTest extends AbstractTest
      */
     public function testAcceptStrategyContentUnmodified()
     {
-        $filter = new ResultCacheFileFilter(__DIR__, ResultCacheStrategy::CONTENT, $this->key, $this->state);
+        $filter = new ResultCacheFileFilter($this->output, __DIR__, ResultCacheStrategy::CONTENT, $this->key, $this->state);
 
         $this->state->expects(self::once())->method('isFileModified')->willReturn(false);
         $this->state->expects(self::once())->method('getViolations')->willReturn(array('violations'));
@@ -67,7 +71,7 @@ class ResultCacheFileFilterTest extends AbstractTest
     public function testAcceptStrategyTimestampModified()
     {
         $timestamp = (string)filemtime(__FILE__);
-        $filter    = new ResultCacheFileFilter(__DIR__, ResultCacheStrategy::TIMESTAMP, $this->key, $this->state);
+        $filter    = new ResultCacheFileFilter($this->output, __DIR__, ResultCacheStrategy::TIMESTAMP, $this->key, $this->state);
 
         $this->state->expects(self::once())->method('isFileModified')->willReturn(true);
 
@@ -82,7 +86,7 @@ class ResultCacheFileFilterTest extends AbstractTest
      */
     public function testAcceptWithoutState()
     {
-        $filter = new ResultCacheFileFilter(__DIR__, ResultCacheStrategy::CONTENT, $this->key, null);
+        $filter = new ResultCacheFileFilter($this->output, __DIR__, ResultCacheStrategy::CONTENT, $this->key, null);
 
         $this->state->expects(self::never())->method('isFileModified')->willReturn(false);
 
@@ -96,7 +100,7 @@ class ResultCacheFileFilterTest extends AbstractTest
      */
     public function testAcceptShouldCacheResults()
     {
-        $filter = new ResultCacheFileFilter(__DIR__, ResultCacheStrategy::CONTENT, $this->key, $this->state);
+        $filter = new ResultCacheFileFilter($this->output, __DIR__, ResultCacheStrategy::CONTENT, $this->key, $this->state);
 
         // expect one invocation
         $this->state->expects(self::once())->method('isFileModified')->willReturn(true);

--- a/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
@@ -5,7 +5,7 @@ namespace PHPMD\Cache;
 use PHPMD\AbstractTest;
 use PHPMD\Cache\Model\ResultCacheKey;
 use PHPMD\Cache\Model\ResultCacheState;
-use PHPMD\Cache\Model\ResultCacheStrategy;
+use PHPMD\Cache\Model\ResultCacheStrategy as Strategy;
 use PHPMD\Console\NullOutput;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
@@ -39,7 +39,7 @@ class ResultCacheFileFilterTest extends AbstractTest
      */
     public function testAcceptStrategyContentModified()
     {
-        $filter = new ResultCacheFileFilter($this->output, __DIR__, ResultCacheStrategy::CONTENT, $this->key, $this->state);
+        $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::CONTENT, $this->key, $this->state);
 
         $this->state->expects(self::once())->method('isFileModified')->willReturn(true);
 
@@ -54,7 +54,7 @@ class ResultCacheFileFilterTest extends AbstractTest
      */
     public function testAcceptStrategyContentUnmodified()
     {
-        $filter = new ResultCacheFileFilter($this->output, __DIR__, ResultCacheStrategy::CONTENT, $this->key, $this->state);
+        $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::CONTENT, $this->key, $this->state);
 
         $this->state->expects(self::once())->method('isFileModified')->willReturn(false);
         $this->state->expects(self::once())->method('getViolations')->willReturn(array('violations'));
@@ -71,7 +71,7 @@ class ResultCacheFileFilterTest extends AbstractTest
     public function testAcceptStrategyTimestampModified()
     {
         $timestamp = (string)filemtime(__FILE__);
-        $filter    = new ResultCacheFileFilter($this->output, __DIR__, ResultCacheStrategy::TIMESTAMP, $this->key, $this->state);
+        $filter    = new ResultCacheFileFilter($this->output, __DIR__, Strategy::TIMESTAMP, $this->key, $this->state);
 
         $this->state->expects(self::once())->method('isFileModified')->willReturn(true);
 
@@ -86,7 +86,7 @@ class ResultCacheFileFilterTest extends AbstractTest
      */
     public function testAcceptWithoutState()
     {
-        $filter = new ResultCacheFileFilter($this->output, __DIR__, ResultCacheStrategy::CONTENT, $this->key, null);
+        $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::CONTENT, $this->key, null);
 
         $this->state->expects(self::never())->method('isFileModified')->willReturn(false);
 
@@ -100,7 +100,7 @@ class ResultCacheFileFilterTest extends AbstractTest
      */
     public function testAcceptShouldCacheResults()
     {
-        $filter = new ResultCacheFileFilter($this->output, __DIR__, ResultCacheStrategy::CONTENT, $this->key, $this->state);
+        $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::CONTENT, $this->key, $this->state);
 
         // expect one invocation
         $this->state->expects(self::once())->method('isFileModified')->willReturn(true);

--- a/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
@@ -27,6 +27,7 @@ class ResultCacheKeyFactoryTest extends AbstractTest
 
     /**
      * @covers ::create
+     * @covers ::getBaselineHash
      * @covers ::createRuleHashes
      * @covers ::getComposerHashes
      */

--- a/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
@@ -4,6 +4,7 @@ namespace PHPMD\Cache;
 
 use PHPMD\AbstractTest;
 use PHPMD\Cache\Model\ResultCacheState;
+use PHPMD\Console\NullOutput;
 use PHPMD\RuleSet;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
@@ -25,7 +26,7 @@ class ResultCacheUpdaterTest extends AbstractTest
             $this->getMockBuilder('\PHPMD\Cache\Model\ResultCacheState')->disableOriginalConstructor()
         );
 
-        $this->updater = new ResultCacheUpdater('/base/path/');
+        $this->updater = new ResultCacheUpdater(new NullOutput(), '/base/path/');
     }
 
     /**

--- a/src/test/php/PHPMD/Console/OutputTest.php
+++ b/src/test/php/PHPMD/Console/OutputTest.php
@@ -42,6 +42,7 @@ class OutputTest extends AbstractTest
      */
     public function testWriteSingleMessage()
     {
+        $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
         $this->output->write("message", false, OutputInterface::VERBOSITY_VERBOSE);
 
         static::assertSame('message', $this->output->getOutput());
@@ -53,6 +54,7 @@ class OutputTest extends AbstractTest
      */
     public function testWriteMultiMessageWithNewline()
     {
+        $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
         $this->output->write(array("foo", "bar"), true, OutputInterface::VERBOSITY_VERBOSE);
 
         static::assertSame("foo\nbar\n", $this->output->getOutput());

--- a/src/test/php/PHPMD/Console/OutputTest.php
+++ b/src/test/php/PHPMD/Console/OutputTest.php
@@ -82,11 +82,31 @@ class OutputTest extends AbstractTest
     public static function verbosityProvider()
     {
         return array(
-            array(Output::VERBOSITY_QUIET, '2', '->write() in QUIET mode only outputs when an explicit QUIET verbosity is passed'),
-            array(Output::VERBOSITY_NORMAL, '123', '->write() in NORMAL mode outputs anything below an explicit VERBOSE verbosity'),
-            array(Output::VERBOSITY_VERBOSE, '1234', '->write() in VERBOSE mode outputs anything below an explicit VERY_VERBOSE verbosity'),
-            array(Output::VERBOSITY_VERY_VERBOSE, '12345', '->write() in VERY_VERBOSE mode outputs anything below an explicit DEBUG verbosity'),
-            array(Output::VERBOSITY_DEBUG, '123456', '->write() in DEBUG mode outputs everything'),
+            array(
+                Output::VERBOSITY_QUIET,
+                '2',
+                '->write() in QUIET mode only outputs when an explicit QUIET verbosity is passed'
+            ),
+            array(
+                Output::VERBOSITY_NORMAL,
+                '123',
+                '->write() in NORMAL mode outputs anything below an explicit VERBOSE verbosity'
+            ),
+            array(
+                Output::VERBOSITY_VERBOSE,
+                '1234',
+                '->write() in VERBOSE mode outputs anything below an explicit VERY_VERBOSE verbosity'
+            ),
+            array(
+                Output::VERBOSITY_VERY_VERBOSE,
+                '12345',
+                '->write() in VERY_VERBOSE mode outputs anything below an explicit DEBUG verbosity'
+            ),
+            array(
+                Output::VERBOSITY_DEBUG,
+                '123456',
+                '->write() in DEBUG mode outputs everything'
+            ),
         );
     }
 

--- a/src/test/php/PHPMD/Console/OutputTest.php
+++ b/src/test/php/PHPMD/Console/OutputTest.php
@@ -6,6 +6,7 @@ use PHPMD\AbstractTest;
 
 /**
  * @coversDefaultClass  \PHPMD\Console\Output
+ * @covers ::__construct
  */
 class OutputTest extends AbstractTest
 {

--- a/src/test/php/PHPMD/Console/OutputTest.php
+++ b/src/test/php/PHPMD/Console/OutputTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace PHPMD\Console;
+
+use PHPMD\AbstractTest;
+
+/**
+ * @coversDefaultClass  \PHPMD\Console\Output
+ */
+class OutputTest extends AbstractTest
+{
+    /** @var TestOutput */
+    private $output;
+
+    /**
+     * @return void
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->output = new TestOutput();
+    }
+
+    /**
+     * @covers ::getVerbosity
+     * @covers ::setVerbosity
+     * @return void
+     */
+    public function testSetGetVerbosity()
+    {
+        $this->output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
+        static::assertSame(OutputInterface::VERBOSITY_VERBOSE, $this->output->getVerbosity());
+
+        $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
+        static::assertSame(OutputInterface::VERBOSITY_DEBUG, $this->output->getVerbosity());
+    }
+
+    /**
+     * @covers ::write
+     * @return void
+     */
+    public function testWriteSingleMessage()
+    {
+        $this->output->write("message", false, OutputInterface::VERBOSITY_VERBOSE);
+
+        static::assertSame('message', $this->output->getOutput());
+    }
+
+    /**
+     * @covers ::write
+     * @return void
+     */
+    public function testWriteMultiMessageWithNewline()
+    {
+        $this->output->write(array("foo", "bar"), true, OutputInterface::VERBOSITY_VERBOSE);
+
+        static::assertSame("foo\nbar\n", $this->output->getOutput());
+    }
+
+    /**
+     * @param int    $verbosity
+     * @param string $expected
+     * @param string $msg
+     * @covers ::write
+     * @dataProvider verbosityProvider
+     */
+    public function testWriteWithVerbosityOption($verbosity, $expected, $msg)
+    {
+        $this->output->setVerbosity($verbosity);
+        $this->output->write('1', false);
+        $this->output->write('2', false, Output::VERBOSITY_QUIET);
+        $this->output->write('3', false, Output::VERBOSITY_NORMAL);
+        $this->output->write('4', false, Output::VERBOSITY_VERBOSE);
+        $this->output->write('5', false, Output::VERBOSITY_VERY_VERBOSE);
+        $this->output->write('6', false, Output::VERBOSITY_DEBUG);
+        static::assertSame($expected, $this->output->getOutput(), $msg);
+    }
+
+    public static function verbosityProvider()
+    {
+        return array(
+            array(Output::VERBOSITY_QUIET, '2', '->write() in QUIET mode only outputs when an explicit QUIET verbosity is passed'),
+            array(Output::VERBOSITY_NORMAL, '123', '->write() in NORMAL mode outputs anything below an explicit VERBOSE verbosity'),
+            array(Output::VERBOSITY_VERBOSE, '1234', '->write() in VERBOSE mode outputs anything below an explicit VERY_VERBOSE verbosity'),
+            array(Output::VERBOSITY_VERY_VERBOSE, '12345', '->write() in VERY_VERBOSE mode outputs anything below an explicit DEBUG verbosity'),
+            array(Output::VERBOSITY_DEBUG, '123456', '->write() in DEBUG mode outputs everything'),
+        );
+    }
+
+    /**
+     * @covers ::writeln
+     * @return void
+     */
+    public function testWritelnMessage()
+    {
+        $this->output->writeln("message", OutputInterface::VERBOSITY_QUIET);
+
+        static::assertSame("message\n", $this->output->getOutput());
+    }
+}

--- a/src/test/php/PHPMD/Console/StreamOutputTest.php
+++ b/src/test/php/PHPMD/Console/StreamOutputTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PHPMD\Console;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \PHPMD\Console\StreamOutput
+ */
+class StreamOutputTest extends TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::doWrite
+     */
+    public function testDoWrite()
+    {
+        $stream = fopen('php://memory', 'w+b');
+        $output = new StreamOutput($stream);
+        $output->write('message');
+
+        fseek($stream, 0);
+        static::assertSame('message', fread($stream, 1024));
+    }
+}

--- a/src/test/php/PHPMD/Console/TestOutput.php
+++ b/src/test/php/PHPMD/Console/TestOutput.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PHPMD\Console;
+
+class TestOutput extends Output
+{
+    /** @var resource */
+    private $stream;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->stream = fopen('php://memory', 'w+b');
+    }
+
+    /**
+     * @param string $message
+     * @return void
+     */
+    protected function doWrite($message)
+    {
+        fwrite($this->stream, $message);
+    }
+
+    public function getOutput()
+    {
+        fseek($this->stream, 0);
+        return fread($this->stream, 1024);
+    }
+}

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -19,6 +19,7 @@ namespace PHPMD\TextUI;
 
 use PHPMD\AbstractTest;
 use PHPMD\Baseline\BaselineMode;
+use PHPMD\Console\OutputInterface;
 use PHPMD\Rule;
 
 /**
@@ -353,6 +354,46 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
         static::assertSame(BaselineMode::NONE, $opts->generateBaseline());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCliOptionVerbosityNormal()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'codesize');
+        $opts = new CommandLineOptions($args);
+        static::assertSame(OutputInterface::VERBOSITY_NORMAL, $opts->getVerbosity());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCliOptionVerbosityVerbose()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'codesize', '-v');
+        $opts = new CommandLineOptions($args);
+        static::assertSame(OutputInterface::VERBOSITY_VERBOSE, $opts->getVerbosity());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCliOptionVerbosityVeryVerbose()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'codesize', '-vv');
+        $opts = new CommandLineOptions($args);
+        static::assertSame(OutputInterface::VERBOSITY_VERY_VERBOSE, $opts->getVerbosity());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCliOptionVerbosityDebug()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'codesize', '-vvv');
+        $opts = new CommandLineOptions($args);
+        static::assertSame(OutputInterface::VERBOSITY_DEBUG, $opts->getVerbosity());
     }
 
     /**


### PR DESCRIPTION
Type: feature
Issue: -
Breaking change: no

Addendum to https://github.com/phpmd/phpmd/pull/1011

I found the lack information of the cache difficult to debug. There's no information presented regarding if the cache is used, which it is read from, or if the cache is still valid. I added a few cli flags to show more information:

## Feature
- Added CLI command flags: `-v, -vv, -vvv`. Which increments the verbosity of the output. Default is 'Normal'.
- If no `-v`, `-vv`, or `-vvv` is specified, the behaviour is currently as it is now and nothing is printed.

## Changes
- Added `OutputInterface` based on Symfony's Console package. Should be drop-in replacement if at some point Symfony Console can/will be used.
- Added `NullOutput` (for tests) and `StreamOutput` classes to be able to write output with verbosity level.
- Added Debug output to several cache classes.
- Added Verbosity levels: `Quiet`, `Normal` (default), `Verbose`, `VeryVerbose` and `Debug`. Currently only `VeryVerbose` and `Debug` is being written to.
- Updated the documentation with the new cli flags.
- Added coverage for my changes.

Note, this branch contains the changes from PR 1011. I don't seem to be able to target that PR in this PR.
