### PR TITLE
Fix the strict option on applyOnClassMethods.

### DIFF
--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -102,6 +102,13 @@ abstract class AbstractRule implements Rule
     private $report = null;
 
     /**
+     * Should this rule force the strict mode.
+     *
+     * @var boolean
+     */
+    private $strict = false;
+
+    /**
      * Returns the name for this rule instance.
      *
      * @return string
@@ -379,6 +386,15 @@ abstract class AbstractRule implements Rule
     }
 
     /**
+     * @param bool $strict
+     * @return void
+     */
+    public function setStrict($strict)
+    {
+        $this->strict = $strict;
+    }
+
+    /**
      * This method adds a violation to all reports for this violation type and
      * for the given <b>$node</b> instance.
      *
@@ -409,7 +425,7 @@ abstract class AbstractRule implements Rule
     protected function applyOnClassMethods(AbstractTypeNode $node)
     {
         foreach ($node->getMethods() as $method) {
-            if ($method->hasSuppressWarningsAnnotationFor($this)) {
+            if (!$this->strict && $method->hasSuppressWarningsAnnotationFor($this)) {
                 continue;
             }
 

--- a/src/main/php/PHPMD/RuleSet.php
+++ b/src/main/php/PHPMD/RuleSet.php
@@ -259,6 +259,9 @@ class RuleSet implements IteratorAggregate
                 continue;
             }
             $rule->setReport($this->report);
+            if (method_exists($rule, 'setStrict')) {
+                $rule->setStrict($this->strict);
+            }
             $rule->apply($node);
         }
     }


### PR DESCRIPTION
Type: bugfix
Issue: Resolves #1020
Breaking change: no

The `CountInLoopExpression` use the `applyOnClassMethods`, that method didn't check the strict option on the ruleset.

The ruleset set the strict on the rule if the function is available. This will prevent a BC break.