### PR TITLE
Fix call to undefined getParent() method

### DIFF
--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -56,9 +56,9 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
             }
         }
 
-        $mainNode = $node->getNode();
-        if (is_callable(array($mainNode, 'getParent'))) {
-            $parent = $mainNode->getParent();
+        $currNode = $node->getNode();
+        if (is_callable(array($currNode, 'getParent'))) {
+            $parent = $currNode->getParent();
         } else {
             $parent = null;
         }

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -58,7 +58,7 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
         }
 
         $currNode = $node->getNode();
-        $parent = is_callable(array($currNode, 'getParent') ? $currNode->getParent() : null;
+        $parent = is_callable(array($currNode, 'getParent')) ? $currNode->getParent() : null;
 
         if ($parent &&
             ($parent instanceof AbstractASTClassOrInterface) &&

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -48,7 +48,6 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
     public function apply(AbstractNode $node)
     {
         $name = $node->getName();
-
         if ($name) {
             $ignorePattern = trim($this->getStringProperty('ignorepattern', ''));
 
@@ -57,14 +56,17 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
             }
         }
 
-        $parent = $node->getNode()->getParent();
-
+        $mainNode = $node->getNode();
+        if (is_callable(array($mainNode, 'getParent'))) {
+            $parent = $mainNode->getParent();
+        } else {
+            $parent = null;
+        }
         if ($parent &&
             ($parent instanceof AbstractASTClassOrInterface) &&
             ($name = $parent->getName())
         ) {
             $exceptions = $this->getExceptionsList();
-
             if (isset($exceptions[$name])) {
                 return;
             }

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -48,6 +48,7 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
     public function apply(AbstractNode $node)
     {
         $name = $node->getName();
+
         if ($name) {
             $ignorePattern = trim($this->getStringProperty('ignorepattern', ''));
 
@@ -57,16 +58,14 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
         }
 
         $currNode = $node->getNode();
-        if (is_callable(array($currNode, 'getParent'))) {
-            $parent = $currNode->getParent();
-        } else {
-            $parent = null;
-        }
+        $parent = is_callable(array($currNode, 'getParent') ? $currNode->getParent() : null;
+
         if ($parent &&
             ($parent instanceof AbstractASTClassOrInterface) &&
             ($name = $parent->getName())
         ) {
             $exceptions = $this->getExceptionsList();
+
             if (isset($exceptions[$name])) {
                 return;
             }


### PR DESCRIPTION
Type: bugfix 
Breaking change: no

Fix PHP Fatal Error: Uncaught error: Call to undefined method PDepend\Source\AST\AST\ASTFunction::getParent() in phpmd\src\main\php\PHPMD\Rule\CleanCode\BooleanArgumentFlag.php:60 for files like:

```
<?php

function sum($a, $b)
{
    return ((int)$a + (int)$b);
}
```
