### PR TITLE
Replace '@package_version@' by the right PHPMD version on reports

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -7,7 +7,7 @@ project.stability = stable
 # Disable pear support. This cannot be removed as long as setup tool is used
 project.pear.uri = pear.example.com
 
-vendor.dir.includes = symfony/**/*,composer/**/*,pdepend/**/*,autoload.php
+vendor.dir.includes = symfony/**/*,composer/**/*,pdepend/**/*,autoload.php,sebastian/**/*
 vendor.dir.excludes = symfony/**/Tests/**/*
 
 # Default coding standard

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     "php": ">=5.3.9",
     "ext-xml": "*",
     "composer/xdebug-handler": "^1.0 || ^2.0 || ^3.0",
-    "pdepend/pdepend": "^2.16.1"
+    "pdepend/pdepend": "^2.16.1",
+    "sebastian/version": "^1.0 || ^2.0 || ^3.0 || ^4.0"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.9.2 || ^3.7.2",

--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -17,6 +17,8 @@
 
 namespace PHPMD;
 
+use SebastianBergmann\Version;
+
 /**
  * Abstract base class for PHPMD rendering engines.
  */
@@ -79,5 +81,39 @@ abstract class AbstractRenderer
     public function end()
     {
         // Just a hook
+    }
+
+    /**
+     * Returns the current version number.
+     *
+     * @return string
+     */
+    public static function getVersion()
+    {
+        $version = PHPMD::VERSION;
+
+        if ('@package_version@' == $version) {
+            $build = __DIR__ . '/../../../../build.properties';
+            if (file_exists($build)) {
+                $data    = @parse_ini_file($build);
+                $version = isset($data['project.version']) ? $data['project.version'] : $version;
+            }
+        }
+        if ('@package_version@' == $version) {
+            // on previous attempt, if "build.properties" file does not exist or did not define "project.version" property
+            // then fallback to git latest tag
+
+            $gitVersion = new Version('2.x-dev', __DIR__ . '/../../../../');
+
+            if (\method_exists($gitVersion, 'asString')) {
+                // compatibility with current version 4.x (or greater)
+                $version = $gitVersion->asString();
+            } else {
+                // make compatibility with previous versions 1.x, 2.x and 3.x
+                $version = $gitVersion->getVersion();
+            }
+        }
+
+        return $version;
     }
 }

--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -100,7 +100,8 @@ abstract class AbstractRenderer
             }
         }
         if ('@package_version@' == $version) {
-            // on previous attempt, if "build.properties" file does not exist or did not define "project.version" property
+            // on previous attempt,
+            // if "build.properties" file does not exist or did not define "project.version" property
             // then fallback to git latest tag
 
             $gitVersion = new Version('2.x-dev', __DIR__ . '/../../../../');

--- a/src/main/php/PHPMD/Renderer/JSONRenderer.php
+++ b/src/main/php/PHPMD/Renderer/JSONRenderer.php
@@ -48,7 +48,7 @@ class JSONRenderer extends AbstractRenderer
     protected function initReportData()
     {
         $data = array(
-            'version' => PHPMD::VERSION,
+            'version' => self::getVersion(),
             'package' => 'phpmd',
             'timestamp' => date('c'),
         );

--- a/src/main/php/PHPMD/Renderer/SARIFRenderer.php
+++ b/src/main/php/PHPMD/Renderer/SARIFRenderer.php
@@ -45,7 +45,7 @@ class SARIFRenderer extends JSONRenderer
                         'driver' => array(
                             'name' => 'PHPMD',
                             'informationUri' => 'https://phpmd.org',
-                            'version' => PHPMD::VERSION,
+                            'version' => self::getVersion(),
                             'rules' => array(),
                         ),
                     ),
@@ -202,7 +202,7 @@ class SARIFRenderer extends JSONRenderer
                 'uriBaseId' => 'WORKINGDIR',
             );
         }
-        
+
         // absolute path with protocol
         return array(
             'uri' => static::pathToUri($path),

--- a/src/main/php/PHPMD/Renderer/XMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/XMLRenderer.php
@@ -56,7 +56,7 @@ class XMLRenderer extends AbstractRenderer
     public function renderReport(Report $report)
     {
         $writer = $this->getWriter();
-        $writer->write('<pmd version="' . PHPMD::VERSION . '" ');
+        $writer->write('<pmd version="' . self::getVersion() . '" ');
         $writer->write('tool="phpmd" ');
         $writer->write('timestamp="' . date('c') . '">');
         $writer->write(PHP_EOL);

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -18,6 +18,7 @@
 namespace PHPMD\TextUI;
 
 use Exception;
+use PHPMD\AbstractRenderer;
 use PHPMD\Baseline\BaselineFileFinder;
 use PHPMD\Baseline\BaselineMode;
 use PHPMD\Baseline\BaselineSetFactory;
@@ -185,15 +186,7 @@ class Command
      */
     private function getVersion()
     {
-        $build = __DIR__ . '/../../../../../build.properties';
-
-        $version = '@package_version@';
-        if (file_exists($build)) {
-            $data    = @parse_ini_file($build);
-            $version = $data['project.version'];
-        }
-
-        return $version;
+        return AbstractRenderer::getVersion();
     }
 
     /**


### PR DESCRIPTION

## Description of problem

When you clone this repository and use it right aways, current version of PHPMD (2.15.0) provide only it's current version identification when you invoke `phpmd --version`, but renderers that show the version still display `@package_version@`.

### XML format

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<pmd version="@package_version@" tool="phpmd" timestamp="2024-01-15T15:31:58+00:00">
</pmd>
```

### JSON format 

```json
{
    "version": "@package_version@",
    "package": "phpmd",
    "timestamp": "2024-01-15T15:27:45+00:00",
    "files": []
}
```

### SARIF format

```json
{
    "version": "2.1.0",
    "$schema": "https:\/\/raw.githubusercontent.com\/oasis-tcs\/sarif-spec\/master\/Schemata\/sarif-schema-2.1.0.json",
    "runs": [
        {
            "tool": {
                "driver": {
                    "name": "PHPMD",
                    "informationUri": "https:\/\/phpmd.org",
                    "version": "@package_version@",
                    "rules": []
                }
            },
            "originalUriBaseIds": {
                "WORKINGDIR": {
                    "uri": "file:\/\/\/shared\/backups\/bartlett\/sarif-php-sdk\/"
                }
            },
            "results": []
        }
    ]
}
```

## Solution

This PR will fix this issue, and always display a version : 
- this current version (if provided) by the  `build.properties` file
- fallback strategy by using the `sebastian/version` dependency if no `project.version` property defined on `build.properties` file

For examples: 

`/shared/backups/forks/phpmd/src/bin/phpmd src/ sarif cleancode -v`

```json
{
    "version": "2.1.0",
    "$schema": "https:\/\/raw.githubusercontent.com\/oasis-tcs\/sarif-spec\/master\/Schemata\/sarif-schema-2.1.0.json",
    "runs": [
        {
            "tool": {
                "driver": {
                    "name": "PHPMD",
                    "informationUri": "https:\/\/phpmd.org",
                    "version": "2.x-dev-g73768f33",
                    "rules": []
                }
            },
            "originalUriBaseIds": {
                "WORKINGDIR": {
                    "uri": "file:\/\/\/shared\/backups\/bartlett\/sarif-php-sdk\/"
                }
            },
            "results": []
        }
    ]
}
```

`/shared/backups/forks/phpmd/src/bin/phpmd src/ json cleancode -v`

```json
{
    "version": "2.x-dev-g73768f33",
    "package": "phpmd",
    "timestamp": "2024-01-16T06:25:22+00:00",
    "files": []
}
```

`/shared/backups/forks/phpmd/src/bin/phpmd src/ xml cleancode -v`

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<pmd version="2.x-dev-g73768f33" tool="phpmd" timestamp="2024-01-16T06:25:28+00:00">
</pmd>
```

