### PR TITLE
Add --verbose and --color options to text renderer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,9 +117,12 @@ Command line options
 
 - The command line interface also accepts the following optional arguments:
 
-  - ``-v, -vv, -vvv`` - The output verbosity level. Will print more information
+  - ``--verbose, -v, -vv, -vvv`` - The output verbosity level. Will print more information
     what is being processed or cached. Will be send to ``STDERR`` to not interfere
-    with report output.
+    with report output. ``text`` output will also have under each error a link
+    to the documentation of the rule and format the location in a way that most
+    IDEs will convert into a link to open the file at the line of the error
+    when clicked.
 
   - ``--minimumpriority`` - The rule priority threshold; rules with lower
     priority than they will not be used.
@@ -159,11 +162,6 @@ Command line options
 
   - ``--baseline-file`` - the filepath to a custom baseline xml file. If absent will
     default to ``phpmd.baseline.xml``
-
-  - ``--verbose`` - get a more verbose output, for instance text renderer
-    will add under each error a link to the documentation of the rule
-    and format the location in a way that most IDEs will convert into
-    a link that will open the file at the line of the error when clicked.
 
   - ``--color`` - enable color in output, for instance text renderer
     will show rule name in yellow and error description in red.

--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,14 @@ Command line options
   - ``--baseline-file`` - the filepath to a custom baseline xml file. If absent will
     default to ``phpmd.baseline.xml``
 
+  - ``--verbose`` - get a more verbose output, for instance text renderer
+    will add under each error a link to the documentation of the rule
+    and format the location in a way that most IDEs will convert into
+    a link that will open the file at the line of the error when clicked.
+
+  - ``--color`` - enable color in output, for instance text renderer
+    will show rule name in yellow and error description in red.
+
   An example command line: ::
 
     phpmd PHP/Depend/DbusUI xml codesize --reportfile phpmd.xml --suffixes php,phtml

--- a/src/main/php/PHPMD/Renderer/Option/Color.php
+++ b/src/main/php/PHPMD/Renderer/Option/Color.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPMD\Renderer\Option;
+
+interface Color
+{
+    /**
+     * @param bool $colored
+     *
+     * @return void
+     */
+    public function setColored($colored);
+}

--- a/src/main/php/PHPMD/Renderer/Option/Verbose.php
+++ b/src/main/php/PHPMD/Renderer/Option/Verbose.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPMD\Renderer\Option;
+
+interface Verbose
+{
+    /**
+     * @param int $level
+     *
+     * @return void
+     */
+    public function setVerbosityLevel($level);
+}

--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Renderer;
 
 use PHPMD\AbstractRenderer;
+use PHPMD\Console\OutputInterface;
 use PHPMD\Renderer\Option\Color;
 use PHPMD\Renderer\Option\Verbose;
 use PHPMD\Report;
@@ -30,7 +31,7 @@ class TextRenderer extends AbstractRenderer implements Verbose, Color
 {
     protected $columnSpacing = 2;
 
-    protected $verbosityLevel = 0;
+    protected $verbosityLevel = OutputInterface::VERBOSITY_NORMAL;
 
     protected $colored = false;
 
@@ -63,7 +64,7 @@ class TextRenderer extends AbstractRenderer implements Verbose, Color
         foreach ($violations as $data) {
             list($violation, $location, $ruleName, $ruleSet, $locationLength, $ruleNameLength) = $data;
 
-            if ($this->verbosityLevel < 1) {
+            if ($this->verbosityLevel < OutputInterface::VERBOSITY_VERBOSE) {
                 $writer->write($location);
                 $writer->write(str_repeat(' ', $longestLocationLength + $this->columnSpacing - $locationLength));
             }
@@ -72,7 +73,7 @@ class TextRenderer extends AbstractRenderer implements Verbose, Color
             $writer->write(str_repeat(' ', $longestRuleNameLength + $this->columnSpacing - $ruleNameLength));
             $writer->write($this->applyColor($violation->getDescription(), 'red'));
 
-            if ($this->verbosityLevel >= 1) {
+            if ($this->verbosityLevel >= OutputInterface::VERBOSITY_VERBOSE) {
                 $writer->write(PHP_EOL);
                 $writer->write('📁 in ' . preg_replace('/:(\d+)$/', ' on line $1', $location) . PHP_EOL);
                 $set = preg_replace('/rules$/', '', strtolower(str_replace(' ', '', $ruleSet)));

--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -76,7 +76,8 @@ class TextRenderer extends AbstractRenderer implements Verbose, Color
                 $writer->write(PHP_EOL);
                 $writer->write('📁 in ' . preg_replace('/:(\d+)$/', ' on line $1', $location) . PHP_EOL);
                 $set = preg_replace('/rules$/', '', strtolower(str_replace(' ', '', $ruleSet)));
-                $writer->write('🔗 ' . $set . '.xml https://phpmd.org/rules/' . $set . '.html#' . strtolower($ruleName) . PHP_EOL);
+                $url = 'https://phpmd.org/rules/' . $set . '.html#' . strtolower($ruleName);
+                $writer->write('🔗 ' . $set . '.xml ' . $url . PHP_EOL);
             }
 
             $writer->write(PHP_EOL);
@@ -92,7 +93,7 @@ class TextRenderer extends AbstractRenderer implements Verbose, Color
 
     public function setVerbosityLevel($level)
     {
-        $this->verbosityLevel = (int) $level;
+        $this->verbosityLevel = (int)$level;
     }
 
     public function setColored($colored)

--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -18,15 +18,21 @@
 namespace PHPMD\Renderer;
 
 use PHPMD\AbstractRenderer;
+use PHPMD\Renderer\Option\Color;
+use PHPMD\Renderer\Option\Verbose;
 use PHPMD\Report;
 
 /**
  * This renderer output a textual log with all found violations and suspect
  * software artifacts.
  */
-class TextRenderer extends AbstractRenderer
+class TextRenderer extends AbstractRenderer implements Verbose, Color
 {
     protected $columnSpacing = 2;
+
+    protected $verbosityLevel = 0;
+
+    protected $colored = false;
 
     /**
      * This method will be called when the engine has finished the source analysis
@@ -44,21 +50,35 @@ class TextRenderer extends AbstractRenderer
 
         foreach ($report->getRuleViolations() as $violation) {
             $location = $violation->getFileName().':'.$violation->getBeginLine();
-            $ruleName = $violation->getRule()->getName();
+            $rule = $violation->getRule();
+            $ruleName = $rule->getName();
+            $ruleSet = $rule->getRuleSetName();
             $locationLength = mb_strlen($location);
             $ruleNameLength = mb_strlen($ruleName);
             $longestLocationLength = max($longestLocationLength, $locationLength);
             $longestRuleNameLength = max($longestRuleNameLength, $ruleNameLength);
-            $violations[] = array($violation, $location, $ruleName, $locationLength, $ruleNameLength);
+            $violations[] = array($violation, $location, $ruleName, $ruleSet, $locationLength, $ruleNameLength);
         }
 
         foreach ($violations as $data) {
-            list($violation, $location, $ruleName, $locationLength, $ruleNameLength) = $data;
-            $writer->write($location);
-            $writer->write(str_repeat(' ', $longestLocationLength + $this->columnSpacing - $locationLength));
-            $writer->write($ruleName);
+            list($violation, $location, $ruleName, $ruleSet, $locationLength, $ruleNameLength) = $data;
+
+            if ($this->verbosityLevel < 1) {
+                $writer->write($location);
+                $writer->write(str_repeat(' ', $longestLocationLength + $this->columnSpacing - $locationLength));
+            }
+
+            $writer->write($this->applyColor($ruleName, 'yellow'));
             $writer->write(str_repeat(' ', $longestRuleNameLength + $this->columnSpacing - $ruleNameLength));
-            $writer->write($violation->getDescription());
+            $writer->write($this->applyColor($violation->getDescription(), 'red'));
+
+            if ($this->verbosityLevel >= 1) {
+                $writer->write(PHP_EOL);
+                $writer->write('📁 in ' . preg_replace('/:(\d+)$/', ' on line $1', $location) . PHP_EOL);
+                $set = preg_replace('/rules$/', '', strtolower(str_replace(' ', '', $ruleSet)));
+                $writer->write('🔗 ' . $set . '.xml https://phpmd.org/rules/' . $set . '.html#' . strtolower($ruleName) . PHP_EOL);
+            }
+
             $writer->write(PHP_EOL);
         }
 
@@ -68,5 +88,30 @@ class TextRenderer extends AbstractRenderer
             $writer->write($error->getMessage());
             $writer->write(PHP_EOL);
         }
+    }
+
+    public function setVerbosityLevel($level)
+    {
+        $this->verbosityLevel = (int) $level;
+    }
+
+    public function setColored($colored)
+    {
+        $this->colored = $colored;
+    }
+
+    protected function applyColor($text, $color)
+    {
+        if (!$this->colored) {
+            return $text;
+        }
+
+        $colors = array(
+            'yellow' => 33,
+            'red' => 31,
+        );
+        $color = isset($colors[$color]) ? $colors[$color] : $color;
+
+        return "\033[{$color}m{$text}\033[0m";
     }
 }

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -762,7 +762,9 @@ class CommandLineOptions
             '--generate-baseline: will generate a phpmd.baseline.xml next ' .
             'to the first ruleset file location' . \PHP_EOL .
             '--update-baseline: will remove any non-existing violations from the phpmd.baseline.xml' . \PHP_EOL .
-            '--baseline-file: a custom location of the baseline file' . \PHP_EOL;
+            '--baseline-file: a custom location of the baseline file' . \PHP_EOL .
+            '--verbose: will return a more verbose output' . \PHP_EOL .
+            '--color: enable color in output' . \PHP_EOL;
     }
 
     /**

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -27,6 +27,8 @@ use PHPMD\Renderer\GitHubRenderer;
 use PHPMD\Renderer\GitLabRenderer;
 use PHPMD\Renderer\HTMLRenderer;
 use PHPMD\Renderer\JSONRenderer;
+use PHPMD\Renderer\Option\Color;
+use PHPMD\Renderer\Option\Verbose;
 use PHPMD\Renderer\SARIFRenderer;
 use PHPMD\Renderer\TextRenderer;
 use PHPMD\Renderer\XMLRenderer;
@@ -189,6 +191,20 @@ class CommandLineOptions
     protected $cacheStrategy;
 
     /**
+     * The level of verbosity as per set in CLI options.
+     *
+     * @var int
+     */
+    protected $verbosityLevel = 0;
+
+    /**
+     * Either the output should be colored.
+     *
+     * @var bool
+     */
+    protected $colored = false;
+
+    /**
      * Constructs a new command line options instance.
      *
      * @param string[] $args
@@ -250,6 +266,12 @@ class CommandLineOptions
                     break;
                 case '--exclude':
                     $this->ignore = array_shift($args);
+                    break;
+                case '--color':
+                    $this->colored = true;
+                    break;
+                case '--verbose':
+                    $this->verbosityLevel = 1;
                     break;
                 case '--version':
                     $this->version = true;
@@ -538,6 +560,26 @@ class CommandLineOptions
      * @throws InvalidArgumentException When the specified renderer does not exist.
      */
     public function createRenderer($reportFormat = null)
+    {
+        $renderer = $this->createRendererWithoutOptions($reportFormat);
+
+        if ($renderer instanceof Verbose) {
+            $renderer->setVerbosityLevel($this->verbosityLevel);
+        }
+
+        if ($renderer instanceof Color) {
+            $renderer->setColored($this->colored);
+        }
+
+        return $renderer;
+    }
+
+    /**
+     * @param string $reportFormat
+     * @return \PHPMD\AbstractRenderer
+     * @throws InvalidArgumentException When the specified renderer does not exist.
+     */
+    protected function createRendererWithoutOptions($reportFormat = null)
     {
         $reportFormat = $reportFormat ?: $this->reportFormat;
 

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -191,13 +191,6 @@ class CommandLineOptions
     protected $cacheStrategy;
 
     /**
-     * The level of verbosity as per set in CLI options.
-     *
-     * @var int
-     */
-    protected $verbosityLevel = 0;
-
-    /**
      * Either the output should be colored.
      *
      * @var bool
@@ -221,6 +214,7 @@ class CommandLineOptions
         $arguments = array();
         while (($arg = array_shift($args)) !== null) {
             switch ($arg) {
+                case '--verbose':
                 case '-v':
                     $this->verbosity = OutputInterface::VERBOSITY_VERBOSE;
                     break;
@@ -269,9 +263,6 @@ class CommandLineOptions
                     break;
                 case '--color':
                     $this->colored = true;
-                    break;
-                case '--verbose':
-                    $this->verbosityLevel = 1;
                     break;
                 case '--version':
                     $this->version = true;
@@ -564,7 +555,7 @@ class CommandLineOptions
         $renderer = $this->createRendererWithoutOptions($reportFormat);
 
         if ($renderer instanceof Verbose) {
-            $renderer->setVerbosityLevel($this->verbosityLevel);
+            $renderer->setVerbosityLevel($this->verbosity);
         }
 
         if ($renderer instanceof Color) {
@@ -736,7 +727,7 @@ class CommandLineOptions
             'Available rulesets: ' . implode(', ', $this->availableRuleSets) . '.' . \PHP_EOL . \PHP_EOL .
             'Optional arguments that may be put after the mandatory arguments:' .
             \PHP_EOL .
-            '-v, -vv, -vvv: Show debug information.' . \PHP_EOL .
+            '--verbose, -v, -vv, -vvv: Show debug information.' . \PHP_EOL .
             '--minimumpriority: rule priority threshold; rules with lower ' .
             'priority than this will not be used' . \PHP_EOL .
             '--reportfile: send report output to a file; default to STDOUT' .
@@ -763,7 +754,6 @@ class CommandLineOptions
             'to the first ruleset file location' . \PHP_EOL .
             '--update-baseline: will remove any non-existing violations from the phpmd.baseline.xml' . \PHP_EOL .
             '--baseline-file: a custom location of the baseline file' . \PHP_EOL .
-            '--verbose: will return a more verbose output' . \PHP_EOL .
             '--color: enable color in output' . \PHP_EOL;
     }
 

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -40,9 +40,12 @@ Command line options
 
 - The command line interface also accepts the following optional arguments:
 
-  - ``-v, -vv, -vvv`` - The output verbosity level. Will print more information
+  - ``--verbose, -v, -vv, -vvv`` - The output verbosity level. Will print more information
     what is being processed or cached. Will be send to ``STDERR`` to not interfere
-    with report output.
+    with report output. ``text`` output will also have under each error a link
+    to the documentation of the rule and format the location in a way that most
+    IDEs will convert into a link to open the file at the line of the error
+    when clicked.
 
   - ``--minimumpriority`` ``--min-priority`` ``--minimum-priority`` - The rule priority threshold; rules with lower
     priority than they will not be used.
@@ -87,11 +90,6 @@ Command line options
 
   -  ``--baseline-file`` - the filepath to a custom baseline xml file. If absent will
     default to ``phpmd.baseline.xml``
-
-  - ``--verbose`` - get a more verbose output, for instance text renderer
-    will add under each error a link to the documentation of the rule
-    and format the location in a way that most IDEs will convert into
-    a link that will open the file at the line of the error when clicked.
 
   - ``--color`` - enable color in output, for instance text renderer
     will show rule name in yellow and error description in red.

--- a/src/site/rst/documentation/index.rst
+++ b/src/site/rst/documentation/index.rst
@@ -88,6 +88,14 @@ Command line options
   -  ``--baseline-file`` - the filepath to a custom baseline xml file. If absent will
     default to ``phpmd.baseline.xml``
 
+  - ``--verbose`` - get a more verbose output, for instance text renderer
+    will add under each error a link to the documentation of the rule
+    and format the location in a way that most IDEs will convert into
+    a link that will open the file at the line of the error when clicked.
+
+  - ``--color`` - enable color in output, for instance text renderer
+    will show rule name in yellow and error description in red.
+
   An example command line: ::
 
     phpmd PHP/Depend/DbusUI xml codesize --reportfile phpmd.xml --suffixes php,phtml

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -19,6 +19,7 @@ namespace PHPMD\Renderer;
 
 use ArrayIterator;
 use PHPMD\AbstractTest;
+use PHPMD\Console\OutputInterface;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\RuleStub;
 use PHPMD\Stubs\WriterStub;
@@ -85,7 +86,7 @@ class TextRendererTest extends AbstractTest
 
         $renderer = new TextRenderer();
         $renderer->setWriter($writer);
-        $renderer->setVerbosityLevel(1);
+        $renderer->setVerbosityLevel(OutputInterface::VERBOSITY_VERBOSE);
 
         $violations = array(
             $this->getRuleViolationMock('/bar.php', 1, 42, $rule, $rule->getDescription()),

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -73,6 +73,82 @@ class TextRendererTest extends AbstractTest
     }
 
     /**
+     * @return void
+     */
+    public function testRendererSupportVerbose()
+    {
+        // Create a writer instance.
+        $writer = new WriterStub();
+        $rule = new RuleStub();
+        $rule->setName('LongerNamedRule');
+        $rule->setDescription('An other description for this rule');
+
+        $renderer = new TextRenderer();
+        $renderer->setWriter($writer);
+        $renderer->setVerbosityLevel(1);
+
+        $violations = array(
+            $this->getRuleViolationMock('/bar.php', 1, 42, $rule, $rule->getDescription()),
+        );
+
+        $report = $this->getReportWithNoViolation();
+        $report->expects($this->once())
+            ->method('getRuleViolations')
+            ->will($this->returnValue(new ArrayIterator($violations)));
+        $report->expects($this->once())
+            ->method('getErrors')
+            ->will($this->returnValue(new ArrayIterator(array())));
+
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        $this->assertEquals(
+            'LongerNamedRule  An other description for this rule' . PHP_EOL .
+            '📁 in /bar.php on line 1' . PHP_EOL .
+            '🔗 testruleset.xml https://phpmd.org/rules/testruleset.html#longernamedrule' . PHP_EOL . PHP_EOL,
+            $writer->getData()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testRendererSupportColor()
+    {
+        // Create a writer instance.
+        $writer = new WriterStub();
+        $rule = new RuleStub();
+        $rule->setName('LongerNamedRule');
+        $rule->setDescription('An other description for this rule');
+
+        $renderer = new TextRenderer();
+        $renderer->setWriter($writer);
+        $renderer->setColored(true);
+
+        $violations = array(
+            $this->getRuleViolationMock('/bar.php', 1, 42, $rule, $rule->getDescription()),
+        );
+
+        $report = $this->getReportWithNoViolation();
+        $report->expects($this->once())
+            ->method('getRuleViolations')
+            ->will($this->returnValue(new ArrayIterator($violations)));
+        $report->expects($this->once())
+            ->method('getErrors')
+            ->will($this->returnValue(new ArrayIterator(array())));
+
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        $this->assertEquals(
+            "/bar.php:1  \033[33mLongerNamedRule\033[0m  \033[31mAn other description for this rule\033[0m" . PHP_EOL,
+            $writer->getData()
+        );
+    }
+
+    /**
      * testRendererAddsProcessingErrorsToTextReport
      *
      * @return void

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -21,6 +21,7 @@ use PHPMD\AbstractTest;
 use PHPMD\Baseline\BaselineMode;
 use PHPMD\Console\OutputInterface;
 use PHPMD\Rule;
+use ReflectionProperty;
 
 /**
  * Test case for the {@link \PHPMD\TextUI\CommandLineOptions} class.
@@ -59,6 +60,42 @@ class CommandLineOptionsTest extends AbstractTest
         $opts = new CommandLineOptions($args);
 
         self::assertEquals(__FILE__, $opts->getInputPath());
+    }
+
+    /**
+     * @return void
+     * @since 2.14.0
+     */
+    public function testVerbose()
+    {
+        $args = array('foo.php', __FILE__, 'text', 'design', '-vvv');
+        $opts = new CommandLineOptions($args);
+        $renbderer = $opts->createRenderer();
+
+        $verbosityExtractor = new ReflectionProperty('PHPMD\\Renderer\\TextRenderer', 'verbosityLevel');
+        $verbosityExtractor->setAccessible(true);
+
+        $verbosityLevel = $verbosityExtractor->getValue($renbderer);
+
+        self::assertSame(OutputInterface::VERBOSITY_DEBUG, $verbosityLevel);
+    }
+
+    /**
+     * @return void
+     * @since 2.14.0
+     */
+    public function testColored()
+    {
+        $args = array('foo.php', __FILE__, 'text', 'design', '--color');
+        $opts = new CommandLineOptions($args);
+        $renbderer = $opts->createRenderer();
+
+        $coloredExtractor = new ReflectionProperty('PHPMD\\Renderer\\TextRenderer', 'colored');
+        $coloredExtractor->setAccessible(true);
+
+        $colored = $coloredExtractor->getValue($renbderer);
+
+        self::assertTrue($colored);
     }
 
     /**


### PR DESCRIPTION
Type: feature
Breaking change: no

### Be fancy!

![image](https://github.com/phpmd/phpmd/assets/5966783/aff1ff71-18f2-4774-b8ae-c9f76c7e5327)

  - ``--verbose`` - get a more verbose output, for instance text renderer will add under each error a link to the documentation of the rule and format the location in a way that most IDEs will convert into a link that will open the file at the line of the error when clicked.

  - ``--color`` - enable color in output, for instance text renderer will show rule name in yellow and error description in red.

