### PR TITLE
Docs for CycloComplexity rule - to patch PDepend

### DIFF
--- a/src/site/rst/rules/codesize.rst
+++ b/src/site/rst/rules/codesize.rst
@@ -9,7 +9,7 @@ CyclomaticComplexity
 
 Since: PHPMD 0.1
 
-Complexity is determined by the number of decision points in a method plus one for the method entry. The decision points are 'if', 'while', 'for', and 'case labels'. Generally, 1-4 is low complexity, 5-7 indicates moderate complexity, 8-10 is high complexity, and 11+ is very high complexity.
+Complexity is determined by the number of decision points in a method plus one for the method entry. The decision points are 'if', 'while', 'for', 'catch', and 'case labels'. Generally, 1-4 is low complexity, 5-7 indicates moderate complexity, 8-10 is high complexity, and 11+ is very high complexity.
 
 Example: ::
 
@@ -70,7 +70,7 @@ Since: PHPMD 0.1
 
 The NPath complexity of a method is the number of acyclic execution paths through that method, that is how many possible outcomes it has.
 
-A threshold of 200 is generally considered the point where measures should be taken to reduce complexity. 
+A threshold of 200 is generally considered the point where measures should be taken to reduce complexity.
 
 Example: ::
 
@@ -193,7 +193,7 @@ Example: ::
       public $something;
       public $var;
       // [... more more public attributes ...]
-  
+
       public function doWork() {}
       public function doMoreWork() {}
       public function doWorkAgain() {}


### PR DESCRIPTION
Type: documentation update
Issue: Resolves #1082 
Breaking change: no 

The definition of Cyclomatic Complexity in the codebase relies on the CCN2 metric in PDepend.

The PDepend code now increments the CCN2 value by one for each Catch statement (but not for Try, as far as I can tell.

This PR updates the Documentation for the rule to include 'catch' in the list of decision points.

This relates to [https://phpmd.org/rules/codesize.html]

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
  
