### PR TITLE
Added the option to the command line to set the number of extra lines in code snippets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,6 +165,7 @@ Command line options
 
   - ``--color`` - enable color in output, for instance text renderer
     will show rule name in yellow and error description in red.
+  - ``--extra-line-in-excerpt`` - specify how many extra lines are added to a code snippet in html format
 
   An example command line: ::
 

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -65,6 +65,18 @@ class HTMLRenderer extends AbstractRenderer
     protected static $compiledHighlightRegex = null;
 
     /**
+     * Specify how many extra lines are added to a code snippet
+     * @var int
+     */
+    protected $extraLineInExcerpt = 2;
+
+    public function __construct($extraLineInExcerpt){
+        if ($extraLineInExcerpt) {
+            $this->extraLineInExcerpt = $extraLineInExcerpt;
+        }
+    }
+
+    /**
      * This method will be called on all renderers before the engine starts the
      * real report processing.
      *
@@ -362,7 +374,7 @@ class HTMLRenderer extends AbstractRenderer
             $excerpt = self::getLineExcerpt(
                 $violation->getFileName(),
                 $violation->getBeginLine(),
-                2
+                $this->extraLineInExcerpt
             );
 
             foreach ($excerpt as $line => $code) {

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -66,12 +66,14 @@ class HTMLRenderer extends AbstractRenderer
 
     /**
      * Specify how many extra lines are added to a code snippet
+     * By default 2
      * @var int
      */
     protected $extraLineInExcerpt = 2;
 
-    public function __construct($extraLineInExcerpt){
-        if ($extraLineInExcerpt) {
+    public function __construct($extraLineInExcerpt = null)
+    {
+        if ($extraLineInExcerpt && is_int($extraLineInExcerpt)) {
             $this->extraLineInExcerpt = $extraLineInExcerpt;
         }
     }

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -820,7 +820,8 @@ class CommandLineOptions
             '--update-baseline: will remove any non-existing violations from the phpmd.baseline.xml' . \PHP_EOL .
             '--baseline-file: a custom location of the baseline file' . \PHP_EOL .
             '--color: enable color in output' . \PHP_EOL .
-            '--extra-line-in-excerpt: Specify how many extra lines are added to a code snippet' . \PHP_EOL;
+            '--extra-line-in-excerpt: Specify how many extra lines are added ' .
+            'to a code snippet in html format' . \PHP_EOL;
     }
 
     /**

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -212,6 +212,12 @@ class CommandLineOptions
     protected $colored = false;
 
     /**
+     * Specify how many extra lines are added to a code snippet
+     * @var int|null
+     */
+    protected $extraLineInExcerpt;
+
+    /**
      * Constructs a new command line options instance.
      *
      * @param string[] $args
@@ -326,6 +332,9 @@ class CommandLineOptions
                 case '--reportfile-xml':
                     preg_match('(^\-\-reportfile\-(checkstyle|github|gitlab|html|json|sarif|text|xml)$)', $arg, $match);
                     $this->reportFiles[$match[1]] = array_shift($args);
+                    break;
+                case '--extra-line-in-excerpt':
+                    $this->extraLineInExcerpt = (int)array_shift($args);
                     break;
                 default:
                     $arguments[] = $arg;
@@ -686,7 +695,7 @@ class CommandLineOptions
      */
     protected function createHtmlRenderer()
     {
-        return new HTMLRenderer();
+        return new HTMLRenderer($this->extraLineInExcerpt);
     }
 
     /**
@@ -801,7 +810,8 @@ class CommandLineOptions
             'to the first ruleset file location' . \PHP_EOL .
             '--update-baseline: will remove any non-existing violations from the phpmd.baseline.xml' . \PHP_EOL .
             '--baseline-file: a custom location of the baseline file' . \PHP_EOL .
-            '--color: enable color in output' . \PHP_EOL;
+            '--color: enable color in output' . \PHP_EOL .
+            '--extra-line-in-excerpt: Specify how many extra lines are added to a code snippet' . \PHP_EOL;
     }
 
     /**

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -587,6 +587,15 @@ class CommandLineOptions
     }
 
     /**
+     * Specify how many extra lines are added to a code snippet
+     *
+     * @return int|null
+     */
+    public function extraLineInExcerpt()
+    {
+        return $this->extraLineInExcerpt;
+    }
+    /**
      * Creates a report renderer instance based on the user's command line
      * argument.
      *

--- a/src/test/php/PHPMD/AbstractTest.php
+++ b/src/test/php/PHPMD/AbstractTest.php
@@ -611,7 +611,7 @@ abstract class AbstractTest extends AbstractStaticTest
     }
 
     /**
-     * Creates a mocked rul violation instance.
+     * Creates a mocked rule violation instance.
      *
      * @param string $file
      * @param string $message

--- a/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -49,7 +49,8 @@ class HTMLRendererTest extends AbstractTest
             ->method('getRuleViolations')
             ->will($this->returnValue(new \ArrayIterator($violations)));
 
-        $renderer = new HTMLRenderer();
+        $extraLineInExcerpt = 2;
+        $renderer = new HTMLRenderer($extraLineInExcerpt);
         $renderer->setWriter($writer);
 
         $renderer->start();

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -726,6 +726,16 @@ class CommandLineOptionsTest extends AbstractTest
         $this->assertEquals($expected, $opts->getReportFiles());
     }
 
+    /**
+     * @return void
+     */
+    public function testCliOptionExtraLineInExcerptShouldBeWithNumber()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'codesize', '--extra-line-in-excerpt', '5');
+        $opts = new CommandLineOptions($args);
+        static::assertSame(5, $opts->extraLineInExcerpt());
+    }
+
     public function dataProviderGetReportFiles()
     {
         return array(


### PR DESCRIPTION
Type: feature
Breaking change: no

Instead of the magic number "2" in the renderReport method in the HTMLRenderer class, the protected field extraLineInExcerpt has been added, which is 2 by default and can be set using the --extra-line-in-excerpt command line argument.
