### PR TITLE
Apply cast spacing from PER-CS 2.0

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,7 +20,6 @@
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
-    <rule ref="Generic.Formatting.NoSpaceAfterCast"/>
     <rule ref="Squiz.Operators.ValidLogicalOperators"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -239,7 +239,7 @@ abstract class AbstractNode
             : null;
 
         return $compilationUnit
-            ? (string)$compilationUnit->getFileName()
+            ? (string) $compilationUnit->getFileName()
             : null; // @TODO: Find the name from some parent node https://github.com/phpmd/phpmd/issues/837
     }
 

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -314,7 +314,7 @@ abstract class AbstractRule implements Rule
      */
     public function getIntProperty(string $name, ?int $default = null): int
     {
-        return (int)$this->getProperty($name, $default);
+        return (int) $this->getProperty($name, $default);
     }
 
     /**
@@ -331,7 +331,7 @@ abstract class AbstractRule implements Rule
      */
     public function getStringProperty(string $name, ?string $default = null): string
     {
-        return (string)$this->getProperty($name, $default);
+        return (string) $this->getProperty($name, $default);
     }
 
     public function setStrict(bool $strict): void

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -40,11 +40,11 @@ class BaselineSetFactory
             }
 
             $methodName = null;
-            if (isset($node['method']) && ((string)$node['method']) !== '') {
-                $methodName = (string)($node['method']);
+            if (isset($node['method']) && ((string) $node['method']) !== '') {
+                $methodName = (string) ($node['method']);
             }
 
-            $baselineSet->addEntry(new ViolationBaseline((string)$node['rule'], (string)$node['file'], $methodName));
+            $baselineSet->addEntry(new ViolationBaseline((string) $node['rule'], (string) $node['file'], $methodName));
         }
 
         return $baselineSet;

--- a/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
@@ -59,7 +59,7 @@ class ResultCacheFileFilter implements Filter
 
         // Determine file hash. Either `timestamp` or `content`
         if ($this->strategy === 'timestamp') {
-            $hash = (string)filemtime($absolute);
+            $hash = (string) filemtime($absolute);
         } else {
             $hash = sha1_file($absolute);
         }

--- a/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
+++ b/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
@@ -37,7 +37,7 @@ class CheckStyleRenderer extends XMLRenderer
             return 'info';
         }
 
-        return (int)$priority === 2 ? 'warning' : 'error';
+        return (int) $priority === 2 ? 'warning' : 'error';
     }
     /**
      * This method will be called when the engine has finished the source analysis

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -455,7 +455,7 @@ class HTMLRenderer extends AbstractRenderer
         if (!$file->eof()) {
             $file->seek($line);
             for ($i = 0; $i <= ($extra * 2); $i++) {
-                $result[++$line] = trim((string)$file->current(), "\n");
+                $result[++$line] = trim((string) $file->current(), "\n");
                 $file->next();
             }
         }

--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -94,7 +94,7 @@ class TextRenderer extends AbstractRenderer implements Verbose, Color
 
     public function setVerbosityLevel($level): void
     {
-        $this->verbosityLevel = (int)$level;
+        $this->verbosityLevel = (int) $level;
     }
 
     public function setColored($colored): void

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -99,7 +99,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
         }
         // non-associative - key name equals to its index
         if ($childCount === 0) {
-            $node->setImage((string)$index);
+            $node->setImage((string) $index);
 
             return $node;
         }

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -206,7 +206,7 @@ class RuleSetFactory
 
         $ruleSet = new RuleSet();
         $ruleSet->setFileName($fileName);
-        $ruleSet->setName((string)$xml['name']);
+        $ruleSet->setName((string) $xml['name']);
 
         if ($this->strict) {
             $ruleSet->setStrict();
@@ -214,7 +214,7 @@ class RuleSetFactory
 
         foreach ($xml->children() as $node) {
             if ($node->getName() === 'php-includepath') {
-                $includePath = (string)$node;
+                $includePath = (string) $node;
 
                 if (is_dir(dirname($fileName) . DIRECTORY_SEPARATOR . $includePath)) {
                     $includePath = dirname($fileName) . DIRECTORY_SEPARATOR . $includePath;
@@ -228,7 +228,7 @@ class RuleSetFactory
 
         foreach ($xml->children() as $node) {
             if ($node->getName() === 'description') {
-                $ruleSet->setDescription((string)$node);
+                $ruleSet->setDescription((string) $node);
             } elseif ($node->getName() === 'rule') {
                 $this->parseRuleNode($ruleSet, $node);
             }
@@ -248,7 +248,7 @@ class RuleSetFactory
      */
     private function parseRuleNode(RuleSet $ruleSet, \SimpleXMLElement $node): void
     {
-        $ref = (string)$node['ref'];
+        $ref = (string) $node['ref'];
 
         if ($ref === '') {
             $this->parseSingleRuleNode($ruleSet, $node);
@@ -296,7 +296,7 @@ class RuleSetFactory
         $ruleSetFactory->setMinimumPriority($this->minimumPriority);
         $ruleSetFactory->setMaximumPriority($this->maximumPriority);
 
-        return $ruleSetFactory->createSingleRuleSet((string)$ruleSetNode['ref']);
+        return $ruleSetFactory->createSingleRuleSet((string) $ruleSetNode['ref']);
     }
 
     /**
@@ -311,7 +311,7 @@ class RuleSetFactory
     private function isIncluded(Rule $rule, \SimpleXMLElement $ruleSetNode)
     {
         foreach ($ruleSetNode->exclude as $exclude) {
-            if ($rule->getName() === (string)$exclude['name']) {
+            if ($rule->getName() === (string) $exclude['name']) {
                 return false;
             }
         }
@@ -336,14 +336,14 @@ class RuleSetFactory
         $ruleSetFolderPath = dirname($ruleSet->getFileName());
 
         if (isset($ruleNode['file'])) {
-            if (is_readable((string)$ruleNode['file'])) {
-                $fileName = (string)$ruleNode['file'];
-            } elseif (is_readable($ruleSetFolderPath . DIRECTORY_SEPARATOR . (string)$ruleNode['file'])) {
-                $fileName = $ruleSetFolderPath . DIRECTORY_SEPARATOR . (string)$ruleNode['file'];
+            if (is_readable((string) $ruleNode['file'])) {
+                $fileName = (string) $ruleNode['file'];
+            } elseif (is_readable($ruleSetFolderPath . DIRECTORY_SEPARATOR . (string) $ruleNode['file'])) {
+                $fileName = $ruleSetFolderPath . DIRECTORY_SEPARATOR . (string) $ruleNode['file'];
             }
         }
 
-        $className = (string)$ruleNode['class'];
+        $className = (string) $ruleNode['class'];
 
         if (!is_readable($fileName)) {
             $fileName = strtr($className, '\\', '/') . '.php';
@@ -369,23 +369,23 @@ class RuleSetFactory
 
         /* @var $rule \PHPMD\Rule */
         $rule = new $className();
-        $rule->setName((string)$ruleNode['name']);
-        $rule->setMessage((string)$ruleNode['message']);
-        $rule->setExternalInfoUrl((string)$ruleNode['externalInfoUrl']);
+        $rule->setName((string) $ruleNode['name']);
+        $rule->setMessage((string) $ruleNode['message']);
+        $rule->setExternalInfoUrl((string) $ruleNode['externalInfoUrl']);
 
         $rule->setRuleSetName($ruleSet->getName());
 
         if (isset($ruleNode['since']) && trim($ruleNode['since']) !== '') {
-            $rule->setSince((string)$ruleNode['since']);
+            $rule->setSince((string) $ruleNode['since']);
         }
 
         foreach ($ruleNode->children() as $node) {
             if ($node->getName() === 'description') {
-                $rule->setDescription((string)$node);
+                $rule->setDescription((string) $node);
             } elseif ($node->getName() === 'example') {
-                $rule->addExample((string)$node);
+                $rule->addExample((string) $node);
             } elseif ($node->getName() === 'priority') {
-                $rule->setPriority((int)$node);
+                $rule->setPriority((int) $node);
             } elseif ($node->getName() === 'properties') {
                 $this->parsePropertiesNode($rule, $node);
             }
@@ -406,7 +406,7 @@ class RuleSetFactory
      */
     private function parseRuleReferenceNode(RuleSet $ruleSet, \SimpleXMLElement $ruleNode): void
     {
-        $ref = (string)$ruleNode['ref'];
+        $ref = (string) $ruleNode['ref'];
 
         $fileName = substr($ref, 0, strpos($ref, '.xml/') + 4);
         $fileName = $this->createRuleSetFileName($fileName);
@@ -419,22 +419,22 @@ class RuleSetFactory
         $rule = $ruleSetRef->getRuleByName($ruleName);
 
         if (isset($ruleNode['name']) && trim($ruleNode['name']) !== '') {
-            $rule->setName((string)$ruleNode['name']);
+            $rule->setName((string) $ruleNode['name']);
         }
         if (isset($ruleNode['message']) && trim($ruleNode['message']) !== '') {
-            $rule->setMessage((string)$ruleNode['message']);
+            $rule->setMessage((string) $ruleNode['message']);
         }
         if (isset($ruleNode['externalInfoUrl']) && trim($ruleNode['externalInfoUrl']) !== '') {
-            $rule->setExternalInfoUrl((string)$ruleNode['externalInfoUrl']);
+            $rule->setExternalInfoUrl((string) $ruleNode['externalInfoUrl']);
         }
 
         foreach ($ruleNode->children() as $node) {
             if ($node->getName() === 'description') {
-                $rule->setDescription((string)$node);
+                $rule->setDescription((string) $node);
             } elseif ($node->getName() === 'example') {
-                $rule->addExample((string)$node);
+                $rule->addExample((string) $node);
             } elseif ($node->getName() === 'priority') {
-                $rule->setPriority((int)$node);
+                $rule->setPriority((int) $node);
             } elseif ($node->getName() === 'properties') {
                 $this->parsePropertiesNode($rule, $node);
             }
@@ -501,10 +501,10 @@ class RuleSetFactory
     private function getPropertyValue(\SimpleXMLElement $propertyNode)
     {
         if (isset($propertyNode->value)) {
-            return (string)$propertyNode->value;
+            return (string) $propertyNode->value;
         }
 
-        return (string)$propertyNode['value'];
+        return (string) $propertyNode['value'];
     }
 
     /**

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -267,12 +267,12 @@ class CommandLineOptions
                 case '--min-priority':
                 case '--minimum-priority':
                 case '--minimumpriority':
-                    $this->minimumPriority = (int)$this->readValue($equalChunk, $args);
+                    $this->minimumPriority = (int) $this->readValue($equalChunk, $args);
                     break;
                 case '--max-priority':
                 case '--maximum-priority':
                 case '--maximumpriority':
-                    $this->maximumPriority = (int)$this->readValue($equalChunk, $args);
+                    $this->maximumPriority = (int) $this->readValue($equalChunk, $args);
                     break;
                 case '--report-file':
                 case '--reportfile':
@@ -363,7 +363,7 @@ class CommandLineOptions
                     $this->reportFiles[$match[1]] = $this->readValue($equalChunk, $args);
                     break;
                 case '--extra-line-in-excerpt':
-                    $this->extraLineInExcerpt = (int)$this->readValue($equalChunk, $args);
+                    $this->extraLineInExcerpt = (int) $this->readValue($equalChunk, $args);
                     break;
                 default:
                     $hasImplicitArguments = true;
@@ -378,10 +378,10 @@ class CommandLineOptions
 
         $validator = new ArgumentsValidator($hasImplicitArguments, $originalArguments, $arguments);
 
-        $this->ruleSets = (string)array_pop($arguments);
+        $this->ruleSets = (string) array_pop($arguments);
         $validator->validate('ruleset', $this->ruleSets);
 
-        $this->reportFormat = (string)array_pop($arguments);
+        $this->reportFormat = (string) array_pop($arguments);
         $validator->validate('report format', $this->reportFormat);
 
         $this->inputPath = implode(',', $arguments);


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Disable the opposing rule in phpcs and apply the style.

Note: I do prefer the no space way, but not worth altering the standard.