### PR TITLE
Group and align PHPDoc

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -50,6 +50,7 @@ return $config
         'no_unused_imports' => true,
         // Using sorting algo "alpha" instead of "none" defined in PER CS v2
         'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
+        'phpdoc_align' => true,
         'phpdoc_indent' => true,
         'phpdoc_order' => [
             'order' => [
@@ -88,6 +89,7 @@ return $config
         ],
         'phpdoc_return_self_reference' => true,
         'phpdoc_scalar' => true,
+        'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_trim' => true,
         'phpdoc_trim_consecutive_blank_line_separation' => true,
@@ -96,6 +98,8 @@ return $config
     ])
     ->setFinder(PhpCsFixer\Finder::create()
         ->exclude('vendor')
-        ->in(__DIR__ . '/src/main/php/PHPMD')
-        ->in(__DIR__ . '/src/test/php/')
+        ->in([
+            __DIR__ . '/src/main/php/PHPMD',
+            __DIR__ . '/src/test/php',
+        ])
     );

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -63,8 +64,9 @@ abstract class AbstractNode
      * to the underlying PDepend AST node.
      *
      * @param string $name
+     *
      * @throws BadMethodCallException When the underlying PDepend node
-     *         does not contain a method named <b>$name</b>.
+     *                                does not contain a method named <b>$name</b>.
      */
     public function __call($name, array $args): mixed
     {
@@ -98,7 +100,9 @@ abstract class AbstractNode
      * Returns a child node at the given index.
      *
      * @param int $index The child offset.
+     *
      * @return AbstractNode
+     *
      * @throws OutOfBoundsException
      */
     public function getChild($index)
@@ -116,6 +120,7 @@ abstract class AbstractNode
      * @template T of PDependNode
      *
      * @param class-string<T> $type The searched child type.
+     *
      * @return ASTNode<T>|null
      */
     public function getFirstChildOfType($type)
@@ -157,6 +162,7 @@ abstract class AbstractNode
      * the current node.
      *
      * @param class-string<PDependNode> $type The searched child type.
+     *
      * @return array<int, AbstractASTNode|ASTArtifact>
      */
     public function findChildrenWithParentType($type)
@@ -178,6 +184,7 @@ abstract class AbstractNode
      * Searches recursive for all children of this node that are of variable.
      *
      * @return array<int, ASTNode<ASTVariable>>
+     *
      * @todo Cover by a test.
      */
     public function findChildrenOfTypeVariable()
@@ -283,6 +290,7 @@ abstract class AbstractNode
      * <b>null</b> when no such metric exists.
      *
      * @param string $name The metric name or abbreviation.
+     *
      * @return ?numeric $name
      */
     public function getMetric($name)

--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -267,11 +268,13 @@ abstract class AbstractRule implements Rule
      * Throws an exception when no property with <b>$name</b> exists
      * and no default value to fall back was given.
      *
-     * @param string $name The name of the property, e.g. "ignore-whitespace".
-     * @param mixed $default An optional default value to fall back instead of throwing an exception.
+     * @param string $name    The name of the property, e.g. "ignore-whitespace".
+     * @param mixed  $default An optional default value to fall back instead of throwing an exception.
+     *
      * @return mixed The value of a configured property.
+     *
      * @throws OutOfBoundsException When no property for <b>$name</b> exists and
-     * no default value to fall back was given.
+     *                              no default value to fall back was given.
      */
     protected function getProperty(string $name, mixed $default = null): mixed
     {
@@ -292,11 +295,13 @@ abstract class AbstractRule implements Rule
      * Throws an exception when no property with <b>$name</b> exists
      * and no default value to fall back was given.
      *
-     * @param string $name The name of the property, e.g. "ignore-whitespace".
+     * @param string    $name    The name of the property, e.g. "ignore-whitespace".
      * @param bool|null $default An optional default value to fall back instead of throwing an exception.
+     *
      * @return bool The value of a configured property as a boolean.
+     *
      * @throws OutOfBoundsException When no property for <b>$name</b> exists and
-     * no default value to fall back was given.
+     *                              no default value to fall back was given.
      */
     public function getBooleanProperty(string $name, ?bool $default = null): bool
     {
@@ -309,11 +314,13 @@ abstract class AbstractRule implements Rule
      * Throws an exception when no property with <b>$name</b> exists
      * and no default value to fall back was given.
      *
-     * @param string $name The name of the property, e.g. "minimum".
+     * @param string   $name    The name of the property, e.g. "minimum".
      * @param int|null $default An optional default value to fall back instead of throwing an exception.
+     *
      * @return int The value of a configured property as an integer.
+     *
      * @throws OutOfBoundsException When no property for <b>$name</b> exists and
-     * no default value to fall back was given.
+     *                              no default value to fall back was given.
      */
     public function getIntProperty(string $name, ?int $default = null): int
     {
@@ -326,11 +333,13 @@ abstract class AbstractRule implements Rule
      * Throws an exception when no property with <b>$name</b> exists
      * and no default value to fall back was given.
      *
-     * @param string $name The name of the property, e.g. "exceptions".
+     * @param string      $name    The name of the property, e.g. "exceptions".
      * @param string|null $default An optional default value to fall back instead of throwing an exception.
+     *
      * @return string The raw string value of a configured property.
+     *
      * @throws OutOfBoundsException When no property for <b>$name</b> exists and
-     * no default value to fall back was given.
+     *                              no default value to fall back was given.
      */
     public function getStringProperty(string $name, ?string $default = null): string
     {
@@ -364,6 +373,7 @@ abstract class AbstractRule implements Rule
      * Apply the current rule on each method of a class node.
      *
      * @param ClassNode|EnumNode|InterfaceNode|TraitNode $node class node containing methods.
+     *
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException

--- a/src/main/php/PHPMD/AbstractWriter.php
+++ b/src/main/php/PHPMD/AbstractWriter.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
+++ b/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
@@ -25,6 +25,7 @@ class BaselineFileFinder
 
     /**
      * The baseline filepath should point to an existing file (or null)
+     *
      * @return $this
      */
     public function existingFile()
@@ -35,6 +36,7 @@ class BaselineFileFinder
 
     /**
      * if true, the finder `must` find a file path, but doesn't necessarily exist
+     *
      * @return $this
      */
     public function notNull()
@@ -47,6 +49,7 @@ class BaselineFileFinder
      * Find the violation baseline file
      *
      * @return string|null
+     *
      * @throws RuntimeException
      */
     public function find()
@@ -84,6 +87,7 @@ class BaselineFileFinder
      * @param string $message
      *
      * @return null
+     *
      * @throws RuntimeException
      */
     private function nullOrThrow($message)

--- a/src/main/php/PHPMD/Baseline/BaselineSet.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSet.php
@@ -16,6 +16,7 @@ class BaselineSet
      * @param string      $ruleName
      * @param string      $fileName
      * @param string|null $methodName
+     *
      * @return bool
      */
     public function contains($ruleName, $fileName, $methodName)

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -11,7 +11,9 @@ class BaselineSetFactory
      * the baseline file.
      *
      * @param string $fileName
+     *
      * @return BaselineSet
+     *
      * @throws RuntimeException
      */
     public static function fromFile($fileName)

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
@@ -35,6 +35,7 @@ class ResultCacheState
 
     /**
      * @param string $filePath
+     *
      * @return array
      */
     public function getViolations($filePath)
@@ -116,6 +117,7 @@ class ResultCacheState
     /**
      * @param string $filePath
      * @param string $hash
+     *
      * @return bool
      */
     public function isFileModified($filePath, $hash)
@@ -150,6 +152,7 @@ class ResultCacheState
     /**
      * @param string    $ruleClassName
      * @param RuleSet[] $ruleSetList
+     *
      * @return Rule|null
      */
     private static function findRuleIn($ruleClassName, array $ruleSetList)

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -28,6 +28,7 @@ class ResultCacheEngineFactory
     /**
      * @param string    $basePath
      * @param RuleSet[] $ruleSetList
+     *
      * @return ResultCacheEngine|null
      */
     public function create($basePath, CommandLineOptions $options, array $ruleSetList)

--- a/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
@@ -45,7 +45,9 @@ class ResultCacheFileFilter implements Filter
 
     /**
      * Stage 1: A hook to allow filtering out certain files from inspection by pdepend.
+     *
      * @inheritDoc
+     *
      * @return bool `true` will inspect the file, when `false` the file will be filtered out.
      */
     public function accept($relative, $absolute): bool

--- a/src/main/php/PHPMD/Cache/ResultCacheStateFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheStateFactory.php
@@ -9,6 +9,7 @@ class ResultCacheStateFactory
 {
     /**
      * @param string $filePath
+     *
      * @return ResultCacheState|null
      */
     public function fromFile($filePath)

--- a/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
@@ -26,6 +26,7 @@ class ResultCacheUpdater
 
     /**
      * @param RuleSet[] $ruleSetList
+     *
      * @return ResultCacheState
      */
     public function update(array $ruleSetList, ResultCacheState $state, Report $report)

--- a/src/main/php/PHPMD/Console/Output.php
+++ b/src/main/php/PHPMD/Console/Output.php
@@ -18,8 +18,8 @@ abstract class Output implements OutputInterface
     /**
      * @param string|string[] $messages
      * @param bool            $newline
-     * @param int             $options A bitmask of options (one of the VERBOSITY constants),
-     *                                 0 is considered the same as self::VERBOSITY_NORMAL
+     * @param int             $options  A bitmask of options (one of the VERBOSITY constants),
+     *                                  0 is considered the same as self::VERBOSITY_NORMAL
      */
     public function write($messages, $newline = false, $options = self::VERBOSITY_NORMAL): void
     {
@@ -45,8 +45,8 @@ abstract class Output implements OutputInterface
 
     /**
      * @param string|string[] $messages
-     * @param int             $options A bitmask of options (one of the VERBOSITY constants),
-     *                                 0 is considered the same as self::VERBOSITY_NORMAL
+     * @param int             $options  A bitmask of options (one of the VERBOSITY constants),
+     *                                  0 is considered the same as self::VERBOSITY_NORMAL
      */
     public function writeln($messages, $options = self::VERBOSITY_NORMAL): void
     {

--- a/src/main/php/PHPMD/Console/OutputInterface.php
+++ b/src/main/php/PHPMD/Console/OutputInterface.php
@@ -17,15 +17,15 @@ interface OutputInterface
     /**
      * @param string|string[] $messages
      * @param bool            $newline
-     * @param int             $options A bitmask of options (one of the VERBOSITY constants),
-     *                                 0 is considered the same as self::VERBOSITY_NORMAL
+     * @param int             $options  A bitmask of options (one of the VERBOSITY constants),
+     *                                  0 is considered the same as self::VERBOSITY_NORMAL
      */
     public function write($messages, $newline = false, $options = self::VERBOSITY_NORMAL): void;
 
     /**
      * @param string|string[] $messages
-     * @param int             $options A bitmask of options (one of the VERBOSITY constants),
-     *                                 0 is considered the same as self::VERBOSITY_NORMAL
+     * @param int             $options  A bitmask of options (one of the VERBOSITY constants),
+     *                                  0 is considered the same as self::VERBOSITY_NORMAL
      */
     public function writeln($messages, $options = self::VERBOSITY_NORMAL): void;
 

--- a/src/main/php/PHPMD/Exception/RuleClassFileNotFoundException.php
+++ b/src/main/php/PHPMD/Exception/RuleClassFileNotFoundException.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Exception/RuleClassNotFoundException.php
+++ b/src/main/php/PHPMD/Exception/RuleClassNotFoundException.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Exception/RuleSetNotFoundException.php
+++ b/src/main/php/PHPMD/Exception/RuleSetNotFoundException.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Node/ASTNode.php
+++ b/src/main/php/PHPMD/Node/ASTNode.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -40,7 +41,7 @@ class ASTNode extends AbstractNode
     /**
      * Constructs a new ast node instance.
      *
-     * @param TNode $node
+     * @param TNode  $node
      * @param string $fileName
      */
     public function __construct(PDependNode $node, $fileName)
@@ -55,7 +56,9 @@ class ASTNode extends AbstractNode
      * instance.
      *
      * @return bool
+     *
      * @SuppressWarnings("PMD.UnusedFormalParameter")
+     *
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
      */
     public function hasSuppressWarningsAnnotationFor(Rule $rule)

--- a/src/main/php/PHPMD/Node/AbstractCallableNode.php
+++ b/src/main/php/PHPMD/Node/AbstractCallableNode.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Node/AbstractNode.php
+++ b/src/main/php/PHPMD/Node/AbstractNode.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Node/Annotation.php
+++ b/src/main/php/PHPMD/Node/Annotation.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Node/Annotations.php
+++ b/src/main/php/PHPMD/Node/Annotations.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Node/ClassNode.php
+++ b/src/main/php/PHPMD/Node/ClassNode.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Node/EnumNode.php
+++ b/src/main/php/PHPMD/Node/EnumNode.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Node/FunctionNode.php
+++ b/src/main/php/PHPMD/Node/FunctionNode.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Node/InterfaceNode.php
+++ b/src/main/php/PHPMD/Node/InterfaceNode.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -135,7 +136,9 @@ class MethodNode extends AbstractCallableNode
      * Otherwise this method will return <b>false</b>.
      *
      * @return bool
+     *
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
+     *
      * @since 1.2.1
      */
     public function isDeclaration()

--- a/src/main/php/PHPMD/Node/NodeInfo.php
+++ b/src/main/php/PHPMD/Node/NodeInfo.php
@@ -8,6 +8,7 @@ class NodeInfo
      * The full filepath of this violation
      *
      * @readonly
+     *
      * @var string|null
      */
     public $fileName;
@@ -16,6 +17,7 @@ class NodeInfo
      * Namespace of the owning/context class or interface of this violation.
      *
      * @readonly
+     *
      * @var string
      */
     public $namespaceName;
@@ -24,6 +26,7 @@ class NodeInfo
      * Name of the owning/context class or interface of this violation.
      *
      * @readonly
+     *
      * @var string|null
      */
     public $className;
@@ -33,6 +36,7 @@ class NodeInfo
      * context.
      *
      * @readonly
+     *
      * @var string|null
      */
     public $methodName;
@@ -42,6 +46,7 @@ class NodeInfo
      * context.
      *
      * @readonly
+     *
      * @var string|null
      */
     public $functionName;
@@ -50,6 +55,7 @@ class NodeInfo
      * The start line number of this violation
      *
      * @readonly
+     *
      * @var int
      */
     public $beginLine;
@@ -58,18 +64,19 @@ class NodeInfo
      * The end line number of this violation
      *
      * @readonly
+     *
      * @var int
      */
     public $endLine;
 
     /**
      * @param string|null $fileName
-     * @param string $namespaceName
+     * @param string      $namespaceName
      * @param string|null $className
      * @param string|null $methodName
      * @param string|null $functionName
-     * @param int $beginLine
-     * @param int $endLine
+     * @param int         $beginLine
+     * @param int         $endLine
      */
     public function __construct(
         $fileName,

--- a/src/main/php/PHPMD/Node/TraitNode.php
+++ b/src/main/php/PHPMD/Node/TraitNode.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -12,6 +12,7 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link      http://phpmd.org/
  */
 
@@ -36,6 +37,7 @@ class PHPMD
      * was found in the processed source code.
      *
      * @var bool
+     *
      * @since 2.10.0
      */
     private $errors = false;
@@ -69,6 +71,7 @@ class PHPMD
      * was found in the processed source code.
      *
      * @var bool
+     *
      * @since 0.2.5
      */
     private $violations = false;
@@ -77,6 +80,7 @@ class PHPMD
      * Additional options for PHPMD or one of it's parser backends.
      *
      * @var array
+     *
      * @since 1.2.0
      */
     private $options = [];
@@ -86,6 +90,7 @@ class PHPMD
      * contains errors.
      *
      * @return bool
+     *
      * @since 2.10.0
      */
     public function hasErrors()
@@ -98,6 +103,7 @@ class PHPMD
      * contains violations.
      *
      * @return bool
+     *
      * @since 0.2.5
      */
     public function hasViolations()
@@ -119,6 +125,7 @@ class PHPMD
      * Returns an array with valid php source file extensions.
      *
      * @return string[]
+     *
      * @since 0.2.0
      */
     public function getFileExtensions()
@@ -140,6 +147,7 @@ class PHPMD
      * Returns an array with string patterns that mark a file path invalid.
      *
      * @return string[]
+     *
      * @since 2.9.0
      */
     public function getIgnorePatterns()
@@ -152,7 +160,9 @@ class PHPMD
      * the source analysis.
      *
      * @param array<string> $ignorePatterns List of ignore patterns.
+     *
      * @return $this
+     *
      * @since 2.9.0
      */
     public function addIgnorePatterns(array $ignorePatterns)
@@ -175,6 +185,7 @@ class PHPMD
 
     /**
      * @param ResultCacheEngine $resultCache
+     *
      * @return $this;
      */
     public function setResultCache($resultCache)

--- a/src/main/php/PHPMD/Parser.php
+++ b/src/main/php/PHPMD/Parser.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/ProcessingError.php
+++ b/src/main/php/PHPMD/ProcessingError.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
+++ b/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
@@ -23,7 +23,9 @@ class CheckStyleRenderer extends XMLRenderer
      * of the rule that's being broken
      *
      * @param int $priority priority of the broken rule
+     *
      * @return string either error, warning or info
+     *
      * @see https://checkstyle.sourceforge.io/version/4.4/property_types.html#severity
      * - priority 1 maps to error level severity
      * - priority 2 maps to warning level severity

--- a/src/main/php/PHPMD/Renderer/GitHubRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitHubRenderer.php
@@ -12,6 +12,7 @@
  * @author Lukas Bestle <project-phpmd@lukasbestle.com>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -12,6 +12,7 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link      http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -69,6 +70,7 @@ class HTMLRenderer extends AbstractRenderer
     /**
      * Specify how many extra lines are added to a code snippet
      * By default 2
+     *
      * @var int
      */
     protected $extraLineInExcerpt = 2;
@@ -433,6 +435,7 @@ class HTMLRenderer extends AbstractRenderer
      * for additional cognitive context.
      *
      * @return array
+     *
      * @throws RuntimeException
      * @throws LogicException
      */

--- a/src/main/php/PHPMD/Renderer/JSONRenderer.php
+++ b/src/main/php/PHPMD/Renderer/JSONRenderer.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -61,7 +62,8 @@ class JSONRenderer extends AbstractRenderer
      * Add violations, if any, to the report data
      *
      * @param Report $report The report with potential violations.
-     * @param array $data The report output to add the violations to.
+     * @param array  $data   The report output to add the violations to.
+     *
      * @return array The report output with violations, if any.
      */
     protected function addViolationsToReport(Report $report, array $data)
@@ -95,7 +97,8 @@ class JSONRenderer extends AbstractRenderer
      * Add errors, if any, to the report data
      *
      * @param Report $report The report with potential errors.
-     * @param array $data The report output to add the errors to.
+     * @param array  $data   The report output to add the errors to.
+     *
      * @return array The report output with errors, if any.
      */
     protected function addErrorsToReport(Report $report, array $data)

--- a/src/main/php/PHPMD/Renderer/SARIFRenderer.php
+++ b/src/main/php/PHPMD/Renderer/SARIFRenderer.php
@@ -12,6 +12,7 @@
  * @author Lukas Bestle <project-phpmd@lukasbestle.com>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -66,7 +67,8 @@ class SARIFRenderer extends JSONRenderer
      * Add violations, if any, to the report data
      *
      * @param Report $report The report with potential violations.
-     * @param array $data The report output to add the violations to.
+     * @param array  $data   The report output to add the violations to.
+     *
      * @return array The report output with violations, if any.
      */
     protected function addViolationsToReport(Report $report, array $data)
@@ -157,7 +159,8 @@ class SARIFRenderer extends JSONRenderer
      * Add errors, if any, to the report data
      *
      * @param Report $report The report with potential errors.
-     * @param array $data The report output to add the errors to.
+     * @param array  $data   The report output to add the errors to.
+     *
      * @return array The report output with errors, if any.
      */
     protected function addErrorsToReport(Report $report, array $data)
@@ -188,6 +191,7 @@ class SARIFRenderer extends JSONRenderer
      * and returns the result as a SARIF `artifactLocation`
      *
      * @param string $path
+     *
      * @return array
      */
     protected static function pathToArtifactLocation($path)
@@ -211,6 +215,7 @@ class SARIFRenderer extends JSONRenderer
      * Converts an absolute path to a file:// URI
      *
      * @param string $path
+     *
      * @return string
      */
     protected static function pathToUri($path)

--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Renderer/XMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/XMLRenderer.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -111,7 +112,7 @@ class XMLRenderer extends AbstractRenderer
      * This method will write a xml attribute named <b>$attr</b> to the output
      * when the given <b>$value</b> is not an empty string and is not <b>null</b>.
      *
-     * @param string $attr The xml attribute name.
+     * @param string  $attr  The xml attribute name.
      * @param ?string $value The attribute value.
      */
     protected function maybeAdd($attr, $value): void

--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -52,6 +53,7 @@ class Report
      * Errors that occurred while parsing the source.
      *
      * @var array
+     *
      * @since 1.2.1
      */
     private $errors = [];
@@ -90,6 +92,7 @@ class Report
      * Returns <b>true</b> when this report does not contain any errors.
      *
      * @return bool
+     *
      * @since 0.2.5
      */
     public function isEmpty()
@@ -135,6 +138,7 @@ class Report
      * error. Otherwise this method will return <b>false</b>.
      *
      * @return bool
+     *
      * @since 1.2.1
      */
     public function hasErrors()
@@ -147,6 +151,7 @@ class Report
      * added to this report.
      *
      * @return Iterator
+     *
      * @since 1.2.1
      */
     public function getErrors()

--- a/src/main/php/PHPMD/Rule.php
+++ b/src/main/php/PHPMD/Rule.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -155,11 +156,13 @@ interface Rule
      * Throws an exception when no property with <b>$name</b> exists
      * and no default value to fall back was given.
      *
-     * @param string $name The name of the property, e.g. "exceptions".
+     * @param string      $name    The name of the property, e.g. "exceptions".
      * @param string|null $default An optional default value to fall back instead of throwing an exception.
+     *
      * @return string The raw string value of a configured property.
+     *
      * @throws OutOfBoundsException When no property for <b>$name</b> exists and
-     * no non-null default value to fall back was given.
+     *                              no non-null default value to fall back was given.
      */
     public function getStringProperty(string $name, ?string $default = null): string;
 

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -51,6 +52,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * can never be unused local variables.
      *
      * @var array(string=>boolean)
+     *
      * @link http://php.net/manual/en/reserved.variables.php
      */
     protected static $superGlobals = [
@@ -75,7 +77,9 @@ abstract class AbstractLocalVariable extends AbstractRule
      * a static object property or something similar.
      *
      * @param ASTNode<ASTVariable> $variable The variable to check.
+     *
      * @return bool
+     *
      * @throws OutOfBoundsException
      */
     protected function isLocal(ASTNode $variable)
@@ -113,6 +117,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * or method postfix.
      *
      * @return bool
+     *
      * @throws OutOfBoundsException
      */
     protected function isRegularVariable(ASTNode $variable)
@@ -140,6 +145,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * instance.
      *
      * @return ASTNode
+     *
      * @throws OutOfBoundsException
      */
     protected function stripWrappedIndexExpression(ASTNode $node)
@@ -173,6 +179,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * insensitive.
      *
      * @param string $name
+     *
      * @return bool
      */
     protected function isFunctionNameEqual(AbstractNode $node, $name)
@@ -185,6 +192,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * This method checks if the last part of function fully qualified name is equal to $name
      *
      * @param string $name
+     *
      * @return bool
      */
     protected function isFunctionNameEndingWith(AbstractNode $node, $name)
@@ -200,7 +208,9 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Prefix self:: and static:: properties with "::".
      *
      * @param AbstractNode|PDependNode $variable
+     *
      * @return string
+     *
      * @throws OutOfBoundsException
      */
     protected function getVariableImage($variable)
@@ -262,7 +272,9 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Reflect function trying as namespaced function first, then global function.
      *
      * @SuppressWarnings(PHPMD.EmptyCatchBlock)
+     *
      * @param string $functionName
+     *
      * @return ReflectionFunction|null
      */
     private function getReflectionFunctionByName($functionName)
@@ -289,6 +301,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Return true if the given variable is passed by reference in a native PHP function.
      *
      * @param ASTPropertyPostfix|ASTVariable|ASTVariableDeclarator $variable
+     *
      * @return bool
      */
     protected function isPassedByReference($variable)
@@ -345,7 +358,9 @@ abstract class AbstractLocalVariable extends AbstractRule
      * image is "$foo", second one is "::$foo".
      *
      * @param ASTPropertyPostfix|ASTVariable|ASTVariableDeclarator $variable
+     *
      * @return string
+     *
      * @throws OutOfBoundsException
      */
     private function prependMemberPrimaryPrefix($image, $variable)
@@ -379,7 +394,8 @@ abstract class AbstractLocalVariable extends AbstractRule
      * ```
      *
      * @param ASTPropertyPostfix|ASTVariable|ASTVariableDeclarator $variable
-     * @param string $image
+     * @param string                                               $image
+     *
      * @return bool
      */
     private function isFieldDeclaration($variable, $image = '$')

--- a/src/main/php/PHPMD/Rule/ClassAware.php
+++ b/src/main/php/PHPMD/Rule/ClassAware.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -54,6 +55,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      * with duplicated entries for any key and emits a rule violation if so.
      *
      * @param ASTNode $node Array node.
+     *
      * @throws OutOfBoundsException
      */
     protected function checkForDuplicatedArrayKeys(ASTNode $node): void
@@ -85,9 +87,11 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      * As current logic doesn't evaluate expressions nor constants,
      * statics, globals, etc. we simply skip them.
      *
-     * @param AbstractASTNode $node Array key to evaluate.
-     * @param int $index Fallback in case of non-associative arrays
+     * @param AbstractASTNode $node  Array key to evaluate.
+     * @param int             $index Fallback in case of non-associative arrays
+     *
      * @return ?AbstractASTNode Key name
+     *
      * @throws OutOfBoundsException
      */
     protected function normalizeKey(AbstractASTNode $node, $index)

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -58,6 +59,7 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
      * Whether the given scope is an else clause
      *
      * @return bool
+     *
      * @throws OutOfBoundsException
      */
     protected function isElseScope(AbstractNode $scope, ASTNode $parent)

--- a/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -29,6 +30,7 @@ use PHPMD\Rule\MethodAware;
  * This rule detects usage of error control operator (@).
  *
  * @author Kamil Szymanaski <kamil.szymanski@gmail.com>
+ *
  * @link http://php.net/manual/en/language.operators.errorcontrol.php
  */
 class ErrorControlOperator extends AbstractRule implements MethodAware, FunctionAware

--- a/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -60,6 +61,7 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
      * Extracts if and elseif statements from method/function body
      *
      * @param AbstractNode $node An instance of MethodNode or FunctionNode class
+     *
      * @return array<int, ASTNode<ASTElseIfStatement>|ASTNode<ASTIfStatement>>
      */
     protected function getStatements(AbstractNode $node)
@@ -74,6 +76,7 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
      * Extracts all expression from statements array
      *
      * @param array<int, ASTNode<ASTElseIfStatement>|ASTNode<ASTIfStatement>> $statements Array of if and elseif clauses
+     *
      * @return array<int, ASTNode<ASTExpression>>
      */
     protected function getExpressions(array $statements)
@@ -95,6 +98,7 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
      * Extracts all assignments from expressions array
      *
      * @param ASTExpression[] $expressions Array of expressions
+     *
      * @return ASTAssignmentExpression[]
      */
     protected function getAssignments(array $expressions)
@@ -110,7 +114,7 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
     /**
      * Signals if any violations have been found in given method or function
      *
-     * @param AbstractNode $node An instance of MethodNode or FunctionNode class
+     * @param AbstractNode              $node        An instance of MethodNode or FunctionNode class
      * @param ASTAssignmentExpression[] $assignments Array of assignments
      */
     protected function addViolations(AbstractNode $node, array $assignments): void

--- a/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -73,6 +74,7 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
      * Check whether a given class node is a self reference
      *
      * @param ASTNode $classNode A class node to check.
+     *
      * @return bool Whether the given class node is a self reference.
      */
     protected function isSelfReference(ASTNode $classNode)
@@ -84,6 +86,7 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
      * Check whether a given class node is in the global namespace
      *
      * @param ASTNode $classNode A class node to check.
+     *
      * @return bool Whether the given class node is in the global namespace.
      */
     protected function isGlobalNamespace(ASTNode $classNode)

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -100,6 +101,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
 
     /**
      * @param string $ignorePattern
+     *
      * @return bool
      */
     protected function isMethodIgnored(AbstractNode $methodCall, $ignorePattern)

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -199,6 +200,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * Check if the given variable was defined in the current context before usage.
      *
      * @return bool
+     *
      * @throws OutOfBoundsException
      */
     protected function checkVariableDefined(ASTNode $variable, AbstractCallableNode $parentNode)
@@ -271,6 +273,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * Add the variable to images.
      *
      * @param ASTPropertyPostfix|ASTVariable|ASTVariableDeclarator $variable
+     *
      * @throws OutOfBoundsException
      */
     protected function addVariableDefinition($variable): void

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseClassName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseClassName.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -28,6 +29,7 @@ use PHPMD\Rule\TraitAware;
  * This rule class detects classes not named in CamelCase.
  *
  * @author Francis Besset <francis.besset@gmail.com>
+ *
  * @since 1.1.0
  */
 class CamelCaseClassName extends AbstractRule implements ClassAware, InterfaceAware, TraitAware, EnumAware

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -26,6 +27,7 @@ use PHPMD\Rule\MethodAware;
  * This rule class detects methods not named in camelCase.
  *
  * @author Francis Besset <francis.besset@gmail.com>
+ *
  * @since 1.1.0
  */
 class CamelCaseMethodName extends AbstractRule implements MethodAware

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
@@ -6,9 +6,11 @@
  * Licensed under BSD License
  * For full copyright and license information, please see the LICENSE file.
  * Redistributions of files must retain the above copyright notice.
+ *
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link      http://phpmd.org/
  */
 
@@ -57,7 +59,9 @@ class CamelCaseNamespace extends AbstractRule implements ClassAware, InterfaceAw
 
     /**
      * Gets array of exceptions from property
+     *
      * @return array<string, int>
+     *
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -29,6 +30,7 @@ use PHPMD\Rule\MethodAware;
  * This rule class detects parameters not named in camelCase.
  *
  * @author Francis Besset <francis.besset@gmail.com>
+ *
  * @since 1.1.0
  */
 class CamelCaseParameterName extends AbstractRule implements MethodAware, FunctionAware

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -29,6 +30,7 @@ use PHPMD\Rule\TraitAware;
  * This rule class detects properties not named in camelCase.
  *
  * @author Francis Besset <francis.besset@gmail.com>
+ *
  * @since 1.1.0
  */
 class CamelCasePropertyName extends AbstractRule implements ClassAware, TraitAware

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -28,6 +29,7 @@ use PHPMD\Rule\MethodAware;
  * This rule class detects variables not named in camelCase.
  *
  * @author Francis Besset <francis.besset@gmail.com>
+ *
  * @since 1.1.0
  */
 class CamelCaseVariableName extends AbstractRule implements MethodAware, FunctionAware

--- a/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
+++ b/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -26,6 +27,7 @@ use PHPMD\Rule\MethodAware;
  * This rule class detects the usage of superglobals.
  *
  * @author Francis Besset <francis.besset@gmail.com>
+ *
  * @since 1.1.0
  */
 class Superglobals extends AbstractRule implements MethodAware, FunctionAware

--- a/src/main/php/PHPMD/Rule/CyclomaticComplexity.php
+++ b/src/main/php/PHPMD/Rule/CyclomaticComplexity.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/CouplingBetweenObjects.php
+++ b/src/main/php/PHPMD/Rule/Design/CouplingBetweenObjects.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/DepthOfInheritance.php
+++ b/src/main/php/PHPMD/Rule/Design/DepthOfInheritance.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -67,6 +68,7 @@ class DevelopmentCodeFragment extends AbstractRule implements MethodAware, Funct
      * development.
      *
      * @return array
+     *
      * @throws OutOfBoundsException
      */
     protected function getSuspectImages()

--- a/src/main/php/PHPMD/Rule/Design/EmptyCatchBlock.php
+++ b/src/main/php/PHPMD/Rule/Design/EmptyCatchBlock.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/EvalExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/EvalExpression.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/ExitExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/ExitExpression.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/GotoStatement.php
+++ b/src/main/php/PHPMD/Rule/Design/GotoStatement.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/LongClass.php
+++ b/src/main/php/PHPMD/Rule/Design/LongClass.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/LongMethod.php
+++ b/src/main/php/PHPMD/Rule/Design/LongMethod.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/LongParameterList.php
+++ b/src/main/php/PHPMD/Rule/Design/LongParameterList.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/NpathComplexity.php
+++ b/src/main/php/PHPMD/Rule/Design/NpathComplexity.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/NumberOfChildren.php
+++ b/src/main/php/PHPMD/Rule/Design/NumberOfChildren.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/TooManyFields.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyFields.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -90,6 +91,7 @@ class TooManyPublicMethods extends AbstractRule implements ClassAware
      * ignoreRegexp is given to the rule using ignorepattern option.
      *
      * @param string $methodName
+     *
      * @return bool
      */
     private function isIgnoredMethodName($methodName)

--- a/src/main/php/PHPMD/Rule/Design/WeightedMethodCount.php
+++ b/src/main/php/PHPMD/Rule/Design/WeightedMethodCount.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/EnumAware.php
+++ b/src/main/php/PHPMD/Rule/EnumAware.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/ExcessivePublicCount.php
+++ b/src/main/php/PHPMD/Rule/ExcessivePublicCount.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/FunctionAware.php
+++ b/src/main/php/PHPMD/Rule/FunctionAware.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/InterfaceAware.php
+++ b/src/main/php/PHPMD/Rule/InterfaceAware.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/MethodAware.php
+++ b/src/main/php/PHPMD/Rule/MethodAware.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -47,6 +48,7 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
      * boolean get method.
      *
      * @return bool
+     *
      * @throws OutOfBoundsException
      */
     protected function isBooleanGetMethod(MethodNode $node)
@@ -86,6 +88,7 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
      * or has no parameters.
      *
      * @return bool
+     *
      * @throws OutOfBoundsException
      */
     protected function isParameterizedOrIgnored(MethodNode $node)

--- a/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Naming/LongClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongClassName.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -70,6 +71,7 @@ class LongClassName extends AbstractRule implements ClassAware, InterfaceAware, 
      * Gets array of prefixes from property
      *
      * @return string[]
+     *
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
@@ -89,6 +91,7 @@ class LongClassName extends AbstractRule implements ClassAware, InterfaceAware, 
      * Gets array of suffixes from property
      *
      * @return string[]
+     *
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -112,6 +113,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      *
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
+     *
      * @SuppressWarnings(PHPMD.LongVariable)
      */
     protected function checkMaximumLength(AbstractNode $node): void
@@ -148,6 +150,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * the given type.
      *
      * @param string $type
+     *
      * @return bool
      */
     protected function isChildOf(AbstractNode $node, $type)
@@ -193,6 +196,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * Gets array of suffixes from property
      *
      * @return string[]
+     *
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException
      */
@@ -209,6 +213,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * Gets array of suffixes from property
      *
      * @return string[]
+     *
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException
      */

--- a/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -179,6 +180,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * variable names in catch-statements.
      *
      * @return bool
+     *
      * @throws OutOfBoundsException
      */
     protected function isNameAllowedInContext(AbstractNode $node)
@@ -198,6 +200,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * Checks if a short name is initialized within a foreach loop statement
      *
      * @return bool
+     *
      * @throws OutOfBoundsException
      */
     protected function isInitializedInLoop(AbstractNode $node)
@@ -246,6 +249,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * the given type.
      *
      * @param string $type
+     *
      * @return bool
      */
     protected function isChildOf(AbstractNode $node, $type)

--- a/src/main/php/PHPMD/Rule/TraitAware.php
+++ b/src/main/php/PHPMD/Rule/TraitAware.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -140,7 +141,9 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      * the initial declaration.
      *
      * @return bool
+     *
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
+     *
      * @since 1.2.1
      */
     protected function isNotDeclaration(AbstractNode $node)
@@ -188,6 +191,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      * Removes all the regular variables from a given node
      *
      * @param AbstractNode $node The node to remove the regular variables from.
+     *
      * @throws OutOfBoundsException
      */
     protected function removeRegularVariables(AbstractNode $node): void

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -189,8 +190,8 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Safely add node to $this->images.
      *
-     * @param string $imageName the name to store the node as
-     * @param ASTNode $node the node being stored
+     * @param string  $imageName the name to store the node as
+     * @param ASTNode $node      the node being stored
      */
     protected function storeImage($imageName, ASTNode $node): void
     {
@@ -265,7 +266,9 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * If it's not a foreach variable, it returns always false.
      *
      * @param ASTNode $variable The variable to check.
+     *
      * @return bool True if allowed, else false.
+     *
      * @throws OutOfBoundsException
      */
     protected function isUnusedForeachVariableAllowed(ASTNode $variable)
@@ -284,6 +287,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * the given type.
      *
      * @param string $type
+     *
      * @return bool
      */
     protected function isChildOf(AbstractNode $node, $type)

--- a/src/main/php/PHPMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateField.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -66,6 +67,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * method.
      *
      * @return AbstractNode[]
+     *
      * @throws OutOfBoundsException
      */
     protected function collectUnusedPrivateFields(ClassNode $class)
@@ -143,6 +145,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * Checks if the given node is a valid property node.
      *
      * @return bool
+     *
      * @since 0.2.6
      */
     protected function isValidPropertyNode(ASTNode $node = null)
@@ -170,6 +173,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * instance or static reference to the given class.
      *
      * @return bool
+     *
      * @throws OutOfBoundsException
      */
     protected function isInScopeOfClass(ClassNode $class, ASTNode $postfix)
@@ -188,7 +192,9 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * Looks for owner of the given variable.
      *
      * @param ASTNode<ASTPropertyPostfix> $postfix
+     *
      * @return AbstractNode
+     *
      * @throws OutOfBoundsException
      */
     protected function getOwner(ASTNode $postfix)

--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -53,6 +54,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * as private and are not used in the same class' context.
      *
      * @return array<string, MethodNode>
+     *
      * @throws OutOfBoundsException
      */
     protected function collectUnusedPrivateMethods(ClassNode $class)
@@ -102,7 +104,9 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * This method removes all used methods from the given methods array.
      *
      * @param array<string, MethodNode> $methods
+     *
      * @return array<string, MethodNode>
+     *
      * @throws OutOfBoundsException
      */
     protected function removeUsedMethods(ClassNode $class, array $methods)
@@ -117,7 +121,9 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * $this->privateMethod() makes "privateMethod" marked as used as an explicit call.
      *
      * @param array<string, MethodNode> $methods
+     *
      * @return array<string, MethodNode>
+     *
      * @throws OutOfBoundsException
      */
     protected function removeExplicitCalls(ClassNode $class, array $methods)
@@ -135,7 +141,9 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * [$this 'privateMethod'] makes "privateMethod" marked as used as very likely to be used as a callable value.
      *
      * @param array<string, MethodNode> $methods
+     *
      * @return array<string, MethodNode>
+     *
      * @throws OutOfBoundsException
      */
     protected function removeCallableArrayRepresentations(ClassNode $class, array $methods)
@@ -159,6 +167,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * and that the second one is a literal static string.
      *
      * @return string|null
+     *
      * @throws OutOfBoundsException
      */
     protected function getMethodNameFromArraySecondElement(AbstractNode $parent)
@@ -185,6 +194,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * instance or static reference to the given class.
      *
      * @return bool
+     *
      * @throws OutOfBoundsException
      */
     protected function isClassScope(ClassNode $class, ASTNode $postfix)

--- a/src/main/php/PHPMD/RuleByNameNotFoundException.php
+++ b/src/main/php/PHPMD/RuleByNameNotFoundException.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/main/php/PHPMD/RuleSet.php
+++ b/src/main/php/PHPMD/RuleSet.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -188,6 +189,7 @@ class RuleSet implements IteratorAggregate
      * This method returns a rule by its name or throws an exception
      *
      * @param string $name The name of the rule to get.
+     *
      * @throws RuleByNameNotFoundException When the rule could not be found.
      */
     public function getRuleByName(string $name): Rule

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -33,6 +34,7 @@ class RuleSetFactory
      * Is the strict mode active?
      *
      * @var bool
+     *
      * @since 1.2.0
      */
     private $strict = false;
@@ -100,7 +102,9 @@ class RuleSetFactory
      * Creates an array of rule-set instances for the given argument.
      *
      * @param string $ruleSetFileNames Comma-separated string of rule-set filenames or identifier.
+     *
      * @return RuleSet[]
+     *
      * @throws RuntimeException
      */
     public function createRuleSets($ruleSetFileNames)
@@ -121,7 +125,9 @@ class RuleSetFactory
      * Creates a single rule-set instance for the given filename or identifier.
      *
      * @param string $ruleSetOrFileName The rule-set filename or identifier.
+     *
      * @return RuleSet
+     *
      * @throws RuleSetNotFoundException
      * @throws RuntimeException
      */
@@ -150,7 +156,9 @@ class RuleSetFactory
      * the input when it is already a filename.
      *
      * @param string $ruleSetOrFileName The rule-set filename or identifier.
+     *
      * @return string Path to rule set file name
+     *
      * @throws RuleSetNotFoundException Thrown if no readable file found
      */
     private function createRuleSetFileName($ruleSetOrFileName)
@@ -168,6 +176,7 @@ class RuleSetFactory
      * Lists available rule-set identifiers in given directory.
      *
      * @param string $directory The directory to scan for rule-sets.
+     *
      * @return string[]
      */
     private static function listRuleSetsInDirectory($directory)
@@ -189,7 +198,9 @@ class RuleSetFactory
      * This method parses the rule-set definition in the given file.
      *
      * @param string $fileName
+     *
      * @return RuleSet
+     *
      * @throws RuntimeException When loading the XML file fails.
      */
     private function parseRuleSetNode($fileName)
@@ -285,7 +296,9 @@ class RuleSetFactory
      * Parses a rule-set xml file referenced by the given rule-set xml element.
      *
      * @return RuleSet
+     *
      * @throws RuntimeException
+     *
      * @since 0.2.3
      */
     private function parseRuleSetReference(SimpleXMLElement $ruleSetNode)
@@ -302,6 +315,7 @@ class RuleSetFactory
      * reference node.
      *
      * @return bool
+     *
      * @since 0.2.3
      */
     private function isIncluded(Rule $rule, SimpleXMLElement $ruleSetNode)
@@ -480,6 +494,7 @@ class RuleSetFactory
      * contains the value as character data.
      *
      * @return string
+     *
      * @since 0.2.5
      */
     private function getPropertyValue(SimpleXMLElement $propertyNode)
@@ -497,7 +512,9 @@ class RuleSetFactory
      * http://pmd.sourceforge.net/pmd-5.0.4/howtomakearuleset.html#Excluding_files_from_a_ruleset
      *
      * @param string $fileName The filename of a rule-set definition.
+     *
      * @return array|null
+     *
      * @throws RuntimeException Thrown if file is not proper xml
      */
     public function getIgnorePattern($fileName)
@@ -537,6 +554,7 @@ class RuleSetFactory
      * and is readable by current user
      *
      * @param string $filePath File path to check against
+     *
      * @return bool True if file exists and is readable, false otherwise
      */
     private function isReadableFile($filePath)
@@ -548,6 +566,7 @@ class RuleSetFactory
      * Returns list of possible file paths to search against code rules
      *
      * @param string $fileName Rule set file name
+     *
      * @return array Array of possible file locations
      */
     private function filePaths($fileName)

--- a/src/main/php/PHPMD/RuleViolation.php
+++ b/src/main/php/PHPMD/RuleViolation.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -65,7 +66,7 @@ class RuleViolation
      * Constructs a new rule violation instance.
      *
      * @param array|string $violationMessage
-     * @param ?numeric $metric
+     * @param ?numeric     $metric
      */
     public function __construct(Rule $rule, NodeInfo $nodeInfo, $violationMessage, $metric = null)
     {

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -12,6 +12,7 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link      http://phpmd.org/
  */
 
@@ -73,6 +74,7 @@ class Command
      * even if any violation or error is found.
      *
      * @return int
+     *
      * @throws InvalidArgumentException
      * @throws RuntimeException
      * @throws LogicException
@@ -205,7 +207,9 @@ class Command
      * value can be used as exit code.
      *
      * @param string[] $args The raw command line arguments array.
+     *
      * @return int
+     *
      * @throws RuntimeException
      */
     public static function main(array $args)

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -12,6 +12,7 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link      http://phpmd.org/
  */
 
@@ -146,6 +147,7 @@ class CommandLineOptions
      * Should PHPMD run in strict mode?
      *
      * @var bool
+     *
      * @since 1.2.0
      */
     protected $strict = false;
@@ -157,6 +159,7 @@ class CommandLineOptions
      * Should PHPMD exit without error code even if error is found?
      *
      * @var bool
+     *
      * @since 2.10.0
      */
     protected $ignoreErrorsOnExit = false;
@@ -177,6 +180,7 @@ class CommandLineOptions
 
     /**
      * Should PHPMD baseline the existing violations and write them to the $baselineFile
+     *
      * @var string allowed modes: NONE, GENERATE or UPDATE
      */
     protected $generateBaseline = BaselineMode::NONE;
@@ -184,24 +188,28 @@ class CommandLineOptions
     /**
      * The baseline source file to read the baseline violations from.
      * Defaults to the path of the (first) ruleset file as phpmd.baseline.xml
+     *
      * @var string|null
      */
     protected $baselineFile;
 
     /**
      * Should PHPMD read or write the result cache state from the cache file
+     *
      * @var bool
      */
     protected $cacheEnabled = false;
 
     /**
      * If set the path to read and write the result cache state from and to.
+     *
      * @var string|null
      */
     protected $cacheFile;
 
     /**
      * If set determine the cache strategy. Either `content` or `timestamp`. Defaults to `content`.
+     *
      * @var string|null
      */
     protected $cacheStrategy;
@@ -215,6 +223,7 @@ class CommandLineOptions
 
     /**
      * Specify how many extra lines are added to a code snippet
+     *
      * @var int|null
      */
     protected $extraLineInExcerpt;
@@ -224,6 +233,7 @@ class CommandLineOptions
      *
      * @param string[] $args
      * @param string[] $availableRuleSets
+     *
      * @throws InvalidArgumentException
      */
     public function __construct(array $args, array $availableRuleSets = [])
@@ -538,6 +548,7 @@ class CommandLineOptions
      * Was the <b>--strict</b> option passed to PHPMD's command line interface?
      *
      * @return bool
+     *
      * @since 1.2.0
      */
     public function hasStrict()
@@ -612,6 +623,7 @@ class CommandLineOptions
      * Was the <b>--ignore-errors-on-exit</b> passed to PHPMD's command line interface?
      *
      * @return bool
+     *
      * @since 2.10.0
      */
     public function ignoreErrorsOnExit()
@@ -651,7 +663,9 @@ class CommandLineOptions
      * </ul>
      *
      * @param string $reportFormat
+     *
      * @return AbstractRenderer
+     *
      * @throws InvalidArgumentException When the specified renderer does not exist.
      */
     public function createRenderer($reportFormat = null)
@@ -671,7 +685,9 @@ class CommandLineOptions
 
     /**
      * @param string $reportFormat
+     *
      * @return AbstractRenderer
+     *
      * @throws InvalidArgumentException When the specified renderer does not exist.
      */
     protected function createRendererWithoutOptions($reportFormat = null)
@@ -776,6 +792,7 @@ class CommandLineOptions
 
     /**
      * @return AbstractRenderer
+     *
      * @throws InvalidArgumentException
      */
     protected function createCustomRenderer()
@@ -913,8 +930,11 @@ class CommandLineOptions
      * exception.
      *
      * @param string $inputFile Specified input file name.
+     *
      * @return string
+     *
      * @throws InvalidArgumentException If the specified input file does not exist.
+     *
      * @since 1.1.0
      */
     protected function readInputFile($inputFile)

--- a/src/main/php/PHPMD/Utility/ExceptionsList.php
+++ b/src/main/php/PHPMD/Utility/ExceptionsList.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -71,6 +72,7 @@ class ExceptionsList implements IteratorAggregate, ArrayAccess
      * Gets array of exceptions from property
      *
      * @return array<string, int>
+     *
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */

--- a/src/main/php/PHPMD/Utility/Paths.php
+++ b/src/main/php/PHPMD/Utility/Paths.php
@@ -11,6 +11,7 @@ class Paths
      *
      * @param string $basePath
      * @param string $filePath
+     *
      * @return string
      */
     public static function getRelativePath($basePath, $filePath)
@@ -32,6 +33,7 @@ class Paths
      *
      * @param string $pathA
      * @param string $pathB
+     *
      * @return string
      */
     public static function concat($pathA, $pathB)
@@ -41,8 +43,11 @@ class Paths
 
     /**
      * Get the realpath of the given path or exception on failure
+     *
      * @param string $path
+     *
      * @return string
+     *
      * @throws RuntimeException
      */
     public static function getRealPath($path)

--- a/src/main/php/PHPMD/Utility/Strings.php
+++ b/src/main/php/PHPMD/Utility/Strings.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -27,8 +28,9 @@ class Strings
     /**
      * Returns the length of the given string, excluding at most one suffix
      *
-     * @param string $stringName String to calculate the length for.
-     * @param array $subtractSuffixes List of suffixes to exclude from the calculated length.
+     * @param string $stringName       String to calculate the length for.
+     * @param array  $subtractSuffixes List of suffixes to exclude from the calculated length.
+     *
      * @return int The length of the string, without suffix, if applicable.
      */
     public static function lengthWithoutSuffixes($stringName, array $subtractSuffixes)
@@ -39,9 +41,10 @@ class Strings
     /**
      * Returns the length of the given string, excluding at most one suffix
      *
-     * @param string $stringName String to calculate the length for.
-     * @param array $subtractPrefixes List of prefixes to exclude from the calculated length.
-     * @param array $subtractSuffixes List of suffixes to exclude from the calculated length.
+     * @param string $stringName       String to calculate the length for.
+     * @param array  $subtractPrefixes List of prefixes to exclude from the calculated length.
+     * @param array  $subtractSuffixes List of suffixes to exclude from the calculated length.
+     *
      * @return int The length of the string, without suffix, if applicable.
      */
     public static function lengthWithoutPrefixesAndSuffixes(
@@ -75,9 +78,11 @@ class Strings
      * Split a string with the given separator, trim whitespaces around the parts and remove any empty strings
      *
      * @param string $listAsString The string to split.
-     * @param string $separator The separator to split the string with, similar to explode.
-     * @param string $trim Extra character to be trimmed off of each value.
+     * @param string $separator    The separator to split the string with, similar to explode.
+     * @param string $trim         Extra character to be trimmed off of each value.
+     *
      * @return array The list of trimmed and filtered parts of the string.
+     *
      * @throws InvalidArgumentException When the separator is an empty string.
      */
     public static function splitToList($listAsString, $separator = ',', $trim = '')
@@ -100,6 +105,7 @@ class Strings
      *
      * @param string $value
      * @param string $trim
+     *
      * @return string
      */
     public static function trim($value, $trim = '')

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -36,6 +37,7 @@ class StreamWriter extends AbstractWriter
      * Constructs a new stream writer instance.
      *
      * @param resource|string $streamResourceOrUri
+     *
      * @throws RuntimeException If the output directory cannot be found.
      */
     public function __construct($streamResourceOrUri)

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -106,6 +107,7 @@ abstract class AbstractStaticTestCase extends TestCase
      * Returns the absolute path for a test resource for the current test.
      *
      * @return string
+     *
      * @since 1.1.0
      */
     protected static function createCodeResourceUriForTest()
@@ -119,6 +121,7 @@ abstract class AbstractStaticTestCase extends TestCase
      * Convert [1, 'a', $any] into [[1], ['a'], [$any]].
      *
      * @param mixed $values list of values.
+     *
      * @return array
      */
     protected static function getValuesAsArrays($values)
@@ -130,7 +133,9 @@ abstract class AbstractStaticTestCase extends TestCase
      * Returns the absolute path for a test resource for the current test.
      *
      * @param string $localPath The local/relative file location
+     *
      * @return string
+     *
      * @since 1.1.0
      */
     protected static function createResourceUriForTest($localPath)
@@ -143,8 +148,9 @@ abstract class AbstractStaticTestCase extends TestCase
     /**
      * Asserts the actual xml output matches against the expected file.
      *
-     * @param string $actualOutput Generated xml output.
+     * @param string $actualOutput     Generated xml output.
      * @param string $expectedFileName File with expected xml result.
+     *
      * @return void
      */
     public static function assertXmlEquals($actualOutput, $expectedFileName)
@@ -175,8 +181,8 @@ abstract class AbstractStaticTestCase extends TestCase
     /**
      * Asserts the actual JSON output matches against the expected file.
      *
-     * @param string $actualOutput Generated JSON output.
-     * @param string $expectedFileName File with expected JSON result.
+     * @param string       $actualOutput        Generated JSON output.
+     * @param string       $expectedFileName    File with expected JSON result.
      * @param bool|Closure $removeDynamicValues If set to `false`, the actual output is not normalized,
      *                                          if set to a closure, the closure is applied on the actual output array.
      *
@@ -216,6 +222,7 @@ abstract class AbstractStaticTestCase extends TestCase
      * Changes the working directory for a single test.
      *
      * @param string $localPath The temporary working directory.
+     *
      * @return void
      */
     protected static function changeWorkingDirectory($localPath = '')
@@ -232,6 +239,7 @@ abstract class AbstractStaticTestCase extends TestCase
      * Creates a full filename for a test content in the <em>_files</b> directory.
      *
      * @param string $localPath
+     *
      * @return string
      */
     protected static function createFileUri($localPath = '')
@@ -243,6 +251,7 @@ abstract class AbstractStaticTestCase extends TestCase
      * Creates a file uri for a temporary test file.
      *
      * @param string|null $fileName
+     *
      * @return string
      */
     protected static function createTempFileUri($fileName = null)
@@ -259,6 +268,7 @@ abstract class AbstractStaticTestCase extends TestCase
      * Returns the trace frame of the calling test case.
      *
      * @return array
+     *
      * @throws ErrorException
      */
     protected static function getCallingTestCase()

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -216,7 +217,9 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Returns the first method or function node for a given test file.
      *
      * @param string $file
+     *
      * @return FunctionNode|MethodNode
+     *
      * @since 2.8.3
      */
     protected function getNodeForTestFile($file)
@@ -247,10 +250,12 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Rethrows the PHPUnit ExpectationFailedException with the base name
      * of the file for better readability.
      *
-     * @param Rule $rule Rule to test.
-     * @param int $expectedInvokes Count of expected invocations.
-     * @param string $file Test file containing a method with the same name to be tested.
+     * @param Rule   $rule            Rule to test.
+     * @param int    $expectedInvokes Count of expected invocations.
+     * @param string $file            Test file containing a method with the same name to be tested.
+     *
      * @return void
+     *
      * @throws ExpectationFailedException
      */
     protected function expectRuleHasViolationsForFile(Rule $rule, $expectedInvokes, $file)
@@ -276,9 +281,9 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Return a human-friendly failure message for a given list of violations and the actual/expected counts.
      *
-     * @param string $file
-     * @param int $expectedInvokes
-     * @param int $actualInvokes
+     * @param string                     $file
+     * @param int                        $expectedInvokes
+     * @param int                        $actualInvokes
      * @param array|iterable|Traversable $violations
      *
      * @return string
@@ -299,6 +304,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Return a human-friendly summary for a list of violations.
      *
      * @param array|iterable|Traversable $violations
+     *
      * @return string
      */
     protected function getViolationsSummary($violations)
@@ -327,6 +333,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Returns the absolute path for a test resource for the current test.
      *
      * @return string
+     *
      * @since 1.1.0
      */
     protected static function createCodeResourceUriForTest()
@@ -340,7 +347,9 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Returns the absolute path for a test resource for the current test.
      *
      * @param string $localPath The local/relative file location
+     *
      * @return string
+     *
      * @since 1.1.0
      */
     protected static function createResourceUriForTest($localPath)
@@ -354,6 +363,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Return URI for a given pattern with directory based on the current called class name.
      *
      * @param string $pattern
+     *
      * @return string
      */
     protected static function createResourceUriForCalledClass($pattern)
@@ -365,6 +375,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Return list of files matching a given pattern with directory based on the current called class name.
      *
      * @param string $pattern
+     *
      * @return string[]
      */
     protected static function getFilesForCalledClass($pattern = '*')
@@ -376,7 +387,8 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Creates a mocked class node instance.
      *
      * @param string $metric
-     * @param int $value
+     * @param int    $value
+     *
      * @return ClassNode
      */
     protected function getClassMock($metric = null, $value = null)
@@ -400,7 +412,8 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Creates a mocked method node instance.
      *
      * @param string $metric
-     * @param int $value
+     * @param int    $value
+     *
      * @return MethodNode
      */
     protected function getMethodMock($metric = null, $value = null)
@@ -412,7 +425,8 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Creates a mocked function node instance.
      *
      * @param string $metric The metric acronym used by PHP_Depend.
-     * @param mixed $value The expected metric return value.
+     * @param mixed  $value  The expected metric return value.
+     *
      * @return FunctionNode
      */
     protected function createFunctionMock($metric = null, $value = null)
@@ -429,7 +443,8 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Initializes the getMetric() method of the given function or method node.
      *
      * @param FunctionNode|MethodNode|PHPUnit_Framework_MockObject_MockObject $mock
-     * @param string $metric
+     * @param string                                                          $metric
+     *
      * @return FunctionNode|MethodNode
      */
     protected function initFunctionOrMethod($mock, $metric, $value)
@@ -450,6 +465,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Creates a mocked report instance.
      *
      * @param int $expectedInvokes Number of expected invokes.
+     *
      * @return PHPUnit_Framework_MockObject_MockObject|Report
      */
     protected function getReportMock($expectedInvokes = -1)
@@ -523,8 +539,9 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Creates a mocked rule-set instance.
      *
-     * @param string $expectedClass Optional class name for apply() expected at least once.
-     * @param int|string $count How often should apply() be called?
+     * @param string     $expectedClass Optional class name for apply() expected at least once.
+     * @param int|string $count         How often should apply() be called?
+     *
      * @return MockObject|RuleSet
      */
     protected function getRuleSetMock($expectedClass = null, $count = '*')
@@ -552,11 +569,12 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Creates a mocked rule violation instance.
      *
-     * @param string $fileName The filename to use.
-     * @param int $beginLine The begin of violation line number to use.
-     * @param int $endLine The end of violation line number to use.
-     * @param object|null $rule The rule object to use.
+     * @param string      $fileName    The filename to use.
+     * @param int         $beginLine   The begin of violation line number to use.
+     * @param int         $endLine     The end of violation line number to use.
+     * @param object|null $rule        The rule object to use.
      * @param string|null $description The violation description to use.
+     *
      * @return MockObject
      */
     protected function getRuleViolationMock(
@@ -608,6 +626,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      *
      * @param string $file
      * @param string $message
+     *
      * @return MockObject|ProcessingError
      */
     protected function getErrorMock(
@@ -643,10 +662,11 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     }
 
     /**
-     * @param string $mockBuilder
+     * @param string                $mockBuilder
      * @param ASTFunction|ASTMethod $mock
-     * @param string $metric The metric acronym used by PHP_Depend.
-     * @param mixed $value The expected metric return value.
+     * @param string                $metric      The metric acronym used by PHP_Depend.
+     * @param mixed                 $value       The expected metric return value.
+     *
      * @return FunctionNode|MethodNode
      */
     private function createFunctionOrMethodMock($mockBuilder, $mock, $metric = null, $value = null)
@@ -665,6 +685,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Returns the PHP_Depend node having the given name.
      *
      * @return PHP_Depend_Code_AbstractItem
+     *
      * @throws ErrorException
      */
     private function getNodeByName(Iterator $nodes, $name)
@@ -681,6 +702,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Returns the PHP_Depend node for the calling test case.
      *
      * @return PHP_Depend_Code_AbstractItem
+     *
      * @throws ErrorException
      */
     private function getNodeForCallingTestCase(Iterator $nodes)
@@ -695,7 +717,9 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * in that file.
      *
      * @param string $sourceFile
+     *
      * @return ASTNamespace
+     *
      * @throws ErrorException
      */
     private function parseSource($sourceFile)

--- a/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
@@ -8,6 +8,7 @@ use RuntimeException;
 
 /**
  * @coversDefaultClass \PHPMD\Baseline\BaselineFileFinder
+ *
  * @covers ::__construct
  */
 class BaselineFileFinderTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @coversDefaultClass \PHPMD\Baseline\BaselineValidator
+ *
  * @covers ::__construct
  */
 class BaselineValidatorTest extends AbstractTestCase
@@ -40,7 +41,9 @@ class BaselineValidatorTest extends AbstractTestCase
      * @param bool   $contains
      * @param string $baselineMode
      * @param bool   $isBaselined
+     *
      * @dataProvider dataProvider
+     *
      * @covers ::isBaselined
      */
     public function testIsBaselined($contains, $baselineMode, $isBaselined)

--- a/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
+++ b/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
@@ -23,6 +23,7 @@ class ViolationBaselineTest extends TestCase
      * Test the give file matches the baseline correctly
      *
      * @return void
+     *
      * @covers ::__construct
      * @covers ::matches
      */
@@ -39,6 +40,7 @@ class ViolationBaselineTest extends TestCase
      * Test the give file matches the baseline correctly
      *
      * @return void
+     *
      * @covers ::__construct
      * @covers ::matches
      */

--- a/src/test/php/PHPMD/Cache/Model/ResultCacheKeyTest.php
+++ b/src/test/php/PHPMD/Cache/Model/ResultCacheKeyTest.php
@@ -6,6 +6,7 @@ use PHPMD\AbstractTestCase;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\Model\ResultCacheKey
+ *
  * @covers ::__construct
  */
 class ResultCacheKeyTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
+++ b/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\Model\ResultCacheState
+ *
  * @covers ::__construct
  */
 class ResultCacheStateTest extends TestCase

--- a/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
@@ -13,6 +13,7 @@ use ReflectionProperty;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheEngineFactory
+ *
  * @covers ::__construct
  */
 class ResultCacheEngineFactoryTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Cache/ResultCacheEngineTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheEngineTest.php
@@ -6,6 +6,7 @@ use PHPMD\AbstractTestCase;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheEngine
+ *
  * @covers ::__construct
  */
 class ResultCacheEngineTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
@@ -11,6 +11,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheFileFilter
+ *
  * @covers ::__construct
  */
 class ResultCacheFileFilterTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
@@ -9,6 +9,7 @@ use PHPMD\RuleSet;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheKeyFactory
+ *
  * @covers ::__construct
  */
 class ResultCacheKeyFactoryTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
@@ -10,6 +10,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheUpdater
+ *
  * @covers ::__construct
  */
 class ResultCacheUpdaterTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Cache/ResultCacheWriterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheWriterTest.php
@@ -9,6 +9,7 @@ use PHPMD\Cache\Model\ResultCacheState;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheWriter
+ *
  * @covers ::__construct
  */
 class ResultCacheWriterTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Console/OutputTest.php
+++ b/src/test/php/PHPMD/Console/OutputTest.php
@@ -6,6 +6,7 @@ use PHPMD\AbstractTestCase;
 
 /**
  * @coversDefaultClass  \PHPMD\Console\Output
+ *
  * @covers ::__construct
  */
 class OutputTest extends AbstractTestCase
@@ -21,6 +22,7 @@ class OutputTest extends AbstractTestCase
 
     /**
      * @return void
+     *
      * @covers ::getVerbosity
      * @covers ::setVerbosity
      */
@@ -35,6 +37,7 @@ class OutputTest extends AbstractTestCase
 
     /**
      * @return void
+     *
      * @covers ::write
      */
     public function testWriteSingleMessage()
@@ -47,6 +50,7 @@ class OutputTest extends AbstractTestCase
 
     /**
      * @return void
+     *
      * @covers ::write
      */
     public function testWriteMultiMessageWithNewline()
@@ -61,7 +65,9 @@ class OutputTest extends AbstractTestCase
      * @param int    $verbosity
      * @param string $expected
      * @param string $msg
+     *
      * @dataProvider verbosityProvider
+     *
      * @covers ::write
      */
     public function testWriteWithVerbosityOption($verbosity, $expected, $msg)
@@ -109,6 +115,7 @@ class OutputTest extends AbstractTestCase
 
     /**
      * @return void
+     *
      * @covers ::writeln
      */
     public function testWritelnMessage()

--- a/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
+++ b/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -31,6 +32,7 @@ class CommandLineInputFileOptionTest extends AbstractTestCase
      * testReportContainsExpectedRuleViolationWarning
      *
      * @return void
+     *
      * @outputBuffering enabled
      */
     public function testReportContainsExpectedRuleViolationWarning()
@@ -45,6 +47,7 @@ class CommandLineInputFileOptionTest extends AbstractTestCase
      * testReportNotContainsRuleViolationWarningForFileNotInList
      *
      * @return void
+     *
      * @outputBuffering enabled
      */
     public function testReportNotContainsRuleViolationWarningForFileNotInList()

--- a/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -31,6 +32,7 @@ class CouplingBetweenObjectsIntegrationTest extends AbstractTestCase
      * testReportContainsCouplingBetweenObjectsWarning
      *
      * @return void
+     *
      * @outputBuffering enabled
      */
     public function testReportContainsCouplingBetweenObjectsWarning()

--- a/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -31,6 +32,7 @@ class GotoStatementIntegrationTest extends AbstractTestCase
      * testReportContainsGotoStatementWarning
      *
      * @return void
+     *
      * @outputBuffering enabled
      */
     public function testReportContainsGotoStatementWarning()

--- a/src/test/php/PHPMD/Node/ASTNodeTest.php
+++ b/src/test/php/PHPMD/Node/ASTNodeTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Node/AnnotationTest.php
+++ b/src/test/php/PHPMD/Node/AnnotationTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Node/AnnotationsTest.php
+++ b/src/test/php/PHPMD/Node/AnnotationsTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Node/ClassNodeTest.php
+++ b/src/test/php/PHPMD/Node/ClassNodeTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Node/FunctionTest.php
+++ b/src/test/php/PHPMD/Node/FunctionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Node/InterfaceNodeTest.php
+++ b/src/test/php/PHPMD/Node/InterfaceNodeTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -159,6 +160,7 @@ class MethodNodeTest extends AbstractTestCase
      * testIsDeclarationReturnsTrueForMethodDeclaration
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testIsDeclarationReturnsTrueForMethodDeclaration()
@@ -171,6 +173,7 @@ class MethodNodeTest extends AbstractTestCase
      * testIsDeclarationReturnsTrueForMethodDeclarationWithParent
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testIsDeclarationReturnsTrueForMethodDeclarationWithParent()
@@ -183,6 +186,7 @@ class MethodNodeTest extends AbstractTestCase
      * testIsDeclarationReturnsFalseForInheritMethodDeclaration
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testIsDeclarationReturnsFalseForInheritMethodDeclaration()
@@ -195,6 +199,7 @@ class MethodNodeTest extends AbstractTestCase
      * testIsDeclarationReturnsFalseForImplementedAbstractMethod
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testIsDeclarationReturnsFalseForImplementedAbstractMethod()
@@ -207,6 +212,7 @@ class MethodNodeTest extends AbstractTestCase
      * testIsDeclarationReturnsFalseForImplementedInterfaceMethod
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testIsDeclarationReturnsFalseForImplementedInterfaceMethod()

--- a/src/test/php/PHPMD/Node/TraitNodeTest.php
+++ b/src/test/php/PHPMD/Node/TraitNodeTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -12,6 +12,7 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link      http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/ParserFactoryTest.php
+++ b/src/test/php/PHPMD/ParserFactoryTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/ParserTest.php
+++ b/src/test/php/PHPMD/ParserTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -134,6 +135,7 @@ class ParserTest extends AbstractTestCase
      * testParserStoreParsingExceptionsInReport
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testParserStoreParsingExceptionsInReport()
@@ -204,6 +206,7 @@ class ParserTest extends AbstractTestCase
      * Creates a mocked PHP_Depend function instance.
      *
      * @param string $fileName Optional file name for the source file.
+     *
      * @return PHP_Depend_Code_Function
      */
     protected function getPHPDependFunctionMock($fileName = '/foo/bar.php')
@@ -223,6 +226,7 @@ class ParserTest extends AbstractTestCase
      * Creates a mocked PHP_Depend method instance.
      *
      * @param string $fileName Optional file name for the source file.
+     *
      * @return PHP_Depend_Code_CodeMethod
      */
     protected function getPHPDependMethodMock($fileName = '/foo/bar.php')
@@ -242,6 +246,7 @@ class ParserTest extends AbstractTestCase
      * Creates a mocked PHP_Depend file instance.
      *
      * @param string $fileName The temporary file name.
+     *
      * @return PHP_Depend_Code_File
      */
     protected function getPHPDependFileMock($fileName)

--- a/src/test/php/PHPMD/ProcessingErrorTest.php
+++ b/src/test/php/PHPMD/ProcessingErrorTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -21,6 +22,7 @@ namespace PHPMD;
  * Test case for the processing error class.
  *
  * @covers \PHPMD\ProcessingError
+ *
  * @since 1.2.1
  */
 class ProcessingErrorTest extends AbstractTestCase
@@ -41,7 +43,9 @@ class ProcessingErrorTest extends AbstractTestCase
      * a given exception message,
      *
      * @param string $message The original exception message
+     *
      * @return void
+     *
      * @dataProvider getParserExceptionMessages
      */
     public function testGetFileReturnsExpectedFileName($message)

--- a/src/test/php/PHPMD/Regression/AbstractRegressionTestCase.php
+++ b/src/test/php/PHPMD/Regression/AbstractRegressionTestCase.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -28,6 +29,7 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      * Creates a full filename for a test content in the <em>_files</b> directory.
      *
      * @param string $localPath The local path within the <em>_files</b> dir.
+     *
      * @return string
      */
     protected static function createFileUri($localPath = '')

--- a/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -35,6 +36,7 @@ class MaximumNestingLevelTicket24975295RegressionTest extends AbstractRegression
      * testLocalVariableUsedInDoubleQuoteStringGetsNotReported
      *
      * @return void
+     *
      * @outputBuffering enabled
      */
     public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported()

--- a/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
+++ b/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php
+++ b/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020RegressionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019RegressionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036RegressionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Regression/UnusedParameterArgvTicket14990109RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/UnusedParameterArgvTicket14990109RegressionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
@@ -10,6 +10,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * @coversDefaultClass \PHPMD\Renderer\BaselineRenderer
+ *
  * @covers ::__construct
  */
 class BaselineRendererTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Renderer/CheckStyleRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/CheckStyleRendererTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -70,6 +71,7 @@ class CheckStyleRendererTest extends AbstractTestCase
      * testRendererAddsProcessingErrorsToXmlReport
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testRendererAddsProcessingErrorsToXmlReport()

--- a/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
@@ -12,6 +12,7 @@
  * @author Lukas Bestle <project-phpmd@lukasbestle.com>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Renderer/GitLabRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/GitLabRendererTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Renderer/JSONRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/JSONRendererTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Renderer/SARIFRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/SARIFRendererTest.php
@@ -12,6 +12,7 @@
  * @author Lukas Bestle <project-phpmd@lukasbestle.com>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Renderer/XMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/XMLRendererTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -70,6 +71,7 @@ class XMLRendererTest extends AbstractTestCase
      * testRendererAddsProcessingErrorsToXmlReport
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testRendererAddsProcessingErrorsToXmlReport()

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -12,6 +12,7 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link      http://phpmd.org/
  */
 
@@ -143,6 +144,7 @@ class ReportTest extends AbstractTestCase
      * testHasErrorsReturnsFalseByDefault
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testHasErrorsReturnsFalseByDefault()
@@ -155,6 +157,7 @@ class ReportTest extends AbstractTestCase
      * testHasErrorsReturnsTrueWhenReportContainsAtLeastOneError
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testHasErrorsReturnsTrueWhenReportContainsAtLeastOneError()
@@ -169,6 +172,7 @@ class ReportTest extends AbstractTestCase
      * testGetErrorsReturnsEmptyIteratorByDefault
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testGetErrorsReturnsEmptyIteratorByDefault()
@@ -181,6 +185,7 @@ class ReportTest extends AbstractTestCase
      * testGetErrorsReturnsPreviousAddedProcessingError
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testGetErrorsReturnsPreviousAddedProcessingError()

--- a/src/test/php/PHPMD/Rule/CleanCode/BooleanArgumentFlagTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/BooleanArgumentFlagTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -43,7 +44,9 @@ class BooleanArgumentFlagTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
+     *
      * @return void
+     *
      * @dataProvider getApplyingCases
      */
     public function testRuleAppliesTo($file)
@@ -55,7 +58,9 @@ class BooleanArgumentFlagTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
+     *
      * @return void
+     *
      * @dataProvider getNotApplyingCases
      */
     public function testRuleDoesNotApplyTo($file)

--- a/src/test/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/CleanCode/ErrorControlOperatorTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/ErrorControlOperatorTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -30,6 +31,7 @@ class ErrorControlOperatorTest extends AbstractTestCase
      * Tests that the rule does not apply to unary operators in functions
      *
      * @return void
+     *
      * @covers ::apply
      */
     public function testDoesNotApplyToOtherUnaryOperatorsInFunction()
@@ -43,6 +45,7 @@ class ErrorControlOperatorTest extends AbstractTestCase
      * Tests that the rule applies error control operators to functions
      *
      * @return void
+     *
      * @covers ::apply
      */
     public function testAppliesToErrorControlOperatorInFunction()
@@ -56,6 +59,7 @@ class ErrorControlOperatorTest extends AbstractTestCase
      * Tests that the rule applies error control operators to classes and methods
      *
      * @return void
+     *
      * @covers ::apply
      */
     public function testAppliedToClassesAndMethods()

--- a/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -42,7 +43,9 @@ class MissingImportTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
+     *
      * @return void
+     *
      * @dataProvider getApplyingCases
      */
     public function testRuleAppliesTo($file)
@@ -57,7 +60,9 @@ class MissingImportTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
+     *
      * @return void
+     *
      * @dataProvider getNotApplyingCases
      */
     public function testRuleDoesNotApplyTo($file)
@@ -69,6 +74,7 @@ class MissingImportTest extends AbstractTestCase
      * Tests that it applies to a class that has fully qualified class names
      *
      * @return void
+     *
      * @covers ::apply
      * @covers ::isSelfReference
      */
@@ -83,6 +89,7 @@ class MissingImportTest extends AbstractTestCase
      * Tests that it does not apply to a class in root namespace when configured.
      *
      * @return void
+     *
      * @covers ::apply
      * @covers ::isGlobalNamespace
      */

--- a/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/CleanCode/UndefinedVariableTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/UndefinedVariableTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -40,7 +41,9 @@ class UndefinedVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
+     *
      * @return void
+     *
      * @dataProvider getApplyingCases
      */
     public function testRuleAppliesTo($file)
@@ -52,7 +55,9 @@ class UndefinedVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
+     *
      * @return void
+     *
      * @dataProvider getNotApplyingCases
      */
     public function testRuleDoesNotApplyTo($file)

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
@@ -6,9 +6,11 @@
  * Licensed under BSD License
  * For full copyright and license information, please see the LICENSE file.
  * Redistributions of files must retain the above copyright notice.
+ *
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link      http://phpmd.org/
  */
 
@@ -21,6 +23,7 @@ use PHPMD\Node\ClassNode;
 
 /**
  * Test case for the camel case class name rule.
+ *
  * @covers \PHPMD\Rule\Controversial\CamelCaseClassName
  */
 class CamelCaseClassNameTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -21,6 +22,7 @@ use PHPMD\AbstractTestCase;
 
 /**
  * Test case for the camel case namespace rule.
+ *
  * @covers \PHPMD\Rule\Controversial\CamelCaseNamespace
  */
 class CamelCaseNamespaceTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -23,6 +24,7 @@ use PHPMD\AbstractTestCase;
  * Test case for the {@link \PHPMD\Rule\Design\CouplingBetweenObjects} class.
  *
  * @covers \PHPMD\Rule\Design\CouplingBetweenObjects
+ *
  * @link https://www.pivotaltracker.com/story/show/10474987
  */
 class CouplingBetweenObjectsTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -23,6 +24,7 @@ use PHPMD\AbstractTestCase;
  * Test case for the {@link \PHPMD\Rule\Design\DevelopmentCodeFragment} class.
  *
  * @covers \PHPMD\Rule\Design\DevelopmentCodeFragment
+ *
  * @link https://github.com/phpmd/phpmd/issues/265
  * @since 2.3.0
  */

--- a/src/test/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
+++ b/src/test/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
+++ b/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -23,6 +24,7 @@ use PHPMD\AbstractTestCase;
  * Test case for the {@link \PHPMD\Rule\Design\GotoStatement} class.
  *
  * @covers \PHPMD\Rule\Design\GotoStatement
+ *
  * @link https://www.pivotaltracker.com/story/show/10474873
  */
 class GotoStatementTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Rule/Design/LongClassTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongClassTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -110,6 +111,7 @@ class LongParameterListTest extends AbstractTestCase
      * Returns a mocked method instance.
      *
      * @param int $parameterCount
+     *
      * @return MethodNode
      */
     private function createMethod($parameterCount)
@@ -133,7 +135,8 @@ class LongParameterListTest extends AbstractTestCase
      * Initializes the getParameterCount() method of the given callable.
      *
      * @param FunctionNode|MethodNode $mock
-     * @param int $parameterCount
+     * @param int                     $parameterCount
+     *
      * @return FunctionNode|MethodNode
      */
     private function initFunctionOrMethodMock($mock, $parameterCount)

--- a/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -164,8 +165,9 @@ class TooManyMethodsTest extends AbstractTestCase
     /**
      * Creates a prepared class node mock
      *
-     * @param int $numberOfMethods
+     * @param int      $numberOfMethods
      * @param string[] $methodNames
+     *
      * @return ClassNode
      */
     private function createClassMock($numberOfMethods, array $methodNames = null)

--- a/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -182,9 +183,10 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     /**
      * Creates a prepared class node mock
      *
-     * @param int $numberOfMethods
+     * @param int        $numberOfMethods
      * @param array|null $publicMethods
      * @param array|null $privateMethods
+     *
      * @return ClassNode
      */
     private function createClassMock($numberOfMethods, array $publicMethods = [], array $privateMethods = [])

--- a/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
+++ b/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -23,6 +24,7 @@ use PHPMD\AbstractTestCase;
  * Test case for the weighted method count rule.
  *
  * @covers \PHPMD\Rule\Design\WeightedMethodCount
+ *
  * @since 0.2.5
  */
 class WeightedMethodCountTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
+++ b/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Naming/LongClassNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/LongClassNameTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -275,6 +276,7 @@ class LongVariableTest extends AbstractTestCase
      * testRuleAppliesForLongPrivateProperty
      *
      * @return void
+     *
      * @since 1.1.0
      */
     public function testRuleAppliesForLongPrivateProperty()
@@ -289,6 +291,7 @@ class LongVariableTest extends AbstractTestCase
      * testRuleAppliesForLongPrivateStaticProperty
      *
      * @return void
+     *
      * @since 1.1.0
      */
     public function testRuleAppliesForLongPrivateStaticProperty()

--- a/src/test/php/PHPMD/Rule/Naming/ShortClassNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortClassNameTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -128,6 +129,7 @@ class ShortMethodNameTest extends AbstractTestCase
      * testRuleAlsoWorksWithoutExceptionListConfigured
      *
      * @return void
+     *
      * @link https://github.com/phpmd/phpmd/issues/80
      * @link https://github.com/phpmd/phpmd/issues/270
      * @since 2.2.2

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -363,6 +364,7 @@ class ShortVariableTest extends AbstractTestCase
      * testRuleAppliesToVariablesWithinForeach
      *
      * @return void
+     *
      * @dataProvider provideClassWithShortForeachVariables
      */
     public function testRuleAppliesToVariablesWithinForeach($allowShortVarInLoop, $expectedErrorsCount)

--- a/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -315,7 +316,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @return void
+     *
      * @since 2.0.0
      */
     public function testFuncGetArgsRuleWorksCaseInsensitive()
@@ -329,6 +332,7 @@ class UnusedFormalParameterTest extends AbstractTestCase
      * testRuleDoesNotApplyToInheritMethod
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testRuleDoesNotApplyToInheritMethod()
@@ -342,6 +346,7 @@ class UnusedFormalParameterTest extends AbstractTestCase
      * testRuleDoesNotApplyToImplementedAbstractMethod
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testRuleDoesNotApplyToImplementedAbstractMethod()
@@ -355,6 +360,7 @@ class UnusedFormalParameterTest extends AbstractTestCase
      * testRuleDoesNotApplyToImplementedInterfaceMethod
      *
      * @return void
+     *
      * @since 1.2.1
      */
     public function testRuleDoesNotApplyToImplementedInterfaceMethod()
@@ -403,7 +409,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @return void
+     *
      * @since 2.0.0
      */
     public function testCompactFunctionRuleDoesNotApply()
@@ -415,7 +423,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @return void
+     *
      * @since 2.0.0
      */
     public function testCompactFunctionRuleOnlyAppliesToUsedParameters()
@@ -427,7 +437,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @return void
+     *
      * @since 2.0.0
      */
     public function testCompactFunctionRuleWorksCaseInsensitive()
@@ -439,7 +451,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @return void
+     *
      * @since 2.0.1
      */
     public function testNamespacedCompactFunctionRuleDoesNotApply()
@@ -451,7 +465,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @return void
+     *
      * @since 2.0.1
      */
     public function testNamespacedCompactFunctionRuleOnlyAppliesToUsedParameters()
@@ -463,7 +479,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
+     *
      * @return void
+     *
      * @since 2.0.1
      */
     public function testNamespacedCompactFunctionRuleWorksCaseInsensitive()

--- a/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -31,6 +32,7 @@ class UnusedLocalVariableTest extends AbstractTestCase
      * Get the rule under test.
      *
      * @param string $file
+     *
      * @return UnusedLocalVariable
      */
     public function getRule($file)
@@ -57,7 +59,9 @@ class UnusedLocalVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
+     *
      * @return void
+     *
      * @dataProvider getApplyingCases
      */
     public function testRuleAppliesTo($file)
@@ -69,7 +73,9 @@ class UnusedLocalVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
+     *
      * @return void
+     *
      * @dataProvider getNotApplyingCases
      */
     public function testRuleDoesNotApplyTo($file)

--- a/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -564,6 +565,7 @@ class RuleSetFactoryTest extends AbstractTestCase
      * identifier.
      *
      * @return void
+     *
      * @covers \PHPMD\Exception\RuleSetNotFoundException
      */
     public function testCreateRuleSetsThrowsExceptionForInvalidIdentifier()
@@ -580,6 +582,7 @@ class RuleSetFactoryTest extends AbstractTestCase
      * for the configured rule does not exist.
      *
      * @return void
+     *
      * @covers \PHPMD\Exception\RuleClassFileNotFoundException
      */
     public function testCreateRuleSetsThrowsExceptionWhenClassFileNotInIncludePath()
@@ -599,6 +602,7 @@ class RuleSetFactoryTest extends AbstractTestCase
      * cannot be found.
      *
      * @return void
+     *
      * @covers \PHPMD\Exception\RuleClassNotFoundException
      */
     public function testCreateRuleSetThrowsExceptionWhenFileNotContainsClass()
@@ -617,6 +621,7 @@ class RuleSetFactoryTest extends AbstractTestCase
      * cannot be found.
      *
      * @return void
+     *
      * @covers \PHPMD\Exception\RuleClassNotFoundException
      */
     public function testCreateRuleSetsThrowsExpectedExceptionForInvalidXmlFile()
@@ -652,6 +657,7 @@ class RuleSetFactoryTest extends AbstractTestCase
      * reference-by-includepath and explicit-classfile-declaration works.
      *
      * @return void
+     *
      * @throws Exception
      */
     public function testAddPHPIncludePath()
@@ -685,6 +691,7 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Checks if PHPMD doesn't treat directories named as code rule as files
      *
      * @return void
+     *
      * @link https://github.com/phpmd/phpmd/issues/47
      */
     public function testIfGettingRuleFilePathExcludeUnreadablePaths()
@@ -717,7 +724,9 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Checks the ruleset XML files provided with PHPMD all provide externalInfoUrls
      *
      * @param string $file The path to the ruleset xml to test
+     *
      * @return void
+     *
      * @dataProvider getDefaultRuleSets
      */
     public function testDefaultRuleSetsProvideExternalInfoUrls($file)
@@ -749,7 +758,8 @@ class RuleSetFactoryTest extends AbstractTestCase
      * class.
      *
      * @param string $files At least one rule configuration file name. You can
-     *        also pass multiple parameters with ruleset configuration files.
+     *                      also pass multiple parameters with ruleset configuration files.
+     *
      * @return \PHPMD\RuleSet[]
      */
     private function createRuleSetsFromAbsoluteFiles(string ...$files)
@@ -764,8 +774,10 @@ class RuleSetFactoryTest extends AbstractTestCase
      * class.
      *
      * @param string $file At least one rule configuration file name. You can
-     *        also pass multiple parameters with ruleset configuration files.
+     *                     also pass multiple parameters with ruleset configuration files.
+     *
      * @return \PHPMD\RuleSet[]
+     *
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
      */
     private function createRuleSetsFromFiles($file)

--- a/src/test/php/PHPMD/RuleSetTest.php
+++ b/src/test/php/PHPMD/RuleSetTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -30,6 +31,7 @@ class RuleTest extends AbstractTestCase
      * testGetBooleanPropertyReturnsTrueForStringValue1
      *
      * @return void
+     *
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
@@ -46,6 +48,7 @@ class RuleTest extends AbstractTestCase
      * testGetBooleanPropertyReturnsTrueForStringValueOn
      *
      * @return void
+     *
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
@@ -62,6 +65,7 @@ class RuleTest extends AbstractTestCase
      * testGetBooleanPropertyReturnsTrueForStringValueTrue
      *
      * @return void
+     *
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
@@ -78,6 +82,7 @@ class RuleTest extends AbstractTestCase
      * testGetBooleanPropertyReturnsTrueForDifferentStringValue
      *
      * @return void
+     *
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
@@ -94,6 +99,7 @@ class RuleTest extends AbstractTestCase
      * Tests the getBooleanProperty method with a fallback value
      *
      * @return void
+     *
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
@@ -109,6 +115,7 @@ class RuleTest extends AbstractTestCase
      * testGetIntPropertyReturnsValueOfTypeInteger
      *
      * @return void
+     *
      * @covers ::getIntProperty
      * @covers ::getProperty
      */
@@ -125,6 +132,7 @@ class RuleTest extends AbstractTestCase
      * testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
+     *
      * @covers ::getIntProperty
      * @covers ::getProperty
      */
@@ -141,6 +149,7 @@ class RuleTest extends AbstractTestCase
      * Tests the getIntProperty method with a fallback value
      *
      * @return void
+     *
      * @covers ::getIntProperty
      * @covers ::getProperty
      */
@@ -156,6 +165,7 @@ class RuleTest extends AbstractTestCase
      * testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
+     *
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
@@ -172,6 +182,7 @@ class RuleTest extends AbstractTestCase
      * testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
+     *
      * @covers ::getStringProperty
      * @covers ::getProperty
      */
@@ -188,6 +199,7 @@ class RuleTest extends AbstractTestCase
      * testGetStringPropertyReturnsStringValue
      *
      * @return void
+     *
      * @covers ::getStringProperty
      * @covers ::getProperty
      */
@@ -204,6 +216,7 @@ class RuleTest extends AbstractTestCase
      * Tests the getStringProperty method with a fallback value
      *
      * @return void
+     *
      * @covers ::getStringProperty
      * @covers ::getProperty
      */

--- a/src/test/php/PHPMD/RuleViolationTest.php
+++ b/src/test/php/PHPMD/RuleViolationTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -23,6 +24,7 @@ use PHPMD\Node\NodeInfo;
  * Test case for the {@link \PHPMD\RuleViolation} class.
  *
  * @covers \PHPMD\RuleViolation
+ *
  * @since 0.2.5
  */
 class RuleViolationTest extends AbstractTestCase

--- a/src/test/php/PHPMD/Stubs/ClassNotFoundRule.php
+++ b/src/test/php/PHPMD/Stubs/ClassNotFoundRule.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Stubs/RuleStub.php
+++ b/src/test/php/PHPMD/Stubs/RuleStub.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -31,7 +32,7 @@ class RuleStub extends AbstractRule implements ClassAware
     /**
      * Constructs a new rule stub instance.
      *
-     * @param string $ruleName The rule name.
+     * @param string $ruleName    The rule name.
      * @param string $ruleSetName The rule-set name.
      */
     public function __construct($ruleName = 'RuleStub', $ruleSetName = 'TestRuleSet')

--- a/src/test/php/PHPMD/Stubs/WriterStub.php
+++ b/src/test/php/PHPMD/Stubs/WriterStub.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 
@@ -48,6 +49,7 @@ class CommandLineOptionsTest extends AbstractTestCase
      * testAssignsInputArgumentToInputProperty
      *
      * @return void
+     *
      * @since 1.1.0
      */
     public function testAssignsInputArgumentToInputProperty()
@@ -60,6 +62,7 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * @return void
+     *
      * @since 2.14.0
      */
     public function testVerbose()
@@ -78,6 +81,7 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * @return void
+     *
      * @since 2.14.0
      */
     public function testColored()
@@ -96,6 +100,7 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * @return void
+     *
      * @since 2.14.0
      */
     public function testStdInDashShortCut()
@@ -108,6 +113,7 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * @return void
+     *
      * @since 2.14.0
      */
     public function testMultipleFiles()
@@ -125,6 +131,7 @@ class CommandLineOptionsTest extends AbstractTestCase
      * testAssignsFormatArgumentToReportFormatProperty
      *
      * @return void
+     *
      * @since 1.1.0
      */
     public function testAssignsFormatArgumentToReportFormatProperty()
@@ -139,6 +146,7 @@ class CommandLineOptionsTest extends AbstractTestCase
      * testAssignsRuleSetsArgumentToRuleSetProperty
      *
      * @return void
+     *
      * @since 1.1.0
      */
     public function testAssignsRuleSetsArgumentToRuleSetProperty()
@@ -153,6 +161,7 @@ class CommandLineOptionsTest extends AbstractTestCase
      * testThrowsExpectedExceptionWhenRequiredArgumentsNotSet
      *
      * @return void
+     *
      * @since 1.1.0
      */
     public function testThrowsExpectedExceptionWhenRequiredArgumentsNotSet()
@@ -253,6 +262,7 @@ class CommandLineOptionsTest extends AbstractTestCase
      * testAssignsInputFileOptionToInputPathProperty
      *
      * @return void
+     *
      * @since 1.1.0
      */
     public function testAssignsInputFileOptionToInputPathProperty()
@@ -269,6 +279,7 @@ class CommandLineOptionsTest extends AbstractTestCase
      * testAssignsFormatArgumentCorrectWhenCalledWithInputFile
      *
      * @return void
+     *
      * @since 1.1.0
      */
     public function testAssignsFormatArgumentCorrectWhenCalledWithInputFile()
@@ -285,6 +296,7 @@ class CommandLineOptionsTest extends AbstractTestCase
      * testAssignsRuleSetsArgumentCorrectWhenCalledWithInputFile
      *
      * @return void
+     *
      * @since 1.1.0
      */
     public function testAssignsRuleSetsArgumentCorrectWhenCalledWithInputFile()
@@ -301,6 +313,7 @@ class CommandLineOptionsTest extends AbstractTestCase
      * testThrowsExpectedExceptionWhenInputFileNotExists
      *
      * @return void
+     *
      * @since 1.1.0
      */
     public function testThrowsExpectedExceptionWhenInputFileNotExists()
@@ -450,6 +463,7 @@ class CommandLineOptionsTest extends AbstractTestCase
      * testCliOptionsIsStrictReturnsFalseByDefault
      *
      * @return void
+     *
      * @since 1.2.0
      */
     public function testCliOptionsIsStrictReturnsFalseByDefault()
@@ -464,6 +478,7 @@ class CommandLineOptionsTest extends AbstractTestCase
      * testCliOptionsAcceptsStrictArgument
      *
      * @return void
+     *
      * @since 1.2.0
      */
     public function testCliOptionsAcceptsStrictArgument()
@@ -706,7 +721,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @param string $reportFormat
      * @param string $expectedClass
+     *
      * @return void
+     *
      * @dataProvider dataProviderCreateRenderer
      */
     public function testCreateRenderer($reportFormat, $expectedClass)
@@ -762,6 +779,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @param string $deprecatedName
      * @param string $newName
+     *
      * @dataProvider dataProviderDeprecatedCliOptions
      */
     public function testDeprecatedCliOptions($deprecatedName, $newName, Closure $result)
@@ -805,6 +823,7 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * @return void
+     *
      * @dataProvider dataProviderGetReportFiles
      */
     public function testGetReportFiles(array $options, array $expected)

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -12,6 +12,7 @@
  * @author    Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license   https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link      http://phpmd.org/
  */
 
@@ -44,6 +45,7 @@ class CommandTest extends AbstractTestCase
 
     /**
      * @return void
+     *
      * @dataProvider dataProviderTestMainWithOption
      */
     public function testMainStrictOptionIsOfByDefault($sourceFile, $expectedExitCode, array $options = null)
@@ -192,7 +194,9 @@ class CommandTest extends AbstractTestCase
     /**
      * @param string $option
      * @param string $value
+     *
      * @return void
+     *
      * @dataProvider dataProviderWithFilter
      */
     public function testWithFilter($option, $value)

--- a/src/test/php/PHPMD/TextUI/StreamFilter.php
+++ b/src/test/php/PHPMD/TextUI/StreamFilter.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Utility/StringsTest.php
+++ b/src/test/php/PHPMD/Utility/StringsTest.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 

--- a/src/test/php/PHPMD/Writer/StreamWriterTest.php
+++ b/src/test/php/PHPMD/Writer/StreamWriterTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \PHPMD\Writer\StreamWriter
+ *
  * @covers ::__construct
  */
 class StreamWriterTest extends TestCase

--- a/src/test/php/bootstrap.php
+++ b/src/test/php/bootstrap.php
@@ -12,6 +12,7 @@
  * @author Manuel Pichler <mapi@phpmd.org>
  * @copyright Manuel Pichler. All rights reserved.
  * @license https://opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link http://phpmd.org/
  */
 


### PR DESCRIPTION
Type: documentation update
Breaking change: no

This separates the PHPDoc groups and aligns there attributes to make it easier to visually navigate ... imo. This mirrors what is done on PDepend.