### PR TITLE
Apply the single line empty body rule from PER-CS 2.0

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -45,6 +45,14 @@
     <!-- PSR-2 base standard -->
     <rule ref="PSR2"/>
 
+    <rule ref="PSR2">
+        <exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>
+        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore">
+        <severity>0</severity>
+    </rule>
+
     <!-- Sniffs from Slevomat standard -->
 
     <!-- Functional - improving the safety and behaviour of code -->

--- a/src/main/php/PHPMD/Rule/ClassAware.php
+++ b/src/main/php/PHPMD/Rule/ClassAware.php
@@ -20,6 +20,4 @@ namespace PHPMD\Rule;
 /**
  * This interface is used to mark a rule implementation as class aware.
  */
-interface ClassAware
-{
-}
+interface ClassAware {}

--- a/src/main/php/PHPMD/Rule/EnumAware.php
+++ b/src/main/php/PHPMD/Rule/EnumAware.php
@@ -20,6 +20,4 @@ namespace PHPMD\Rule;
 /**
  * This interface is used to mark a rule implementation as enum aware.
  */
-interface EnumAware
-{
-}
+interface EnumAware {}

--- a/src/main/php/PHPMD/Rule/FunctionAware.php
+++ b/src/main/php/PHPMD/Rule/FunctionAware.php
@@ -20,6 +20,4 @@ namespace PHPMD\Rule;
 /**
  * This interface is used to mark a rule implementation as function aware.
  */
-interface FunctionAware
-{
-}
+interface FunctionAware {}

--- a/src/main/php/PHPMD/Rule/InterfaceAware.php
+++ b/src/main/php/PHPMD/Rule/InterfaceAware.php
@@ -20,6 +20,4 @@ namespace PHPMD\Rule;
 /**
  * This interface marks a rule implementation as interface aware,
  */
-interface InterfaceAware
-{
-}
+interface InterfaceAware {}

--- a/src/main/php/PHPMD/Rule/MethodAware.php
+++ b/src/main/php/PHPMD/Rule/MethodAware.php
@@ -20,6 +20,4 @@ namespace PHPMD\Rule;
 /**
  * This interface marks a rule implementation as method aware,
  */
-interface MethodAware
-{
-}
+interface MethodAware {}

--- a/src/main/php/PHPMD/Rule/TraitAware.php
+++ b/src/main/php/PHPMD/Rule/TraitAware.php
@@ -20,6 +20,4 @@ namespace PHPMD\Rule;
 /**
  * This interface is used to mark a rule implementation as trait aware.
  */
-interface TraitAware
-{
-}
+interface TraitAware {}


### PR DESCRIPTION
Type: refactoring
Breaking change: no

phpcs news build in config is PSR12 which like PSR2 does not define a special case for empty bodies, so the solution is to disable the 3 rules for checking for that.