### PR TITLE
Add the composer.json and composer.lock file to the .phar file.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -48,6 +48,8 @@
         <copy todir="${output.dir}/src/main/resources/rulesets">
             <fileset dir="${commons.srcdir.resource}/rulesets" />
         </copy>
+        <copy file="${basedir}/composer.json" todir="${output.dir}/" />
+        <copy file="${basedir}/composer.lock" todir="${output.dir}/" />
     </target>
 
     <!--


### PR DESCRIPTION
Type: feature
Issue: Resolves #1056
Breaking change: no

This PR adds the composer.json and the composer.lock file used during the creation of the phar.