### PR TITLE
Prevent nested list in AUTHORS

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,7 +30,7 @@ Contributors
 - bahulneel (Since 2012) / https://github.com/bahulneel
 - Willem Stuursma (Since 2012) / https://github.com/willemstuursma
 - Nimlhug (Since 2012) / https://github.com/Nimlhug
-- A. Martin Llano (Since 2012) / https://github.com/amllano
+- \A. Martin Llano (Since 2012) / https://github.com/amllano
 - Juan Basso (Since 2012) / https://github.com/jrbasso
 - Brian Ridley (Since 2013) / https://github.com/ptlis
 - Radosław Mejer (Since 2014) / https://github.com/radmen


### PR DESCRIPTION
Starting a list item with "A." turns it into a nested list.
