### PR TITLE
Add php-cs-fixer as a developer tool

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Run PHPCS for the codestyle
         run: vendor/bin/phpcs
 
-      - name: Run PHP Coding Standards Fixer
+      - name: Run PHP Coding Standards Fixer Check
         run: |
           vendor/bin/php-cs-fixer fix --dry-run --diff --ansi || true
           vendor/bin/php-cs-fixer fix --dry-run --format=checkstyle | cs2pr

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -7,6 +7,7 @@ on:
       - '**.php'
       - 'composer.json'
       - 'phpcs.xml.dist'
+      - '.php-cs-fixer.php'
       - '.github/workflows/codestyle.yml'
   pull_request:
     branches: [ '*' ]
@@ -14,6 +15,7 @@ on:
       - '**.php'
       - 'composer.json'
       - 'phpcs.xml.dist'
+      - '.php-cs-fixer.php'
       - '.github/workflows/codestyle.yml'
 
 jobs:
@@ -25,33 +27,39 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.3]
-        dependency-version: [prefer-stable]
+          php: [8.1]
 
     name: Codestyle check
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: none
-          tools: composer:v2
+          tools: composer:v2, cs2pr
 
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v3
         with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.dependency-version }}-${{ hashFiles('**/composer.json') }}
+          path: |
+            vendor
+            .php-cs-fixer.cache
+          key: ${{ runner.os }}-codestyle-${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.dependency-version }}
+            ${{ runner.os }}-codestyle
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
 
       - name: Run PHPCS for the codestyle
         run: vendor/bin/phpcs
+
+      - name: Run PHP Coding Standards Fixer
+        run: |
+          vendor/bin/php-cs-fixer fix --dry-run --diff --ansi || true
+          vendor/bin/php-cs-fixer fix --dry-run --format=checkstyle | cs2pr

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 composer.lock
 vendor
 dist
+.php-cs-fixer.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * This document has been generated with
+ * https://mlocati.github.io/php-cs-fixer-configurator/#version:3.54.0|configurator
+ * you can change this configuration by importing this file.
+ */
+$config = new PhpCsFixer\Config();
+return $config
+    ->setRules([
+        'blank_line_after_namespace' => true,
+        'blank_lines_before_namespace' => true,
+        'fully_qualified_strict_types' => true,
+        'global_namespace_import' => true,
+        'no_empty_phpdoc' => true,
+        'no_leading_import_slash' => true,
+        'no_superfluous_phpdoc_tags' => true,
+        'no_unused_imports' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
+        'phpdoc_indent' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param', // Input, thus first
+                'return', // Output, thus second
+                'throws', // Important exceptional situations
+                'var', // For properties & inline type hints only
+                'global', // Hints for properties & methods in classes
+                'property', // Hints for properties & methods in classes
+                'property-read', // Hints for properties & methods in classes
+                'property-write', // Hints for properties & methods in classes
+                'method', // Hints for properties & methods in classes
+                'dataProvider', // For tests only, defines the input
+                'covers', // For tests only, defines the coverage
+                'author', // Normally comes before copyright
+                'copyright', // Normally comes before license
+                'license', // Should be after author and copyright
+                'see', // Links & examples
+                'link', // Links & examples
+                'example', // Links & examples
+                'internal', // Would be important, if present
+                'api', // Category & packages
+                'category', // Category & packages
+                'package', // Category & packages
+                'subpackage', // Category & packages
+                'uses', // Usage
+                'used-by', // Usage
+                'source', // Source & version
+                'version', // Source & version
+                'since', // Source & version
+                'filesource', // phpDocumentor specific
+                'ignore', // phpDocumentor specific
+                'deprecated', // Should be to the end to better notice them
+                'todo', // Should be last to better notice them
+            ],
+        ],
+        'phpdoc_return_self_reference' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
+        'phpdoc_types_order' => ['null_adjustment' => 'always_last'],
+        'phpdoc_var_annotation_correct_order' => true,
+        'single_line_after_imports' => true,
+    ])
+    ->setFinder(PhpCsFixer\Finder::create()
+        ->exclude('vendor')
+        ->in(__DIR__ . '/src/main/php/PHPMD')
+    )
+;

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
     "ext-simplexml": "*",
     "brianium/paratest": "^7.3",
     "easy-doc/easy-doc": "^1.3.2",
+    "friendsofphp/php-cs-fixer": "^3.54",
     "gregwar/rst": "^1.0",
     "mikey179/vfsstream": "^1.6.8",
     "phpstan/phpstan": "~1.10.67",
@@ -63,6 +64,7 @@
   "scripts": {
     "test": "paratest",
     "cs-check": "phpcs -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
+    "cs-fixer": "php-cs-fixer fix",
     "cs-fix": "phpcbf -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
     "build-website": "easy-doc build src/site/config.php --verbose"
   },

--- a/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
+++ b/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
@@ -21,13 +21,13 @@ class CheckStyleRenderer extends XMLRenderer
     /**
      * Get a violation severity level according to the priority
      * of the rule that's being broken
+     *
+     * @param int $priority priority of the broken rule
+     * @return string either error, warning or info
      * @see https://checkstyle.sourceforge.io/version/4.4/property_types.html#severity
      * - priority 1 maps to error level severity
      * - priority 2 maps to warning level severity
      * - priority > 2 maps to info level severity
-     *
-     * @param int $priority priority of the broken rule
-     * @return string either error, warning or info
      */
     protected function mapPriorityToSeverity($priority)
     {

--- a/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
@@ -17,7 +17,6 @@
 
 namespace PHPMD\Rule\CleanCode;
 
-use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTAssignmentExpression;
 use PDepend\Source\AST\ASTElseIfStatement;
 use PDepend\Source\AST\ASTExpression;


### PR DESCRIPTION
Breaking change: no

This adds the php-cs-fixer tool as a dev dependency, and uses it to check that PRs comply with the project code style.  The configured rules are what the code base already complies with and has been gone over in various other PRs. It can be used by a developer to apply the code style by running the following command:

```
vendor/bin/php-cs-fixer fix
```

It is also helpful for applying various upgrades to the code like migrating to never versions of PHPUnit or PHP it self:
```
vendor/bin/php-cs-fixer fix --rules=array_syntax
```

It has a rich config format and can be adjust to fit most style, you can find a handy online tool for doing so here:
https://mlocati.github.io/php-cs-fixer-configurator

The following is a list of what code style the applied rules are part of:

PSR-2+
- blank_line_after_namespace
- blank_lines_before_namespace
- single_line_after_imports

PSR-12+
- no_leading_import_slash
- ordered_imports

Symfony
- fully_qualified_strict_types
- global_namespace_import
- no_empty_phpdoc
- no_superfluous_phpdoc_tags
- no_unused_imports
- phpdoc_indent
- phpdoc_order
- phpdoc_return_self_reference
- phpdoc_scalar
- phpdoc_single_line_var_spacing
- phpdoc_trim
- phpdoc_trim_consecutive_blank_line_separation
- phpdoc_types_order

Other
- phpdoc_var_annotation_correct_order
