### PR TITLE
Fix deprecation to pass null to strlen() in ShortMethodName

### DIFF
--- a/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
@@ -28,7 +28,7 @@ use PHPMD\Rule\MethodAware;
 class ShortMethodName extends AbstractRule implements MethodAware, FunctionAware
 {
     /**
-     * Extracts all variable and variable declarator nodes from the given node
+     * Extracts all method and function nodes from the given node
      * and checks the variable name length against the configured minimum
      * length.
      *
@@ -38,13 +38,15 @@ class ShortMethodName extends AbstractRule implements MethodAware, FunctionAware
     public function apply(AbstractNode $node)
     {
         $threshold = $this->getIntProperty('minimum');
-        if ($threshold <= strlen($node->getName())) {
+        $name = (string)$node->getName();
+
+        if (strlen($name) >= $threshold) {
             return;
         }
 
         $exceptions = $this->getExceptionsList();
 
-        if (in_array($node->getName(), $exceptions)) {
+        if (in_array($name, $exceptions, true)) {
             return;
         }
 

--- a/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
@@ -132,11 +132,19 @@ class ShortMethodNameTest extends AbstractTest
      * @link https://github.com/phpmd/phpmd/issues/80
      * @link https://github.com/phpmd/phpmd/issues/270
      */
-    public function testRuleAlsoWorksWithoutExceptionListConfigured()
+    public function testRuleAppliesAlsoWithoutExceptionListConfiguredOnMock()
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 100);
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethodMock());
+    }
+
+    public function testRuleAppliesAlsoWithoutExceptionListConfigured()
+    {
+        $rule = new ShortMethodName();
+        $rule->addProperty('minimum', 100);
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getMethod());
     }
 }

--- a/src/test/resources/files/Rule/Naming/ShortMethodName/testRuleAppliesAlsoWithoutExceptionListConfigured.php
+++ b/src/test/resources/files/Rule/Naming/ShortMethodName/testRuleAppliesAlsoWithoutExceptionListConfigured.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleAppliesAlsoWithoutExceptionListConfigured
+{
+    public function testRuleAppliesAlsoWithoutExceptionListConfigured()
+    {
+
+    }
+}


### PR DESCRIPTION
Type: bugfix (PHP deprecation)
Breaking change: no
