### PR TITLE
Upgrade to PDepend 3.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "php": "^8.1",
     "ext-xml": "*",
     "composer/xdebug-handler": "^3.0",
-    "pdepend/pdepend": "^2.16.1"
+    "pdepend/pdepend": "3.x-dev"
   },
   "require-dev": {
     "ext-json": "*",

--- a/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
@@ -48,7 +48,7 @@ class ResultCacheFileFilter implements Filter
      * @inheritDoc
      * @return bool `true` will inspect the file, when `false` the file will be filtered out.
      */
-    public function accept($relative, $absolute)
+    public function accept($relative, $absolute): bool
     {
         $filePath = Paths::getRelativePath($this->basePath, $absolute);
 

--- a/src/main/php/PHPMD/Node/Annotations.php
+++ b/src/main/php/PHPMD/Node/Annotations.php
@@ -46,7 +46,7 @@ class Annotations
      */
     public function __construct(\PHPMD\AbstractNode $node)
     {
-        $comment = $node->getDocComment();
+        $comment = $node->getComment();
         if ($comment === null) {
             return;
         }

--- a/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
@@ -77,7 +77,7 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
      */
     protected function isReturnTypeBoolean(MethodNode $node)
     {
-        $comment = $node->getDocComment();
+        $comment = $node->getComment();
         if ($comment === null) {
             return false;
         }

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -96,7 +96,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
     protected function isInheritedSignature(AbstractNode $node)
     {
         if ($node instanceof MethodNode) {
-            $comment = $node->getDocComment();
+            $comment = $node->getComment();
 
             return $comment && preg_match('/@inheritdoc/i', $comment);
         }

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -224,14 +224,13 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     protected function getNodeForTestFile($file)
     {
         $source = $this->parseSource($file);
-        $class = $source
-            ->getTypes()
-            ->current();
+        $type = $source
+            ->getTypes();
         $nodeClassName = 'PHPMD\\Node\\FunctionNode';
         $getter = 'getFunctions';
 
-        if ($class) {
-            $source = $class;
+        if ($type->count()) {
+            $source = $type->current();
             $nodeClassName = 'PHPMD\\Node\\MethodNode';
             $getter = 'getMethods';
         }

--- a/src/test/php/PHPMD/Node/AnnotationsTest.php
+++ b/src/test/php/PHPMD/Node/AnnotationsTest.php
@@ -47,7 +47,7 @@ class AnnotationsTest extends AbstractTestCase
         $class = $this->getClassMock();
         $class->expects($this->once())
             ->method('__call')
-            ->with($this->equalTo('getDocComment'))
+            ->with($this->equalTo('getComment'))
             ->will(
                 $this->returnValue(
                     '/**
@@ -72,7 +72,7 @@ class AnnotationsTest extends AbstractTestCase
         $class = $this->getClassMock();
         $class->expects($this->once())
             ->method('__call')
-            ->with($this->equalTo('getDocComment'))
+            ->with($this->equalTo('getComment'))
             ->will($this->returnValue('/** @SuppressWarnings("PMD") */'));
 
         $annotations = new Annotations($class);
@@ -89,7 +89,7 @@ class AnnotationsTest extends AbstractTestCase
         $class = $this->getClassMock();
         $class->expects($this->once())
             ->method('__call')
-            ->with($this->equalTo('getDocComment'))
+            ->with($this->equalTo('getComment'))
             ->will(
                 $this->returnValue(
                     '/**

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -222,7 +222,7 @@ class CommandTest extends AbstractTestCase
     {
         return [
             ['--suffixes', '.class.php'],
-            ['--exclude', 'ccn_,npath_,parse_error'],
+            ['--exclude', 'ccn_,*npath_,*parse_error'],
         ];
     }
 


### PR DESCRIPTION
This upgrades to the latest development build of PDepend 3.x. This is necessary in order to resolve PHPStan level 4. But also serves as a step in upgrading to the final version of PDepend 3.x in an iterative fashion.

- Update filter return type
- Use getComment() intead of getDocComment()
- Avoid OOB on iterators
- Update exclude pattern