### PR TITLE
Resolve all types (PHPStan level 6)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "php": "^8.1",
     "ext-xml": "*",
     "composer/xdebug-handler": "^3.0",
-    "pdepend/pdepend": "3.x-dev"
+    "pdepend/pdepend": "3.x-dev#bd4de6b346154c3b8e96dc41e5a84fe33b973970"
   },
   "require-dev": {
     "ext-json": "*",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ parameters:
     paths:
         - src/main
     rememberPossiblyImpureFunctionValues: false
-    level: 4
+    level: 5
     exceptions:
         reportUncheckedExceptionDeadCatch: true
         implicitThrows: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ parameters:
     paths:
         - src/main
     rememberPossiblyImpureFunctionValues: false
-    level: 5
+    level: 6
     exceptions:
         reportUncheckedExceptionDeadCatch: true
         implicitThrows: false

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -20,7 +20,6 @@ namespace PHPMD;
 use BadMethodCallException;
 use OutOfBoundsException;
 use PDepend\Source\AST\AbstractASTArtifact;
-use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTVariable;
@@ -95,6 +94,28 @@ abstract class AbstractNode
     }
 
     /**
+     * Returns the first parent node of the specified type
+     *
+     * @template T of PDependNode
+     *
+     * @param class-string<T> $type The searched parent type.
+     * @return ASTNode<T>|null
+     */
+    public function getParentOfType($type)
+    {
+        $parent = $this->node->getParent();
+
+        while ($parent) {
+            if ($parent instanceof $type) {
+                return new ASTNode($parent, $this->getFileName());
+            }
+            $parent = $parent->getParent();
+        }
+
+        return null;
+    }
+
+    /**
      * Returns a child node at the given index.
      *
      * @param int $index The child offset.
@@ -157,7 +178,7 @@ abstract class AbstractNode
      * the current node.
      *
      * @param class-string<PDependNode> $type The searched child type.
-     * @return array<int, AbstractASTNode|ASTArtifact>
+     * @return list<PDependNode>
      */
     public function findChildrenWithParentType($type)
     {
@@ -206,7 +227,7 @@ abstract class AbstractNode
      */
     public function getImage()
     {
-        return $this->node->getName();
+        return $this->node->getImage();
     }
 
     /**
@@ -217,7 +238,7 @@ abstract class AbstractNode
      */
     public function getName()
     {
-        return $this->node->getName();
+        return $this->node->getImage();
     }
 
     /**

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -20,7 +20,6 @@ namespace PHPMD;
 use BadMethodCallException;
 use OutOfBoundsException;
 use PDepend\Source\AST\AbstractASTArtifact;
-use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTVariable;
 use PHPMD\Node\ASTNode;
@@ -29,7 +28,7 @@ use PHPMD\Node\ASTNode;
  * This is an abstract base class for PHPMD code nodes, it is just a wrapper
  * around PDepend's object model.
  *
- * @template TNode of ASTArtifact|PDependNode
+ * @template-covariant TNode of PDependNode
  *
  * @mixin TNode
  */
@@ -81,7 +80,7 @@ abstract class AbstractNode
      * Returns the parent of this node or <b>null</b> when no parent node
      * exists.
      *
-     * @return AbstractNode|null
+     * @return ASTNode|null
      */
     public function getParent()
     {
@@ -119,7 +118,7 @@ abstract class AbstractNode
      * Returns a child node at the given index.
      *
      * @param int $index The child offset.
-     * @return AbstractNode
+     * @return ASTNode
      * @throws OutOfBoundsException
      */
     public function getChild($index)
@@ -155,9 +154,7 @@ abstract class AbstractNode
      * type.
      *
      * @template T of PDependNode
-     *
      * @param class-string<T> $type The searched child type.
-     *
      * @return array<int, ASTNode<T>>
      */
     public function findChildrenOfType($type)

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -61,6 +61,7 @@ abstract class AbstractNode
      * to the underlying PDepend AST node.
      *
      * @param string $name
+     * @param array<mixed> $args
      * @throws BadMethodCallException When the underlying PDepend node
      *         does not contain a method named <b>$name</b>.
      */
@@ -80,7 +81,7 @@ abstract class AbstractNode
      * Returns the parent of this node or <b>null</b> when no parent node
      * exists.
      *
-     * @return ASTNode|null
+     * @return ASTNode<PDependNode>|null
      */
     public function getParent()
     {
@@ -118,7 +119,7 @@ abstract class AbstractNode
      * Returns a child node at the given index.
      *
      * @param int $index The child offset.
-     * @return ASTNode
+     * @return ASTNode<PDependNode>
      * @throws OutOfBoundsException
      */
     public function getChild($index)
@@ -155,7 +156,7 @@ abstract class AbstractNode
      *
      * @template T of PDependNode
      * @param class-string<T> $type The searched child type.
-     * @return array<int, ASTNode<T>>
+     * @return list<ASTNode<T>>
      */
     public function findChildrenOfType($type)
     {

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -20,6 +20,7 @@ namespace PHPMD;
 use InvalidArgumentException;
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
+use PDepend\Source\AST\ASTNode;
 use PHPMD\Node\AbstractTypeNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\EnumNode;
@@ -63,7 +64,7 @@ abstract class AbstractRule implements Rule
     /**
      * A list of code examples for this rule.
      *
-     * @var array<string>
+     * @var list<string>
      */
     private array $examples = [];
 
@@ -185,7 +186,7 @@ abstract class AbstractRule implements Rule
     /**
      * Returns a list of examples for this rule.
      *
-     * @return string[]
+     * @return list<string>
      */
     public function getExamples(): array
     {
@@ -346,6 +347,9 @@ abstract class AbstractRule implements Rule
     /**
      * This method adds a violation to all reports for this violation type and
      * for the given <b>$node</b> instance.
+     *
+     * @param AbstractNode<ASTNode> $node
+     * @param array<int, string> $args
      */
     protected function addViolation(
         AbstractNode $node,
@@ -380,14 +384,4 @@ abstract class AbstractRule implements Rule
             $this->apply($method);
         }
     }
-
-    /**
-     * This method should implement the violation analysis algorithm of concrete
-     * rule implementations. All extending classes must implement this method.
-     *
-     * @throws OutOfBoundsException
-     * @throws InvalidArgumentException
-     * @throws ASTClassOrInterfaceRecursiveInheritanceException
-     */
-    abstract public function apply(AbstractNode $node): void;
 }

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -26,6 +26,7 @@ use PHPMD\Node\EnumNode;
 use PHPMD\Node\InterfaceNode;
 use PHPMD\Node\NodeInfoFactory;
 use PHPMD\Node\TraitNode;
+use RuntimeException;
 
 /**
  * This is the abstract base class for PHPMD rules.
@@ -367,6 +368,7 @@ abstract class AbstractRule implements Rule
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException
+     * @throws RuntimeException
      */
     protected function applyOnClassMethods(AbstractTypeNode $node): void
     {

--- a/src/main/php/PHPMD/Baseline/BaselineSet.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSet.php
@@ -4,7 +4,7 @@ namespace PHPMD\Baseline;
 
 class BaselineSet
 {
-    /** @var array<string, ViolationBaseline[]> */
+    /** @var array<string, list<ViolationBaseline>> */
     private $violations = [];
 
     public function addEntry(ViolationBaseline $entry): void

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheKey.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheKey.php
@@ -32,7 +32,7 @@ class ResultCacheKey
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     public function toArray()
     {

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
@@ -13,11 +13,11 @@ class ResultCacheState
     /** @var ResultCacheKey */
     private $cacheKey;
 
-    /** @var array{files?: array<string, array{hash: string, violations?: array}>} */
+    /** @var array{files?: array<string, array{hash: string, violations?: list<array<string, mixed>>}>} */
     private $state;
 
     /**
-     * @param array{files?: array<string, array{hash: string, violations?: array}>} $state
+     * @param array{files?: array<string, array{hash: string, violations?: list<array<string, mixed>>}>} $state
      */
     public function __construct(ResultCacheKey $cacheKey, $state = [])
     {
@@ -35,7 +35,7 @@ class ResultCacheState
 
     /**
      * @param string $filePath
-     * @return array
+     * @return list<array<string, mixed>>
      */
     public function getViolations($filePath)
     {
@@ -48,6 +48,7 @@ class ResultCacheState
 
     /**
      * @param string $filePath
+     * @param list<array<string, mixed>> $violations
      */
     public function setViolations($filePath, array $violations): void
     {
@@ -74,8 +75,9 @@ class ResultCacheState
     }
 
     /**
-     * @param string    $basePath
-     * @param RuleSet[] $ruleSetList
+     * @param string $basePath
+     * @param list<RuleSet> $ruleSetList
+     * @return list<RuleViolation>
      */
     public function getRuleViolations($basePath, array $ruleSetList)
     {
@@ -130,14 +132,15 @@ class ResultCacheState
     /**
      * @param string $filePath
      * @param string $hash
+     * @return void
      */
     public function setFileState($filePath, $hash)
     {
-        return $this->state['files'][$filePath]['hash'] = $hash;
+        $this->state['files'][$filePath]['hash'] = $hash;
     }
 
     /**
-     * @return array
+     * @return array<string, array<string, mixed>>
      */
     public function toArray()
     {

--- a/src/main/php/PHPMD/Cache/ResultCacheKeyFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheKeyFactory.php
@@ -2,7 +2,6 @@
 
 namespace PHPMD\Cache;
 
-use PHPMD\AbstractRule;
 use PHPMD\Cache\Model\ResultCacheKey;
 use PHPMD\RuleSet;
 use PHPMD\Utility\Paths;
@@ -27,6 +26,7 @@ class ResultCacheKeyFactory
     /**
      * @param bool      $strict
      * @param RuleSet[] $ruleSetList
+     * @return ResultCacheKey
      */
     public function create($strict, array $ruleSetList)
     {
@@ -51,7 +51,6 @@ class ResultCacheKeyFactory
     {
         $result = [];
         foreach ($ruleSetList as $ruleSet) {
-            /** @var AbstractRule $rule */
             foreach ($ruleSet->getRules() as $rule) {
                 $result[$rule::class] = hash('sha1', serialize($rule));
             }

--- a/src/main/php/PHPMD/Cache/ResultCacheStateFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheStateFactory.php
@@ -31,6 +31,7 @@ class ResultCacheStateFactory
     }
 
     /**
+     * @param array<string, mixed> $data
      * @return ResultCacheKey|null
      */
     private function createCacheKey(array $data)

--- a/src/main/php/PHPMD/Node/ASTNode.php
+++ b/src/main/php/PHPMD/Node/ASTNode.php
@@ -24,7 +24,7 @@ use PHPMD\Rule;
 /**
  * Wrapper around a PHP_Depend ast node.
  *
- * @template TNode of PDependNode
+ * @template-covariant TNode of PDependNode
  *
  * @extends AbstractNode<TNode>
  */

--- a/src/main/php/PHPMD/Node/AbstractCallableNode.php
+++ b/src/main/php/PHPMD/Node/AbstractCallableNode.php
@@ -22,7 +22,7 @@ use PDepend\Source\AST\AbstractASTCallable;
 /**
  * Abstract base class for PHP_Depend function and method wrappers.
  *
- * @template TNode of AbstractASTCallable
+ * @template-covariant TNode of AbstractASTCallable
  *
  * @extends AbstractNode<TNode>
  */

--- a/src/main/php/PHPMD/Node/AbstractNode.php
+++ b/src/main/php/PHPMD/Node/AbstractNode.php
@@ -24,7 +24,7 @@ use PHPMD\Rule;
 /**
  * Abstract base class for all code nodes.
  *
- * @template TNode of ASTArtifact
+ * @template-covariant TNode of ASTArtifact
  *
  * @extends BaseNode<TNode>
  */

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -23,7 +23,7 @@ use PDepend\Source\AST\ASTArtifact;
 /**
  * Abstract base class for classes and interfaces.
  *
- * @template TNode of ASTArtifact
+ * @template-covariant TNode of ASTArtifact
  *
  * @extends AbstractNode<TNode>
  */

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -48,7 +48,7 @@ abstract class AbstractTypeNode extends AbstractNode
      * Returns an <b>array</b> with all methods defined in the context class or
      * interface.
      *
-     * @return MethodNode[]
+     * @return list<MethodNode>
      */
     public function getMethods()
     {
@@ -64,7 +64,7 @@ abstract class AbstractTypeNode extends AbstractNode
      * Returns an array with the names of all methods within this class or
      * interface node.
      *
-     * @return string[]
+     * @return list<string>
      */
     public function getMethodNames()
     {

--- a/src/main/php/PHPMD/Node/Annotations.php
+++ b/src/main/php/PHPMD/Node/Annotations.php
@@ -29,7 +29,7 @@ class Annotations
     /**
      * Detected annotations.
      *
-     * @var Annotation[]
+     * @var list<Annotation>
      */
     private $annotations = [];
 

--- a/src/main/php/PHPMD/Node/EnumNode.php
+++ b/src/main/php/PHPMD/Node/EnumNode.php
@@ -21,6 +21,8 @@ use PDepend\Source\AST\ASTEnum;
 
 /**
  * Wrapper around PHP_Depend's enum objects.
+ *
+ * @extends AbstractTypeNode<ASTEnum>
  */
 class EnumNode extends AbstractTypeNode
 {

--- a/src/main/php/PHPMD/Node/InterfaceNode.php
+++ b/src/main/php/PHPMD/Node/InterfaceNode.php
@@ -21,6 +21,8 @@ use PDepend\Source\AST\ASTInterface;
 
 /**
  * Wrapper around PHP_Depend's interface objects.
+ *
+ * @extends AbstractTypeNode<ASTInterface>
  */
 class InterfaceNode extends AbstractTypeNode
 {

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Node;
 
+use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PDepend\Source\AST\ASTEnum;
@@ -112,7 +113,7 @@ class MethodNode extends AbstractCallableNode
     /**
      * Returns the parent class or interface instance.
      *
-     * @return AbstractTypeNode
+     * @return AbstractTypeNode<ASTArtifact>
      * @throws RuntimeException
      */
     public function getParentType()

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -20,9 +20,11 @@ namespace PHPMD\Node;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PDepend\Source\AST\ASTEnum;
+use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTTrait;
 use PHPMD\Rule;
+use RuntimeException;
 
 /**
  * Wrapper around a PHP_Depend method node.
@@ -96,6 +98,7 @@ class MethodNode extends AbstractCallableNode
      * instance.
      *
      * @return bool
+     * @throws RuntimeException
      */
     public function hasSuppressWarningsAnnotationFor(Rule $rule)
     {
@@ -110,6 +113,7 @@ class MethodNode extends AbstractCallableNode
      * Returns the parent class or interface instance.
      *
      * @return AbstractTypeNode
+     * @throws RuntimeException
      */
     public function getParentType()
     {
@@ -127,7 +131,11 @@ class MethodNode extends AbstractCallableNode
             return new EnumNode($parentNode);
         }
 
-        return new InterfaceNode($parentNode);
+        if ($parentNode instanceof ASTInterface) {
+            return new InterfaceNode($parentNode);
+        }
+
+        throw new RuntimeException('Unexpected method parent type: ' . $parentNode::class);
     }
 
     /**

--- a/src/main/php/PHPMD/Node/NodeInfoFactory.php
+++ b/src/main/php/PHPMD/Node/NodeInfoFactory.php
@@ -2,10 +2,15 @@
 
 namespace PHPMD\Node;
 
+use PDepend\Source\AST\ASTNode;
 use PHPMD\AbstractNode as PHPMDAbstractNode;
 
 class NodeInfoFactory
 {
+    /**
+     * @param PHPMDAbstractNode<ASTNode> $node
+     * @return NodeInfo
+     */
     public static function fromNode(PHPMDAbstractNode $node)
     {
         $className = null;

--- a/src/main/php/PHPMD/Node/TraitNode.php
+++ b/src/main/php/PHPMD/Node/TraitNode.php
@@ -21,6 +21,8 @@ use PDepend\Source\AST\ASTTrait;
 
 /**
  * Wrapper around PHP_Depend's interface objects.
+ *
+ * @extends AbstractTypeNode<ASTTrait>
  */
 class TraitNode extends AbstractTypeNode
 {

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -42,14 +42,14 @@ class PHPMD
     /**
      * List of valid file extensions for analyzed files.
      *
-     * @var array(string)
+     * @var list<string>
      */
     private $fileExtensions = ['php', 'php3', 'php4', 'php5', 'inc'];
 
     /**
      * List of exclude directory patterns.
      *
-     * @var array(string)
+     * @var list<string>
      */
     private $ignorePatterns = ['.git', '.svn', 'CVS', '.bzr', '.hg', 'SCCS'];
 
@@ -75,7 +75,7 @@ class PHPMD
     /**
      * Additional options for PHPMD or one of it's parser backends.
      *
-     * @var array
+     * @var array<string, string>
      * @since 1.2.0
      */
     private $options = [];
@@ -186,7 +186,7 @@ class PHPMD
     /**
      * Returns additional options for PHPMD or one of it's parser backends.
      *
-     * @return array
+     * @return array<string, string>
      */
     public function getOptions()
     {
@@ -196,7 +196,7 @@ class PHPMD
     /**
      * Sets additional options for PHPMD or one of it's parser backends.
      *
-     * @param array $options Additional backend or PHPMD options.
+     * @param array<string, string> $options Additional backend or PHPMD options.
      */
     public function setOptions(array $options): void
     {
@@ -209,10 +209,9 @@ class PHPMD
      * argument. The result will be passed to all given renderer instances.
      *
      * @param string             $inputPath
-     * @param array|null         $ignorePattern
+     * @param string[]|null      $ignorePattern
      * @param AbstractRenderer[] $renderers
      * @param RuleSet[]          $ruleSetList
-     *
      * @throws Exception
      */
     public function processFiles(

--- a/src/main/php/PHPMD/Parser.php
+++ b/src/main/php/PHPMD/Parser.php
@@ -23,6 +23,7 @@ use PDepend\Engine;
 use PDepend\Metrics\Analyzer;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Report\CodeAwareGenerator;
+use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
@@ -31,6 +32,7 @@ use PDepend\Source\AST\ASTEnum;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\ASTVisitor\AbstractASTVisitor;
 use PHPMD\Node\AbstractNode;
@@ -49,21 +51,21 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
     /**
      * The analysing rule-set instance.
      *
-     * @var RuleSet[]
+     * @var list<RuleSet>
      */
     private $ruleSets = [];
 
     /**
      * The metric containing analyzer instances.
      *
-     * @var AnalyzerNodeAware[]
+     * @var list<AnalyzerNodeAware>
      */
     private $analyzers = [];
 
     /**
      * The raw PDepend code nodes.
      *
-     * @var ASTArtifactList
+     * @var ASTArtifactList<ASTNamespace>
      */
     private $artifacts = null;
 
@@ -280,6 +282,8 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
 
     /**
      * Sets the context code nodes.
+     *
+     * @param ASTArtifactList<ASTNamespace> $artifacts
      */
     public function setArtifacts(ASTArtifactList $artifacts): void
     {
@@ -289,6 +293,7 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
     /**
      * Applies all rule-sets to the given <b>$node</b> instance.
      *
+     * @param AbstractNode<ASTArtifact> $node
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException
@@ -305,6 +310,8 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
     /**
      * Collects the collected metrics for the given node and adds them to the
      * <b>$node</b>.
+     *
+     * @param AbstractNode<ASTArtifact> $node
      */
     private function collectMetrics(AbstractNode $node): void
     {

--- a/src/main/php/PHPMD/Parser.php
+++ b/src/main/php/PHPMD/Parser.php
@@ -33,6 +33,7 @@ use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\ASTVisitor\AbstractASTVisitor;
+use PHPMD\Node\AbstractNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\EnumNode;
 use PHPMD\Node\FunctionNode;

--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -38,7 +38,7 @@ class ParserFactory
     /**
      * Mapping between phpmd option names and those used by pdepend.
      *
-     * @var array
+     * @var array<string, string>
      */
     private $phpmd2pdepend = [
         'coverage' => 'coverage-report',

--- a/src/main/php/PHPMD/Renderer/AnsiRenderer.php
+++ b/src/main/php/PHPMD/Renderer/AnsiRenderer.php
@@ -49,8 +49,8 @@ class AnsiRenderer extends AbstractRenderer
     {
         $maxLength = null;
         foreach ($report->getRuleViolations() as $violation) {
-            if ($maxLength === null || strlen($violation->getBeginLine()) > $maxLength) {
-                $maxLength = strlen($violation->getBeginLine());
+            if ($maxLength === null || strlen((string) $violation->getBeginLine()) > $maxLength) {
+                $maxLength = strlen((string) $violation->getBeginLine());
             }
         }
 
@@ -76,7 +76,7 @@ class AnsiRenderer extends AbstractRenderer
     {
         $this->getWriter()->write(sprintf(
             " %s | \e[31mVIOLATION\e[0m | %s" . PHP_EOL,
-            str_pad($violation->getBeginLine(), $padding, ' '),
+            str_pad((string) $violation->getBeginLine(), $padding, ' '),
             $violation->getDescription()
         ));
     }

--- a/src/main/php/PHPMD/Renderer/AnsiRenderer.php
+++ b/src/main/php/PHPMD/Renderer/AnsiRenderer.php
@@ -3,7 +3,6 @@
 namespace PHPMD\Renderer;
 
 use PHPMD\AbstractRenderer;
-use PHPMD\ProcessingError;
 use PHPMD\Report;
 use PHPMD\RuleViolation;
 
@@ -87,7 +86,6 @@ class AnsiRenderer extends AbstractRenderer
             return;
         }
 
-        /** @var ProcessingError $error */
         foreach ($report->getErrors() as $error) {
             $errorHeader = sprintf(
                 "\e[33mERROR\e[0m while parsing %s",

--- a/src/main/php/PHPMD/Renderer/GitHubRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitHubRenderer.php
@@ -38,7 +38,7 @@ class GitHubRenderer extends AbstractRenderer
             $writer->write('::warning file=');
             $writer->write($violation->getFileName());
             $writer->write(',line=');
-            $writer->write($violation->getBeginLine());
+            $writer->write((string) $violation->getBeginLine());
             $writer->write('::');
             $writer->write($violation->getDescription());
             $writer->write(PHP_EOL);

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -19,7 +19,6 @@ namespace PHPMD\Renderer;
 
 use PHPMD\AbstractRenderer;
 use PHPMD\Report;
-use PHPMD\RuleViolation;
 
 /**
  * This class will render a GitLab compatible JSON report.
@@ -45,13 +44,12 @@ class GitLabRenderer extends AbstractRenderer
      *
      * @param Report $report The report with potential violations.
      *
-     * @return array The report output with violations, if any.
+     * @return list<array<string, mixed>> The report output with violations, if any.
      */
     protected function addViolationsToReport(Report $report)
     {
         $data = [];
 
-        /** @var RuleViolation $violation */
         foreach ($report->getRuleViolations() as $violation) {
             $violationResult = [
                 'type' => 'issue',
@@ -90,9 +88,8 @@ class GitLabRenderer extends AbstractRenderer
      * Add errors, if any, to GitLab Code Quality report format
      *
      * @param Report $report The report with potential errors.
-     * @param array  $data   The report output to add the errors to.
-     *
-     * @return array The report output with errors, if any.
+     * @param array<int, array<string, mixed>> $data The report output to add the errors to.
+     * @return array<int, array<string, mixed>> The report output with errors, if any.
      */
     protected function addErrorsToReport(Report $report, array $data)
     {
@@ -121,7 +118,7 @@ class GitLabRenderer extends AbstractRenderer
     /**
      * Encode report data to the JSON representation string
      *
-     * @param array $data The report data
+     * @param array<mixed> $data The report data
      *
      * @return string
      */

--- a/src/main/php/PHPMD/Renderer/JSONRenderer.php
+++ b/src/main/php/PHPMD/Renderer/JSONRenderer.php
@@ -20,7 +20,6 @@ namespace PHPMD\Renderer;
 use PHPMD\AbstractRenderer;
 use PHPMD\PHPMD;
 use PHPMD\Report;
-use PHPMD\RuleViolation;
 
 /**
  * This class will render a JSON report.
@@ -44,7 +43,7 @@ class JSONRenderer extends AbstractRenderer
     /**
      * Create report data and add renderer meta properties
      *
-     * @return array
+     * @return array<string, string>
      */
     protected function initReportData()
     {
@@ -61,13 +60,12 @@ class JSONRenderer extends AbstractRenderer
      * Add violations, if any, to the report data
      *
      * @param Report $report The report with potential violations.
-     * @param array $data The report output to add the violations to.
-     * @return array The report output with violations, if any.
+     * @param array<string, mixed> $data The report output to add the violations to.
+     * @return array<string, mixed> The report output with violations, if any.
      */
     protected function addViolationsToReport(Report $report, array $data)
     {
         $filesList = [];
-        /** @var RuleViolation $violation */
         foreach ($report->getRuleViolations() as $violation) {
             $fileName = $violation->getFileName();
             $rule = $violation->getRule();
@@ -95,8 +93,8 @@ class JSONRenderer extends AbstractRenderer
      * Add errors, if any, to the report data
      *
      * @param Report $report The report with potential errors.
-     * @param array $data The report output to add the errors to.
-     * @return array The report output with errors, if any.
+     * @param array<string, mixed> $data The report output to add the errors to.
+     * @return array<string, mixed> The report output with errors, if any.
      */
     protected function addErrorsToReport(Report $report, array $data)
     {
@@ -114,7 +112,7 @@ class JSONRenderer extends AbstractRenderer
     /**
      * Encode report data to the JSON representation string
      *
-     * @param array $data The report data
+     * @param array<mixed> $data The report data
      *
      * @return string
      */

--- a/src/main/php/PHPMD/Renderer/SARIFRenderer.php
+++ b/src/main/php/PHPMD/Renderer/SARIFRenderer.php
@@ -19,7 +19,6 @@ namespace PHPMD\Renderer;
 
 use PHPMD\PHPMD;
 use PHPMD\Report;
-use PHPMD\RuleViolation;
 
 /**
  * This class will render a SARIF (Static Analysis
@@ -30,7 +29,7 @@ class SARIFRenderer extends JSONRenderer
     /**
      * Create report data and add renderer meta properties
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function initReportData()
     {
@@ -66,8 +65,10 @@ class SARIFRenderer extends JSONRenderer
      * Add violations, if any, to the report data
      *
      * @param Report $report The report with potential violations.
-     * @param array $data The report output to add the violations to.
-     * @return array The report output with violations, if any.
+     * @param array<string, array<int, array<string, array<string, array<mixed>>>>> $data The report output to add the
+     *                                                                                    violations to.
+     * @return array<string, array<int, array<string, array<string, array<mixed>>>>> The report output with violations,
+     *                                                                               if any.
      */
     protected function addViolationsToReport(Report $report, array $data)
     {
@@ -75,7 +76,6 @@ class SARIFRenderer extends JSONRenderer
         $results = [];
         $ruleIndices = [];
 
-        /** @var RuleViolation $violation */
         foreach ($report->getRuleViolations() as $violation) {
             $rule = $violation->getRule();
             $ruleRef = str_replace(' ', '', $rule->getRuleSetName()) . '/' . $rule->getName();
@@ -157,8 +157,10 @@ class SARIFRenderer extends JSONRenderer
      * Add errors, if any, to the report data
      *
      * @param Report $report The report with potential errors.
-     * @param array $data The report output to add the errors to.
-     * @return array The report output with errors, if any.
+     * @param array<string, array<int, array<string, list<array<string, mixed>>>>> $data The report output to add the
+     *                                                                                   errors to.
+     * @return array<string, array<int, array<string, list<array<string, mixed>>>>> The report output with errors, if
+     *                                                                              any.
      */
     protected function addErrorsToReport(Report $report, array $data)
     {
@@ -188,7 +190,7 @@ class SARIFRenderer extends JSONRenderer
      * and returns the result as a SARIF `artifactLocation`
      *
      * @param string $path
-     * @return array
+     * @return array<string, string>
      */
     protected static function pathToArtifactLocation($path)
     {

--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -29,11 +29,11 @@ use PHPMD\Report;
  */
 class TextRenderer extends AbstractRenderer implements Verbose, Color
 {
-    protected $columnSpacing = 2;
+    protected int $columnSpacing = 2;
 
-    protected $verbosityLevel = OutputInterface::VERBOSITY_NORMAL;
+    protected int $verbosityLevel = OutputInterface::VERBOSITY_NORMAL;
 
-    protected $colored = false;
+    protected bool $colored = false;
 
     /**
      * This method will be called when the engine has finished the source analysis
@@ -99,7 +99,7 @@ class TextRenderer extends AbstractRenderer implements Verbose, Color
         $this->colored = $colored;
     }
 
-    protected function applyColor($text, $color)
+    protected function applyColor(string $text, string $color): string
     {
         if (!$this->colored) {
             return $text;
@@ -109,7 +109,7 @@ class TextRenderer extends AbstractRenderer implements Verbose, Color
             'yellow' => 33,
             'red' => 31,
         ];
-        $color = $colors[$color] ?? $color;
+        $color = $colors[$color] ?? 0;
 
         return "\033[{$color}m{$text}\033[0m";
     }

--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -30,7 +30,7 @@ class Report
     /**
      * List of rule violations detected in the analyzed source code.
      *
-     * @var array
+     * @var array<string, array<int, list<RuleViolation>>>
      */
     private $ruleViolations = [];
 
@@ -51,7 +51,7 @@ class Report
     /**
      * Errors that occurred while parsing the source.
      *
-     * @var array
+     * @var list<ProcessingError>
      * @since 1.2.1
      */
     private $errors = [];

--- a/src/main/php/PHPMD/Rule.php
+++ b/src/main/php/PHPMD/Rule.php
@@ -20,6 +20,7 @@ namespace PHPMD;
 use InvalidArgumentException;
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
+use PDepend\Source\AST\ASTNode;
 
 /**
  * Base interface for a PHPMD rule.
@@ -90,6 +91,8 @@ interface Rule
 
     /**
      * Returns a list of examples for this rule.
+     *
+     * @return list<string>
      */
     public function getExamples(): array;
 
@@ -167,6 +170,7 @@ interface Rule
      * This method should implement the violation analysis algorithm of concrete
      * rule implementations. All extending classes must implement this method.
      *
+     * @param AbstractNode<ASTNode> $node The node to check upon.
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -149,7 +149,7 @@ abstract class AbstractLocalVariable extends AbstractRule
         }
 
         $parent = $node->getParent();
-        if ($parent->getChild(0)->getNode() === $node->getNode()) {
+        if ($parent?->getChild(0)->getNode() === $node->getNode()) {
             return $this->stripWrappedIndexExpression($parent);
         }
 
@@ -344,7 +344,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * same variable and won't overlap in a storage keyed by image as first one
      * image is "$foo", second one is "::$foo".
      *
-     * @param ASTPropertyPostfix|ASTVariable|ASTVariableDeclarator $variable
+     * @param PDependNode $variable
      * @return string
      * @throws OutOfBoundsException
      */
@@ -378,7 +378,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * }
      * ```
      *
-     * @param ASTPropertyPostfix|ASTVariable|ASTVariableDeclarator $variable
+     * @param PDependNode $variable
      * @param string $image
      * @return bool
      */

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -20,14 +20,12 @@ namespace PHPMD\Rule;
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTArrayIndexExpression;
-use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTPropertyPostfix;
 use PDepend\Source\AST\ASTStringIndexExpression;
 use PDepend\Source\AST\ASTVariable;
-use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
@@ -42,7 +40,7 @@ use ReflectionFunction;
 abstract class AbstractLocalVariable extends AbstractRule
 {
     /**
-     * @var array Self reference class names.
+     * @var list<string> Self reference class names.
      */
     protected $selfReferences = ['self', 'static'];
 
@@ -50,7 +48,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * PHP super globals that are available in all php scopes, so that they
      * can never be unused local variables.
      *
-     * @var array(string=>boolean)
+     * @var array<string, bool>
      * @link http://php.net/manual/en/reserved.variables.php
      */
     protected static $superGlobals = [
@@ -90,6 +88,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Tests if the given variable represents one of the PHP super globals
      * that are available in scopes.
      *
+     * @param AbstractNode<ASTVariable> $variable
      * @return bool
      */
     protected function isSuperGlobal(AbstractNode $variable)
@@ -101,6 +100,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Tests if the given variable does not represent one of the PHP super globals
      * that are available in scopes.
      *
+     * @param AbstractNode<ASTVariable> $variable
      * @return bool
      */
     protected function isNotSuperGlobal(AbstractNode $variable)
@@ -112,6 +112,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Tests if the given variable node is a regular variable an not property
      * or method postfix.
      *
+     * @param ASTNode<ASTVariable> $variable
      * @return bool
      * @throws OutOfBoundsException
      */
@@ -139,7 +140,8 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Removes all index expressions that are wrapped around the given node
      * instance.
      *
-     * @return ASTNode
+     * @param ASTNode<PDependNode> $node
+     * @return ASTNode<PDependNode>
      * @throws OutOfBoundsException
      */
     protected function stripWrappedIndexExpression(ASTNode $node)
@@ -159,6 +161,7 @@ abstract class AbstractLocalVariable extends AbstractRule
     /**
      * Tests if the given variable node os part of an index expression.
      *
+     * @param ASTNode<PDependNode> $node
      * @return bool
      */
     protected function isWrappedByIndexExpression(ASTNode $node)
@@ -172,6 +175,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * PHP is case insensitive so we should compare function names case
      * insensitive.
      *
+     * @param AbstractNode<PDependNode> $node
      * @param string $name
      * @return bool
      */
@@ -184,6 +188,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * AST puts namespace prefix to global functions called from a namespace.
      * This method checks if the last part of function fully qualified name is equal to $name
      *
+     * @param AbstractNode<PDependNode> $node
      * @param string $name
      * @return bool
      */
@@ -199,7 +204,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      *
      * Prefix self:: and static:: properties with "::".
      *
-     * @param AbstractNode|PDependNode $variable
+     * @param AbstractNode<PDependNode>|PDependNode $variable
      * @return string
      * @throws OutOfBoundsException
      */
@@ -223,6 +228,8 @@ abstract class AbstractLocalVariable extends AbstractRule
     }
 
     /**
+     * @param string $image
+     * @return ?string
      * @throws OutOfBoundsException
      */
     protected function getParentMemberPrimaryPrefixImage($image, ASTPropertyPostfix $postfix)
@@ -247,7 +254,8 @@ abstract class AbstractLocalVariable extends AbstractRule
      *
      * Or return the input as is if it's not an ASTNode PHPMD node.
      *
-     * @return ASTArtifact|PDependNode
+     * @param ASTNode<PDependNode>|PDependNode $node
+     * @return PDependNode
      */
     protected function getNode($node)
     {
@@ -288,18 +296,18 @@ abstract class AbstractLocalVariable extends AbstractRule
     /**
      * Return true if the given variable is passed by reference in a native PHP function.
      *
-     * @param ASTPropertyPostfix|ASTVariable|ASTVariableDeclarator $variable
+     * @param ASTVariable $variable
      * @return bool
      */
     protected function isPassedByReference($variable)
     {
-        $parent = $this->getNode($variable->getParent());
+        $parent = $variable->getParent();
 
         if (!($parent instanceof ASTArguments)) {
             return false;
         }
 
-        $argumentPosition = array_search($this->getNode($variable), $parent->getChildren());
+        $argumentPosition = array_search($variable, $parent->getChildren());
         $parentParent = $parent->getParent();
         if ($parentParent === null) {
             return false;
@@ -348,7 +356,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * @return string
      * @throws OutOfBoundsException
      */
-    private function prependMemberPrimaryPrefix($image, $variable)
+    private function prependMemberPrimaryPrefix(string $image, $variable)
     {
         $parent = $variable->getParent();
 

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -19,6 +19,7 @@ namespace PHPMD\Rule\CleanCode;
 
 use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTFormalParameter;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTValue;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
@@ -70,7 +71,7 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
         $this->scanFormalParameters($node);
     }
 
-    protected function isBooleanValue(ASTValue $value = null)
+    protected function isBooleanValue(ASTValue $value = null): bool
     {
         return $value?->isValueAvailable() && is_bool($value->getValue());
     }
@@ -89,6 +90,9 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
         return $this->exceptions;
     }
 
+    /**
+     * @param AbstractNode<ASTNode> $node
+     */
     private function scanFormalParameters(AbstractNode $node): void
     {
         foreach ($node->findChildrenOfType(ASTFormalParameter::class) as $param) {

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -57,7 +57,7 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
         }
 
         $currNode = $node->getNode();
-        $parent = is_callable([$currNode, 'getParent']) ? $currNode->getParent() : null;
+        $parent = $currNode->getParent();
 
         if ($parent &&
             ($parent instanceof AbstractASTClassOrInterface) &&

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -20,7 +20,6 @@ namespace PHPMD\Rule\CleanCode;
 use OutOfBoundsException;
 use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTArray;
-use PDepend\Source\AST\ASTArrayElement;
 use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTNode as PDependASTNode;
 use PHPMD\AbstractNode;
@@ -53,14 +52,16 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      * This method checks if a given function or method contains an array literal
      * with duplicated entries for any key and emits a rule violation if so.
      *
-     * @param ASTNode $node Array node.
+     * @param ASTNode<ASTArray> $node Array node.
      * @throws OutOfBoundsException
      */
     protected function checkForDuplicatedArrayKeys(ASTNode $node): void
     {
         $keys = [];
-        /** @var ASTArrayElement $arrayElement */
         foreach ($node->getChildren() as $index => $arrayElement) {
+            if (!$arrayElement instanceof AbstractASTNode) {
+                continue;
+            }
             $arrayElement = $this->normalizeKey($arrayElement, $index);
             if (null === $arrayElement) {
                 // skip everything that can't be resolved easily

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -42,6 +42,10 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
         foreach ($node->findChildrenOfType(ASTScopeStatement::class) as $scope) {
             $parent = $scope->getParent();
 
+            if (!$parent) {
+                continue;
+            }
+
             if (!$this->isIfOrElseIfStatement($parent)) {
                 continue;
             }

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Rule\CleanCode;
 
 use OutOfBoundsException;
+use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTScopeStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -61,6 +62,8 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
     /**
      * Whether the given scope is an else clause
      *
+     * @param AbstractNode<ASTScopeStatement> $scope
+     * @param ASTNode<PDependNode> $parent
      * @return bool
      * @throws OutOfBoundsException
      */
@@ -75,6 +78,7 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
     /**
      * Whether the parent node is an if or an elseif clause
      *
+     * @param ASTNode<PDependNode> $parent
      * @return bool
      */
     protected function isIfOrElseIfStatement(ASTNode $parent)

--- a/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
@@ -40,7 +40,7 @@ class ErrorControlOperator extends AbstractRule implements MethodAware, Function
     {
         foreach ($node->findChildrenOfType(ASTUnaryExpression::class) as $unaryExpression) {
             if ($unaryExpression->getImage() === '@') {
-                $this->addViolation($node, [$unaryExpression->getBeginLine()]);
+                $this->addViolation($node, [(string) $unaryExpression->getBeginLine()]);
             }
         }
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
@@ -24,6 +24,8 @@ use PDepend\Source\AST\ASTIfStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
+use PHPMD\Node\FunctionNode;
+use PHPMD\Node\MethodNode;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
 
@@ -94,8 +96,8 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
     /**
      * Extracts all assignments from expressions array
      *
-     * @param ASTExpression[] $expressions Array of expressions
-     * @return ASTAssignmentExpression[]
+     * @param array<int, ASTNode<ASTExpression>> $expressions Array of expressions
+     * @return array<int, ASTNode<ASTAssignmentExpression>>
      */
     protected function getAssignments(array $expressions)
     {
@@ -111,7 +113,7 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
      * Signals if any violations have been found in given method or function
      *
      * @param AbstractNode $node An instance of MethodNode or FunctionNode class
-     * @param ASTAssignmentExpression[] $assignments Array of assignments
+     * @param array<int, ASTNode<ASTAssignmentExpression>> $assignments Array of assignments
      */
     protected function addViolations(AbstractNode $node, array $assignments): void
     {

--- a/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PDepend\Source\AST\ASTAllocationExpression;
+use PDepend\Source\AST\ASTNode as PDependNode;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
@@ -32,14 +33,12 @@ use PHPMD\Rule\MethodAware;
 class MissingImport extends AbstractRule implements MethodAware, FunctionAware
 {
     /**
-     * @var array Self reference class names.
+     * @var list<string> Self reference class names.
      */
     protected $selfReferences = ['self', 'static'];
 
     /**
      * Checks for missing class imports and warns about it
-     *
-     * @param AbstractNode $node The node to check upon.
      */
     public function apply(AbstractNode $node): void
     {
@@ -64,7 +63,10 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
             $fqcnLength = strlen($className);
 
             if ($classNameLength === $fqcnLength && substr($className, 0, 1) !== '$') {
-                $this->addViolation($classNode, [$classNode->getBeginLine(), $classNode->getStartColumn()]);
+                $this->addViolation(
+                    $classNode,
+                    [(string) $classNode->getBeginLine(), (string) $classNode->getStartColumn()]
+                );
             }
         }
     }
@@ -72,7 +74,7 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
     /**
      * Check whether a given class node is a self reference
      *
-     * @param ASTNode $classNode A class node to check.
+     * @param ASTNode<PDependNode> $classNode A class node to check.
      * @return bool Whether the given class node is a self reference.
      */
     protected function isSelfReference(ASTNode $classNode)
@@ -83,7 +85,7 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
     /**
      * Check whether a given class node is in the global namespace
      *
-     * @param ASTNode $classNode A class node to check.
+     * @param ASTNode<PDependNode> $classNode A class node to check.
      * @return bool Whether the given class node is in the global namespace.
      */
     protected function isGlobalNamespace(ASTNode $classNode)

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -72,9 +72,10 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
     }
 
     /**
+     * @param AbstractNode<ASTMemberPrimaryPrefix> $methodCall
      * @throws OutOfBoundsException
      */
-    protected function isStaticMethodCall(AbstractNode $methodCall)
+    protected function isStaticMethodCall(AbstractNode $methodCall): bool
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTClassOrInterfaceReference &&
             $methodCall->getChild(1)->getNode() instanceof ASTMethodPostfix &&
@@ -83,22 +84,25 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
     }
 
     /**
+     * @param AbstractNode<ASTMemberPrimaryPrefix> $methodCall
      * @throws OutOfBoundsException
      */
-    protected function isCallingParent(AbstractNode $methodCall)
+    protected function isCallingParent(AbstractNode $methodCall): bool
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTParentReference;
     }
 
     /**
+     * @param AbstractNode<ASTMemberPrimaryPrefix> $methodCall
      * @throws OutOfBoundsException
      */
-    protected function isCallingSelf(AbstractNode $methodCall)
+    protected function isCallingSelf(AbstractNode $methodCall): bool
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTSelfReference;
     }
 
     /**
+     * @param AbstractNode<ASTMemberPrimaryPrefix> $methodCall
      * @param string $ignorePattern
      * @return bool
      */

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -30,6 +30,9 @@ use PHPMD\Rule\MethodAware;
  */
 class CamelCaseMethodName extends AbstractRule implements MethodAware
 {
+    /**
+     * @var list<string>
+     */
     protected $ignoredMethods = [
         '__construct',
         '__destruct',
@@ -72,7 +75,7 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
     /**
      * @throws OutOfBoundsException
      */
-    protected function isValid($methodName)
+    protected function isValid(string $methodName): bool
     {
         // disallow any consecutive uppercase letters
         if ($this->getBooleanProperty('camelcase-abbreviations', false)

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -20,8 +20,7 @@ namespace PHPMD\Rule\Controversial;
 use OutOfBoundsException;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\FunctionNode;
-use PHPMD\Node\MethodNode;
+use PHPMD\Node\AbstractCallableNode;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
 
@@ -39,7 +38,7 @@ class CamelCaseParameterName extends AbstractRule implements MethodAware, Functi
      */
     public function apply(AbstractNode $node): void
     {
-        if (!$node instanceof FunctionNode && !$node instanceof MethodNode) {
+        if (!$node instanceof AbstractCallableNode) {
             return;
         }
 

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -57,7 +57,7 @@ class CamelCaseParameterName extends AbstractRule implements MethodAware, Functi
     /**
      * @throws OutOfBoundsException
      */
-    protected function isValid($parameterName)
+    protected function isValid(string $parameterName): bool
     {
         // disallow any consecutive uppercase letters
         if ($this->getBooleanProperty('camelcase-abbreviations', false)

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
@@ -60,7 +60,7 @@ class CamelCasePropertyName extends AbstractRule implements ClassAware, TraitAwa
     /**
      * @throws OutOfBoundsException
      */
-    private function isValid($propertyName)
+    private function isValid(string $propertyName): bool
     {
         // disallow any consecutive uppercase letters
         if ($this->getBooleanProperty('camelcase-abbreviations', false)

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
@@ -19,6 +19,7 @@ namespace PHPMD\Rule\Controversial;
 
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTPropertyPostfix;
+use PDepend\Source\AST\ASTVariable;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
@@ -33,7 +34,7 @@ use PHPMD\Rule\MethodAware;
 class CamelCaseVariableName extends AbstractRule implements MethodAware, FunctionAware
 {
     /**
-     * @var array
+     * @var list<string>
      */
     protected $exceptions = [
         '$php_errormsg',
@@ -70,9 +71,10 @@ class CamelCaseVariableName extends AbstractRule implements MethodAware, Functio
     }
 
     /**
+     * @param AbstractNode<ASTVariable> $variable
      * @throws OutOfBoundsException
      */
-    protected function isValid($variable)
+    protected function isValid(AbstractNode $variable): bool
     {
         $image = $variable->getImage();
 

--- a/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
+++ b/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
@@ -30,6 +30,9 @@ use PHPMD\Rule\MethodAware;
  */
 class Superglobals extends AbstractRule implements MethodAware, FunctionAware
 {
+    /**
+     * @var list<string>
+     */
     protected $superglobals = [
         '$GLOBALS',
         '$_SERVER',

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -23,6 +23,7 @@ use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTForStatement;
 use PDepend\Source\AST\ASTFunctionPostfix;
 use PDepend\Source\AST\ASTNode as PDependNode;
+use PDepend\Source\AST\ASTStatement;
 use PDepend\Source\AST\ASTWhileStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -54,14 +55,14 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
     /**
      * List of functions to search against
      *
-     * @var array
+     * @var list<string>
      */
     protected $unwantedFunctions = ['count', 'sizeof'];
 
     /**
      * List of already processed functions
      *
-     * @var array
+     * @var array<string, bool>
      */
     protected $processedFunctions = [];
 
@@ -93,7 +94,6 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
             $node->findChildrenOfType(ASTDoWhileStatement::class)
         );
 
-        /** @var AbstractNode $loop */
         foreach ($loops as $loop) {
             $this->findViolations($loop);
         }
@@ -103,7 +103,7 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
      * Scans for expressions and count() or sizeof() functions inside,
      * if found, triggers a violation
      *
-     * @param AbstractNode $loop Loop statement to look against
+     * @param AbstractNode<ASTStatement> $loop Loop statement to look against
      */
     protected function findViolations(AbstractNode $loop): void
     {
@@ -131,6 +131,8 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
     /**
      * Checks whether node in a direct child of the loop
      *
+     * @param AbstractNode<ASTStatement> $loop
+     * @param ASTNode<ASTExpression> $expression
      * @return bool
      */
     protected function isDirectChild(AbstractNode $loop, ASTNode $expression)
@@ -166,6 +168,7 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
     /**
      * Checks the given function against the list of unwanted functions
      *
+     * @param ASTNode<ASTFunctionPostfix> $function
      * @return bool
      */
     protected function isUnwantedFunction(ASTNode $function)

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -17,11 +17,12 @@
 
 namespace PHPMD\Rule\Design;
 
-use PDepend\Source\AST\AbstractASTNode;
+use InvalidArgumentException;
 use PDepend\Source\AST\ASTDoWhileStatement;
 use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTForStatement;
 use PDepend\Source\AST\ASTFunctionPostfix;
+use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTWhileStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -32,6 +33,7 @@ use PHPMD\Node\TraitNode;
 use PHPMD\Rule\ClassAware;
 use PHPMD\Rule\EnumAware;
 use PHPMD\Rule\TraitAware;
+use RuntimeException;
 
 /**
  * Count In Loop Expression Rule
@@ -45,6 +47,7 @@ use PHPMD\Rule\TraitAware;
  * - do-while() loops
  *
  * @author Kamil Szymanski <kamilszymanski@gmail.com>
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAware, EnumAware
 {
@@ -71,6 +74,9 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
 
     /**
      * Gets a list of loops in a node and iterates over them
+     *
+     * @throws RuntimeException
+     * @throws InvalidArgumentException
      */
     public function apply(AbstractNode $node): void
     {
@@ -145,7 +151,7 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
      *
      * @return string
      */
-    protected function getHash(AbstractASTNode $node)
+    protected function getHash(PDependNode $node)
     {
         return sprintf(
             '%s:%s:%s:%s:%s',

--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -66,7 +66,7 @@ class DevelopmentCodeFragment extends AbstractRule implements MethodAware, Funct
      * Returns an array with function images that are normally only used during
      * development.
      *
-     * @return array
+     * @return list<string>
      * @throws OutOfBoundsException
      */
     protected function getSuspectImages()

--- a/src/main/php/PHPMD/Rule/Design/LongParameterList.php
+++ b/src/main/php/PHPMD/Rule/Design/LongParameterList.php
@@ -19,8 +19,7 @@ namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\FunctionNode;
-use PHPMD\Node\MethodNode;
+use PHPMD\Node\AbstractCallableNode;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
 
@@ -35,7 +34,7 @@ class LongParameterList extends AbstractRule implements FunctionAware, MethodAwa
      */
     public function apply(AbstractNode $node): void
     {
-        if (!$node instanceof FunctionNode && !$node instanceof MethodNode) {
+        if (!$node instanceof AbstractCallableNode) {
             return;
         }
 

--- a/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
@@ -19,7 +19,7 @@ namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\AbstractTypeNode;
+use PHPMD\Node\ClassNode;
 use PHPMD\Rule\ClassAware;
 
 /**
@@ -40,13 +40,16 @@ class TooManyMethods extends AbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node): void
     {
+        if (!$node instanceof ClassNode) {
+            return;
+        }
+
         $this->ignoreRegexp = $this->getStringProperty('ignorepattern');
 
         $threshold = $this->getIntProperty('maxmethods');
         if ($node->getMetric('nom') <= $threshold) {
             return;
         }
-        /** @var AbstractTypeNode $node */
         $nom = $this->countMethods($node);
         if ($nom <= $threshold) {
             return;
@@ -67,7 +70,7 @@ class TooManyMethods extends AbstractRule implements ClassAware
      *
      * @return int
      */
-    protected function countMethods(AbstractTypeNode $node)
+    protected function countMethods(ClassNode $node)
     {
         $count = 0;
         foreach ($node->getMethodNames() as $name) {

--- a/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
@@ -19,7 +19,7 @@ namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\AbstractTypeNode;
+use PHPMD\Node\ClassNode;
 use PHPMD\Rule\ClassAware;
 
 /**
@@ -40,6 +40,10 @@ class TooManyPublicMethods extends AbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node): void
     {
+        if (!$node instanceof ClassNode) {
+            return;
+        }
+
         $this->ignoreRegexp = $this->getStringProperty('ignorepattern');
 
         $threshold = $this->getIntProperty('maxmethods');
@@ -49,7 +53,6 @@ class TooManyPublicMethods extends AbstractRule implements ClassAware
             return;
         }
 
-        /** @var AbstractTypeNode $node */
         $nom = $this->countMethods($node);
 
         if ($nom <= $threshold) {
@@ -72,7 +75,7 @@ class TooManyPublicMethods extends AbstractRule implements ClassAware
      *
      * @return int
      */
-    protected function countMethods(AbstractTypeNode $node)
+    protected function countMethods(ClassNode $node)
     {
         $count = 0;
         foreach ($node->getMethods() as $method) {

--- a/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
@@ -36,7 +36,10 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
      */
     public function apply(AbstractNode $node): void
     {
-        /** @var MethodNode $node */
+        if (!$node instanceof MethodNode) {
+            return;
+        }
+
         if ($this->isBooleanGetMethod($node)) {
             $this->addViolation($node, [$node->getImage()]);
         }

--- a/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
@@ -23,6 +23,7 @@ use PHPMD\AbstractRule;
 use PHPMD\Node\InterfaceNode;
 use PHPMD\Node\MethodNode;
 use PHPMD\Rule\MethodAware;
+use RuntimeException;
 
 /**
  * This rule class will detect methods that define a php4 style constructor
@@ -33,6 +34,8 @@ class ConstructorWithNameAsEnclosingClass extends AbstractRule implements Method
     /**
      * Is method has the same name as the enclosing class
      * (php4 style constructor).
+     *
+     * @throws RuntimeException
      */
     public function apply(AbstractNode $node): void
     {

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -21,6 +21,7 @@ use InvalidArgumentException;
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -54,7 +55,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * Temporary map holding variables that were already processed in the
      * current context.
      *
-     * @var array(string=>boolean)
+     * @var array<string, bool>
      */
     protected $processedVariables = [];
 
@@ -96,6 +97,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * Checks if the variable name of the given node is smaller/equal to the
      * configured threshold.
      *
+     * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
@@ -110,6 +112,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
     /**
      * Template method that performs the real node image check.
      *
+     * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      * @SuppressWarnings(PHPMD.LongVariable)
@@ -136,6 +139,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * Checks if a short name is acceptable in the current context. For the
      * moment the only context is a static member.
      *
+     * @param AbstractNode<ASTNode> $node
      * @return bool
      */
     protected function isNameAllowedInContext(AbstractNode $node)
@@ -153,6 +157,8 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
 
     /**
      * Flags the given node as already processed.
+     *
+     * @param AbstractNode<ASTNode> $node
      */
     protected function addProcessed(AbstractNode $node): void
     {
@@ -162,6 +168,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
     /**
      * Checks if the given node was already processed.
      *
+     * @param AbstractNode<ASTNode> $node
      * @return bool
      */
     protected function isNotProcessed(AbstractNode $node)

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -140,27 +140,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      */
     protected function isNameAllowedInContext(AbstractNode $node)
     {
-        return $this->isChildOf($node, ASTMemberPrimaryPrefix::class);
-    }
-
-    /**
-     * Checks if the given node is a direct or indirect child of a node with
-     * the given type.
-     *
-     * @param string $type
-     * @return bool
-     */
-    protected function isChildOf(AbstractNode $node, $type)
-    {
-        $parent = $node->getParent();
-        while (is_object($parent)) {
-            if ($parent->isInstanceOf($type)) {
-                return true;
-            }
-            $parent = $parent->getParent();
-        }
-
-        return false;
+        return $node->getParentOfType(ASTMemberPrimaryPrefix::class) !== null;
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -250,15 +250,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      */
     protected function isChildOf(AbstractNode $node, $type)
     {
-        $parent = $node->getParent();
-        while (is_object($parent)) {
-            if ($parent->isInstanceOf($type)) {
-                return true;
-            }
-            $parent = $parent->getParent();
-        }
-
-        return false;
+        return $node->getParentOfType($type) !== null;
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -24,6 +24,7 @@ use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTForeachStatement;
 use PDepend\Source\AST\ASTForInit;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -43,7 +44,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * Temporary map holding variables that were already processed in the
      * current context.
      *
-     * @var array(string=>boolean)
+     * @var array<string, bool>
      */
     protected $processedVariables = [];
 
@@ -79,6 +80,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * Checks the variable name length against the configured minimum
      * length.
      *
+     * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
@@ -100,6 +102,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * Checks the variable name length against the configured minimum
      * length.
      *
+     * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
@@ -121,6 +124,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * Checks if the variable name of the given node is greater/equal to the
      * configured threshold or if the given node is an allowed context.
      *
+     * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
@@ -135,6 +139,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
     /**
      * Template method that performs the real node image check.
      *
+     * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
@@ -178,6 +183,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * moment these contexts are the init section of a for-loop and short
      * variable names in catch-statements.
      *
+     * @param AbstractNode<ASTNode> $node
      * @return bool
      * @throws OutOfBoundsException
      */
@@ -197,6 +203,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
     /**
      * Checks if a short name is initialized within a foreach loop statement
      *
+     * @param AbstractNode<ASTNode> $node
      * @return bool
      * @throws OutOfBoundsException
      */
@@ -223,7 +230,10 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
     /**
      * Returns an array of parent nodes of the specified type
      *
-     * @return array
+     * @template T of ASTNode
+     * @param AbstractNode<ASTNode> $node
+     * @param class-string<T> $type
+     * @return list<AbstractNode<T>>
      */
     protected function getParentsOfType(AbstractNode $node, $type)
     {
@@ -245,7 +255,8 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * Checks if the given node is a direct or indirect child of a node with
      * the given type.
      *
-     * @param string $type
+     * @param AbstractNode<ASTNode> $node
+     * @param class-string<ASTNode> $type
      * @return bool
      */
     protected function isChildOf(AbstractNode $node, $type)
@@ -263,6 +274,8 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
 
     /**
      * Flags the given node as already processed.
+     *
+     * @param AbstractNode<ASTNode> $node
      */
     protected function addProcessed(AbstractNode $node): void
     {
@@ -272,6 +285,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
     /**
      * Checks if the given node was already processed.
      *
+     * @param AbstractNode<ASTNode> $node
      * @return bool
      */
     protected function isNotProcessed(AbstractNode $node)

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Rule;
 
 use OutOfBoundsException;
+use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PDepend\Source\AST\ASTCompoundVariable;
 use PDepend\Source\AST\ASTExpression;
@@ -33,6 +34,8 @@ use PHPMD\Node\MethodNode;
 /**
  * This rule collects all formal parameters of a given function or method that
  * are not used in a statement of the artifact's body.
+ *
+ * @SuppressWarnings("PMD.CouplingBetweenObjects")
  */
 class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAware, MethodAware
 {
@@ -160,6 +163,11 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
     {
         // First collect the formal parameters containers
         foreach ($node->findChildrenOfType(ASTFormalParameters::class) as $parameters) {
+            $parent = $parameters->getParentOfType(AbstractASTCallable::class);
+            if ($parent->getNode() !== $node->getNode()) {
+                continue;
+            }
+
             // Now get all declarators in the formal parameters container
             $declarators = $parameters->findChildrenOfType(ASTVariableDeclarator::class);
 

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -19,6 +19,7 @@ namespace PHPMD\Rule;
 
 use InvalidArgumentException;
 use OutOfBoundsException;
+use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\ASTAssignmentExpression;
 use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTCompoundVariable;
@@ -142,7 +143,10 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
         }
 
         foreach ($node->findChildrenOfType(ASTVariableDeclarator::class) as $variable) {
-            $this->collectVariable($variable);
+            $parent = $variable->getParentOfType(AbstractASTCallable::class);
+            if ($parent->getNode() === $node->getNode()) {
+                $this->collectVariable($variable);
+            }
         }
 
         foreach ($node->findChildrenOfType(ASTFunctionPostfix::class) as $func) {

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -20,6 +20,7 @@ namespace PHPMD\Rule;
 use InvalidArgumentException;
 use OutOfBoundsException;
 use PDepend\Source\AST\AbstractASTCallable;
+use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTAssignmentExpression;
 use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTCompoundVariable;
@@ -47,7 +48,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Found variable images within a single method or function.
      *
-     * @var array(string)
+     * @var array<string, list<ASTNode<AbstractASTNode>>>
      */
     protected $images = [];
 
@@ -64,9 +65,12 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      */
     public function apply(AbstractNode $node): void
     {
+        if (!$node instanceof AbstractCallableNode) {
+            return;
+        }
+
         $this->images = [];
 
-        /** @var AbstractCallableNode $node */
         $this->collectVariables($node);
         $this->removeParameters($node);
 
@@ -80,6 +84,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Return true if one of the passed nodes contains variables usages.
      *
+     * @param array<int, ASTNode<AbstractASTNode>> $nodes
      * @return bool
      */
     protected function containsUsages(array $nodes)
@@ -108,6 +113,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * are also found in the formal parameters of the given method or/and
      * function node.
      *
+     * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
     protected function removeParameters(AbstractCallableNode $node): void
@@ -128,6 +134,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * method/function node and stores their image in the <b>$_images</b>
      * property.
      *
+     * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
     protected function collectVariables(AbstractCallableNode $node): void
@@ -161,6 +168,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Stores the given compound variable node in an internal list of found variables.
      *
+     * @param ASTNode<ASTCompoundVariable> $node
      * @throws OutOfBoundsException
      */
     protected function collectCompoundVariableInString(ASTNode $node): void
@@ -183,18 +191,19 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Stores the given variable node in an internal list of found variables.
      *
+     * @param ASTNode<ASTExpression> $node
      * @throws OutOfBoundsException
      */
     protected function collectVariable(ASTNode $node): void
     {
-        $this->storeImage($this->getVariableImage($node), $node);
+        $this->storeImage($this->getVariableImage($node->getNode()), $node);
     }
 
     /**
      * Safely add node to $this->images.
      *
      * @param string $imageName the name to store the node as
-     * @param ASTNode $node the node being stored
+     * @param ASTNode<AbstractASTNode> $node the node being stored
      */
     protected function storeImage($imageName, ASTNode $node): void
     {
@@ -207,6 +216,8 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
 
     /**
      * Stores the given literal node in an internal list of found variables.
+     *
+     * @param ASTNode<ASTLiteral> $node
      */
     protected function collectLiteral(ASTNode $node): void
     {
@@ -222,6 +233,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Template method that performs the real node image check.
      *
+     * @param ASTNode<AbstractASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
@@ -256,6 +268,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * moment these contexts are the init section of a for-loop and short
      * variable names in catch-statements.
      *
+     * @param AbstractNode<AbstractASTNode> $node
      * @return bool
      */
     protected function isNameAllowedInContext(AbstractNode $node)
@@ -268,7 +281,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      *
      * If it's not a foreach variable, it returns always false.
      *
-     * @param ASTNode $variable The variable to check.
+     * @param ASTNode<AbstractASTNode> $variable The variable to check.
      * @return bool True if allowed, else false.
      * @throws OutOfBoundsException
      */
@@ -287,7 +300,8 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * Checks if the given node is a direct or indirect child of a node with
      * the given type.
      *
-     * @param string $type
+     * @param AbstractNode<AbstractASTNode> $node
+     * @param class-string<AbstractASTNode> $type
      * @return bool
      */
     protected function isChildOf(AbstractNode $node, $type)

--- a/src/main/php/PHPMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateField.php
@@ -25,7 +25,6 @@ use PDepend\Source\AST\ASTIdentifier;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTPropertyPostfix;
 use PDepend\Source\AST\ASTSelfReference;
-use PDepend\Source\AST\ASTStaticReference;
 use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
@@ -55,7 +54,10 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node): void
     {
-        /** @var ClassNode $field */
+        if (!$node instanceof ClassNode) {
+            return;
+        }
+
         foreach ($this->collectUnusedPrivateFields($node) as $field) {
             $this->addViolation($field, [$field->getImage()]);
         }
@@ -178,7 +180,6 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
 
         return (
             $owner->isInstanceOf(ASTSelfReference::class) ||
-            $owner->isInstanceOf(ASTStaticReference::class) ||
             strcasecmp($owner->getImage(), '$this') === 0 ||
             strcasecmp($owner->getImage(), $class->getImage()) === 0
         );

--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -23,13 +23,13 @@ use PDepend\Source\AST\ASTArrayElement;
 use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTMethodPostfix;
 use PDepend\Source\AST\ASTSelfReference;
-use PDepend\Source\AST\ASTStaticReference;
 use PDepend\Source\AST\ASTVariable;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\MethodNode;
+use RuntimeException;
 
 /**
  * This rule collects all private methods in a class that aren't used in any
@@ -40,9 +40,15 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
     /**
      * This method checks that all private class methods are at least accessed
      * by one method.
+     *
+     * @throws RuntimeException
      */
     public function apply(AbstractNode $class): void
     {
+        if (!$class instanceof ClassNode) {
+            return;
+        }
+
         foreach ($this->collectUnusedPrivateMethods($class) as $node) {
             $this->addViolation($node, [$node->getImage()]);
         }
@@ -54,6 +60,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      *
      * @return array<string, MethodNode>
      * @throws OutOfBoundsException
+     * @throws RuntimeException
      */
     protected function collectUnusedPrivateMethods(ClassNode $class)
     {
@@ -65,7 +72,8 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
     /**
      * Collects all private methods declared in the given class node.
      *
-     * @return AbstractNode[]
+     * @return array<string, MethodNode>
+     * @throws RuntimeException
      */
     protected function collectPrivateMethods(ClassNode $class)
     {
@@ -85,6 +93,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * analysis.
      *
      * @return bool
+     * @throws RuntimeException
      */
     protected function acceptMethod(ClassNode $class, MethodNode $method)
     {
@@ -194,7 +203,6 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
         return (
             $owner->isInstanceOf(ASTMethodPostfix::class) ||
             $owner->isInstanceOf(ASTSelfReference::class) ||
-            $owner->isInstanceOf(ASTStaticReference::class) ||
             strcasecmp($owner->getImage(), '$this') === 0 ||
             strcasecmp($owner->getImage(), $class->getImage()) === 0
         );

--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -20,8 +20,10 @@ namespace PHPMD\Rule;
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTArray;
 use PDepend\Source\AST\ASTArrayElement;
+use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTMethodPostfix;
+use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTSelfReference;
 use PDepend\Source\AST\ASTVariable;
 use PHPMD\AbstractNode;
@@ -41,6 +43,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * This method checks that all private class methods are at least accessed
      * by one method.
      *
+     * @param AbstractNode<PDependNode> $class
      * @throws RuntimeException
      */
     public function apply(AbstractNode $class): void
@@ -167,6 +170,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * Return represented method name if the given element is a 2-items array
      * and that the second one is a literal static string.
      *
+     * @param AbstractNode<PDependNode> $parent
      * @return string|null
      * @throws OutOfBoundsException
      */
@@ -193,6 +197,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * This method checks that the given method postfix is accessed on an
      * instance or static reference to the given class.
      *
+     * @param ASTNode<ASTExpression> $postfix
      * @return bool
      * @throws OutOfBoundsException
      */

--- a/src/main/php/PHPMD/RuleSet.php
+++ b/src/main/php/PHPMD/RuleSet.php
@@ -21,8 +21,9 @@ use ArrayIterator;
 use InvalidArgumentException;
 use IteratorAggregate;
 use OutOfBoundsException;
+use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
-use PHPMD\Node\AbstractTypeNode;
+use PHPMD\Node\AbstractNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\EnumNode;
 use PHPMD\Node\FunctionNode;
@@ -38,6 +39,8 @@ use PHPMD\Rule\TraitAware;
 
 /**
  * This class is a collection of concrete source analysis rules.
+ *
+ * @implements IteratorAggregate<int, Rule>
  */
 class RuleSet implements IteratorAggregate
 {
@@ -71,7 +74,7 @@ class RuleSet implements IteratorAggregate
     /**
      * Mapping between marker interfaces and concrete context code node classes.
      *
-     * @var array<class-string, class-string<AbstractTypeNode>>
+     * @var array<class-string, class-string<AbstractNode<ASTArtifact>>>
      */
     private array $applyTo = [
         ClassAware::class => ClassNode::class,
@@ -85,7 +88,7 @@ class RuleSet implements IteratorAggregate
     /**
      * Mapping of rules that apply to a concrete code node type.
      *
-     * @var array<class-string<AbstractTypeNode>, array<int, Rule>>
+     * @var array<class-string<AbstractNode<ASTArtifact>>, list<Rule>>
      */
     private $rules = [
         ClassNode::class => [],
@@ -204,6 +207,8 @@ class RuleSet implements IteratorAggregate
     /**
      * This method returns an iterator will all rules that belong to this
      * rule-set.
+     *
+     * @return ArrayIterator<int, Rule>
      */
     public function getRules(): ArrayIterator
     {
@@ -234,6 +239,7 @@ class RuleSet implements IteratorAggregate
     /**
      * Applies all registered rules that match against the concrete node type.
      *
+     * @param AbstractNode<ASTArtifact> $node
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException
@@ -250,7 +256,6 @@ class RuleSet implements IteratorAggregate
 
         // Apply all rules to this node
         foreach ($this->rules[$className] as $rule) {
-            /** @var Rule $rule */
             if ($node->hasSuppressWarningsAnnotationFor($rule) && !$this->strict) {
                 continue;
             }
@@ -264,6 +269,8 @@ class RuleSet implements IteratorAggregate
 
     /**
      * Returns an iterator with all rules that are part of this rule-set.
+     *
+     * @return ArrayIterator<int, Rule>
      */
     public function getIterator(): ArrayIterator
     {

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -100,7 +100,7 @@ class RuleSetFactory
      * Creates an array of rule-set instances for the given argument.
      *
      * @param string $ruleSetFileNames Comma-separated string of rule-set filenames or identifier.
-     * @return RuleSet[]
+     * @return list<RuleSet>
      * @throws RuntimeException
      */
     public function createRuleSets($ruleSetFileNames)
@@ -168,7 +168,7 @@ class RuleSetFactory
      * Lists available rule-set identifiers in given directory.
      *
      * @param string $directory The directory to scan for rule-sets.
-     * @return string[]
+     * @return list<string>
      */
     private static function listRuleSetsInDirectory($directory)
     {
@@ -497,7 +497,7 @@ class RuleSetFactory
      * http://pmd.sourceforge.net/pmd-5.0.4/howtomakearuleset.html#Excluding_files_from_a_ruleset
      *
      * @param string $fileName The filename of a rule-set definition.
-     * @return array|null
+     * @return list<string>|null
      * @throws RuntimeException Thrown if file is not proper xml
      */
     public function getIgnorePattern($fileName)
@@ -548,7 +548,7 @@ class RuleSetFactory
      * Returns list of possible file paths to search against code rules
      *
      * @param string $fileName Rule set file name
-     * @return array Array of possible file locations
+     * @return list<string> Array of possible file locations
      */
     private function filePaths($fileName)
     {

--- a/src/main/php/PHPMD/RuleViolation.php
+++ b/src/main/php/PHPMD/RuleViolation.php
@@ -50,7 +50,7 @@ class RuleViolation
      * The arguments for the description/message text or <b>null</b>
      * when the arguments are unknown.
      *
-     * @var array|null
+     * @var array<int, string>|null
      */
     private $args = null;
 
@@ -64,7 +64,7 @@ class RuleViolation
     /**
      * Constructs a new rule violation instance.
      *
-     * @param array|string $violationMessage
+     * @param array<string, mixed>|string $violationMessage
      * @param ?numeric $metric
      */
     public function __construct(Rule $rule, NodeInfo $nodeInfo, $violationMessage, $metric = null)
@@ -112,7 +112,7 @@ class RuleViolation
      * Returns the arguments for the description/message text or <b>null</b>
      * when the arguments are unknown.
      *
-     * @return array|null
+     * @return array<int, string>|null
      */
     public function getArgs()
     {

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -94,14 +94,14 @@ class CommandLineOptions
     /**
      * Additional report files.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $reportFiles = [];
 
     /**
      * List of deprecations.
      *
-     * @var array
+     * @var list<string>
      */
     protected $deprecations = [];
 
@@ -171,7 +171,7 @@ class CommandLineOptions
     /**
      * List of available rule-sets.
      *
-     * @var array(string)
+     * @var array<int, string>
      */
     protected $availableRuleSets = [];
 
@@ -454,7 +454,7 @@ class CommandLineOptions
      * Returns a hash with report files specified for different renderers. The
      * key represents the report format and the value the report file location.
      *
-     * @return array
+     * @return array<string, string|null>
      */
     public function getReportFiles()
     {

--- a/src/main/php/PHPMD/Utility/ArgumentsValidator.php
+++ b/src/main/php/PHPMD/Utility/ArgumentsValidator.php
@@ -6,20 +6,15 @@ use InvalidArgumentException;
 
 class ArgumentsValidator
 {
-    /** @var bool */
-    private $hasImplicitArguments;
-
-    /** @var string[] */
-    private $originalArguments;
-
-    /** @var string[] */
-    private $arguments;
-
-    public function __construct($hasImplicitArguments, $originalArguments, $arguments)
-    {
-        $this->hasImplicitArguments = $hasImplicitArguments;
-        $this->originalArguments = $originalArguments;
-        $this->arguments = $arguments;
+    /**
+     * @param string[] $originalArguments
+     * @param string[] $arguments
+     */
+    public function __construct(
+        private bool $hasImplicitArguments,
+        private array $originalArguments,
+        private array $arguments,
+    ) {
     }
 
     /**

--- a/src/main/php/PHPMD/Utility/ExceptionsList.php
+++ b/src/main/php/PHPMD/Utility/ExceptionsList.php
@@ -25,12 +25,16 @@ use OutOfBoundsException;
 use PHPMD\Rule;
 use RuntimeException;
 
+/**
+ * @implements IteratorAggregate<string, string>
+ * @implements ArrayAccess<string, string>
+ */
 class ExceptionsList implements IteratorAggregate, ArrayAccess
 {
     /**
      * Temporary cache of configured exceptions. Have name as key
      *
-     * @var array<string, int>
+     * @var array<string, string>
      */
     protected array $exceptions;
 
@@ -70,34 +74,33 @@ class ExceptionsList implements IteratorAggregate, ArrayAccess
     /**
      * Gets array of exceptions from property
      *
-     * @return array<string, int>
+     * @return array<string, string>
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
     protected function getExceptionsList(): array
     {
         if (!isset($this->exceptions)) {
-            $this->exceptions = array_flip(
-                Strings::splitToList(
-                    $this->rule->getStringProperty('exceptions', ''),
-                    $this->separator,
-                    $this->trim
-                )
+            $values = Strings::splitToList(
+                $this->rule->getStringProperty('exceptions', ''),
+                $this->separator,
+                $this->trim
             );
+
+            $this->exceptions = array_combine($values, $values);
         }
 
         return $this->exceptions;
     }
 
     /**
+     * @return ArrayIterator<string, string>
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
     public function getIterator(): ArrayIterator
     {
-        $keys = array_keys($this->getExceptionsList());
-
-        return new ArrayIterator(array_combine($keys, $keys));
+        return new ArrayIterator($this->getExceptionsList());
     }
 
     /**
@@ -113,7 +116,7 @@ class ExceptionsList implements IteratorAggregate, ArrayAccess
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
-    public function offsetGet($offset): int
+    public function offsetGet($offset): string
     {
         $exceptions = $this->getExceptionsList();
         $value = $exceptions[Strings::trim($offset, $this->trim)] ?? null;

--- a/src/main/php/PHPMD/Utility/Strings.php
+++ b/src/main/php/PHPMD/Utility/Strings.php
@@ -28,7 +28,7 @@ class Strings
      * Returns the length of the given string, excluding at most one suffix
      *
      * @param string $stringName String to calculate the length for.
-     * @param array $subtractSuffixes List of suffixes to exclude from the calculated length.
+     * @param array<int, string> $subtractSuffixes List of suffixes to exclude from the calculated length.
      * @return int The length of the string, without suffix, if applicable.
      */
     public static function lengthWithoutSuffixes($stringName, array $subtractSuffixes)
@@ -40,8 +40,8 @@ class Strings
      * Returns the length of the given string, excluding at most one suffix
      *
      * @param string $stringName String to calculate the length for.
-     * @param array $subtractPrefixes List of prefixes to exclude from the calculated length.
-     * @param array $subtractSuffixes List of suffixes to exclude from the calculated length.
+     * @param array<int, string> $subtractPrefixes List of prefixes to exclude from the calculated length.
+     * @param array<int, string> $subtractSuffixes List of suffixes to exclude from the calculated length.
      * @return int The length of the string, without suffix, if applicable.
      */
     public static function lengthWithoutPrefixesAndSuffixes(
@@ -77,7 +77,7 @@ class Strings
      * @param string $listAsString The string to split.
      * @param string $separator The separator to split the string with, similar to explode.
      * @param string $trim Extra character to be trimmed off of each value.
-     * @return array The list of trimmed and filtered parts of the string.
+     * @return array<int, string> The list of trimmed and filtered parts of the string.
      * @throws InvalidArgumentException When the separator is an empty string.
      */
     public static function splitToList($listAsString, $separator = ',', $trim = '')

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -43,7 +43,7 @@ abstract class AbstractStaticTestCase extends TestCase
     /**
      * Temporary files created by a test.
      *
-     * @var array(string)
+     * @var list<string>
      */
     private static $tempFiles = [];
 

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -23,6 +23,7 @@ use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Source\Language\PHP\PHPParserGeneric;
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
@@ -523,7 +524,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Creates a mocked rule-set instance.
      *
-     * @param string $expectedClass Optional class name for apply() expected at least once.
+     * @param class-string<ASTNode> $expectedClass Optional class name for apply() expected at least once.
      * @param int|string $count How often should apply() be called?
      * @return MockObject|RuleSet
      */

--- a/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
@@ -229,7 +229,7 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *
      * <code>
      * class Foo {
-     *     private $bar = array();
+     *     private $bar = [];
      *     // ...
      *     public function baz() {
      *         return $this->bar[42];

--- a/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleNotAppliesToMethodWithReturnTypeNotBoolean.php
+++ b/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleNotAppliesToMethodWithReturnTypeNotBoolean.php
@@ -18,7 +18,7 @@
 class testRuleNotAppliesToMethodWithReturnTypeNotBoolean
 {
     /**
-     * @return array(boolean)
+     * @return array<boolean>
      */
     function getFooBar()
     {


### PR DESCRIPTION
Type: refactor / documentation update
Breaking change: yes

Depends on:
- https://github.com/phpmd/phpmd/pull/1143

Add missing typehints. A few existing types where adjusted to better express the data flow.

ExceptionsList was refactored a bit so that it's state is more consistent, before it would sometimes act as a list of int and sometimes a list of string, but only the string type was ever used so I made it consistent with that.