### PR TITLE
Bump code style to PSR-12 for phpcs

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,7 +10,6 @@
     <arg name="extensions" value="php"/>
 
     <!-- General sniffs -->
-    <rule ref="Generic.Files.LineLength"/>
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
     <rule ref="Squiz.Commenting.FunctionCommentThrowTag"/>
     <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
@@ -33,16 +32,9 @@
     <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
     <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
-    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
-    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
-        <properties>
-            <property name="equalsSpacing" value="1"/>
-        </properties>
-    </rule>
 
     <!-- PSR-2 base standard -->
-    <rule ref="PSR2"/>
+    <rule ref="PSR12"/>
 
     <rule ref="PSR2">
         <exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/AbstractWriter.php
+++ b/src/main/php/PHPMD/AbstractWriter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Cache/ResultCacheStateFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheStateFactory.php
@@ -36,7 +36,8 @@ class ResultCacheStateFactory
      */
     private function createCacheKey(array $data)
     {
-        if (!array_key_exists('strict', $data) ||
+        if (
+            !array_key_exists('strict', $data) ||
             !array_key_exists('baselineHash', $data) ||
             !array_key_exists('rules', $data) ||
             !array_key_exists('composer', $data) ||

--- a/src/main/php/PHPMD/Exception/RuleClassFileNotFoundException.php
+++ b/src/main/php/PHPMD/Exception/RuleClassFileNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Exception/RuleClassNotFoundException.php
+++ b/src/main/php/PHPMD/Exception/RuleClassNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Exception/RuleSetNotFoundException.php
+++ b/src/main/php/PHPMD/Exception/RuleSetNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Node/ASTNode.php
+++ b/src/main/php/PHPMD/Node/ASTNode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Node/AbstractCallableNode.php
+++ b/src/main/php/PHPMD/Node/AbstractCallableNode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Node/AbstractNode.php
+++ b/src/main/php/PHPMD/Node/AbstractNode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Node/Annotation.php
+++ b/src/main/php/PHPMD/Node/Annotation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *
@@ -66,10 +67,12 @@ final class Annotation
         if (in_array($this->value, ['PHPMD', 'PMD'], true)) {
             return true;
         }
-        if (preg_match(
-            '/^(PH)?PMD\.' . preg_replace('/^.*\/([^\/]*)$/', '$1', $rule->getName()) . '/',
-            $this->value
-        )) {
+        if (
+            preg_match(
+                '/^(PH)?PMD\.' . preg_replace('/^.*\/([^\/]*)$/', '$1', $rule->getName()) . '/',
+                $this->value
+            )
+        ) {
             return true;
         }
 

--- a/src/main/php/PHPMD/Node/Annotations.php
+++ b/src/main/php/PHPMD/Node/Annotations.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Node/ClassNode.php
+++ b/src/main/php/PHPMD/Node/ClassNode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Node/EnumNode.php
+++ b/src/main/php/PHPMD/Node/EnumNode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Node/FunctionNode.php
+++ b/src/main/php/PHPMD/Node/FunctionNode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Node/InterfaceNode.php
+++ b/src/main/php/PHPMD/Node/InterfaceNode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Node/TraitNode.php
+++ b/src/main/php/PHPMD/Node/TraitNode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Parser.php
+++ b/src/main/php/PHPMD/Parser.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/ProcessingError.php
+++ b/src/main/php/PHPMD/ProcessingError.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Renderer/GitHubRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitHubRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Renderer/JSONRenderer.php
+++ b/src/main/php/PHPMD/Renderer/JSONRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Renderer/SARIFRenderer.php
+++ b/src/main/php/PHPMD/Renderer/SARIFRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Renderer/XMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/XMLRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule.php
+++ b/src/main/php/PHPMD/Rule.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *
@@ -196,7 +197,8 @@ abstract class AbstractLocalVariable extends AbstractRule
 
         $previousChildImage = $postfix->getChild(0)->getImage();
 
-        if ($postfix instanceof ASTMemberPrimaryPrefix &&
+        if (
+            $postfix instanceof ASTMemberPrimaryPrefix &&
             in_array($previousChildImage, $this->selfReferences, true)
         ) {
             return $previousChildImage;

--- a/src/main/php/PHPMD/Rule/ClassAware.php
+++ b/src/main/php/PHPMD/Rule/ClassAware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *
@@ -60,7 +61,8 @@ final class BooleanArgumentFlag extends AbstractRule implements FunctionAware, M
         $currNode = $node->getNode();
         $parent = $currNode->getParent();
 
-        if ($parent &&
+        if (
+            $parent &&
             ($parent instanceof AbstractASTClassOrInterface) &&
             ($name = $parent->getName()) &&
             $this->getExceptionsList()->contains($name)

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseClassName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseClassName.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *
@@ -76,8 +77,10 @@ final class CamelCaseMethodName extends AbstractRule implements MethodAware
     private function isValid(string $methodName): bool
     {
         // disallow any consecutive uppercase letters
-        if ($this->getBooleanProperty('camelcase-abbreviations', false)
-            && preg_match('/[A-Z]{2}/', $methodName) === 1) {
+        if (
+            $this->getBooleanProperty('camelcase-abbreviations', false)
+            && preg_match('/[A-Z]{2}/', $methodName) === 1
+        ) {
             return false;
         }
 

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  * Copyright (c) Manuel Pichler <mapi@phpmd.org>.

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *
@@ -60,8 +61,10 @@ final class CamelCaseParameterName extends AbstractRule implements FunctionAware
     private function isValid(string $parameterName): bool
     {
         // disallow any consecutive uppercase letters
-        if ($this->getBooleanProperty('camelcase-abbreviations', false)
-            && preg_match('/[A-Z]{2}/', $parameterName) === 1) {
+        if (
+            $this->getBooleanProperty('camelcase-abbreviations', false)
+            && preg_match('/[A-Z]{2}/', $parameterName) === 1
+        ) {
             return false;
         }
 

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *
@@ -63,8 +64,10 @@ final class CamelCasePropertyName extends AbstractRule implements ClassAware, Tr
     private function isValid(string $propertyName): bool
     {
         // disallow any consecutive uppercase letters
-        if ($this->getBooleanProperty('camelcase-abbreviations', false)
-            && preg_match('/[A-Z]{2}/', $propertyName) === 1) {
+        if (
+            $this->getBooleanProperty('camelcase-abbreviations', false)
+            && preg_match('/[A-Z]{2}/', $propertyName) === 1
+        ) {
             return false;
         }
 

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *
@@ -81,8 +82,10 @@ final class CamelCaseVariableName extends AbstractRule implements FunctionAware,
         }
 
         // disallow any consecutive uppercase letters
-        if ($this->getBooleanProperty('camelcase-abbreviations', false)
-            && preg_match('/[A-Z]{2}/', $image) === 1) {
+        if (
+            $this->getBooleanProperty('camelcase-abbreviations', false)
+            && preg_match('/[A-Z]{2}/', $image) === 1
+        ) {
             return false;
         }
 

--- a/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
+++ b/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/CyclomaticComplexity.php
+++ b/src/main/php/PHPMD/Rule/CyclomaticComplexity.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/CouplingBetweenObjects.php
+++ b/src/main/php/PHPMD/Rule/Design/CouplingBetweenObjects.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/DepthOfInheritance.php
+++ b/src/main/php/PHPMD/Rule/Design/DepthOfInheritance.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *
@@ -42,7 +43,8 @@ final class DepthOfInheritance extends AbstractRule implements ClassAware
         }
 
         $dit = $node->getMetric('dit');
-        if (($comparison === 1 && $dit > $threshold) ||
+        if (
+            ($comparison === 1 && $dit > $threshold) ||
             ($comparison === 2 && $dit >= $threshold)
         ) {
             $this->addViolation(

--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/EmptyCatchBlock.php
+++ b/src/main/php/PHPMD/Rule/Design/EmptyCatchBlock.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/EvalExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/EvalExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/ExitExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/ExitExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/GotoStatement.php
+++ b/src/main/php/PHPMD/Rule/Design/GotoStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/LongClass.php
+++ b/src/main/php/PHPMD/Rule/Design/LongClass.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/LongMethod.php
+++ b/src/main/php/PHPMD/Rule/Design/LongMethod.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/LongParameterList.php
+++ b/src/main/php/PHPMD/Rule/Design/LongParameterList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/NpathComplexity.php
+++ b/src/main/php/PHPMD/Rule/Design/NpathComplexity.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/NumberOfChildren.php
+++ b/src/main/php/PHPMD/Rule/Design/NumberOfChildren.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/TooManyFields.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyFields.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Design/WeightedMethodCount.php
+++ b/src/main/php/PHPMD/Rule/Design/WeightedMethodCount.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/EnumAware.php
+++ b/src/main/php/PHPMD/Rule/EnumAware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/ExcessivePublicCount.php
+++ b/src/main/php/PHPMD/Rule/ExcessivePublicCount.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/FunctionAware.php
+++ b/src/main/php/PHPMD/Rule/FunctionAware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/InterfaceAware.php
+++ b/src/main/php/PHPMD/Rule/InterfaceAware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/MethodAware.php
+++ b/src/main/php/PHPMD/Rule/MethodAware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Naming/LongClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongClassName.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/TraitAware.php
+++ b/src/main/php/PHPMD/Rule/TraitAware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateField.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *
@@ -178,7 +179,8 @@ final class UnusedPrivateMethod extends AbstractRule implements ClassAware
         if ($parent->isInstanceOf(ASTArrayElement::class)) {
             $array = $parent->getParent();
 
-            if ($array?->isInstanceOf(ASTArray::class)
+            if (
+                $array?->isInstanceOf(ASTArray::class)
                 && count($array->getChildren()) === 2
             ) {
                 $secondElement = $array->getChild(1)->getChild(0);

--- a/src/main/php/PHPMD/RuleByNameNotFoundException.php
+++ b/src/main/php/PHPMD/RuleByNameNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/RuleSet.php
+++ b/src/main/php/PHPMD/RuleSet.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/RuleViolation.php
+++ b/src/main/php/PHPMD/RuleViolation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *
@@ -161,9 +162,11 @@ final class Command
             return ExitCode::Error;
         }
 
-        if ($phpmd->hasViolations()
+        if (
+            $phpmd->hasViolations()
             && !$opts->ignoreViolationsOnExit()
-            && $opts->generateBaseline() === BaselineMode::None) {
+            && $opts->generateBaseline() === BaselineMode::None
+        ) {
             return ExitCode::Violation;
         }
 

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/TextUI/ExitCode.php
+++ b/src/main/php/PHPMD/TextUI/ExitCode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Utility/ExceptionsList.php
+++ b/src/main/php/PHPMD/Utility/ExceptionsList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Utility/Strings.php
+++ b/src/main/php/PHPMD/Utility/Strings.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
+++ b/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Node/ASTNodeTest.php
+++ b/src/test/php/PHPMD/Node/ASTNodeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Node/AnnotationTest.php
+++ b/src/test/php/PHPMD/Node/AnnotationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Node/AnnotationsTest.php
+++ b/src/test/php/PHPMD/Node/AnnotationsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Node/ClassNodeTest.php
+++ b/src/test/php/PHPMD/Node/ClassNodeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Node/FunctionTest.php
+++ b/src/test/php/PHPMD/Node/FunctionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Node/InterfaceNodeTest.php
+++ b/src/test/php/PHPMD/Node/InterfaceNodeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Node/TraitNodeTest.php
+++ b/src/test/php/PHPMD/Node/TraitNodeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/ParserFactoryTest.php
+++ b/src/test/php/PHPMD/ParserFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/ParserTest.php
+++ b/src/test/php/PHPMD/ParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/ProcessingErrorTest.php
+++ b/src/test/php/PHPMD/ProcessingErrorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Regression/AbstractRegressionTestCase.php
+++ b/src/test/php/PHPMD/Regression/AbstractRegressionTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
+++ b/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php
+++ b/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020RegressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019RegressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036RegressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Regression/UnusedParameterArgvTicket14990109RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/UnusedParameterArgvTicket14990109RegressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Renderer/CheckStyleRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/CheckStyleRendererTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Renderer/GitLabRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/GitLabRendererTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Renderer/JSONRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/JSONRendererTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Renderer/SARIFRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/SARIFRendererTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Renderer/XMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/XMLRendererTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/CleanCode/BooleanArgumentFlagTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/BooleanArgumentFlagTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/CleanCode/ErrorControlOperatorTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/ErrorControlOperatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/CleanCode/UndefinedVariableTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/UndefinedVariableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  * Copyright (c) Manuel Pichler <mapi@phpmd.org>.

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
+++ b/src/test/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
+++ b/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/LongClassTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongClassTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
+++ b/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
+++ b/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Naming/LongClassNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/LongClassNameTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Naming/ShortClassNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortClassNameTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/RuleSetTest.php
+++ b/src/test/php/PHPMD/RuleSetTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/RuleViolationTest.php
+++ b/src/test/php/PHPMD/RuleViolationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Stubs/ClassNotFoundRule.php
+++ b/src/test/php/PHPMD/Stubs/ClassNotFoundRule.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Stubs/RuleStub.php
+++ b/src/test/php/PHPMD/Stubs/RuleStub.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Stubs/WriterStub.php
+++ b/src/test/php/PHPMD/Stubs/WriterStub.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/TextUI/StreamFilter.php
+++ b/src/test/php/PHPMD/TextUI/StreamFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *

--- a/src/test/php/PHPMD/Utility/StringsTest.php
+++ b/src/test/php/PHPMD/Utility/StringsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *


### PR DESCRIPTION
Type: refactoring
Breaking change: no

This configures phpcs to follow the PSR-12 standard which is the basis for PER-CS 2.0 which is our chosen base standard. The disabled rules are part of PSR-12 and so do not need to be explicitly enabled any more.