### PR TITLE
Add CamelCaseNamespace rule

### DIFF
--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ * @author    Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ * @link      http://phpmd.org/
+ */
+
+namespace PHPMD\Rule\Controversial;
+
+use PHPMD\AbstractNode;
+use PHPMD\AbstractRule;
+use PHPMD\Rule\ClassAware;
+use PHPMD\Rule\EnumAware;
+use PHPMD\Rule\InterfaceAware;
+use PHPMD\Rule\TraitAware;
+use PHPMD\Utility\Strings;
+
+/**
+ * This rule class detects namespace parts that are not named in CamelCase.
+ */
+class CamelCaseNamespace extends AbstractRule implements ClassAware, InterfaceAware, TraitAware, EnumAware
+{
+    /** @var array<string, int>|null */
+    protected $exceptions;
+
+    public function apply(AbstractNode $node)
+    {
+        $pattern = '/^[A-Z][a-zA-Z0-9]*$/';
+        if ($this->getBooleanProperty('camelcase-abbreviations', false)) {
+            // disallow any consecutive uppercase letters
+            $pattern = '/^([A-Z][a-z0-9]+)*$/';
+        }
+
+        $exceptions              = $this->getExceptionsList();
+        $fullyQualifiedNamespace = $node->getNamespaceName();
+        $namespaceNames          = $fullyQualifiedNamespace === '' ? array() : explode('\\', $fullyQualifiedNamespace);
+
+        foreach ($namespaceNames as $namespaceName) {
+            if (isset($exceptions[$namespaceName])) {
+                continue;
+            }
+
+            if (!preg_match($pattern, $namespaceName)) {
+                $this->addViolation($node, array($namespaceName, $fullyQualifiedNamespace));
+            }
+        }
+    }
+
+    /**
+     * Gets array of exceptions from property
+     * @return array<string, int>
+     */
+    protected function getExceptionsList()
+    {
+        if ($this->exceptions === null) {
+            $this->exceptions = array_flip(
+                Strings::splitToList($this->getStringProperty('exceptions', ''), ',')
+            );
+        }
+
+        return $this->exceptions;
+    }
+}

--- a/src/main/resources/rulesets/controversial.xml
+++ b/src/main/resources/rulesets/controversial.xml
@@ -58,6 +58,35 @@ class class_name {
         </example>
     </rule>
 
+    <rule name="CamelCaseNamespace"
+          since="2.16"
+          message = "The name {0} in namespace {1} is not named in CamelCase."
+          class="PHPMD\Rule\Controversial\CamelCaseNamespace"
+          externalInfoUrl="#">
+        <description>
+            <![CDATA[
+A rule to use CamelCase notation to name namespaces.
+            ]]>
+        </description>
+        <priority>1</priority>
+        <properties>
+            <property name="camelcase-abbreviations"
+                      description="Name should be CamelCase including abbreviations."
+                      value="false" />
+            <property name="exceptions"
+                      description="Comma-separated class name list of exceptions"
+                      value=""/>
+        </properties>
+        <example>
+            <![CDATA[
+use example\name_space;
+
+class class_name {
+}
+            ]]>
+        </example>
+    </rule>
+
     <rule name="CamelCasePropertyName"
           since="0.2"
           message = "The property {0} is not named in camelCase."

--- a/src/site/rst/rules/controversial.rst
+++ b/src/site/rst/rules/controversial.rst
@@ -37,6 +37,28 @@ Example: ::
 | camelcase-abbreviations           | false         | Name should be CamelCase including abbreviations.       |
 +-----------------------------------+---------------+---------------------------------------------------------+
 
+CamelCaseNamespace
+==================
+
+Since: PHPMD 2.16
+
+A rule to use CamelCase notation to name namespaces.
+
+Example: ::
+
+  use example\name_space;
+
+  class class_name {
+  }
+
++-----------------------------------+---------------+---------------------------------------------------------+
+| Name                              | Default Value | Description                                             |
++===================================+===============+=========================================================+
+| camelcase-abbreviations           | false         | Name should be CamelCase including abbreviations.       |
++-----------------------------------+---------------+---------------------------------------------------------+
+| exceptions                        |               | Comma-separated class name list of exceptions.          |
++-----------------------------------+---------------+---------------------------------------------------------+
+
 CamelCasePropertyName
 =====================
 

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Rule\Controversial;
+
+use PHPMD\AbstractTest;
+
+/**
+ * Test case for the camel case namespace rule.
+ * @covers \PHPMD\Rule\Controversial\CamelCaseNamespace
+ */
+class CamelCaseNamespaceTest extends AbstractTest
+{
+    /**
+     * Rule does not apply for valid namespace.
+     */
+    public function testRuleDoesNotApplyForValidNamespace()
+    {
+        $report = $this->getReportWithNoViolation();
+
+        $rule = new CamelCaseNamespace();
+        $rule->setReport($report);
+        $rule->apply($this->getClass());
+    }
+
+    /**
+     * Rule does apply for incorrect namespace.
+     */
+    public function testRuleDoesApplyForIncorrectNamespace()
+    {
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new CamelCaseNamespace();
+        $rule->setReport($report);
+        $rule->apply($this->getClass());
+    }
+
+    /**
+     * Rule does not apply for namespace with uppercase abbreviation.
+     */
+    public function testRuleDoesNotApplyForNamespaceWithUppercaseAbbreviation()
+    {
+        $report = $this->getReportWithNoViolation();
+
+        $rule = new CamelCaseNamespace();
+        $rule->setReport($report);
+        $rule->apply($this->getClass());
+    }
+
+    /**
+     * Rule does apply for namespace with uppercase abbreviation.
+     */
+    public function testRuleDoesApplyForNamespaceWithUppercaseAbbreviation()
+    {
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new CamelCaseNamespace();
+        $rule->setReport($report);
+        $rule->addProperty('camelcase-abbreviations', 'true');
+        $rule->apply($this->getClass());
+    }
+
+    /**
+     * Rule does not apply for invalid namespace in exception list.
+     */
+    public function testRuleDoesNotApplyForNamespaceInException()
+    {
+        $report = $this->getReportWithNoViolation();
+
+        $rule = new CamelCaseNamespace();
+        $rule->setReport($report);
+        $rule->addProperty('camelcase-abbreviations', 'true');
+        $rule->addProperty('exceptions', 'URL');
+        $rule->apply($this->getClass());
+    }
+}

--- a/src/test/resources/files/Rule/Controversial/CamelCaseNamespace/testRuleDoesApplyForIncorrectNamespace.php
+++ b/src/test/resources/files/Rule/Controversial/CamelCaseNamespace/testRuleDoesApplyForIncorrectNamespace.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Invalid\Is_Namespace;
+
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+class testRuleDoesApplyForIncorrectNamespace
+{
+}

--- a/src/test/resources/files/Rule/Controversial/CamelCaseNamespace/testRuleDoesApplyForNamespaceWithUppercaseAbbreviation.php
+++ b/src/test/resources/files/Rule/Controversial/CamelCaseNamespace/testRuleDoesApplyForNamespaceWithUppercaseAbbreviation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Invalid\IsNamespace\URL;
+
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+class testRuleDoesApplyForNamespaceWithUppercaseAbbreviation
+{
+}

--- a/src/test/resources/files/Rule/Controversial/CamelCaseNamespace/testRuleDoesNotApplyForNamespaceInException.php
+++ b/src/test/resources/files/Rule/Controversial/CamelCaseNamespace/testRuleDoesNotApplyForNamespaceInException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Valid\IsNamespace\URL;
+
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+class testRuleDoesNotApplyForNamespaceInException
+{
+}

--- a/src/test/resources/files/Rule/Controversial/CamelCaseNamespace/testRuleDoesNotApplyForNamespaceWithUppercaseAbbreviation.php
+++ b/src/test/resources/files/Rule/Controversial/CamelCaseNamespace/testRuleDoesNotApplyForNamespaceWithUppercaseAbbreviation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Valid\IsNamespace\URL;
+
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+class testRuleDoesNotApplyForNamespaceWithUppercaseAbbreviation
+{
+}

--- a/src/test/resources/files/Rule/Controversial/CamelCaseNamespace/testRuleDoesNotApplyForValidNamespace.php
+++ b/src/test/resources/files/Rule/Controversial/CamelCaseNamespace/testRuleDoesNotApplyForValidNamespace.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Valid\IsNamespace;
+
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+class testRuleDoesNotApplyForValidNamespace
+{
+}


### PR DESCRIPTION
Type: feature
Issue: -
Breaking change: yes (maybe)

In extension of #1076, #1078 and #1079, added a new rule `CamelCaseNamespace`.

This will inspect the *parts* of the namespace, and report if a part is not in CamelCase.

**Good**
- `Example\Lib\URL\UrlFactory`
- `Example\IO\File`

**Bad**
- `example\Lib\Url`
- `Example\IO\File_Writer\Writer`

## Options
- `camelcase-abbreviations` - default: `false`. If `true` will disallow `URL` and `IO` in the examples above.
- `exceptions` - comma separated list of namespace names to allow anyway.

## Changes
Added coverage for correct/invalid name for the rule with `camelcase-abbreviations` and `exceptions` set and not set.
Updated the documentation to include the new property.
Updated the controversial ruleset to include this new rule.

## Breaking change
As with any new rule, this most likely will trigger new errors in existing projects. Unsure if this falls under "breaking change".

## Notes
Reading https://www.php-fig.org/psr/psr-4/#2-specification it doesn't necessarily state the namespace should only be in CamelCase. However i've seen many projects and libraries adhere to this standard though.
