### PR TITLE
Add missing nullable returns

### DIFF
--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -76,7 +76,7 @@ abstract class AbstractNode
      * Returns the parent of this node or <b>null</b> when no parent node
      * exists.
      *
-     * @return ASTNode
+     * @return ASTNode|null
      */
     public function getParent()
     {
@@ -315,7 +315,7 @@ abstract class AbstractNode
      * Returns the name of the parent type or <b>null</b> when this node has no
      * parent type.
      *
-     * @return string
+     * @return string|null
      */
     abstract public function getParentName();
 

--- a/src/main/php/PHPMD/Node/ASTNode.php
+++ b/src/main/php/PHPMD/Node/ASTNode.php
@@ -93,7 +93,7 @@ class ASTNode extends \PHPMD\AbstractNode
      * Returns the name of the parent type or <b>null</b> when this node has no
      * parent type.
      *
-     * @return string
+     * @return string|null
      */
     public function getParentName()
     {
@@ -103,7 +103,7 @@ class ASTNode extends \PHPMD\AbstractNode
     /**
      * Returns the name of the parent namespace.
      *
-     * @return string
+     * @return ?string
      */
     public function getNamespaceName()
     {
@@ -114,7 +114,7 @@ class ASTNode extends \PHPMD\AbstractNode
      * Returns the full qualified name of a class, an interface, a method or
      * a function.
      *
-     * @return string
+     * @return ?string
      */
     public function getFullQualifiedName()
     {

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -97,7 +97,7 @@ abstract class AbstractTypeNode extends AbstractNode
      * Returns the name of the parent type or <b>null</b> when this node has no
      * parent type.
      *
-     * @return string
+     * @return string|null
      */
     public function getParentName()
     {

--- a/src/main/php/PHPMD/Node/FunctionNode.php
+++ b/src/main/php/PHPMD/Node/FunctionNode.php
@@ -48,7 +48,7 @@ class FunctionNode extends AbstractCallableNode
      * Returns the name of the parent type or <b>null</b> when this node has no
      * parent type.
      *
-     * @return string
+     * @return string|null
      */
     public function getParentName()
     {

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -56,7 +56,7 @@ class MethodNode extends AbstractCallableNode
      * Returns the name of the parent type or <b>null</b> when this node has no
      * parent type.
      *
-     * @return string
+     * @return string|null
      */
     public function getParentName()
     {

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -88,7 +88,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      *
      * @param AbstractASTNode $node Array key to evaluate.
      * @param int $index Fallback in case of non-associative arrays
-     * @return AbstractASTNode Key name
+     * @return ?AbstractASTNode Key name
      */
     protected function normalizeKey(AbstractASTNode $node, $index)
     {

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -421,7 +421,7 @@ class CommandLineOptions
      * Returns the output filename for a generated report or <b>null</b> when
      * the report should be displayed in STDOUT.
      *
-     * @return string
+     * @return string|null
      */
     public function getReportFile()
     {
@@ -432,7 +432,7 @@ class CommandLineOptions
      * Returns the output filename for the errors or <b>null</b> when
      * the report should be displayed in STDERR.
      *
-     * @return string
+     * @return string|null
      */
     public function getErrorFile()
     {
@@ -494,7 +494,7 @@ class CommandLineOptions
      * Returns the file name of a supplied code coverage report or <b>NULL</b>
      * if the user has not supplied the --coverage option.
      *
-     * @return string
+     * @return string|null
      */
     public function getCoverageReport()
     {
@@ -505,7 +505,7 @@ class CommandLineOptions
      * Returns a string of comma-separated extensions for valid php source code
      * filenames or <b>null</b> when this argument was not set.
      *
-     * @return string
+     * @return string|null
      */
     public function getExtensions()
     {
@@ -516,7 +516,7 @@ class CommandLineOptions
      * Returns string of comma-separated pattern that is used to exclude
      * directories or <b>null</b> when this argument was not set.
      *
-     * @return string
+     * @return string|null
      */
     public function getIgnore()
     {

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -28,7 +28,7 @@ class StreamWriter extends AbstractWriter
     /**
      * The stream resource handle
      *
-     * @var resource
+     * @var ?resource
      */
     private $stream = null;
 


### PR DESCRIPTION
Type: documentation update  
Breaking change: no

?type vs type|null can be cleaned up once we have settled on a code style and configured a tool to handle it.
