### PR TITLE
Allow option and value separated with equal sign

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,6 +171,16 @@ Command line options
 
     phpmd PHP/Depend/DbusUI xml codesize --reportfile phpmd.xml --suffixes php,phtml
 
+  Options can be before or after arguments, and separated to their value either with a space or ``=``, so this syntax
+  is equivalent to the previous one: ::
+
+    phpmd --reportfile=phpmd.xml --suffixes=php,phtml PHP/Depend/DbusUI xml codesize
+
+  Strings starting with ``-`` will be recognized as option names. If you have arguments starting with ``-``, set options
+  first, then use ``--`` to mark the explicit start or the arguments list: ::
+
+    phpmd --reportfile phpmd.xml --suffixes php,phtml -- -foo/Folder xml codesize
+
 Using multiple rule sets
 ````````````````````````
 

--- a/README.rst
+++ b/README.rst
@@ -171,8 +171,8 @@ Command line options
 
     phpmd PHP/Depend/DbusUI xml codesize --reportfile phpmd.xml --suffixes php,phtml
 
-  Options can be before or after arguments, and separated to their value either with a space or ``=``, so this syntax
-  is equivalent to the previous one: ::
+  Options can be before or after arguments. They can be separated from their value either with a space or an equal (``=``) sign.
+  Thus, the following syntax is equivalent to the previous one: ::
 
     phpmd --reportfile=phpmd.xml --suffixes=php,phtml PHP/Depend/DbusUI xml codesize
 

--- a/README.rst
+++ b/README.rst
@@ -169,17 +169,17 @@ Command line options
 
   An example command line: ::
 
-    phpmd PHP/Depend/DbusUI xml codesize --reportfile phpmd.xml --suffixes php,phtml
+    phpmd PHP/Depend/DbusUI xml codesize --reportfile "phpmd.xml" --suffixes "php,phtml"
 
   Options can be before or after arguments. They can be separated from their value either with a space or an equal (``=``) sign.
   Thus, the following syntax is equivalent to the previous one: ::
 
-    phpmd --reportfile=phpmd.xml --suffixes=php,phtml PHP/Depend/DbusUI xml codesize
+    phpmd --reportfile="phpmd.xml" --suffixes="php,phtml" PHP/Depend/DbusUI xml codesize
 
   Strings starting with ``-`` will be recognized as option names. If you have arguments starting with ``-``, set options
   first, then use ``--`` to mark the explicit start or the arguments list: ::
 
-    phpmd --reportfile phpmd.xml --suffixes php,phtml -- -foo/Folder xml codesize
+    phpmd --reportfile "phpmd.xml" --suffixes "php,phtml" -- -foo/Folder xml codesize
 
 Using multiple rule sets
 ````````````````````````

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -863,7 +863,9 @@ class CommandLineOptions
             '--baseline-file: a custom location of the baseline file' . \PHP_EOL .
             '--color: enable color in output' . \PHP_EOL .
             '--extra-line-in-excerpt: Specify how many extra lines are added ' .
-            'to a code snippet in html format' . \PHP_EOL;
+            'to a code snippet in html format' . \PHP_EOL .
+            '--: Explicit argument separator: anything after -- will be read as an argument even if' .
+            'it starts with "-" or matches the name of an option' . \PHP_EOL;
     }
 
     /**

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -864,7 +864,7 @@ class CommandLineOptions
             '--color: enable color in output' . \PHP_EOL .
             '--extra-line-in-excerpt: Specify how many extra lines are added ' .
             'to a code snippet in html format' . \PHP_EOL .
-            '--: Explicit argument separator: anything after -- will be read as an argument even if' .
+            '--: Explicit argument separator: Anything after "--" will be read as an argument even if' .
             'it starts with "-" or matches the name of an option' . \PHP_EOL;
     }
 

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -925,13 +925,28 @@ class CommandLineOptions
         throw new InvalidArgumentException("Input file '{$inputFile}' not exists.");
     }
 
+    /**
+     * Throw an exception if a boolean option has a value (is followed by equal).
+     *
+     * @param string[] $equalChunk The CLI parameter split in 2 by "=" sign
+     *
+     * @throws InvalidArgumentException if a boolean option has a value (is followed by equal)
+     */
     private function refuseValue(array $equalChunk)
     {
         if (count($equalChunk) > 1) {
-            throw new InvalidArgumentException($equalChunk[0] . ' option does not accept value');
+            throw new InvalidArgumentException($equalChunk[0] . ' option does not accept a value');
         }
     }
 
+    /**
+     * Return value for an option either what is after "=" sign if present, else take the next CLI parameter.
+     *
+     * @param string[] $equalChunk The CLI parameter split in 2 by "=" sign
+     * @param string[] &$args      The remaining CLI parameters not yet parsed
+     *
+     * return string|null
+     */
     private function readValue(array $equalChunk, array &$args)
     {
         if (count($equalChunk) > 1) {

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -945,7 +945,7 @@ class CommandLineOptions
      * @param string[] $equalChunk The CLI parameter split in 2 by "=" sign
      * @param string[] &$args      The remaining CLI parameters not yet parsed
      *
-     * return string|null
+     * @return string|null
      */
     private function readValue(array $equalChunk, array &$args)
     {

--- a/src/main/php/PHPMD/Utility/ArgumentsValidator.php
+++ b/src/main/php/PHPMD/Utility/ArgumentsValidator.php
@@ -9,8 +9,10 @@ class ArgumentsValidator
 {
     /** @var bool */
     private $hasImplicitArguments;
+    
     /** @var string[] */
     private $originalArguments;
+    
     /** @var string[] */
     private $arguments;
 

--- a/src/main/php/PHPMD/Utility/ArgumentsValidator.php
+++ b/src/main/php/PHPMD/Utility/ArgumentsValidator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace PHPMD\Utility;
+
+use InvalidArgumentException;
+use RuntimeException;
+
+class ArgumentsValidator
+{
+    /** @var bool */
+    private $hasImplicitArguments;
+    /** @var string[] */
+    private $originalArguments;
+    /** @var string[] */
+    private $arguments;
+
+    public function __construct($hasImplicitArguments, $originalArguments, $arguments)
+    {
+        $this->hasImplicitArguments = $hasImplicitArguments;
+        $this->originalArguments = $originalArguments;
+        $this->arguments = $arguments;
+    }
+
+    public function validate($name, $value)
+    {
+        if (!$this->hasImplicitArguments) {
+            return;
+        }
+
+        if (substr($value, 0, 1) !== '-') {
+            return;
+        }
+
+        $options = array_diff($this->originalArguments, $this->arguments, array('--'));
+
+        throw new InvalidArgumentException(
+            'Unknown option ' . $value . '.' . PHP_EOL .
+            'If you intend to use "' . $value . '" as a value for ' . $name . ' argument, ' .
+            'use the explicit argument separator:' . PHP_EOL .
+            rtrim('phpmd ' . implode(' ', $options)) . ' -- ' .
+            implode(' ', $this->arguments)
+        );
+    }
+}

--- a/src/main/php/PHPMD/Utility/ArgumentsValidator.php
+++ b/src/main/php/PHPMD/Utility/ArgumentsValidator.php
@@ -9,10 +9,10 @@ class ArgumentsValidator
 {
     /** @var bool */
     private $hasImplicitArguments;
-    
+
     /** @var string[] */
     private $originalArguments;
-    
+
     /** @var string[] */
     private $arguments;
 
@@ -23,6 +23,16 @@ class ArgumentsValidator
         $this->arguments = $arguments;
     }
 
+    /**
+     * Throw an exception if the given $value cannot be used as a value for the argument $name.
+     *
+     * @param string $name
+     * @param string $value
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException if the given $value cannot be used as a value for the argument $name
+     */
     public function validate($name, $value)
     {
         if (!$this->hasImplicitArguments) {

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -215,7 +215,7 @@ class CommandLineOptionsTest extends AbstractTest
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage --color option does not accept value
+     * @expectedExceptionMessage --color option does not accept a value
      *
      * @covers \PHPMD\TextUI\ArgumentsValidator
      */

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -151,6 +151,103 @@ class CommandLineOptionsTest extends AbstractTest
     }
 
     /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown option --help.
+     *
+     * @covers \PHPMD\TextUI\ArgumentsValidator
+     */
+    public function testThrowsExpectedExceptionWhenOptionNotFound()
+    {
+        if (method_exists($this, 'expectExceptionMessage')) {
+            self::expectExceptionMessage(
+                'Unknown option --help.' . PHP_EOL .
+                'If you intend to use "--help" as a value for ruleset argument, ' .
+                'use the explicit argument separator:' . PHP_EOL .
+                'phpmd -- text design --help'
+            );
+        }
+
+        $args = array(__FILE__, 'text', 'design', '--help');
+        new CommandLineOptions($args);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown option -foobar
+     *
+     * @covers \PHPMD\TextUI\ArgumentsValidator
+     */
+    public function testThrowsExpectedExceptionWhenOptionNotFoundInFront()
+    {
+        if (method_exists($this, 'expectExceptionMessage')) {
+            self::expectExceptionMessage(
+                'Unknown option -foobar.' . PHP_EOL .
+                'If you intend to use "-foobar" as a value for input path argument, ' .
+                'use the explicit argument separator:' . PHP_EOL .
+                'phpmd -- -foobar text design'
+            );
+        }
+
+        $args = array(__FILE__, '-foobar', 'text', 'design');
+        new CommandLineOptions($args);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown option --help.
+     *
+     * @covers \PHPMD\TextUI\ArgumentsValidator
+     */
+    public function testThrowsExpectedExceptionWhenOptionNotFoundUsingArgumentSeparator()
+    {
+        if (method_exists($this, 'expectExceptionMessage')) {
+            self::expectExceptionMessage(
+                'Unknown option --help.' . PHP_EOL .
+                'If you intend to use "--help" as a value for input path argument, ' .
+                'use the explicit argument separator:' . PHP_EOL .
+                'phpmd -- --help text design'
+            );
+        }
+
+        $args = array(__FILE__, '--help', '--', 'text', 'design');
+        new CommandLineOptions($args);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage --color option does not accept value
+     *
+     * @covers \PHPMD\TextUI\ArgumentsValidator
+     */
+    public function testThrowsExpectedExceptionWhenBooleanOptionReceiveValue()
+    {
+        $args = array(__FILE__, '--color=on', 'text', 'design');
+        new CommandLineOptions($args);
+    }
+
+    /**
+     * @covers \PHPMD\TextUI\ArgumentsValidator
+     */
+    public function testOptionEqualSyntax()
+    {
+        $args = array(__FILE__, '--exclude=*/vendor/*', '-', 'text', 'design');
+        $opts = new CommandLineOptions($args);
+
+        self::assertSame('*/vendor/*', $opts->getIgnore());
+    }
+
+    /**
+     * @covers \PHPMD\TextUI\ArgumentsValidator
+     */
+    public function testArgumentSeparatorEnforced()
+    {
+        $args = array(__FILE__, '--', '--help', 'text', 'design');
+        $opts = new CommandLineOptions($args);
+
+        self::assertSame('--help', $opts->getInputPath());
+    }
+
+    /**
      * testAssignsInputFileOptionToInputPathProperty
      *
      * @return void
@@ -163,7 +260,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array('foo.php', 'text', 'design', '--inputfile', $uri);
         $opts = new CommandLineOptions($args);
 
-        self::assertEquals('Dir1/Class1.php,Dir2/Class2.php', $opts->getInputPath());
+        self::assertSame('Dir1/Class1.php,Dir2/Class2.php', $opts->getInputPath());
     }
 
     /**
@@ -179,7 +276,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array('foo.php', 'text', 'design', '--inputfile', $uri);
         $opts = new CommandLineOptions($args);
 
-        self::assertEquals('text', $opts->getReportFormat());
+        self::assertSame('text', $opts->getReportFormat());
     }
 
     /**
@@ -195,7 +292,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array('foo.php', 'text', 'design', '--inputfile', $uri);
         $opts = new CommandLineOptions($args);
 
-        self::assertEquals('design', $opts->getRuleSets());
+        self::assertSame('design', $opts->getRuleSets());
     }
 
     /**
@@ -273,7 +370,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertContains('--ignore-errors-on-exit:', $opts->usage());
+        self::assertContains('--ignore-errors-on-exit:', $opts->usage());
     }
 
     /**
@@ -312,7 +409,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertContains('--ignore-violations-on-exit:', $opts->usage());
+        self::assertContains('--ignore-violations-on-exit:', $opts->usage());
     }
 
     /**
@@ -325,7 +422,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertContains(
+        self::assertContains(
             'Available formats: ansi, baseline, checkstyle, github, gitlab, html, json, sarif, text, xml.',
             $opts->usage()
         );
@@ -341,7 +438,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertContains('--strict:', $opts->usage());
+        self::assertContains('--strict:', $opts->usage());
     }
 
     /**
@@ -385,7 +482,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, '--minimumpriority', 42, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertEquals(42, $opts->getMinimumPriority());
+        self::assertSame(42, $opts->getMinimumPriority());
     }
 
     /**
@@ -396,7 +493,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, '--maximumpriority', 42, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertEquals(42, $opts->getMaximumPriority());
+        self::assertSame(42, $opts->getMaximumPriority());
     }
 
     /**
@@ -497,7 +594,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertEquals(Rule::LOWEST_PRIORITY, $opts->getMinimumPriority());
+        self::assertSame(Rule::LOWEST_PRIORITY, $opts->getMinimumPriority());
     }
 
     /**
@@ -508,7 +605,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertNull($opts->getCoverageReport());
+        self::assertNull($opts->getCoverageReport());
     }
 
     /**
@@ -527,7 +624,7 @@ class CommandLineOptionsTest extends AbstractTest
             )
         );
 
-        $this->assertEquals(__METHOD__, $opts->getCoverageReport());
+        self::assertSame(__METHOD__, $opts->getCoverageReport());
     }
 
     /**
@@ -544,8 +641,8 @@ class CommandLineOptionsTest extends AbstractTest
             )
         );
 
-        $this->assertSame(ResultCacheStrategy::CONTENT, $opts->cacheStrategy());
-        $this->assertFalse($opts->isCacheEnabled());
+        self::assertSame(ResultCacheStrategy::CONTENT, $opts->cacheStrategy());
+        self::assertFalse($opts->isCacheEnabled());
 
         $opts = new CommandLineOptions(
             array(
@@ -559,8 +656,8 @@ class CommandLineOptionsTest extends AbstractTest
             )
         );
 
-        $this->assertSame(ResultCacheStrategy::TIMESTAMP, $opts->cacheStrategy());
-        $this->assertTrue($opts->isCacheEnabled());
+        self::assertSame(ResultCacheStrategy::TIMESTAMP, $opts->cacheStrategy());
+        self::assertTrue($opts->isCacheEnabled());
 
         $opts = new CommandLineOptions(
             array(
@@ -576,9 +673,9 @@ class CommandLineOptionsTest extends AbstractTest
             )
         );
 
-        $this->assertSame(ResultCacheStrategy::CONTENT, $opts->cacheStrategy());
-        $this->assertSame('abc', $opts->cacheFile());
-        $this->assertTrue($opts->isCacheEnabled());
+        self::assertSame(ResultCacheStrategy::CONTENT, $opts->cacheStrategy());
+        self::assertSame('abc', $opts->cacheFile());
+        self::assertTrue($opts->isCacheEnabled());
     }
 
     /**
@@ -589,16 +686,16 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize', '--ignore', 'foo/bar', '--error-file', 'abc');
         $opts = new CommandLineOptions($args);
 
-        $this->assertSame('abc', $opts->getErrorFile());
-        $this->assertSame('foo/bar', $opts->getIgnore());
-        $this->assertSame(array(
+        self::assertSame('abc', $opts->getErrorFile());
+        self::assertSame('foo/bar', $opts->getIgnore());
+        self::assertSame(array(
             'The --ignore option is deprecated, please use --exclude instead.',
         ), $opts->getDeprecations());
 
         $args = array(__FILE__, __FILE__, 'text', 'codesize', '--exclude', 'bar/biz');
         $opts = new CommandLineOptions($args);
 
-        $this->assertSame('bar/biz', $opts->getIgnore());
+        self::assertSame('bar/biz', $opts->getIgnore());
     }
 
     /**
@@ -612,7 +709,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, $reportFormat, 'codesize');
         $opts = new CommandLineOptions($args);
 
-        $this->assertInstanceOf($expectedClass, $opts->createRenderer($reportFormat));
+        self::assertInstanceOf($expectedClass, $opts->createRenderer($reportFormat));
     }
 
     /**
@@ -673,7 +770,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize', sprintf('--%s', $deprecatedName), '42');
         $opts = new CommandLineOptions($args);
 
-        $this->assertSame(
+        self::assertSame(
             array(
                 sprintf(
                     'The --%s option is deprecated, please use --%s instead.',
@@ -688,7 +785,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array(__FILE__, __FILE__, 'text', 'codesize', sprintf('--%s', $newName), '42');
         $opts = new CommandLineOptions($args);
 
-        $this->assertSame(
+        self::assertSame(
             array(),
             $opts->getDeprecations()
         );
@@ -723,7 +820,7 @@ class CommandLineOptionsTest extends AbstractTest
         $args = array_merge(array(__FILE__, __FILE__, 'text', 'codesize'), $options);
         $opts = new CommandLineOptions($args);
 
-        $this->assertEquals($expected, $opts->getReportFiles());
+        self::assertEquals($expected, $opts->getReportFiles());
     }
 
     /**


### PR DESCRIPTION
Type: feature
Issue: Resolves #1035
Breaking change: yes

- Allow option and value separated with equal
- Implement argument separator `--`

It's a BC for users having file/directory names starting with `-` and passing them as argument of the `phpmd` command.

If this change is merged, they will see an error asking them add `--` in their command line to explicitly separate options from arguments.

In PHPMD 2.13.0 calling the command with trailing malformed or unknown options were silently ignored.

In PHPMD 2.14.0, it raises an error because it ends in producing an invalid argument value.

With this change, we'll get an helpful error for the user and give them a way for disambiguation if they really intend an option-like value to be used as an argument:

Calling:
```
phpmd -- foo/test.php text foo/phpmd.xml --help --exclude=*/vendor/*
```

You'll get:
```
Unknown option --help.
If you intend to use "--help" as a value for ruleset argument, use the explicit argument separator:
phpmd --exclude=*/vendor/* -- foo/test.php text foo/phpmd.xml --help
```