### PR TITLE
Allow Symfony 7

### DIFF
--- a/.github/workflows/generate_phar.yml
+++ b/.github/workflows/generate_phar.yml
@@ -2,10 +2,9 @@ name: Generate phar
 
 on:
   push:
-    tags:
-      - "*"
-    branches:
-      - "*"
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
   release:
     types:
       - created

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -1,0 +1,78 @@
+name: Symfony
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      COMPOSER_NO_INTERACTION: 1
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ 8.3 ]
+        symfony: [ 2, 3, 4, 5, 6, 7 ]
+
+    name: Symfony ${{ matrix.symfony }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, imagick
+          tools: composer:v2
+          coverage: none
+
+      - name: Cache library packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-
+
+      - name: Cache test packages
+        id: composer-test-cache
+        uses: actions/cache@v3
+        with:
+          path: src/test/vendor
+          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-test-${{ matrix.symfony }}-${{ hashFiles('src/test/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-symfony-test-${{ matrix.symfony }}-
+
+      - name: Set Symfony version
+        run: |
+          composer require  --no-update --no-interaction \
+            symfony/dependency-injection:^${{ matrix.symfony }} \
+            symfony/filesystem:^${{ matrix.symfony }} \
+            symfony/config:^${{ matrix.symfony }}
+
+      - name: Upgrade PHPUnit
+        if: matrix.php >= 7.2
+        run: cd src/test && composer require phpunit/phpunit:^5.7.27 --no-update --no-interaction --dev
+
+      - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer update --prefer-dist --no-progress --prefer-stable --ignore-platform-req=php+
+
+      - name: Install test dependencies
+        if: steps.composer-test-cache.outputs.cache-hit != 'true'
+        run: cd src/test && composer update --prefer-dist --no-progress --prefer-stable --ignore-platform-req=php+
+
+      - name: Fix PHP compatibility
+        if: steps.composer-test-cache.outputs.cache-hit != 'true'
+        run: php src/test/php/fix-php-compatibility.php
+
+      - name: Check Symfony version
+        run: php src/test/symfony-version.php
+
+      - name: Run test suite
+        run: src/test/vendor/bin/phpunit -v

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -1,5 +1,10 @@
 name: Symfony
 
+# Ensure tests pass whatever is the major version of Symfony installed
+# along with the library
+# Guarantee to users that it can be installed and ran with no conflict
+# in a composer project that also include Symfony dependencies
+
 on:
   push:
     branches: [ '**' ]

--- a/.github/workflows/tests-with-composer.yml
+++ b/.github/workflows/tests-with-composer.yml
@@ -1,0 +1,53 @@
+name: Composer test script
+
+# Ensure composer test can be run from both fresh build and with test/vendor
+# folder already installed, making sure contributors can rely on it to work locally.
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '8.3' ]
+
+    name: PHP ${{ matrix.php }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, imagick
+          tools: composer:v2
+          coverage: none
+
+      - name: Imagick SVG support
+        continue-on-error: true
+        run: sudo apt-get install libmagickcore-6.q16-3-extra
+
+      - name: Cache library packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-composer-${{ matrix.setup }}-
+
+      - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer up
+
+      - name: Run `composer test` twice
+        run: |
+          composer test
+          composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,11 +2,9 @@ name: Tests
 
 on:
   push:
-    branches:
-      - "*"
+    branches: [ '**' ]
   pull_request:
-    branches:
-      - "*"
+    branches: [ '**' ]
 
 jobs:
   php-tests:
@@ -17,17 +15,17 @@ jobs:
 
     strategy:
       matrix:
-        php: [5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
-        dependency-version: [prefer-lowest, prefer-stable]
+        php: [ 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 ]
+        setup: [ lowest, stable ]
         exclude:
-          - dependency-version: prefer-lowest
+          - setup: lowest
             php: 7.2
-          - dependency-version: prefer-lowest
+          - setup: lowest
             php: 7.3
-          - dependency-version: prefer-lowest
+          - setup: lowest
             php: 7.4
 
-    name: PHP ${{ matrix.php }} - ${{ matrix.dependency-version }}
+    name: PHP ${{ matrix.php }} - ${{ matrix.setup }}
 
     steps:
       - name: Checkout code
@@ -40,28 +38,40 @@ jobs:
           coverage: none
           tools: composer:v2
 
-      - name: Cache Composer packages
+      - name: Cache library packages
         id: composer-cache
         uses: actions/cache@v3
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.dependency-version }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.dependency-version }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.json') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-
+
+      - name: Cache test packages
+        id: composer-test-cache
+        uses: actions/cache@v3
+        with:
+          path: src/test/vendor
+          key: ${{ runner.os }}-php-test-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('src/test/composer.json') }}
+          restore-keys: ${{ runner.os }}-php-test-${{ matrix.php }}-${{ matrix.setup }}-
 
       - name: Upgrade PHPUnit
         if: matrix.php >= 7.2
-        run: composer require phpunit/phpunit:^5.7.27 --no-update --no-interaction --dev
+        run: cd src/test && composer require phpunit/phpunit:^5.7.27 --no-update --no-interaction --dev
 
       - name: Downgrade Symfony
         if: matrix.php >= 8.0 && matrix.dependency-version == 'prefer-stable'
         run: composer require symfony/config:^6.4 --no-update --no-interaction --dev
 
       - name: Install dependencies
-        run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress ${{ matrix.php >= 8 && '--ignore-platform-req=php' || '' }}
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer update --no-progress --prefer-${{ matrix.setup }} --prefer-dist --no-progress --ignore-platform-req=php+
+
+      - name: Install test dependencies
+        if: steps.composer-test-cache.outputs.cache-hit != 'true'
+        run: cd src/test && composer update --no-progress --prefer-dist --prefer-stable --ignore-platform-req=php+
 
       - name: Fix PHP compatibility
         run: php src/test/php/fix-php-compatibility.php
 
       - name: Execute Unit Tests
-        run: vendor/bin/phpunit
+        run: src/test/vendor/bin/phpunit -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,9 @@
 name: Tests
 
+# Ensure tests pass whatever is the minor PHP version currently supported (see strategy.matrix.php)
+# crossed with "lowest" setup (install the lowest possible dependency versions allowed by the range)
+# and with "stable" setup (install the highest possible dependency stable versions allowed by the range)
+
 on:
   push:
     branches: [ '**' ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           - setup: lowest
             php: 7.4
 
-    name: PHP ${{ matrix.php }} - ${{ matrix.setup }}
+    name: PHP ${{ matrix.php }} - prefer-${{ matrix.setup }}
 
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 /*.xml
 composer.lock
 vendor
+src/test/vendor
 dist

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,4 +23,4 @@ install:
 
 test_script:
   - cd C:\projects\phpmd
-  - vendor\bin\phpunit.bat
+  - php composer.phar test

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     "src/bin/phpmd"
   ],
   "scripts": {
-    "test": "phpunit",
+    "test": "cd src/test && composer update && cd ../.. && php src/test/php/fix-php-compatibility.php && php src/test/vendor/bin/phpunit --no-coverage",
     "cs-check": "phpcs -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
     "cs-fix": "phpcbf -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
     "build-website": "easy-doc build src/site/config.php --verbose"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "php": ">=5.3.9",
     "ext-xml": "*",
     "composer/xdebug-handler": "^1.0 || ^2.0 || ^3.0",
-    "pdepend/pdepend": "dev-fix/symfony-compatibility as 2.16.1"
+    "pdepend/pdepend": "^2.16.1"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.9.2 || ^3.7.2",
@@ -58,7 +58,7 @@
     "src/bin/phpmd"
   ],
   "scripts": {
-    "test": "cd src/test && composer update && cd ../.. && php src/test/php/fix-php-compatibility.php && php src/test/vendor/bin/phpunit --no-coverage",
+    "test": "php src/test/php/install-test-vendor.php && php src/test/vendor/bin/phpunit --no-coverage",
     "cs-check": "phpcs -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
     "cs-fix": "phpcbf -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
     "build-website": "easy-doc build src/site/config.php --verbose"

--- a/composer.json
+++ b/composer.json
@@ -37,12 +37,11 @@
   "minimum-stability": "stable",
   "require": {
     "php": ">=5.3.9",
-    "pdepend/pdepend": "^2.15.1",
     "ext-xml": "*",
-    "composer/xdebug-handler": "^1.0 || ^2.0 || ^3.0"
+    "composer/xdebug-handler": "^1.0 || ^2.0 || ^3.0",
+    "pdepend/pdepend": "dev-fix/symfony-compatibility as 2.16.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.36 || ^5.7.27",
     "squizlabs/php_codesniffer": "^2.9.2 || ^3.7.2",
     "mikey179/vfsstream": "^1.6.8",
     "gregwar/rst": "^1.0",

--- a/src/phar/compatibility.php
+++ b/src/phar/compatibility.php
@@ -3,12 +3,34 @@
 function replaceInFiles(array $files, array $replacements)
 {
     foreach ($files as $file) {
-        $oldContent = file_get_contents($file);
-        $newContent = strtr($oldContent, $replacements);
+        echo "File $file:\n";
+
+        if (!file_exists($file)) {
+            echo "File not found.\n";
+
+            continue;
+        }
+
+        $oldContent = @file_get_contents($file) ?: '';
+        $newContents = $oldContent;
+
+        foreach ($replacements as $key => $operation) {
+            if ($operation instanceof Closure) {
+                $newContents = call_user_func($operation, $newContents);
+                unset($replacements[$key]);
+            }
+        }
+
+        $newContent = strtr($newContents, $replacements);
 
         if ($oldContent !== $newContent) {
             file_put_contents($file, $newContent);
+            echo "Content changed.\n";
+
+            continue;
         }
+
+        echo "Replace pattern not found.\n";
     }
 }
 
@@ -22,3 +44,36 @@ replaceInFiles(
         ' libxml_disable_entity_loader(' => ' @libxml_disable_entity_loader(',
     )
 );
+
+$source = __DIR__ . '/../../vendor/pdepend/pdepend/src/main/php';
+
+$replacements = array(
+    $source . '/PDepend/DependencyInjection/Configuration.php' => array(
+        function ($contents) {
+            global $source;
+
+            $extract = (string)file_get_contents($source . '/Lazy/PDepend/DependencyInjection/Configuration.weak.php');
+            $pattern = '(// <AbstractConfiguration>[\s\S]+</AbstractConfiguration>)';
+
+            if (!preg_match($pattern, $extract, $match)) {
+                return $contents;
+            }
+
+            return preg_replace($pattern, $match[0], $contents);
+        },
+    ),
+    $source . '/Lazy/PDepend/DependencyInjection/Configuration.weak.php' => array(
+        function () {
+            return '';
+        },
+    ),
+    $source . '/Lazy/PDepend/DependencyInjection/Configuration.strong.php' => array(
+        function () {
+            return '';
+        },
+    ),
+);
+
+foreach ($replacements as $file => $callbacks) {
+    replaceInFiles(array($file), $callbacks);
+}

--- a/src/test/composer.json
+++ b/src/test/composer.json
@@ -1,0 +1,9 @@
+{
+  "name": "phpmd/phpmd-tester",
+  "license": "BSD-3-Clause",
+  "type": "library",
+  "require": {
+    "php": ">=5.3.9",
+    "phpunit/phpunit": "^4.8.36 || ^5.7.27"
+  }
+}

--- a/src/test/composer.json
+++ b/src/test/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "phpmd/phpmd-tester",
+  "description": "Test-related dependencies for phpmd/phpmd",
   "license": "BSD-3-Clause",
   "type": "library",
   "require": {

--- a/src/test/php/fix-php-compatibility.php
+++ b/src/test/php/fix-php-compatibility.php
@@ -1,10 +1,11 @@
 <?php
 
+$vendorPath = __DIR__ . '/../vendor';
 $replacements = array(
     /**
      * Patch phpunit/phpunit-mock-objects Generator.php file to not create double nullable tokens: `??`
      */
-    __DIR__ . '/../../../vendor/phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php' => array(
+    $vendorPath . '/phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php' => array(
         array(
             "if (version_compare(PHP_VERSION, '7.1', '>=') && " .
             "\$parameter->allowsNull() && !\$parameter->isVariadic()) {",
@@ -12,7 +13,7 @@ $replacements = array(
             "\$parameter->allowsNull() && !\$parameter->isVariadic()) {",
         ),
     ),
-    __DIR__ . '/../../../vendor/phpunit/phpunit/src/Util/Configuration.php' => array(
+    $vendorPath . '/phpunit/phpunit/src/Util/Configuration.php' => array(
         array(
             'final private function',
             'private function',
@@ -22,14 +23,20 @@ $replacements = array(
             '',
         ),
     ),
-    __DIR__ . '/../../../vendor/phpunit/phpunit/src/Framework/Constraint.php' => array(
+    $vendorPath . '/phpunit/phpunit/src/Framework/Constraint.php' => array(
         array(
             'public function count()',
             "#[\\ReturnTypeWillChange]\npublic function count()",
             '#[\\ReturnTypeWillChange]',
         ),
     ),
-    __DIR__ . '/../../../vendor/phpunit/php-token-stream/src/Token/Stream.php' => array(
+    $vendorPath . '/phpunit/php-token-stream/src/Token.php' => array(
+        array(
+            '$docComment = $this->getDocblock();',
+            '$docComment = (string) $this->getDocblock();',
+        ),
+    ),
+    $vendorPath . '/phpunit/php-token-stream/src/Token/Stream.php' => array(
         array(
             'public function offsetExists',
             "#[\\ReturnTypeWillChange]\npublic function offsetExists",
@@ -86,7 +93,7 @@ $replacements = array(
             '#[\\ReturnTypeWillChange]',
         ),
     ),
-    __DIR__ . '/../../../vendor/phpunit/phpunit/src/Util/TestSuiteIterator.php' => array(
+    $vendorPath . '/phpunit/phpunit/src/Util/TestSuiteIterator.php' => array(
         array(
             'public function current',
             "#[\\ReturnTypeWillChange]\npublic function current",
@@ -123,13 +130,13 @@ $replacements = array(
             "#[\\ReturnTypeWillChange]\npublic function hasChildren",
         ),
     ),
-    __DIR__ . '/../../../vendor/phpunit/php-code-coverage/src/Report/Html/Renderer/File.php' => (PHP_VERSION >= 7) ? array(
+    $vendorPath . '/phpunit/php-code-coverage/src/Report/Html/Renderer/File.php' => (PHP_VERSION >= 7) ? array(
         array(
             '$numTests = count($coverageData[$i]);',
             '$numTests = count($coverageData[$i] ?? []);',
         ),
     ) : array(),
-    __DIR__ . '/../../../vendor/phpunit/phpunit/src/Extensions/PhptTestCase.php' => array(
+    $vendorPath . '/phpunit/phpunit/src/Extensions/PhptTestCase.php' => array(
         array(
             'public function count()',
             "#[\\ReturnTypeWillChange]\npublic function count()",
@@ -141,26 +148,14 @@ $replacements = array(
             'xdebug.mode=coverage',
         ),
     ),
-    __DIR__ . '/../../../vendor/phpunit/phpunit/src/Framework/TestCase.php' => array(
+    $vendorPath . '/phpunit/phpunit/src/Framework/TestCase.php' => array(
         array(
             'public function count(',
             "#[\\ReturnTypeWillChange]\npublic function count(",
             '#[\\ReturnTypeWillChange]',
         ),
     ),
-    __DIR__ . '/../../../vendor/phpunit/phpunit/src/Framework/TestSuite.php' => array(
-        array(
-            'public function count(',
-            "#[\\ReturnTypeWillChange]\npublic function count(",
-            '#[\\ReturnTypeWillChange]',
-        ),
-        array(
-            'public function getIterator(',
-            "#[\\ReturnTypeWillChange]\npublic function getIterator(",
-            '#[\\ReturnTypeWillChange]',
-        ),
-    ),
-    __DIR__ . '/../../../vendor/phpunit/phpunit/src/Framework/TestResult.php' => array(
+    $vendorPath . '/phpunit/phpunit/src/Framework/TestSuite.php' => array(
         array(
             'public function count(',
             "#[\\ReturnTypeWillChange]\npublic function count(",
@@ -172,14 +167,32 @@ $replacements = array(
             '#[\\ReturnTypeWillChange]',
         ),
     ),
-    __DIR__ . '/../../../vendor/phpunit/php-code-coverage/src/CodeCoverage.php' => (PHP_VERSION >= 7) ? array(
+    $vendorPath . '/phpunit/phpunit/src/Framework/TestResult.php' => array(
+        array(
+            'public function count(',
+            "#[\\ReturnTypeWillChange]\npublic function count(",
+            '#[\\ReturnTypeWillChange]',
+        ),
+        array(
+            'public function getIterator(',
+            "#[\\ReturnTypeWillChange]\npublic function getIterator(",
+            '#[\\ReturnTypeWillChange]',
+        ),
+    ),
+    $vendorPath . '/phpunit/phpunit/src/Util/Getopt.php' => array(
+        array(
+            'strlen($opt_arg)',
+            'strlen((string) $opt_arg)',
+        ),
+    ),
+    $vendorPath . '/phpunit/php-code-coverage/src/CodeCoverage.php' => (PHP_VERSION >= 7) ? array(
         array(
             '$docblock = $token->getDocblock();',
             '$docblock = $token->getDocblock() ?? \'\';',
             '$docblock = $token->getDocblock() ?? \'\';',
         ),
     ) : array(),
-    __DIR__ . '/../../../vendor/phpunit/phpunit/src/Runner/Filter/Test.php' => array(
+    $vendorPath . '/phpunit/phpunit/src/Runner/Filter/Test.php' => array(
         array(
             'public function accept(',
             "#[\\ReturnTypeWillChange]\npublic function accept(",

--- a/src/test/php/fix-php-compatibility.php
+++ b/src/test/php/fix-php-compatibility.php
@@ -16,18 +16,17 @@ $replacements = array(
     $vendorPath . '/phpunit/phpunit/src/Util/Configuration.php' => array(
         array(
             'final private function',
-            'private function',
+            '/** @final */ private function',
         ),
         array(
             '$target = &$GLOBALS;',
-            '',
+            '// Access to $GLOBALS removed',
         ),
     ),
     $vendorPath . '/phpunit/phpunit/src/Framework/Constraint.php' => array(
         array(
             'public function count()',
             "#[\\ReturnTypeWillChange]\npublic function count()",
-            '#[\\ReturnTypeWillChange]',
         ),
     ),
     $vendorPath . '/phpunit/php-token-stream/src/Token.php' => array(
@@ -40,94 +39,82 @@ $replacements = array(
         array(
             'public function offsetExists',
             "#[\\ReturnTypeWillChange]\npublic function offsetExists",
-            '#[\\ReturnTypeWillChange]',
         ),
         array(
             'public function offsetGet',
             "#[\\ReturnTypeWillChange]\npublic function offsetGet",
-            '#[\\ReturnTypeWillChange]',
         ),
         array(
             'public function offsetSet',
             "#[\\ReturnTypeWillChange]\npublic function offsetSet",
-            '#[\\ReturnTypeWillChange]',
         ),
         array(
             'public function offsetUnset',
             "#[\\ReturnTypeWillChange]\npublic function offsetUnset",
-            '#[\\ReturnTypeWillChange]',
         ),
         array(
             'public function count',
             "#[\\ReturnTypeWillChange]\npublic function count",
-            '#[\\ReturnTypeWillChange]',
         ),
         array(
             'public function seek',
             "#[\\ReturnTypeWillChange]\npublic function seek",
-            '#[\\ReturnTypeWillChange]',
         ),
         array(
             'public function current',
             "#[\\ReturnTypeWillChange]\npublic function current",
-            '#[\\ReturnTypeWillChange]',
         ),
         array(
             'public function next',
             "#[\\ReturnTypeWillChange]\npublic function next",
-            '#[\\ReturnTypeWillChange]',
         ),
         array(
             'public function key',
             "#[\\ReturnTypeWillChange]\npublic function key",
-            '#[\\ReturnTypeWillChange]',
         ),
         array(
             'public function valid',
             "#[\\ReturnTypeWillChange]\npublic function valid",
-            '#[\\ReturnTypeWillChange]',
         ),
         array(
             'public function rewind',
             "#[\\ReturnTypeWillChange]\npublic function rewind",
-            '#[\\ReturnTypeWillChange]',
         ),
     ),
     $vendorPath . '/phpunit/phpunit/src/Util/TestSuiteIterator.php' => array(
         array(
             'public function current',
             "#[\\ReturnTypeWillChange]\npublic function current",
-            "#[\\ReturnTypeWillChange]\npublic function current",
         ),
         array(
             'public function next',
-            "#[\\ReturnTypeWillChange]\npublic function next",
             "#[\\ReturnTypeWillChange]\npublic function next",
         ),
         array(
             'public function key',
             "#[\\ReturnTypeWillChange]\npublic function key",
-            "#[\\ReturnTypeWillChange]\npublic function key",
         ),
         array(
             'public function valid',
-            "#[\\ReturnTypeWillChange]\npublic function valid",
             "#[\\ReturnTypeWillChange]\npublic function valid",
         ),
         array(
             'public function rewind',
             "#[\\ReturnTypeWillChange]\npublic function rewind",
-            "#[\\ReturnTypeWillChange]\npublic function rewind",
         ),
         array(
             'public function getChildren',
-            "#[\\ReturnTypeWillChange]\npublic function getChildren",
             "#[\\ReturnTypeWillChange]\npublic function getChildren",
         ),
         array(
             'public function hasChildren',
             "#[\\ReturnTypeWillChange]\npublic function hasChildren",
-            "#[\\ReturnTypeWillChange]\npublic function hasChildren",
+        ),
+    ),
+    $vendorPath . '/phpunit/php-file-iterator/src/Iterator.php' => array(
+        array(
+            'public function accept(',
+            "#[\\ReturnTypeWillChange]\npublic function accept(",
         ),
     ),
     $vendorPath . '/phpunit/php-code-coverage/src/Report/Html/Renderer/File.php' => (PHP_VERSION >= 7) ? array(
@@ -140,12 +127,14 @@ $replacements = array(
         array(
             'public function count()',
             "#[\\ReturnTypeWillChange]\npublic function count()",
-            '#[\\ReturnTypeWillChange]',
         ),
         array(
             'xdebug.default_enable=0',
             'xdebug.mode=coverage',
-            'xdebug.mode=coverage',
+        ),
+        array(
+            "'track_errors=1',",
+            "// 'track_errors=1',",
         ),
     ),
     $vendorPath . '/phpunit/phpunit/src/Framework/TestCase.php' => array(
@@ -159,24 +148,20 @@ $replacements = array(
         array(
             'public function count(',
             "#[\\ReturnTypeWillChange]\npublic function count(",
-            '#[\\ReturnTypeWillChange]',
         ),
         array(
             'public function getIterator(',
             "#[\\ReturnTypeWillChange]\npublic function getIterator(",
-            '#[\\ReturnTypeWillChange]',
         ),
     ),
     $vendorPath . '/phpunit/phpunit/src/Framework/TestResult.php' => array(
         array(
             'public function count(',
             "#[\\ReturnTypeWillChange]\npublic function count(",
-            '#[\\ReturnTypeWillChange]',
         ),
         array(
             'public function getIterator(',
             "#[\\ReturnTypeWillChange]\npublic function getIterator(",
-            '#[\\ReturnTypeWillChange]',
         ),
     ),
     $vendorPath . '/phpunit/phpunit/src/Util/Getopt.php' => array(
@@ -184,11 +169,14 @@ $replacements = array(
             'strlen($opt_arg)',
             'strlen((string) $opt_arg)',
         ),
+        array(
+            'while (list($i, $arg) = each($args)) {',
+            'foreach ($args as $i => $arg) {',
+        ),
     ),
     $vendorPath . '/phpunit/php-code-coverage/src/CodeCoverage.php' => (PHP_VERSION >= 7) ? array(
         array(
             '$docblock = $token->getDocblock();',
-            '$docblock = $token->getDocblock() ?? \'\';',
             '$docblock = $token->getDocblock() ?? \'\';',
         ),
     ) : array(),
@@ -196,7 +184,6 @@ $replacements = array(
         array(
             'public function accept(',
             "#[\\ReturnTypeWillChange]\npublic function accept(",
-            '#[\\ReturnTypeWillChange]',
         ),
     ),
 );
@@ -211,11 +198,11 @@ foreach ($replacements as $file => $patterns) {
     }
 
     foreach ($patterns as $replacement) {
-        list($from, $to, $exclude) = array_pad($replacement, 3, null);
+        list($from, $to) = $replacement;
 
         $contents = @file_get_contents($file) ?: '';
 
-        if ($exclude && strpos($contents, $exclude) !== false) {
+        if (strpos($contents, $to) !== false) {
             echo "Already changed.\n";
 
             continue;

--- a/src/test/php/install-test-vendor.php
+++ b/src/test/php/install-test-vendor.php
@@ -1,0 +1,14 @@
+<?php
+
+$cwd = getcwd();
+chdir(__DIR__ . '/..');
+$phar = $cwd . '/composer.phar';
+$composer = file_exists($phar) ? 'php ' . escapeshellarg(realpath($phar)) : 'composer';
+$command = $composer . ' update --ignore-platform-req=php+';
+
+echo "> $command\n";
+echo shell_exec($command);
+
+require __DIR__ . '/fix-php-compatibility.php';
+
+chdir($cwd);

--- a/src/test/symfony-version.php
+++ b/src/test/symfony-version.php
@@ -1,0 +1,19 @@
+<?php
+
+$installed = require __DIR__.'/../../vendor/composer/installed.php';
+$versions = $installed['versions'];
+
+$symfonyPackages = array(
+    'config',
+    'dependency-injection',
+    'filesystem',
+    'yaml'
+);
+
+foreach ($symfonyPackages as $package) {
+    echo "$package: ".
+        (isset($versions['symfony/'.$package]['pretty_version'])
+            ? $versions['symfony/'.$package]['pretty_version']
+            : 'not installed').
+        "\n";
+}

--- a/src/test/symfony-version.php
+++ b/src/test/symfony-version.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Check which version of Symfony packages that PDepend depends on
+ * is installed.
+ * It can be used in CI to see with which exact version tests were
+ * run for a given commit.
+ */
+
 $installed = require __DIR__.'/../../vendor/composer/installed.php';
 $versions = $installed['versions'];
 


### PR DESCRIPTION
Type: compatibility
Breaking change: no
Follows up https://github.com/pdepend/pdepend/pull/699

- Update to PDepend 2.16.1 (supporting Symfony 7)
- Move test dependencies in the test folder (so it can have different Symfony packages version without conflict)
- Test each Symfony version in GitHub Actions
- Make `composer test` automatically installing test dependencies