### PR TITLE
Implement generic types (resolves PHPStan level 2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "easy-doc/easy-doc": "^1.3.2",
     "gregwar/rst": "^1.0",
     "mikey179/vfsstream": "^1.6.8",
-    "phpstan/phpstan": "~1.10",
+    "phpstan/phpstan": "~1.10.67",
     "phpunit/phpunit": "^10.5.20",
     "squizlabs/php_codesniffer": "^3.8.0"
   },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,4 +2,4 @@ parameters:
     paths:
         - src/main
     rememberPossiblyImpureFunctionValues: false
-    level: 1
+    level: 2

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -20,16 +20,21 @@ namespace PHPMD;
 use BadMethodCallException;
 use PDepend\Source\AST\AbstractASTArtifact;
 use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\AST\ASTNode as PDependNode;
 use PHPMD\Node\ASTNode;
 
 /**
  * This is an abstract base class for PHPMD code nodes, it is just a wrapper
  * around PDepend's object model.
+ *
+ * @template TNode of \PDepend\Source\AST\ASTArtifact|PDependNode
+ *
+ * @mixin TNode
  */
 abstract class AbstractNode
 {
     /**
-     * @var \PDepend\Source\AST\ASTArtifact|\PDepend\Source\AST\ASTNode $node
+     * @var TNode $node
      */
     private $node = null;
 
@@ -43,7 +48,7 @@ abstract class AbstractNode
     /**
      * Constructs a new PHPMD node.
      *
-     * @param \PDepend\Source\AST\ASTArtifact|\PDepend\Source\AST\ASTNode $node
+     * @param TNode $node
      */
     public function __construct($node)
     {
@@ -76,7 +81,7 @@ abstract class AbstractNode
      * Returns the parent of this node or <b>null</b> when no parent node
      * exists.
      *
-     * @return ASTNode|null
+     * @return AbstractNode|null
      */
     public function getParent()
     {
@@ -92,7 +97,7 @@ abstract class AbstractNode
      * Returns a child node at the given index.
      *
      * @param integer $index The child offset.
-     * @return \PHPMD\Node\ASTNode
+     * @return AbstractNode
      */
     public function getChild($index)
     {
@@ -106,12 +111,14 @@ abstract class AbstractNode
      * Returns the first child of the given type or <b>null</b> when this node
      * has no child of the given type.
      *
-     * @param string $type The searched child type.
-     * @return ASTNode|null
+     * @template T of PDependNode
+     *
+     * @param class-string<T> $type The searched child type.
+     * @return ASTNode<T>|null
      */
     public function getFirstChildOfType($type)
     {
-        $node = $this->node->getFirstChildOfType('PDepend\Source\AST\AST' . $type);
+        $node = $this->node->getFirstChildOfType($type);
 
         if ($node === null) {
             return null;
@@ -124,12 +131,15 @@ abstract class AbstractNode
      * Searches recursive for all children of this node that are of the given
      * type.
      *
-     * @param string $type The searched child type.
-     * @return ASTNode[]
+     * @template T of PDependNode
+     *
+     * @param class-string<T> $type The searched child type.
+     *
+     * @return array<int, ASTNode<T>>
      */
     public function findChildrenOfType($type)
     {
-        $children = $this->node->findChildrenOfType('PDepend\Source\AST\AST' . $type);
+        $children = $this->node->findChildrenOfType($type);
 
         $nodes = [];
 
@@ -144,12 +154,12 @@ abstract class AbstractNode
      * List all first-level children of the nodes of the given type found in any depth of
      * the current node.
      *
-     * @param string $type The searched child type.
-     * @return ASTNode[]
+     * @param class-string<PDependNode> $type The searched child type.
+     * @return array<int, \PDepend\Source\AST\AbstractASTNode|\PDepend\Source\AST\ASTArtifact>
      */
     public function findChildrenWithParentType($type)
     {
-        $children = $this->node->findChildrenOfType('PDepend\Source\AST\AST' . $type);
+        $children = $this->node->findChildrenOfType($type);
 
         $nodes = [];
 
@@ -170,20 +180,21 @@ abstract class AbstractNode
      */
     public function findChildrenOfTypeVariable()
     {
-        return $this->findChildrenOfType('Variable');
+        return $this->findChildrenOfType('PDepend\Source\AST\ASTVariable');
     }
 
     /**
      * Tests if this node represents the the given type.
      *
-     * @param string $type The expected node type.
-     * @return boolean
+     * @template T of PDependNode
+     *
+     * @param class-string<T> $class The expected node type.
+     *
+     * @phpstan-assert-if-true static<T> $this
      */
-    public function isInstanceOf($type)
+    public function isInstanceOf($class): bool
     {
-        $class = 'PDepend\Source\AST\AST' . $type;
-
-        return ($this->node instanceof $class);
+        return $this->node instanceof $class;
     }
 
     /**
@@ -246,7 +257,7 @@ abstract class AbstractNode
     /**
      * Returns the wrapped PDepend node instance.
      *
-     * @return \PDepend\Source\AST\ASTArtifact
+     * @return TNode
      */
     public function getNode()
     {

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
@@ -13,11 +13,11 @@ class ResultCacheState
     /** @var ResultCacheKey */
     private $cacheKey;
 
-    /** @var array{files: array<string, array{hash: string, violations: array}>} */
+    /** @var array{files?: array<string, array{hash: string, violations?: array}>} */
     private $state;
 
     /**
-     * @param array{files: array<string, array{hash: string, violations: array}>} $state
+     * @param array{files?: array<string, array{hash: string, violations?: array}>} $state
      */
     public function __construct(ResultCacheKey $cacheKey, $state = [])
     {

--- a/src/main/php/PHPMD/Node/ASTNode.php
+++ b/src/main/php/PHPMD/Node/ASTNode.php
@@ -21,6 +21,10 @@ use PHPMD\Rule;
 
 /**
  * Wrapper around a PHP_Depend ast node.
+ *
+ * @template TNode of \PDepend\Source\AST\ASTNode
+ *
+ * @extends \PHPMD\AbstractNode<TNode>
  */
 class ASTNode extends \PHPMD\AbstractNode
 {
@@ -34,7 +38,7 @@ class ASTNode extends \PHPMD\AbstractNode
     /**
      * Constructs a new ast node instance.
      *
-     * @param \PDepend\Source\AST\ASTNode $node
+     * @param TNode $node
      * @param string $fileName
      */
     public function __construct(\PDepend\Source\AST\ASTNode $node, $fileName)

--- a/src/main/php/PHPMD/Node/AbstractCallableNode.php
+++ b/src/main/php/PHPMD/Node/AbstractCallableNode.php
@@ -21,6 +21,10 @@ use PDepend\Source\AST\AbstractASTCallable;
 
 /**
  * Abstract base class for PHP_Depend function and method wrappers.
+ *
+ * @template TNode of AbstractASTCallable
+ *
+ * @extends AbstractNode<TNode>
  */
 abstract class AbstractCallableNode extends AbstractNode
 {

--- a/src/main/php/PHPMD/Node/AbstractNode.php
+++ b/src/main/php/PHPMD/Node/AbstractNode.php
@@ -21,6 +21,10 @@ use PHPMD\Rule;
 
 /**
  * Abstract base class for all code nodes.
+ *
+ * @template TNode of \PDepend\Source\AST\ASTArtifact
+ *
+ * @extends \PHPMD\AbstractNode<TNode>
  */
 abstract class AbstractNode extends \PHPMD\AbstractNode
 {

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -21,6 +21,10 @@ use PDepend\Source\AST\AbstractASTClassOrInterface;
 
 /**
  * Abstract base class for classes and interfaces.
+ *
+ * @template TNode of \PDepend\Source\AST\ASTArtifact
+ *
+ * @extends AbstractNode<TNode>
  */
 abstract class AbstractTypeNode extends AbstractNode
 {

--- a/src/main/php/PHPMD/Node/Annotations.php
+++ b/src/main/php/PHPMD/Node/Annotations.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Node;
 
 use PHPMD\Rule;
+use PDepend\Source\AST\AbstractASTArtifact;
 
 /**
  * Collection of code annotations.
@@ -41,7 +42,7 @@ class Annotations
     /**
      * Constructs a new collection instance.
      *
-     * @param \PHPMD\AbstractNode $node
+     * @param \PHPMD\AbstractNode<AbstractASTArtifact> $node
      */
     public function __construct(\PHPMD\AbstractNode $node)
     {

--- a/src/main/php/PHPMD/Node/ClassNode.php
+++ b/src/main/php/PHPMD/Node/ClassNode.php
@@ -21,6 +21,8 @@ use PDepend\Source\AST\ASTClass;
 
 /**
  * Wrapper around PHP_Depend's class objects.
+ *
+ * @extends AbstractTypeNode<ASTClass>
  */
 class ClassNode extends AbstractTypeNode
 {

--- a/src/main/php/PHPMD/Node/FunctionNode.php
+++ b/src/main/php/PHPMD/Node/FunctionNode.php
@@ -21,6 +21,8 @@ use PDepend\Source\AST\ASTFunction;
 
 /**
  * Wrapper around a PDepend function node.
+ *
+ * @extends AbstractCallableNode<ASTFunction>
  */
 class FunctionNode extends AbstractCallableNode
 {

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -26,6 +26,8 @@ use PHPMD\Rule;
 /**
  * Wrapper around a PHP_Depend method node.
  *
+ * @extends AbstractCallableNode<ASTMethod>
+ *
  * Methods available on $node via PHPMD\AbstractNode::__call
  *
  * @method bool isPrivate() Returns true if this node is marked as private.

--- a/src/main/php/PHPMD/Renderer/AnsiRenderer.php
+++ b/src/main/php/PHPMD/Renderer/AnsiRenderer.php
@@ -106,7 +106,7 @@ class AnsiRenderer extends AbstractRenderer
             return;
         }
 
-        /** @var ProcessingError $error */
+        /** @var \PHPMD\ProcessingError $error */
         foreach ($report->getErrors() as $error) {
             $errorHeader = sprintf(
                 "\e[33mERROR\e[0m while parsing %s",

--- a/src/main/php/PHPMD/Renderer/JSONRenderer.php
+++ b/src/main/php/PHPMD/Renderer/JSONRenderer.php
@@ -20,6 +20,7 @@ namespace PHPMD\Renderer;
 use PHPMD\AbstractRenderer;
 use PHPMD\PHPMD;
 use PHPMD\Report;
+use PHPMD\RuleViolation;
 
 /**
  * This class will render a JSON report.

--- a/src/main/php/PHPMD/Renderer/SARIFRenderer.php
+++ b/src/main/php/PHPMD/Renderer/SARIFRenderer.php
@@ -20,6 +20,7 @@ namespace PHPMD\Renderer;
 use PHPMD\PHPMD;
 use PHPMD\Report;
 use PHPMD\Renderer\JSONRenderer;
+use PHPMD\RuleViolation;
 
 /**
  * This class will render a SARIF (Static Analysis

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -70,7 +70,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Tests if the given variable node represents a local variable or if it is
      * a static object property or something similar.
      *
-     * @param \PHPMD\Node\ASTNode $variable The variable to check.
+     * @param \PHPMD\Node\ASTNode<\PDepend\Source\AST\ASTVariable> $variable The variable to check.
      * @return boolean
      */
     protected function isLocal(ASTNode $variable)
@@ -117,14 +117,15 @@ abstract class AbstractLocalVariable extends AbstractRule
         $node = $this->stripWrappedIndexExpression($variable);
         $parent = $node->getParent();
 
-        if ($parent->isInstanceOf('PropertyPostfix')) {
+        if ($parent->isInstanceOf('PDepend\Source\AST\ASTPropertyPostfix')) {
             $primaryPrefix = $parent->getParent();
-            if ($primaryPrefix->getParent()->isInstanceOf('MemberPrimaryPrefix')) {
-                return !$primaryPrefix->getParent()->isStatic();
+            $primaryPrefixParent = $primaryPrefix->getParent();
+            if ($primaryPrefixParent->isInstanceOf(ASTMemberPrimaryPrefix::class)) {
+                return !$primaryPrefixParent->isStatic();
             }
 
             return ($parent->getChild(0)->getNode() !== $node->getNode()
-                || !$primaryPrefix->isStatic()
+                || ($primaryPrefix->isInstanceOf(ASTMemberPrimaryPrefix::class) && !$primaryPrefix->isStatic())
             );
         }
 
@@ -160,8 +161,8 @@ abstract class AbstractLocalVariable extends AbstractRule
      */
     protected function isWrappedByIndexExpression(ASTNode $node)
     {
-        return ($node->getParent()->isInstanceOf('ArrayIndexExpression')
-            || $node->getParent()->isInstanceOf('StringIndexExpression')
+        return ($node->getParent()->isInstanceOf('PDepend\Source\AST\ASTArrayIndexExpression')
+            || $node->getParent()->isInstanceOf('PDepend\Source\AST\ASTStringIndexExpression')
         );
     }
 

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -92,8 +92,8 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
 
     private function scanFormalParameters(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('FormalParameter') as $param) {
-            $declarator = $param->getFirstChildOfType('VariableDeclarator');
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTFormalParameter') as $param) {
+            $declarator = $param->getFirstChildOfType('PDepend\Source\AST\ASTVariableDeclarator');
             $value = $declarator->getValue();
 
             if (!$this->isBooleanValue($value)) {

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -25,6 +25,7 @@ use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
+use PDepend\Source\AST\ASTArrayElement;
 
 /**
  * Duplicated Array Key Rule
@@ -44,8 +45,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('Array') as $arrayNode) {
-            /** @var ASTNode $arrayNode */
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTArray') as $arrayNode) {
             $this->checkForDuplicatedArrayKeys($arrayNode);
         }
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -40,7 +40,7 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('ScopeStatement') as $scope) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTScopeStatement') as $scope) {
             $parent = $scope->getParent();
 
             if (!$this->isIfOrElseIfStatement($parent)) {

--- a/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
@@ -41,7 +41,7 @@ class ErrorControlOperator extends AbstractRule implements MethodAware, Function
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('UnaryExpression') as $unaryExpression) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTUnaryExpression') as $unaryExpression) {
             if ($unaryExpression->getImage() === '@') {
                 $this->addViolation($node, [$unaryExpression->getBeginLine()]);
             }

--- a/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
@@ -17,6 +17,11 @@
 
 namespace PHPMD\Rule\CleanCode;
 
+use PDepend\Source\AST\ASTArrayElement;
+use PDepend\Source\AST\ASTAssignmentExpression;
+use PDepend\Source\AST\ASTElseIfStatement;
+use PDepend\Source\AST\ASTExpression;
+use PDepend\Source\AST\ASTIfStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
@@ -38,14 +43,6 @@ use PHPMD\Rule\MethodAware;
 class IfStatementAssignment extends AbstractRule implements MethodAware, FunctionAware
 {
     /**
-     * @var array List of statement types where to forbid assignation.
-     */
-    protected $ifStatements = [
-        'IfStatement',
-        'ElseIfStatement',
-    ];
-
-    /**
      * This method checks if method/function has if clauses
      * that use assignment instead of comparison.
      *
@@ -65,26 +62,33 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
      * Extracts if and elseif statements from method/function body
      *
      * @param AbstractNode $node An instance of MethodNode or FunctionNode class
-     * @return ASTNode[]
+     * @return array<int, ASTNode<ASTIfStatement>|ASTNode<ASTElseIfStatement>>
      */
     protected function getStatements(AbstractNode $node)
     {
-        return call_user_func_array('array_merge', array_map(function ($type) use ($node) {
-            return $node->findChildrenOfType($type);
-        }, $this->ifStatements));
+        return [
+            ...$node->findChildrenOfType(ASTIfStatement::class),
+            ...$node->findChildrenOfType(ASTElseIfStatement::class),
+        ];
     }
 
     /**
      * Extracts all expression from statements array
      *
-     * @param ASTNode[] $statements Array of if and elseif clauses
-     * @return ASTExpression[]
+     * @param array<int, ASTNode<ASTIfStatement>|ASTNode<ASTElseIfStatement>> $statements Array of if and elseif clauses
+     * @return array<int, ASTNode<ASTExpression>>
      */
     protected function getExpressions(array $statements)
     {
-        return array_map(function (ASTNode $statement) {
-            return $statement->getFirstChildOfType('Expression');
-        }, $statements);
+        $nodes = [];
+        foreach ($statements as $statement) {
+            $node = $statement->getFirstChildOfType(ASTExpression::class);
+            if ($node) {
+                $nodes[] = $node;
+            }
+        }
+
+        return $nodes;
     }
 
     /**
@@ -96,9 +100,8 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
     protected function getAssignments(array $expressions)
     {
         $assignments = [];
-        /** @var ASTNode $expression */
         foreach ($expressions as $expression) {
-            $assignments = array_merge($assignments, $expression->findChildrenOfType('AssignmentExpression'));
+            $assignments = [...$assignments, ...$expression->findChildrenOfType(ASTAssignmentExpression::class)];
         }
 
         return $assignments;

--- a/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
@@ -45,12 +45,11 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
     {
         $ignoreGlobal = $this->getBooleanProperty('ignore-global');
 
-        foreach ($node->findChildrenOfType('AllocationExpression') as $allocationNode) {
-            if (!$allocationNode) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTAllocationExpression') as $allocationNode) {
+            $classNode = $allocationNode->getChild(0);
+            if (!$classNode instanceof ASTNode) {
                 continue;
             }
-
-            $classNode = $allocationNode->getChild(0);
 
             if ($this->isSelfReference($classNode)) {
                 continue;

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -52,7 +52,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
     {
         $ignoreRegexp = trim($this->getStringProperty('ignorepattern', ''));
         $exceptions = $this->getExceptionsList();
-        $nodes = $node->findChildrenOfType('MemberPrimaryPrefix');
+        $nodes = $node->findChildrenOfType('PDepend\Source\AST\ASTMemberPrimaryPrefix');
 
         foreach ($nodes as $methodCall) {
             if ($this->isMethodIgnored($methodCall, $ignoreRegexp)) {
@@ -100,7 +100,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
             return false;
         }
 
-        $methodName = $methodCall->getFirstChildOfType('MethodPostfix');
+        $methodName = $methodCall->getFirstChildOfType('PDepend\Source\AST\ASTMethodPostfix');
 
         return $methodName !== null && preg_match($ignorePattern, $methodName->getName()) === 1;
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -62,7 +62,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
         $this->collect($node);
 
-        foreach ($node->findChildrenOfType('Class') as $class) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTClass') as $class) {
             /** @var ASTClass $class */
 
             $this->collectProperties($class);
@@ -119,7 +119,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectGlobalStatements(AbstractNode $node): void
     {
-        foreach ($node->findChildrenWithParentType('GlobalStatement') as $variable) {
+        foreach ($node->findChildrenWithParentType('PDepend\Source\AST\ASTGlobalStatement') as $variable) {
             $this->addVariableDefinition($variable);
         }
     }
@@ -132,7 +132,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectExceptionCatches(AbstractCallableNode $node): void
     {
-        foreach ($node->findChildrenWithParentType('CatchStatement') as $child) {
+        foreach ($node->findChildrenWithParentType('PDepend\Source\AST\ASTCatchStatement') as $child) {
             if ($child instanceof ASTVariable) {
                 $this->addVariableDefinition($child);
             }
@@ -147,7 +147,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectListExpressions(AbstractCallableNode $node): void
     {
-        foreach ($node->findChildrenWithParentType('ListExpression') as $variable) {
+        foreach ($node->findChildrenWithParentType('PDepend\Source\AST\ASTListExpression') as $variable) {
             $this->addVariableDefinition($variable);
         }
     }
@@ -160,7 +160,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectForeachStatements(AbstractCallableNode $node): void
     {
-        foreach ($node->findChildrenWithParentType('ForeachStatement') as $child) {
+        foreach ($node->findChildrenWithParentType('PDepend\Source\AST\ASTForeachStatement') as $child) {
             if ($child instanceof ASTVariable) {
                 $this->addVariableDefinition($child);
             }
@@ -185,7 +185,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectClosureParameters(AbstractCallableNode $node): void
     {
-        $closures = $node->findChildrenOfType('Closure');
+        $closures = $node->findChildrenOfType('PDepend\Source\AST\ASTClosure');
 
         foreach ($closures as $closure) {
             $this->collectParameters($closure);
@@ -215,10 +215,10 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
     protected function collectParameters(AbstractNode $node): void
     {
         // Get formal parameter container
-        $parameters = $node->getFirstChildOfType('FormalParameters');
+        $parameters = $node->getFirstChildOfType('PDepend\Source\AST\ASTFormalParameters');
 
         // Now get all declarators in the formal parameters container
-        $declarators = $parameters->findChildrenOfType('VariableDeclarator');
+        $declarators = $parameters->findChildrenOfType('PDepend\Source\AST\ASTVariableDeclarator');
 
         foreach ($declarators as $declarator) {
             $this->addVariableDefinition($declarator);
@@ -233,7 +233,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectAssignments(AbstractCallableNode $node): void
     {
-        foreach ($node->findChildrenOfType('AssignmentExpression') as $assignment) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTAssignmentExpression') as $assignment) {
             $variable = $assignment->getChild(0);
 
             if ($variable->getNode() instanceof ASTArray) {
@@ -247,7 +247,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
             $this->addVariableDefinition($variable);
         }
 
-        foreach ($node->findChildrenOfType('StaticVariableDeclaration') as $static) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTStaticVariableDeclaration') as $static) {
             $variable = $static->getChild(0);
             $this->addVariableDefinition($variable);
         }
@@ -261,7 +261,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectPropertyPostfix(AbstractNode $node): void
     {
-        foreach ($node->findChildrenWithParentType('PropertyPostfix') as $child) {
+        foreach ($node->findChildrenWithParentType('PDepend\Source\AST\ASTPropertyPostfix') as $child) {
             if ($child instanceof ASTVariable) {
                 $this->addVariableDefinition($child);
             }

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -21,6 +21,8 @@ use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
+use PHPMD\Node\FunctionNode;
+use PHPMD\Node\MethodNode;
 
 /**
  * This rule class detects parameters not named in camelCase.
@@ -39,6 +41,10 @@ class CamelCaseParameterName extends AbstractRule implements MethodAware, Functi
      */
     public function apply(AbstractNode $node): void
     {
+        if (!$node instanceof FunctionNode && !$node instanceof MethodNode) {
+            return;
+        }
+
         foreach ($node->getParameters() as $parameter) {
             if (!$this->isValid($parameter->getName())) {
                 $this->addViolation(

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
@@ -21,6 +21,8 @@ use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
 use PHPMD\Rule\TraitAware;
+use PHPMD\Node\ClassNode;
+use PHPMD\Node\TraitNode;
 
 /**
  * This rule class detects properties not named in camelCase.
@@ -39,6 +41,10 @@ class CamelCasePropertyName extends AbstractRule implements ClassAware, TraitAwa
      */
     public function apply(AbstractNode $node): void
     {
+        if (!$node instanceof ClassNode && !$node instanceof TraitNode) {
+            return;
+        }
+
         foreach ($node->getProperties() as $property) {
             $propertyName = $property->getName();
 

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
@@ -94,7 +94,7 @@ class CamelCaseVariableName extends AbstractRule implements MethodAware, Functio
             return true;
         }
 
-        if ($variable->getParent()->isInstanceOf('PropertyPostfix')) {
+        if ($variable->getParent()->isInstanceOf('PDepend\Source\AST\ASTPropertyPostfix')) {
             return true;
         }
 

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -80,9 +80,9 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
 
         $this->currentNamespace = $node->getNamespaceName() . '\\';
         $loops = array_merge(
-            $node->findChildrenOfType('ForStatement'),
-            $node->findChildrenOfType('WhileStatement'),
-            $node->findChildrenOfType('DoWhileStatement')
+            $node->findChildrenOfType('PDepend\Source\AST\ASTForStatement'),
+            $node->findChildrenOfType('PDepend\Source\AST\ASTWhileStatement'),
+            $node->findChildrenOfType('PDepend\Source\AST\ASTDoWhileStatement')
         );
 
         /** @var AbstractNode $loop */
@@ -99,12 +99,12 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
      */
     protected function findViolations(AbstractNode $loop): void
     {
-        foreach ($loop->findChildrenOfType('Expression') as $expression) {
+        foreach ($loop->findChildrenOfType('PDepend\Source\AST\ASTExpression') as $expression) {
             if ($this->isDirectChild($loop, $expression)) {
                 continue;
             }
 
-            foreach ($expression->findChildrenOfType('FunctionPostfix') as $function) {
+            foreach ($expression->findChildrenOfType('PDepend\Source\AST\ASTFunctionPostfix') as $function) {
                 if (!$this->isUnwantedFunction($function)) {
                     continue;
                 }

--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -43,7 +43,7 @@ class DevelopmentCodeFragment extends AbstractRule implements MethodAware, Funct
     {
         $ignoreNS = $this->getBooleanProperty('ignore-namespaces');
         $namespace = $node->getNamespaceName();
-        foreach ($node->findChildrenOfType('FunctionPostfix') as $postfix) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTFunctionPostfix') as $postfix) {
             $fragment = $postfix->getImage();
             if ($ignoreNS) {
                 $fragment = str_replace("{$namespace}\\", "", $fragment);

--- a/src/main/php/PHPMD/Rule/Design/EmptyCatchBlock.php
+++ b/src/main/php/PHPMD/Rule/Design/EmptyCatchBlock.php
@@ -39,8 +39,8 @@ class EmptyCatchBlock extends AbstractRule implements MethodAware, FunctionAware
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('CatchStatement') as $catchBlock) {
-            $scope = $catchBlock->getFirstChildOfType('ScopeStatement');
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTCatchStatement') as $catchBlock) {
+            $scope = $catchBlock->getFirstChildOfType('PDepend\Source\AST\ASTScopeStatement');
             if (count($scope->getChildren()) === 0) {
                 $this->addViolation($catchBlock, [$node->getName()]);
             }

--- a/src/main/php/PHPMD/Rule/Design/EvalExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/EvalExpression.php
@@ -36,7 +36,7 @@ class EvalExpression extends AbstractRule implements MethodAware, FunctionAware
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('EvalExpression') as $eval) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTEvalExpression') as $eval) {
             $this->addViolation($eval, [$node->getType(), $node->getName()]);
         }
     }

--- a/src/main/php/PHPMD/Rule/Design/ExitExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/ExitExpression.php
@@ -36,7 +36,7 @@ class ExitExpression extends AbstractRule implements MethodAware, FunctionAware
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('ExitExpression') as $exit) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTExitExpression') as $exit) {
             $this->addViolation($exit, [$node->getType(), $node->getName()]);
         }
     }

--- a/src/main/php/PHPMD/Rule/Design/GotoStatement.php
+++ b/src/main/php/PHPMD/Rule/Design/GotoStatement.php
@@ -38,7 +38,7 @@ class GotoStatement extends AbstractRule implements MethodAware, FunctionAware
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('GotoStatement') as $goto) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTGotoStatement') as $goto) {
             $this->addViolation($goto, [$node->getType(), $node->getName()]);
         }
     }

--- a/src/main/php/PHPMD/Rule/Design/LongParameterList.php
+++ b/src/main/php/PHPMD/Rule/Design/LongParameterList.php
@@ -21,6 +21,8 @@ use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
+use PHPMD\Node\FunctionNode;
+use PHPMD\Node\MethodNode;
 
 /**
  * This rule class checks for excessive long function and method parameter lists.
@@ -36,6 +38,10 @@ class LongParameterList extends AbstractRule implements FunctionAware, MethodAwa
      */
     public function apply(AbstractNode $node): void
     {
+        if (!$node instanceof FunctionNode && !$node instanceof MethodNode) {
+            return;
+        }
+
         $threshold = $this->getIntProperty('minimum');
         $count = $node->getParameterCount();
         if ($count < $threshold) {

--- a/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
@@ -39,7 +39,7 @@ class ConstantNamingConventions extends AbstractRule implements ClassAware, Inte
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('ConstantDeclarator') as $declarator) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTConstantDeclarator') as $declarator) {
             if ($declarator->getImage() !== strtoupper($declarator->getImage())) {
                 $this->addViolation($declarator, [$declarator->getImage()]);
             }

--- a/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
@@ -21,6 +21,7 @@ use PDepend\Source\AST\ASTTrait;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\InterfaceNode;
+use PHPMD\Node\MethodNode;
 use PHPMD\Rule\MethodAware;
 
 /**
@@ -38,6 +39,9 @@ class ConstructorWithNameAsEnclosingClass extends AbstractRule implements Method
      */
     public function apply(AbstractNode $node): void
     {
+        if (!$node instanceof MethodNode) {
+            return;
+        }
         if ($node->getNode()->getParent() instanceof ASTTrait) {
             return;
         }

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -66,9 +66,9 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
         $this->resetProcessed();
 
         if ($node->getType() === 'class') {
-            $fields = $node->findChildrenOfType('FieldDeclaration');
+            $fields = $node->findChildrenOfType('PDepend\Source\AST\ASTFieldDeclaration');
             foreach ($fields as $field) {
-                $declarators = $field->findChildrenOfType('VariableDeclarator');
+                $declarators = $field->findChildrenOfType('PDepend\Source\AST\ASTVariableDeclarator');
                 foreach ($declarators as $declarator) {
                     $this->checkNodeImage($declarator);
                 }
@@ -77,7 +77,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
 
             return;
         }
-        $declarators = $node->findChildrenOfType('VariableDeclarator');
+        $declarators = $node->findChildrenOfType('PDepend\Source\AST\ASTVariableDeclarator');
         foreach ($declarators as $declarator) {
             $this->checkNodeImage($declarator);
         }
@@ -139,7 +139,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      */
     protected function isNameAllowedInContext(AbstractNode $node)
     {
-        return $this->isChildOf($node, 'MemberPrimaryPrefix');
+        return $this->isChildOf($node, 'PDepend\Source\AST\ASTMemberPrimaryPrefix');
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -79,9 +79,9 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      */
     protected function applyClass(AbstractNode $node): void
     {
-        $fields = $node->findChildrenOfType('FieldDeclaration');
+        $fields = $node->findChildrenOfType('PDepend\Source\AST\ASTFieldDeclaration');
         foreach ($fields as $field) {
-            $declarators = $field->findChildrenOfType('VariableDeclarator');
+            $declarators = $field->findChildrenOfType('PDepend\Source\AST\ASTVariableDeclarator');
             foreach ($declarators as $declarator) {
                 $this->checkNodeImage($declarator);
             }
@@ -100,7 +100,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      */
     protected function applyNonClass(AbstractNode $node): void
     {
-        $declarators = $node->findChildrenOfType('VariableDeclarator');
+        $declarators = $node->findChildrenOfType('PDepend\Source\AST\ASTVariableDeclarator');
         foreach ($declarators as $declarator) {
             $this->checkNodeImage($declarator);
         }
@@ -180,13 +180,13 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
     {
         $parent = $node->getParent();
 
-        if ($parent && $parent->isInstanceOf('ForeachStatement')) {
+        if ($parent && $parent->isInstanceOf('PDepend\Source\AST\ASTForeachStatement')) {
             return $this->isInitializedInLoop($node);
         }
 
-        return $this->isChildOf($node, 'CatchStatement')
-            || $this->isChildOf($node, 'ForInit')
-            || $this->isChildOf($node, 'MemberPrimaryPrefix');
+        return $this->isChildOf($node, 'PDepend\Source\AST\ASTCatchStatement')
+            || $this->isChildOf($node, 'PDepend\Source\AST\ASTForInit')
+            || $this->isChildOf($node, 'PDepend\Source\AST\ASTMemberPrimaryPrefix');
     }
 
     /**
@@ -203,7 +203,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
 
         $exceptionVariables = [];
 
-        $parentForeaches = $this->getParentsOfType($node, 'ForeachStatement');
+        $parentForeaches = $this->getParentsOfType($node, 'PDepend\Source\AST\ASTForeachStatement');
         foreach ($parentForeaches as $foreach) {
             foreach ($foreach->getChildren() as $foreachChild) {
                 $exceptionVariables[] = $foreachChild->getImage();

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -160,9 +160,9 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
     protected function collectParameters(AbstractNode $node): void
     {
         // First collect the formal parameters containers
-        foreach ($node->findChildrenOfType('FormalParameters') as $parameters) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTFormalParameters') as $parameters) {
             // Now get all declarators in the formal parameters container
-            $declarators = $parameters->findChildrenOfType('VariableDeclarator');
+            $declarators = $parameters->findChildrenOfType('PDepend\Source\AST\ASTVariableDeclarator');
 
             foreach ($declarators as $declarator) {
                 $this->nodes[$declarator->getImage()] = $declarator;
@@ -224,12 +224,12 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      */
     protected function removeCompoundVariables(AbstractNode $node): void
     {
-        $compoundVariables = $node->findChildrenOfType('CompoundVariable');
+        $compoundVariables = $node->findChildrenOfType('PDepend\Source\AST\ASTCompoundVariable');
 
         foreach ($compoundVariables as $compoundVariable) {
             $variablePrefix = $compoundVariable->getImage();
 
-            foreach ($compoundVariable->findChildrenOfType('Expression') as $child) {
+            foreach ($compoundVariable->findChildrenOfType('PDepend\Source\AST\ASTExpression') as $child) {
                 $variableImage = $variablePrefix . $child->getImage();
 
                 if (isset($this->nodes[$variableImage])) {
@@ -249,7 +249,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      */
     protected function removeVariablesUsedByFuncGetArgs(AbstractNode $node): void
     {
-        $functionCalls = $node->findChildrenOfType('FunctionPostfix');
+        $functionCalls = $node->findChildrenOfType('PDepend\Source\AST\ASTFunctionPostfix');
 
         foreach ($functionCalls as $functionCall) {
             if ($this->isFunctionNameEqual($functionCall, 'func_get_args')) {
@@ -257,7 +257,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
             }
 
             if ($this->isFunctionNameEndingWith($functionCall, 'compact')) {
-                foreach ($functionCall->findChildrenOfType('Literal') as $literal) {
+                foreach ($functionCall->findChildrenOfType('PDepend\Source\AST\ASTLiteral') as $literal) {
                     unset($this->nodes['$' . trim($literal->getImage(), '"\'')]);
                 }
             }
@@ -279,10 +279,10 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
             return;
         }
 
-        /** @var ASTFormalParameter&ASTNode $parameter */
-        foreach ($node->findChildrenOfType('FormalParameter') as $parameter) {
+        /** @var ASTFormalParameter $parameter */
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTFormalParameter') as $parameter) {
             if ($parameter->isPromoted()) {
-                $variable = $parameter->getFirstChildOfType('VariableDeclarator');
+                $variable = $parameter->getFirstChildOfType('PDepend\Source\AST\ASTVariableDeclarator');
                 if ($variable !== null) {
                     unset($this->nodes[$variable->getImage()]);
                 }

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -80,7 +80,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
         foreach ($nodes as $node) {
             $parent = $node->getParent();
 
-            if (!$parent->isInstanceOf('AssignmentExpression')) {
+            if (!$parent->isInstanceOf('PDepend\Source\AST\ASTAssignmentExpression')) {
                 return true;
             }
 
@@ -103,10 +103,10 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     protected function removeParameters(AbstractCallableNode $node): void
     {
         // Get formal parameter container
-        $parameters = $node->getFirstChildOfType('FormalParameters');
+        $parameters = $node->getFirstChildOfType('PDepend\Source\AST\ASTFormalParameters');
 
         // Now get all declarators in the formal parameters container
-        $declarators = $parameters->findChildrenOfType('VariableDeclarator');
+        $declarators = $parameters->findChildrenOfType('PDepend\Source\AST\ASTVariableDeclarator');
 
         foreach ($declarators as $declarator) {
             unset($this->images[$this->getVariableImage($declarator)]);
@@ -130,18 +130,17 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
             }
         }
 
-        foreach ($node->findChildrenOfType('CompoundVariable') as $variable) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTCompoundVariable') as $variable) {
             $this->collectCompoundVariableInString($variable);
         }
 
-        foreach ($node->findChildrenOfType('VariableDeclarator') as $variable) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTVariableDeclarator') as $variable) {
             $this->collectVariable($variable);
         }
 
-        foreach ($node->findChildrenOfType('FunctionPostfix') as $func) {
+        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTFunctionPostfix') as $func) {
             if ($this->isFunctionNameEndingWith($func, 'compact')) {
-                foreach ($func->findChildrenOfType('Literal') as $literal) {
-                    /** @var $literal ASTNode */
+                foreach ($func->findChildrenOfType('PDepend\Source\AST\ASTLiteral') as $literal) {
                     $this->collectLiteral($literal);
                 }
             }
@@ -162,7 +161,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
         if (in_array($parentNode, $candidateParentNodes)) {
             $variablePrefix = $node->getImage();
 
-            foreach ($node->findChildrenOfType('Expression') as $child) {
+            foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTExpression') as $child) {
                 $variableName = $this->getVariableImage($child);
                 $variableImage = $variablePrefix . $variableName;
 
@@ -240,7 +239,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
         $parent = $node->getParent();
 
         // ASTFormalParameter should be handled by the UnusedFormalParameter rule
-        if ($parent && $parent->isInstanceOf('FormalParameter')) {
+        if ($parent && $parent->isInstanceOf('PDepend\Source\AST\ASTFormalParameter')) {
             return;
         }
 
@@ -257,7 +256,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      */
     protected function isNameAllowedInContext(AbstractNode $node)
     {
-        return $this->isChildOf($node, 'CatchStatement');
+        return $this->isChildOf($node, 'PDepend\Source\AST\ASTCatchStatement');
     }
 
     /**
@@ -270,7 +269,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      */
     protected function isUnusedForeachVariableAllowed(ASTNode $variable)
     {
-        $isForeachVariable = $this->isChildOf($variable, 'ForeachStatement');
+        $isForeachVariable = $this->isChildOf($variable, 'PDepend\Source\AST\ASTForeachStatement');
 
         if (!$isForeachVariable) {
             return false;

--- a/src/main/php/PHPMD/RuleSet.php
+++ b/src/main/php/PHPMD/RuleSet.php
@@ -19,6 +19,7 @@ namespace PHPMD;
 
 use ArrayIterator;
 use IteratorAggregate;
+use PHPMD\Node\AbstractTypeNode;
 
 /**
  * This class is a collection of concrete source analysis rules.
@@ -55,7 +56,7 @@ class RuleSet implements IteratorAggregate
     /**
      * Mapping between marker interfaces and concrete context code node classes.
      *
-     * @var array(string=>string)
+     * @var array<class-string, class-string<AbstractTypeNode>>
      */
     private array $applyTo = [
         'PHPMD\\Rule\\ClassAware' => 'PHPMD\\Node\\ClassNode',
@@ -69,7 +70,7 @@ class RuleSet implements IteratorAggregate
     /**
      * Mapping of rules that apply to a concrete code node type.
      *
-     * @var array(string=>array)
+     * @var array<class-string<AbstractTypeNode>, array<int, Rule>>
      */
     private $rules = [
         'PHPMD\\Node\\ClassNode' => [],


### PR DESCRIPTION
Type: refactoring / documentation update

This documents just enough of the magic for PHPStan level 2 to pass.

Level 2:
- unknown methods checked on all expressions (not just `$this`)
- validating PHPDocs

I realize that use of FQN is a bit inconsistent here, but I'm thinking we can do a general clean up of this later.