### PR TITLE
The result cache should still work if there are no composer or baseline files.

### DIFF
--- a/src/main/php/PHPMD/Cache/ResultCacheStateFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheStateFactory.php
@@ -35,13 +35,11 @@ class ResultCacheStateFactory
      */
     private function createCacheKey(array $data)
     {
-        if (isset(
-            $data['strict'],
-            $data['baselineHash'],
-            $data['rules'],
-            $data['composer'],
-            $data['phpVersion']
-        ) === false
+        if (array_key_exists('strict', $data) === false ||
+            array_key_exists('baselineHash', $data) === false ||
+            array_key_exists('rules', $data) === false ||
+            array_key_exists('composer', $data) === false ||
+            array_key_exists('phpVersion', $data) === false
         ) {
             return null;
         }

--- a/src/test/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
@@ -71,4 +71,25 @@ class ResultCacheStateFactoryTest extends AbstractTest
         static::assertTrue($state->isFileModified('file2', 'file1-hash'));
         static::assertSame(array('violations'), $state->getViolations('file2'));
     }
+
+    /**
+     * @covers ::fromFile
+     * @covers ::createCacheKey
+     */
+    public function testFromFileWithCacheWithoutBaselineOrComposer()
+    {
+        $state = $this->factory->fromFile(static::createResourceUriForTest('.minimal-cache.php'));
+        static::assertNotNull($state);
+
+        // assert cache key
+        $expectedKey = new ResultCacheKey(
+            false,
+            null,
+            array('rule' => 'hash'),
+            array(),
+            70000
+        );
+        $cacheKey    = $state->getCacheKey();
+        static::assertEquals($expectedKey, $cacheKey);
+    }
 }

--- a/src/test/resources/files/Cache/ResultCacheStateFactory/.minimal-cache.php
+++ b/src/test/resources/files/Cache/ResultCacheStateFactory/.minimal-cache.php
@@ -1,0 +1,18 @@
+<?php
+
+return array(
+    'key'   =>
+        array(
+            'strict'       => false,
+            'baselineHash' => null,
+            'rules'        =>
+                array(
+                    'rule' => 'hash',
+                ),
+            'composer'     => array(),
+            'phpVersion'   => 70000,
+        ),
+    'state' =>
+        array(
+        ),
+);


### PR DESCRIPTION
Type: bugfix
Originated from: #1011
Breaking change: no

The result cache will generate cache data with 5 keys. One of those keys is `baselineHash`, which _can_ be `null`. However I used
isset (instead of `array_keys_exist`), to check if all keys were present. Ive changed this to `array_keys_exist` instead.

Added testcase for the original problem.

Thanks @mvoelker for the investigation of the problem.