### PR TITLE
Fix a crash if the isPassedByReference want to check the parent of a …

### DIFF
--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -288,12 +288,17 @@ abstract class AbstractLocalVariable extends AbstractRule
     {
         $parent = $this->getNode($variable->getParent());
 
-        if (!($parent && $parent instanceof ASTArguments)) {
+        if (!($parent instanceof ASTArguments)) {
             return false;
         }
 
         $argumentPosition = array_search($this->getNode($variable), $parent->getChildren());
-        $function = $this->getNode($parent->getParent());
+        $parentParent = $parent->getParent();
+        if ($parentParent === null) {
+            return false;
+        }
+        $function = $this->getNode($parentParent);
+
         $functionParent = $this->getNode($function->getParent());
         $functionName = $function->getImage();
 


### PR DESCRIPTION
…parent that does not exist. #1016

Type: bugfix
Issue: Resolves #1016
Breaking change: no

The getParent on AbstractASTNode can return a null, if that happens we get a crash because the null is passed forward while it isn't useful.