### PR TITLE
Backport for 2.x of fixes from 3.x

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -2,16 +2,14 @@ name: Codestyle
 
 on:
   push:
-    branches:
-      - "*"
+    branches: [ 'master', '2.x', '3.x' ]
     paths:
       - '**.php'
       - 'composer.json'
       - 'phpcs.xml.dist'
       - '.github/workflows/codestyle.yml'
   pull_request:
-    branches:
-      - "*"
+    branches: [ '*' ]
     paths:
       - '**.php'
       - 'composer.json'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,11 +2,9 @@ name: Coverage
 
 on:
   push:
-    branches:
-      - "*"
+    branches: [ 'master', '2.x', '3.x' ]
   pull_request:
-    branches:
-      - "*"
+    branches: [ '*' ]
 
 jobs:
   php-tests:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           path: vendor
           key: ${{ runner.os }}-coverage-${{ matrix.php }}-${{ hashFiles('composer.json') }}
-          restore-keys: ${{ runner.os }}-coverage-${{ matrix.php }}-
 
       - name: Cache test packages
         id: composer-test-cache
@@ -47,7 +46,6 @@ jobs:
         with:
           path: src/test/vendor
           key: ${{ runner.os }}-coverage-test-${{ matrix.php }}-${{ hashFiles('src/test/composer.json') }}
-          restore-keys: ${{ runner.os }}-coverage-test-${{ matrix.php }}-
 
       - name: Upgrade PHPUnit
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -67,7 +67,8 @@ jobs:
         run: src/test/vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
 
       - name: Archive code coverage results
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml
+          disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -72,3 +72,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/generate_phar.yml
+++ b/.github/workflows/generate_phar.yml
@@ -2,9 +2,9 @@ name: Generate phar
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ 'master', '2.x', '3.x' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ '*' ]
   release:
     types:
       - created

--- a/.github/workflows/generate_phar.yml
+++ b/.github/workflows/generate_phar.yml
@@ -56,7 +56,7 @@ jobs:
         run: ant package -D-phar:filename=./phpmd.phar && ./phpmd.phar --version
 
       - name: Sign phar
-        if: github.repository == 'phpmd/phpmd'
+        if: github.repository == 'phpmd/phpmd' && github.event_name == 'release'
         env:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -42,16 +42,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-${{ hashFiles('composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-
+          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-${{ hashFiles('composer.json') }}
 
       - name: Cache test packages
         id: composer-test-cache
         uses: actions/cache@v3
         with:
           path: src/test/vendor
-          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-test-${{ matrix.symfony }}-${{ hashFiles('src/test/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-symfony-test-${{ matrix.symfony }}-
+          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-test-${{ matrix.symfony }}-${{ hashFiles('src/test/composer.json') }}
 
       - name: Set Symfony version
         run: |

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -7,9 +7,9 @@ name: Symfony
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ 'master', '2.x', '3.x' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ '*' ]
 
 jobs:
   tests:

--- a/.github/workflows/tests-with-composer.yml
+++ b/.github/workflows/tests-with-composer.yml
@@ -40,8 +40,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-composer-${{ matrix.setup }}-
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests-with-composer.yml
+++ b/.github/workflows/tests-with-composer.yml
@@ -5,9 +5,9 @@ name: Composer test script
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ 'master', '2.x', '3.x' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ '*' ]
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.json') }}
-          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-
 
       - name: Cache test packages
         id: composer-test-cache
@@ -56,7 +55,6 @@ jobs:
         with:
           path: src/test/vendor
           key: ${{ runner.os }}-php-test-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('src/test/composer.json') }}
-          restore-keys: ${{ runner.os }}-php-test-${{ matrix.php }}-${{ matrix.setup }}-
 
       - name: Upgrade PHPUnit
         if: matrix.php >= 7.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,9 @@ name: Tests
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ 'master', '2.x', '3.x' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ '*' ]
 
 jobs:
   php-tests:

--- a/src/conf/phar_bootstrap.stub
+++ b/src/conf/phar_bootstrap.stub
@@ -22,7 +22,7 @@
 define('PHP_PMD_RELEASE', 'phar');
 
 // Disable deprecations as they are not actionable by end users
-@set_error_handler(E_ALL ^ (E_USER_DEPRECATED | E_DEPRECATED));
+@set_error_handler(null, E_ALL ^ (E_USER_DEPRECATED | E_DEPRECATED));
 
 Phar::mapPhar('${archive.alias}');
 

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -76,7 +76,7 @@ abstract class AbstractNode
      * Returns the parent of this node or <b>null</b> when no parent node
      * exists.
      *
-     * @return ASTNode
+     * @return ASTNode|null
      */
     public function getParent()
     {
@@ -315,7 +315,7 @@ abstract class AbstractNode
      * Returns the name of the parent type or <b>null</b> when this node has no
      * parent type.
      *
-     * @return string
+     * @return string|null
      */
     abstract public function getParentName();
 

--- a/src/main/php/PHPMD/Node/ASTNode.php
+++ b/src/main/php/PHPMD/Node/ASTNode.php
@@ -93,7 +93,7 @@ class ASTNode extends \PHPMD\AbstractNode
      * Returns the name of the parent type or <b>null</b> when this node has no
      * parent type.
      *
-     * @return string
+     * @return string|null
      */
     public function getParentName()
     {
@@ -103,7 +103,7 @@ class ASTNode extends \PHPMD\AbstractNode
     /**
      * Returns the name of the parent namespace.
      *
-     * @return string
+     * @return ?string
      */
     public function getNamespaceName()
     {
@@ -114,7 +114,7 @@ class ASTNode extends \PHPMD\AbstractNode
      * Returns the full qualified name of a class, an interface, a method or
      * a function.
      *
-     * @return string
+     * @return ?string
      */
     public function getFullQualifiedName()
     {

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -97,7 +97,7 @@ abstract class AbstractTypeNode extends AbstractNode
      * Returns the name of the parent type or <b>null</b> when this node has no
      * parent type.
      *
-     * @return string
+     * @return string|null
      */
     public function getParentName()
     {

--- a/src/main/php/PHPMD/Node/FunctionNode.php
+++ b/src/main/php/PHPMD/Node/FunctionNode.php
@@ -48,7 +48,7 @@ class FunctionNode extends AbstractCallableNode
      * Returns the name of the parent type or <b>null</b> when this node has no
      * parent type.
      *
-     * @return string
+     * @return string|null
      */
     public function getParentName()
     {

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -56,7 +56,7 @@ class MethodNode extends AbstractCallableNode
      * Returns the name of the parent type or <b>null</b> when this node has no
      * parent type.
      *
-     * @return string
+     * @return string|null
      */
     public function getParentName()
     {

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -88,7 +88,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      *
      * @param AbstractASTNode $node Array key to evaluate.
      * @param int $index Fallback in case of non-associative arrays
-     * @return AbstractASTNode Key name
+     * @return ?AbstractASTNode Key name
      */
     protected function normalizeKey(AbstractASTNode $node, $index)
     {

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -421,7 +421,7 @@ class CommandLineOptions
      * Returns the output filename for a generated report or <b>null</b> when
      * the report should be displayed in STDOUT.
      *
-     * @return string
+     * @return string|null
      */
     public function getReportFile()
     {
@@ -432,7 +432,7 @@ class CommandLineOptions
      * Returns the output filename for the errors or <b>null</b> when
      * the report should be displayed in STDERR.
      *
-     * @return string
+     * @return string|null
      */
     public function getErrorFile()
     {
@@ -494,7 +494,7 @@ class CommandLineOptions
      * Returns the file name of a supplied code coverage report or <b>NULL</b>
      * if the user has not supplied the --coverage option.
      *
-     * @return string
+     * @return string|null
      */
     public function getCoverageReport()
     {
@@ -505,7 +505,7 @@ class CommandLineOptions
      * Returns a string of comma-separated extensions for valid php source code
      * filenames or <b>null</b> when this argument was not set.
      *
-     * @return string
+     * @return string|null
      */
     public function getExtensions()
     {
@@ -516,7 +516,7 @@ class CommandLineOptions
      * Returns string of comma-separated pattern that is used to exclude
      * directories or <b>null</b> when this argument was not set.
      *
-     * @return string
+     * @return string|null
      */
     public function getIgnore()
     {

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -28,7 +28,7 @@ class StreamWriter extends AbstractWriter
     /**
      * The stream resource handle
      *
-     * @var resource
+     * @var ?resource
      */
     private $stream = null;
 


### PR DESCRIPTION
Type: bugfix
Breaking change: no

A few things back-ported from the 3.x branch:
- Fix deprecation error suppression
- Fix upload of code coverage to CodeCov (now requires a token)
- A few missing nullable types
- GitHub actions being run with previous versions of the dependencies
- Only build each branch once (previously builds where done 2x when the PR was from a branch on the same repo)