### PR TITLE
Dedupe violation for CamelCaseVariableName

### DIFF
--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
@@ -56,14 +56,16 @@ class CamelCaseVariableName extends AbstractRule implements MethodAware, Functio
      */
     public function apply(AbstractNode $node)
     {
+        $variables = array();
+
         foreach ($node->findChildrenOfTypeVariable() as $variable) {
             if (!$this->isValid($variable)) {
-                $this->addViolation(
-                    $node,
-                    array(
-                        $variable->getImage(),
-                    )
-                );
+                $variableName = $variable->getImage();
+
+                if (!isset($variables[$variableName])) {
+                    $variables[$variableName] = true;
+                    $this->addViolation($variable, array($variableName));
+                }
             }
         }
     }

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
@@ -88,6 +88,21 @@ class CamelCaseVariableNameTest extends AbstractTest
     }
 
     /**
+     * Tests that the rule does NOT apply if name allowed by config
+     *
+     * @return void
+     */
+    public function testRuleDoesNotApplyIfExcluded()
+    {
+        $report = $this->getReportWithNoViolation();
+
+        $rule = new CamelCaseVariableName();
+        $rule->setReport($report);
+        $rule->addProperty('allow-underscore', 'false');
+        $rule->apply($this->getClass());
+    }
+
+    /**
      * Tests that the rule does apply for a valid variable name
      * with an underscore at the beginning when it is allowed.
      *

--- a/src/test/resources/files/Rule/Controversial/CamelCaseVariableName/testRuleDoesNotApplyIfExcluded.php
+++ b/src/test/resources/files/Rule/Controversial/CamelCaseVariableName/testRuleDoesNotApplyIfExcluded.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyIfExcluded
+{
+    public function validVariableName()
+    {
+        var_dump($_POST);
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix #467
Breaking change: no

- Dedupe violation for `CamelCaseVariableName`
- Use line of first occurrence instead of line of parent function
- Add test for uncovered exceptions