### PR TITLE
Only try to sign the phar file on the main repository.

### DIFF
--- a/.github/workflows/generate_phar.yml
+++ b/.github/workflows/generate_phar.yml
@@ -56,6 +56,7 @@ jobs:
         run: ant package -D-phar:filename=./phpmd.phar && ./phpmd.phar --version
 
       - name: Sign phar
+        if: github.repository == 'phpmd/phpmd'
         env:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}


### PR DESCRIPTION
Type: bugfix
Issue: Resolves -
Breaking change: no

Currently the generate_phar action tries to sign the phar file on any repository (=every fork) with this change it only will sign it if the repository is phpmd/phpmd.