### PR TITLE
Update camel case namespace documentation

### DIFF
--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
@@ -38,9 +38,9 @@ class CamelCaseNamespace extends AbstractRule implements ClassAware, InterfaceAw
             $pattern = '/^([A-Z][a-z0-9]+)*$/';
         }
 
-        $exceptions              = $this->getExceptionsList();
-        $fullyQualifiedNamespace = $node->getNamespaceName();
-        $namespaceNames          = $fullyQualifiedNamespace === '' ? array() : explode('\\', $fullyQualifiedNamespace);
+        $exceptions     = $this->getExceptionsList();
+        $fullNamespace  = $node->getNamespaceName();
+        $namespaceNames = $fullNamespace === '' ? array() : explode('\\', $fullNamespace);
 
         foreach ($namespaceNames as $namespaceName) {
             if (isset($exceptions[$namespaceName])) {
@@ -48,7 +48,7 @@ class CamelCaseNamespace extends AbstractRule implements ClassAware, InterfaceAw
             }
 
             if (!preg_match($pattern, $namespaceName)) {
-                $this->addViolation($node, array($namespaceName, $fullyQualifiedNamespace));
+                $this->addViolation($node, array($namespaceName, $fullNamespace));
             }
         }
     }

--- a/src/site/rst/rules/index.rst
+++ b/src/site/rst/rules/index.rst
@@ -42,6 +42,7 @@ Controversial Rules
 
 - `Superglobals <controversial.html#superglobals>`_: Accessing a super-global variable directly is considered a bad practice. These variables should be encapsulated in objects that are provided by a framework, for instance.
 - `CamelCaseClassName <controversial.html#camelcaseclassname>`_: It is considered best practice to use the CamelCase notation to name classes.
+- `CamelCaseNamespace <controversial.html#camelcasenamespace>`_: A rule to use CamelCase notation to name namespaces.
 - `CamelCasePropertyName <controversial.html#camelcasepropertyname>`_: It is considered best practice to use the camelCase notation to name attributes.
 - `CamelCaseMethodName <controversial.html#camelcasemethodname>`_: It is considered best practice to use the camelCase notation to name methods.
 - `CamelCaseParameterName <controversial.html#camelcaseparametername>`_: It is considered best practice to use the camelCase notation to name parameters.


### PR DESCRIPTION
Type: Bugfix + documentation update
Issue: -
Breaking no

Fixes 2 issues in my PR for CamelCaseNamespace rule:

- The documentation index did not contain a reference to the rule.
- The variable name `$fullyQualifiedNamespace` was too long and triggered inspection issue in the `Generate phar` job.
