### PR TITLE
Option to force camelcase abbreviations in class names

### DIFF
--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseClassName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseClassName.php
@@ -41,7 +41,13 @@ class CamelCaseClassName extends AbstractRule implements ClassAware, InterfaceAw
      */
     public function apply(AbstractNode $node)
     {
-        if (!preg_match('/^[A-Z][a-zA-Z0-9]*$/', $node->getName())) {
+        $pattern = '/^[A-Z][a-zA-Z0-9]*$/';
+        if ($this->getBooleanProperty('camelcase-abbreviations')) {
+            // disallow any consecutive uppercase letters
+            $pattern = '/^([A-Z][a-z0-9]+)*$/';
+        }
+
+        if (!preg_match($pattern, $node->getName())) {
             $this->addViolation(
                 $node,
                 array(

--- a/src/main/resources/rulesets/controversial.xml
+++ b/src/main/resources/rulesets/controversial.xml
@@ -45,7 +45,11 @@ It is considered best practice to use the CamelCase notation to name classes.
             ]]>
         </description>
         <priority>1</priority>
-        <properties />
+        <properties>
+            <property name="camelcase-abbreviations"
+                      description="Name should be CamelCase including abbreviations."
+                      value="false" />
+        </properties>
         <example>
             <![CDATA[
 class class_name {

--- a/src/site/rst/rules/controversial.rst
+++ b/src/site/rst/rules/controversial.rst
@@ -31,6 +31,12 @@ Example: ::
   class class_name {
   }
 
++-----------------------------------+---------------+---------------------------------------------------------+
+| Name                              | Default Value | Description                                             |
++===================================+===============+=========================================================+
+| camelcase-abbreviations           | false         | Name should be CamelCase including abbreviations.       |
++-----------------------------------+---------------+---------------------------------------------------------+
+
 CamelCasePropertyName
 =====================
 
@@ -129,4 +135,3 @@ Remark
   This document is based on a ruleset xml-file, that was taken from the original source of the `PMD`__ project. This means that most parts of the content on this page are the intellectual work of the PMD community and its contributors and not of the PHPMD project.
 
 __ http://pmd.sourceforge.net/
-        

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ * @author    Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ * @link      http://phpmd.org/
+ */
+
+namespace PHPMD\Rule\Controversial;
+
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTNamespace;
+use PHPMD\AbstractTest;
+use PHPMD\Node\ClassNode;
+
+/**
+ * Test case for the camel case class name rule.
+ * @covers \PHPMD\Rule\Controversial\CamelCaseClassName
+ */
+class CamelCaseClassNameTest extends AbstractTest
+{
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyForValidClassName()
+    {
+        $report = $this->getReportWithNoViolation();
+
+        $rule = new CamelCaseClassName();
+        $rule->setReport($report);
+        $rule->addProperty('camelcase-abbreviations', 'false');
+        $rule->apply($this->createClassNode('ValidClass'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyForValidClassNameWithUppercaseAbbreviation()
+    {
+        $report = $this->getReportWithNoViolation();
+
+        $rule = new CamelCaseClassName();
+        $rule->setReport($report);
+        $rule->addProperty('camelcase-abbreviations', 'false');
+        $rule->apply($this->createClassNode('ValidURLClass'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesApplyForClassNameWithUppercaseAbbreviation()
+    {
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new CamelCaseClassName();
+        $rule->setReport($report);
+        $rule->addProperty('camelcase-abbreviations', 'true');
+        $rule->apply($this->createClassNode('ValidURLClass'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleDoesNotApplyForClassNameWithCamelcaseAbbreviation()
+    {
+        $report = $this->getReportWithNoViolation();
+
+        $rule = new CamelCaseClassName();
+        $rule->setReport($report);
+        $rule->addProperty('camelcase-abbreviations', 'true');
+        $rule->apply($this->createClassNode('ValidUrlClass'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleAppliesForClassNameWithLowerCase()
+    {
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new CamelCaseClassName();
+        $rule->setReport($report);
+        $rule->addProperty('camelcase-abbreviations', 'false');
+        $rule->apply($this->createClassNode('invalidClass'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testRuleAppliesForClassNameWithLowerCaseAndCamelcaseAbbreviation()
+    {
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new CamelCaseClassName();
+        $rule->setReport($report);
+        $rule->addProperty('camelcase-abbreviations', 'true');
+        $rule->apply($this->createClassNode('invalidClass'));
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return ClassNode
+     */
+    private function createClassNode($className)
+    {
+        $astClass = new ASTClass($className);
+        $astClass->setNamespace(new ASTNamespace('phpmd'));
+
+        return new ClassNode($astClass);
+    }
+}


### PR DESCRIPTION
Type: feature
Issue: -
Breaking change: no

Add `camelcase-abbreviations` option to the rule `/Controversial/CamelCaseClassName` to be slightly more restrictive.

**Allowed class names with camelcase-abbreviations: false**
- URL / Url
- HTTPStatus / HttpStatus
- FTPClient / FtpClient

**Allowed class names with camelcase-abbreviations: true**
- Url
- HttpStatus
- FtpClient

The default is set to false, to maintain current behaviour.

## Changes:

- Updated the `/Controversial/CamelCaseClassName` rule.
- Updated the documentation to include the new property.
- Added coverage for the rule.




<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
  
 ## Adding a New Rule

- Add the new rule to the matching rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new rule, e.g. ``src/site/rst/rules/naming.rst``
- Implement the new rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new rule in the rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new rule *should* apply
-- Cover the case when the new rule *should not* apply
-- Cover edge cases of the new rule

## Adding a New Rule Property

- Add the new property to rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new property, e.g. ``src/site/rst/rules/naming.rst``
- Implement new property in rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new property in rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new property is not set and the rule *should not* apply
-- Cover the case when the new property is not set and the rule *should* apply
-- Cover case when the new property is set and the rule *should not* apply
-- Cover case when the new property is set and the rule *should* apply
-- Cover edge cases of the new property, if any
-->
