### PR TITLE
Consider [$this, 'foo'] as a usage of foo() method of the current class

### DIFF
--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -50,7 +50,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * as private and are not used in the same class' context.
      *
      * @param ClassNode $class
-     * @return ASTMethodPostfix[]
+     * @return array<string, MethodNode>
      */
     protected function collectUnusedPrivateMethods(ClassNode $class)
     {
@@ -107,38 +107,77 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      */
     protected function removeUsedMethods(ClassNode $class, array $methods)
     {
-        // $this->privateMethod() makes "privateMethod" marked as used
-        // as an explicit call
+        $methods = $this->removeExplicitCalls($class, $methods);
+        $methods = $this->removeCallableArrayRepresentations($class, $methods);
+
+        return $methods;
+    }
+
+    /**
+     * $this->privateMethod() makes "privateMethod" marked as used as an explicit call.
+     *
+     * @param ClassNode $class
+     * @param array<string, MethodNode> $methods
+     * @return array<string, MethodNode>
+     */
+    protected function removeExplicitCalls(ClassNode $class, array $methods)
+    {
         foreach ($class->findChildrenOfType('MethodPostfix') as $postfix) {
             if ($this->isClassScope($class, $postfix)) {
                 unset($methods[strtolower($postfix->getImage())]);
             }
         }
 
-        // [$this 'privateMethod'] makes "privateMethod" marked as used
-        // as very likely to be used as a callable value
+        return $methods;
+    }
+
+    /**
+     * [$this 'privateMethod'] makes "privateMethod" marked as used as very likely to be used as a callable value.
+     *
+     * @param ClassNode $class
+     * @param array<string, MethodNode> $methods
+     * @return array<string, MethodNode>
+     */
+    protected function removeCallableArrayRepresentations(ClassNode $class, array $methods)
+    {
         foreach ($class->findChildrenOfType('Variable') as $variable) {
             if ($this->isClassScope($class, $variable) && $variable->getImage() === '$this') {
-                $parent = $variable->getParent();
+                $method = $this->getMethodNameFromArraySecondElement($variable->getParent());
 
-                if ($parent instanceof ASTNode && $parent->isInstanceOf('ArrayElement')) {
-                    $array = $parent->getParent();
-
-                    if ($array instanceof ASTNode
-                        && $array->isInstanceOf('Array')
-                        && count($array->getChildren()) === 2
-                    ) {
-                        $secondElement = $array->getChild(1)->getChild(0);
-
-                        if ($secondElement->isInstanceOf('Literal')) {
-                            unset($methods[strtolower(substr($secondElement->getImage(), 1, -1))]);
-                        }
-                    }
+                if ($method) {
+                    unset($methods[strtolower($method)]);
                 }
             }
         }
 
         return $methods;
+    }
+
+    /**
+     * Return represented method name if the given element is a 2-items array
+     * and that the second one is a literal static string.
+     *
+     * @param ASTNode|null $parent
+     * @return string|null
+     */
+    protected function getMethodNameFromArraySecondElement($parent)
+    {
+        if ($parent instanceof ASTNode && $parent->isInstanceOf('ArrayElement')) {
+            $array = $parent->getParent();
+
+            if ($array instanceof ASTNode
+                && $array->isInstanceOf('Array')
+                && count($array->getChildren()) === 2
+            ) {
+                $secondElement = $array->getChild(1)->getChild(0);
+
+                if ($secondElement->isInstanceOf('Literal')) {
+                    return substr($secondElement->getImage(), 1, -1);
+                }
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
@@ -121,6 +121,18 @@ class UnusedPrivateMethodTest extends AbstractTest
     }
 
     /**
+     * testRuleDoesNotApplyToMethodUsedViaCallable
+     *
+     * @return void
+     */
+    public function testRuleDoesNotApplyToMethodUsedViaCallable()
+    {
+        $rule = new UnusedPrivateMethod();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getClass());
+    }
+
+    /**
      * testRuleDoesNotApplyToPrivateConstructor
      *
      * @return void

--- a/src/test/resources/files/Rule/UnusedPrivateMethod/testRuleDoesNotApplyToMethodUsedViaCallable.php
+++ b/src/test/resources/files/Rule/UnusedPrivateMethod/testRuleDoesNotApplyToMethodUsedViaCallable.php
@@ -15,7 +15,7 @@
  * @link http://phpmd.org/
  */
 
-class testRuleAppliesToUnusedPrivateMethod
+class testRuleDoesNotApplyToMethodUsedViaCallable
 {
     private function foo()
     {
@@ -24,10 +24,6 @@ class testRuleAppliesToUnusedPrivateMethod
 
     public function allOfThoseWontMakeItUsed()
     {
-        foo();
-        $other->foo();
-        array_map([$other, 'foo'], [1]);
-        array_map([$this, 'foo' . 'bar'], [1]);
-        array_map(array($this, 'foo' . 'bar'), [1]);
+        array_map(array($this, 'foo'), array(1));
     }
 }


### PR DESCRIPTION
Type: bugfix
Issue: Resolves #897 Resolves #502 Resolves #1066
Breaking change: no

It's acknowledged that the presence of `[$this, 'foo']` in the code does not ensure the method `foo` of the current class will be called. But the same applies to `$var = static fn () => $this->foo();` which marks `foo` as used but we don't know if `$var` will actually be called. So assuming that an array of 2 elements (with the first being `$this` and the second being a literal string) represents a callable is a guess but not that much approximative than explicit usages, also because there is very few valid use case for such value not to be used as callable in real life, we can be quite confident that it would increase the accuracy of the detection.

And because false positive of this rule is more annoying than false negative for this rule for most of our users, this would overall improve usability.