### PR TITLE
Option to force camelcase abbreviations in method names

### DIFF
--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -73,6 +73,12 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
 
     protected function isValid($methodName)
     {
+        // disallow any consecutive uppercase letters
+        if ($this->getBooleanProperty('camelcase-abbreviations', false)
+            && preg_match('/[A-Z]{2}/', $methodName) === 1) {
+            return false;
+        }
+
         if ($this->getBooleanProperty('allow-underscore-test') && strpos($methodName, 'test') === 0) {
             return preg_match('/^test[a-zA-Z0-9]*(_[a-z][a-zA-Z0-9]*)*$/', $methodName);
         }

--- a/src/main/resources/rulesets/controversial.xml
+++ b/src/main/resources/rulesets/controversial.xml
@@ -104,6 +104,9 @@ It is considered best practice to use the camelCase notation to name methods.
             <property name="allow-underscore-test"
                       description="Is it allowed to have underscores in test method names."
                       value="false" />
+            <property name="camelcase-abbreviations"
+                      description="Name should be camelCase including abbreviations."
+                      value="false" />
         </properties>
         <example>
             <![CDATA[

--- a/src/site/rst/rules/controversial.rst
+++ b/src/site/rst/rules/controversial.rst
@@ -83,6 +83,8 @@ This rule has the following properties:
 +-----------------------------------+---------------+---------------------------------------------------------+
 | allow-underscore-test             | false         | Is it allowed to have underscores in test method names. |
 +-----------------------------------+---------------+---------------------------------------------------------+
+| camelcase-abbreviations           | false         | Name should be camelCase including abbreviations.       |
++-----------------------------------+---------------+---------------------------------------------------------+
 
 CamelCaseParameterName
 ======================

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -44,6 +44,42 @@ class CamelCaseMethodNameTest extends AbstractTest
     }
 
     /**
+     * Tests that the rule does apply for method name
+     * with all caps abbreviation.
+     *
+     * @return void
+     */
+    public function testRuleDoesApplyForMethodNameWithAllCapsAbbreviation()
+    {
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new CamelCaseMethodName();
+        $rule->setReport($report);
+        $rule->addProperty('camelcase-abbreviations', 'true');
+        $rule->addProperty('allow-underscore', 'false');
+        $rule->addProperty('allow-underscore-test', 'false');
+        $rule->apply($this->getMethod());
+    }
+
+    /**
+     * Tests that the rule does not apply for method name
+     * with camelcase abbreviation.
+     *
+     * @return void
+     */
+    public function testRuleDoesNotApplyForMethodNameWithCamelcaseAbbreviation()
+    {
+        $report = $this->getReportWithNoViolation();
+
+        $rule = new CamelCaseMethodName();
+        $rule->setReport($report);
+        $rule->addProperty('camelcase-abbreviations', 'true');
+        $rule->addProperty('allow-underscore', 'false');
+        $rule->addProperty('allow-underscore-test', 'false');
+        $rule->apply($this->getMethod());
+    }
+
+    /**
      * Tests that the rule does apply for an method name
      * starting with a capital.
      *

--- a/src/test/resources/files/Rule/Controversial/CamelCaseMethodName/testRuleDoesApplyForMethodNameWithAllCapsAbbreviation.php
+++ b/src/test/resources/files/Rule/Controversial/CamelCaseMethodName/testRuleDoesApplyForMethodNameWithAllCapsAbbreviation.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesApplyForMethodNameWithAllCapsAbbreviation
+{
+    public function getURL()
+    {
+    }
+}

--- a/src/test/resources/files/Rule/Controversial/CamelCaseMethodName/testRuleDoesNotApplyForMethodNameWithCamelcaseAbbreviation.php
+++ b/src/test/resources/files/Rule/Controversial/CamelCaseMethodName/testRuleDoesNotApplyForMethodNameWithCamelcaseAbbreviation.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyForMethodNameWithCamelcaseAbbreviation
+{
+    public function getUrl()
+    {
+    }
+}


### PR DESCRIPTION
Type: feature
Issue: -
Breaking change: no

In extension of #1076 and #1078, also added `camelcase-abbreviations` config option to `CamelCaseMethodName`.

Added coverage for correct/invalid name for each rule with `camelcase-abbreviations` enabled.
Updated the documentation to include the new property.
Updated the controversial ruleset with default `false`.
