### PR TITLE
Enable additional PER-CS 2.0 rules

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -7,8 +7,10 @@
  */
 $config = new PhpCsFixer\Config();
 return $config
+    ->setRiskyAllowed(true)
     ->setRules([
         '@PER-CS2.0' => true,
+        '@PER-CS2.0:risky' => true,
         'binary_operator_spaces' => true, // Going beyond PER CS v2
         'ordered_class_elements' => [
             'order' => [
@@ -96,6 +98,8 @@ return $config
     ])
     ->setFinder(PhpCsFixer\Finder::create()
         ->exclude('vendor')
-        ->in(__DIR__ . '/src/main/php/PHPMD')
-        ->in(__DIR__ . '/src/test/php/')
+        ->in([
+            __DIR__ . '/src/main/php/PHPMD',
+            __DIR__ . '/src/test/php',
+        ])
     );


### PR DESCRIPTION
Type: refactoring / documentation update
Breaking change: no

This fully enables all the PER-CS 2.0 rules in php-cs-fixer, these rules are marked as risky as they require that a human check that they do not have an unintended effect, but this should not be an issue for us as we require a human to review the changes already. Since there are no violations found in the code base this simply changes the config.