### PR TITLE
Import classes and use ::class instead of strings and FQNs

### DIFF
--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -19,6 +19,8 @@ namespace PHPMD;
 
 use BadMethodCallException;
 use PDepend\Source\AST\AbstractASTArtifact;
+use PDepend\Source\AST\AbstractASTNode;
+use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTVariable;
 use PHPMD\Node\ASTNode;
@@ -27,7 +29,7 @@ use PHPMD\Node\ASTNode;
  * This is an abstract base class for PHPMD code nodes, it is just a wrapper
  * around PDepend's object model.
  *
- * @template TNode of \PDepend\Source\AST\ASTArtifact|PDependNode
+ * @template TNode of ASTArtifact|PDependNode
  *
  * @mixin TNode
  */
@@ -153,7 +155,7 @@ abstract class AbstractNode
      * the current node.
      *
      * @param class-string<PDependNode> $type The searched child type.
-     * @return array<int, \PDepend\Source\AST\AbstractASTNode|\PDepend\Source\AST\ASTArtifact>
+     * @return array<int, AbstractASTNode|ASTArtifact>
      */
     public function findChildrenWithParentType($type)
     {
@@ -178,7 +180,7 @@ abstract class AbstractNode
      */
     public function findChildrenOfTypeVariable()
     {
-        return $this->findChildrenOfType('PDepend\Source\AST\ASTVariable');
+        return $this->findChildrenOfType(ASTVariable::class);
     }
 
     /**

--- a/src/main/php/PHPMD/Node/ASTNode.php
+++ b/src/main/php/PHPMD/Node/ASTNode.php
@@ -17,16 +17,18 @@
 
 namespace PHPMD\Node;
 
+use PDepend\Source\AST\ASTNode as PDependNode;
+use PHPMD\AbstractNode;
 use PHPMD\Rule;
 
 /**
  * Wrapper around a PHP_Depend ast node.
  *
- * @template TNode of \PDepend\Source\AST\ASTNode
+ * @template TNode of PDependNode
  *
- * @extends \PHPMD\AbstractNode<TNode>
+ * @extends AbstractNode<TNode>
  */
-class ASTNode extends \PHPMD\AbstractNode
+class ASTNode extends AbstractNode
 {
     /**
      * The source file of this node.
@@ -41,7 +43,7 @@ class ASTNode extends \PHPMD\AbstractNode
      * @param TNode $node
      * @param string $fileName
      */
-    public function __construct(\PDepend\Source\AST\ASTNode $node, $fileName)
+    public function __construct(PDependNode $node, $fileName)
     {
         parent::__construct($node);
 

--- a/src/main/php/PHPMD/Node/AbstractNode.php
+++ b/src/main/php/PHPMD/Node/AbstractNode.php
@@ -17,16 +17,18 @@
 
 namespace PHPMD\Node;
 
+use PDepend\Source\AST\ASTArtifact;
+use PHPMD\AbstractNode as BaseNode;
 use PHPMD\Rule;
 
 /**
  * Abstract base class for all code nodes.
  *
- * @template TNode of \PDepend\Source\AST\ASTArtifact
+ * @template TNode of ASTArtifact
  *
- * @extends \PHPMD\AbstractNode<TNode>
+ * @extends BaseNode<TNode>
  */
-abstract class AbstractNode extends \PHPMD\AbstractNode
+abstract class AbstractNode extends BaseNode
 {
     /**
      * Annotations associated with node instance.

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -18,11 +18,12 @@
 namespace PHPMD\Node;
 
 use PDepend\Source\AST\AbstractASTClassOrInterface;
+use PDepend\Source\AST\ASTArtifact;
 
 /**
  * Abstract base class for classes and interfaces.
  *
- * @template TNode of \PDepend\Source\AST\ASTArtifact
+ * @template TNode of ASTArtifact
  *
  * @extends AbstractNode<TNode>
  */
@@ -47,7 +48,7 @@ abstract class AbstractTypeNode extends AbstractNode
      * Returns an <b>array</b> with all methods defined in the context class or
      * interface.
      *
-     * @return \PHPMD\Node\MethodNode[]
+     * @return MethodNode[]
      */
     public function getMethods()
     {

--- a/src/main/php/PHPMD/Node/Annotations.php
+++ b/src/main/php/PHPMD/Node/Annotations.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Node;
 
 use PDepend\Source\AST\AbstractASTArtifact;
+use PHPMD\AbstractNode;
 use PHPMD\Rule;
 
 /**
@@ -28,7 +29,7 @@ class Annotations
     /**
      * Detected annotations.
      *
-     * @var \PHPMD\Node\Annotation[]
+     * @var Annotation[]
      */
     private $annotations = [];
 
@@ -42,9 +43,9 @@ class Annotations
     /**
      * Constructs a new collection instance.
      *
-     * @param \PHPMD\AbstractNode<AbstractASTArtifact> $node
+     * @param AbstractNode<AbstractASTArtifact> $node
      */
-    public function __construct(\PHPMD\AbstractNode $node)
+    public function __construct(AbstractNode $node)
     {
         $comment = $node->getComment();
         if ($comment === null) {

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -207,10 +207,10 @@ class PHPMD
      * path. It will apply rules defined in the comma-separated <b>$ruleSets</b>
      * argument. The result will be passed to all given renderer instances.
      *
-     * @param string                    $inputPath
-     * @param array|null                $ignorePattern
-     * @param \PHPMD\AbstractRenderer[] $renderers
-     * @param \PHPMD\RuleSet[]          $ruleSetList
+     * @param string             $inputPath
+     * @param array|null         $ignorePattern
+     * @param AbstractRenderer[] $renderers
+     * @param RuleSet[]          $ruleSetList
      */
     public function processFiles(
         $inputPath,

--- a/src/main/php/PHPMD/Parser.php
+++ b/src/main/php/PHPMD/Parser.php
@@ -21,6 +21,7 @@ use PDepend\Engine;
 use PDepend\Metrics\Analyzer;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Report\CodeAwareGenerator;
+use PDepend\Report\NoLogOutputException;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTEnum;
@@ -44,14 +45,14 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
     /**
      * The analysing rule-set instance.
      *
-     * @var \PHPMD\RuleSet[]
+     * @var RuleSet[]
      */
     private $ruleSets = [];
 
     /**
      * The metric containing analyzer instances.
      *
-     * @var \PDepend\Metrics\AnalyzerNodeAware[]
+     * @var AnalyzerNodeAware[]
      */
     private $analyzers = [];
 
@@ -137,7 +138,7 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
     /**
      * Closes the logger process and writes the output file.
      *
-     * @throws \PDepend\Report\NoLogOutputException If the no log target exists.
+     * @throws NoLogOutputException If the no log target exists.
      */
     public function close(): void
     {

--- a/src/main/php/PHPMD/Renderer/AnsiRenderer.php
+++ b/src/main/php/PHPMD/Renderer/AnsiRenderer.php
@@ -3,6 +3,7 @@
 namespace PHPMD\Renderer;
 
 use PHPMD\AbstractRenderer;
+use PHPMD\ProcessingError;
 use PHPMD\Report;
 use PHPMD\RuleViolation;
 
@@ -87,7 +88,7 @@ class AnsiRenderer extends AbstractRenderer
             return;
         }
 
-        /** @var \PHPMD\ProcessingError $error */
+        /** @var ProcessingError $error */
         foreach ($report->getErrors() as $error) {
             $errorHeader = sprintf(
                 "\e[33mERROR\e[0m while parsing %s",

--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -100,7 +100,7 @@ class Report
     /**
      * Returns an iterator with all occurred rule violations.
      *
-     * @return ArrayIterator<int, \PHPMD\RuleViolation>
+     * @return ArrayIterator<int, RuleViolation>
      */
     public function getRuleViolations()
     {

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -19,9 +19,12 @@ namespace PHPMD\Rule;
 
 use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTArrayIndexExpression;
+use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTPropertyPostfix;
+use PDepend\Source\AST\ASTStringIndexExpression;
 use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
@@ -70,7 +73,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Tests if the given variable node represents a local variable or if it is
      * a static object property or something similar.
      *
-     * @param \PHPMD\Node\ASTNode<\PDepend\Source\AST\ASTVariable> $variable The variable to check.
+     * @param ASTNode<ASTVariable> $variable The variable to check.
      * @return bool
      */
     protected function isLocal(ASTNode $variable)
@@ -114,7 +117,7 @@ abstract class AbstractLocalVariable extends AbstractRule
         $node = $this->stripWrappedIndexExpression($variable);
         $parent = $node->getParent();
 
-        if ($parent->isInstanceOf('PDepend\Source\AST\ASTPropertyPostfix')) {
+        if ($parent->isInstanceOf(ASTPropertyPostfix::class)) {
             $primaryPrefix = $parent->getParent();
             $primaryPrefixParent = $primaryPrefix->getParent();
             if ($primaryPrefixParent->isInstanceOf(ASTMemberPrimaryPrefix::class)) {
@@ -156,8 +159,8 @@ abstract class AbstractLocalVariable extends AbstractRule
      */
     protected function isWrappedByIndexExpression(ASTNode $node)
     {
-        return ($node->getParent()->isInstanceOf('PDepend\Source\AST\ASTArrayIndexExpression')
-            || $node->getParent()->isInstanceOf('PDepend\Source\AST\ASTStringIndexExpression')
+        return ($node->getParent()->isInstanceOf(ASTArrayIndexExpression::class)
+            || $node->getParent()->isInstanceOf(ASTStringIndexExpression::class)
         );
     }
 
@@ -233,7 +236,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      *
      * Or return the input as is if it's not an ASTNode PHPMD node.
      *
-     * @return \PDepend\Source\AST\ASTArtifact|\PDepend\Source\AST\ASTNode
+     * @return ASTArtifact|PDependNode
      */
     protected function getNode($node)
     {

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -18,7 +18,9 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PDepend\Source\AST\AbstractASTClassOrInterface;
+use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTValue;
+use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
@@ -89,8 +91,8 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
 
     private function scanFormalParameters(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTFormalParameter') as $param) {
-            $declarator = $param->getFirstChildOfType('PDepend\Source\AST\ASTVariableDeclarator');
+        foreach ($node->findChildrenOfType(ASTFormalParameter::class) as $param) {
+            $declarator = $param->getFirstChildOfType(ASTVariableDeclarator::class);
             $value = $declarator->getValue();
 
             if (!$this->isBooleanValue($value)) {

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PDepend\Source\AST\AbstractASTNode;
+use PDepend\Source\AST\ASTArray;
 use PDepend\Source\AST\ASTArrayElement;
 use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTNode as PDependASTNode;
@@ -42,7 +43,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTArray') as $arrayNode) {
+        foreach ($node->findChildrenOfType(ASTArray::class) as $arrayNode) {
             $this->checkForDuplicatedArrayKeys($arrayNode);
         }
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\CleanCode;
 
+use PDepend\Source\AST\ASTScopeStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
@@ -37,7 +38,7 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTScopeStatement') as $scope) {
+        foreach ($node->findChildrenOfType(ASTScopeStatement::class) as $scope) {
             $parent = $scope->getParent();
 
             if (!$this->isIfOrElseIfStatement($parent)) {

--- a/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\CleanCode;
 
+use PDepend\Source\AST\ASTUnaryExpression;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
@@ -37,7 +38,7 @@ class ErrorControlOperator extends AbstractRule implements MethodAware, Function
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTUnaryExpression') as $unaryExpression) {
+        foreach ($node->findChildrenOfType(ASTUnaryExpression::class) as $unaryExpression) {
             if ($unaryExpression->getImage() === '@') {
                 $this->addViolation($node, [$unaryExpression->getBeginLine()]);
             }

--- a/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\CleanCode;
 
+use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTAssignmentExpression;
 use PDepend\Source\AST\ASTElseIfStatement;
 use PDepend\Source\AST\ASTExpression;
@@ -116,7 +117,7 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
     protected function addViolations(AbstractNode $node, array $assignments): void
     {
         $processesViolations = [];
-        /** @var \PDepend\Source\AST\AbstractASTNode $assignment */
+        /** @var AbstractASTNode $assignment */
         foreach ($assignments as $assignment) {
             if (null === $assignment || $assignment->getImage() !== '=') {
                 continue;

--- a/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\CleanCode;
 
+use PDepend\Source\AST\ASTAllocationExpression;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
@@ -44,7 +45,7 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
     {
         $ignoreGlobal = $this->getBooleanProperty('ignore-global');
 
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTAllocationExpression') as $allocationNode) {
+        foreach ($node->findChildrenOfType(ASTAllocationExpression::class) as $allocationNode) {
             $classNode = $allocationNode->getChild(0);
             if (!$classNode instanceof ASTNode) {
                 continue;

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PDepend\Source\AST\ASTClassOrInterfaceReference;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTMethodPostfix;
 use PDepend\Source\AST\ASTParentReference;
 use PDepend\Source\AST\ASTSelfReference;
@@ -49,7 +50,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
     {
         $ignoreRegexp = trim($this->getStringProperty('ignorepattern', ''));
         $exceptions = $this->getExceptionsList();
-        $nodes = $node->findChildrenOfType('PDepend\Source\AST\ASTMemberPrimaryPrefix');
+        $nodes = $node->findChildrenOfType(ASTMemberPrimaryPrefix::class);
 
         foreach ($nodes as $methodCall) {
             if ($this->isMethodIgnored($methodCall, $ignoreRegexp)) {
@@ -97,7 +98,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
             return false;
         }
 
-        $methodName = $methodCall->getFirstChildOfType('PDepend\Source\AST\ASTMethodPostfix');
+        $methodName = $methodCall->getFirstChildOfType(ASTMethodPostfix::class);
 
         return $methodName !== null && preg_match($ignorePattern, $methodName->getName()) === 1;
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -18,8 +18,16 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PDepend\Source\AST\ASTArray;
+use PDepend\Source\AST\ASTAssignmentExpression;
+use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTClosure;
+use PDepend\Source\AST\ASTForeachStatement;
+use PDepend\Source\AST\ASTFormalParameters;
+use PDepend\Source\AST\ASTGlobalStatement;
+use PDepend\Source\AST\ASTListExpression;
 use PDepend\Source\AST\ASTPropertyPostfix;
+use PDepend\Source\AST\ASTStaticVariableDeclaration;
 use PDepend\Source\AST\ASTUnaryExpression;
 use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
@@ -35,6 +43,8 @@ use PHPMD\Rule\MethodAware;
 /**
  * This rule collects all undefined variables within a given function or method
  * that are used by any code in the analyzed source artifact.
+ *
+ * @SuppressWarnings("PMD.CouplingBetweenObjects")
  */
 class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, MethodAware
 {
@@ -59,7 +69,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
         $this->collect($node);
 
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTClass') as $class) {
+        foreach ($node->findChildrenOfType(ASTClass::class) as $class) {
             /** @var ASTClass $class */
 
             $this->collectProperties($class);
@@ -108,12 +118,10 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
     /**
      * Stores the given literal node in an global of found variables.
-     *
-     * @param \PHPMD\Node\AbstractNode $node
      */
     protected function collectGlobalStatements(AbstractNode $node): void
     {
-        foreach ($node->findChildrenWithParentType('PDepend\Source\AST\ASTGlobalStatement') as $variable) {
+        foreach ($node->findChildrenWithParentType(ASTGlobalStatement::class) as $variable) {
             $this->addVariableDefinition($variable);
         }
     }
@@ -123,7 +131,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectExceptionCatches(AbstractCallableNode $node): void
     {
-        foreach ($node->findChildrenWithParentType('PDepend\Source\AST\ASTCatchStatement') as $child) {
+        foreach ($node->findChildrenWithParentType(ASTCatchStatement::class) as $child) {
             if ($child instanceof ASTVariable) {
                 $this->addVariableDefinition($child);
             }
@@ -135,7 +143,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectListExpressions(AbstractCallableNode $node): void
     {
-        foreach ($node->findChildrenWithParentType('PDepend\Source\AST\ASTListExpression') as $variable) {
+        foreach ($node->findChildrenWithParentType(ASTListExpression::class) as $variable) {
             $this->addVariableDefinition($variable);
         }
     }
@@ -145,7 +153,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectForeachStatements(AbstractCallableNode $node): void
     {
-        foreach ($node->findChildrenWithParentType('PDepend\Source\AST\ASTForeachStatement') as $child) {
+        foreach ($node->findChildrenWithParentType(ASTForeachStatement::class) as $child) {
             if ($child instanceof ASTVariable) {
                 $this->addVariableDefinition($child);
             }
@@ -167,7 +175,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectClosureParameters(AbstractCallableNode $node): void
     {
-        $closures = $node->findChildrenOfType('PDepend\Source\AST\ASTClosure');
+        $closures = $node->findChildrenOfType(ASTClosure::class);
 
         foreach ($closures as $closure) {
             $this->collectParameters($closure);
@@ -188,16 +196,14 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
     /**
      * Collect parameter names of method/function.
-     *
-     * @param \PHPMD\Node\AbstractNode $node
      */
     protected function collectParameters(AbstractNode $node): void
     {
         // Get formal parameter container
-        $parameters = $node->getFirstChildOfType('PDepend\Source\AST\ASTFormalParameters');
+        $parameters = $node->getFirstChildOfType(ASTFormalParameters::class);
 
         // Now get all declarators in the formal parameters container
-        $declarators = $parameters->findChildrenOfType('PDepend\Source\AST\ASTVariableDeclarator');
+        $declarators = $parameters->findChildrenOfType(ASTVariableDeclarator::class);
 
         foreach ($declarators as $declarator) {
             $this->addVariableDefinition($declarator);
@@ -209,7 +215,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      */
     protected function collectAssignments(AbstractCallableNode $node): void
     {
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTAssignmentExpression') as $assignment) {
+        foreach ($node->findChildrenOfType(ASTAssignmentExpression::class) as $assignment) {
             $variable = $assignment->getChild(0);
 
             if ($variable->getNode() instanceof ASTArray) {
@@ -223,7 +229,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
             $this->addVariableDefinition($variable);
         }
 
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTStaticVariableDeclaration') as $static) {
+        foreach ($node->findChildrenOfType(ASTStaticVariableDeclaration::class) as $static) {
             $variable = $static->getChild(0);
             $this->addVariableDefinition($variable);
         }
@@ -231,12 +237,10 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
     /**
      * Collect postfix property.
-     *
-     * @param \PHPMD\Node\AbstractNode $node
      */
     protected function collectPropertyPostfix(AbstractNode $node): void
     {
-        foreach ($node->findChildrenWithParentType('PDepend\Source\AST\ASTPropertyPostfix') as $child) {
+        foreach ($node->findChildrenWithParentType(ASTPropertyPostfix::class) as $child) {
             if ($child instanceof ASTVariable) {
                 $this->addVariableDefinition($child);
             }

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\Controversial;
 
+use PDepend\Source\AST\ASTPropertyPostfix;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
@@ -91,7 +92,7 @@ class CamelCaseVariableName extends AbstractRule implements MethodAware, Functio
             return true;
         }
 
-        if ($variable->getParent()->isInstanceOf('PDepend\Source\AST\ASTPropertyPostfix')) {
+        if ($variable->getParent()->isInstanceOf(ASTPropertyPostfix::class)) {
             return true;
         }
 

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -18,6 +18,11 @@
 namespace PHPMD\Rule\Design;
 
 use PDepend\Source\AST\AbstractASTNode;
+use PDepend\Source\AST\ASTDoWhileStatement;
+use PDepend\Source\AST\ASTExpression;
+use PDepend\Source\AST\ASTForStatement;
+use PDepend\Source\AST\ASTFunctionPostfix;
+use PDepend\Source\AST\ASTWhileStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
@@ -77,9 +82,9 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
 
         $this->currentNamespace = $node->getNamespaceName() . '\\';
         $loops = array_merge(
-            $node->findChildrenOfType('PDepend\Source\AST\ASTForStatement'),
-            $node->findChildrenOfType('PDepend\Source\AST\ASTWhileStatement'),
-            $node->findChildrenOfType('PDepend\Source\AST\ASTDoWhileStatement')
+            $node->findChildrenOfType(ASTForStatement::class),
+            $node->findChildrenOfType(ASTWhileStatement::class),
+            $node->findChildrenOfType(ASTDoWhileStatement::class)
         );
 
         /** @var AbstractNode $loop */
@@ -96,12 +101,12 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
      */
     protected function findViolations(AbstractNode $loop): void
     {
-        foreach ($loop->findChildrenOfType('PDepend\Source\AST\ASTExpression') as $expression) {
+        foreach ($loop->findChildrenOfType(ASTExpression::class) as $expression) {
             if ($this->isDirectChild($loop, $expression)) {
                 continue;
             }
 
-            foreach ($expression->findChildrenOfType('PDepend\Source\AST\ASTFunctionPostfix') as $function) {
+            foreach ($expression->findChildrenOfType(ASTFunctionPostfix::class) as $function) {
                 if (!$this->isUnwantedFunction($function)) {
                     continue;
                 }

--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\Design;
 
+use PDepend\Source\AST\ASTFunctionPostfix;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\MethodNode;
@@ -40,7 +41,7 @@ class DevelopmentCodeFragment extends AbstractRule implements MethodAware, Funct
     {
         $ignoreNS = $this->getBooleanProperty('ignore-namespaces');
         $namespace = $node->getNamespaceName();
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTFunctionPostfix') as $postfix) {
+        foreach ($node->findChildrenOfType(ASTFunctionPostfix::class) as $postfix) {
             $fragment = $postfix->getImage();
             if ($ignoreNS) {
                 $fragment = str_replace("{$namespace}\\", "", $fragment);

--- a/src/main/php/PHPMD/Rule/Design/EmptyCatchBlock.php
+++ b/src/main/php/PHPMD/Rule/Design/EmptyCatchBlock.php
@@ -17,6 +17,8 @@
 
 namespace PHPMD\Rule\Design;
 
+use PDepend\Source\AST\ASTCatchStatement;
+use PDepend\Source\AST\ASTScopeStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
@@ -36,8 +38,8 @@ class EmptyCatchBlock extends AbstractRule implements MethodAware, FunctionAware
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTCatchStatement') as $catchBlock) {
-            $scope = $catchBlock->getFirstChildOfType('PDepend\Source\AST\ASTScopeStatement');
+        foreach ($node->findChildrenOfType(ASTCatchStatement::class) as $catchBlock) {
+            $scope = $catchBlock->getFirstChildOfType(ASTScopeStatement::class);
             if (count($scope->getChildren()) === 0) {
                 $this->addViolation($catchBlock, [$node->getName()]);
             }

--- a/src/main/php/PHPMD/Rule/Design/EvalExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/EvalExpression.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\Design;
 
+use PDepend\Source\AST\ASTEvalExpression;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
@@ -33,7 +34,7 @@ class EvalExpression extends AbstractRule implements MethodAware, FunctionAware
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTEvalExpression') as $eval) {
+        foreach ($node->findChildrenOfType(ASTEvalExpression::class) as $eval) {
             $this->addViolation($eval, [$node->getType(), $node->getName()]);
         }
     }

--- a/src/main/php/PHPMD/Rule/Design/ExitExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/ExitExpression.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\Design;
 
+use PDepend\Source\AST\ASTExitExpression;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
@@ -33,7 +34,7 @@ class ExitExpression extends AbstractRule implements MethodAware, FunctionAware
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTExitExpression') as $exit) {
+        foreach ($node->findChildrenOfType(ASTExitExpression::class) as $exit) {
             $this->addViolation($exit, [$node->getType(), $node->getName()]);
         }
     }

--- a/src/main/php/PHPMD/Rule/Design/GotoStatement.php
+++ b/src/main/php/PHPMD/Rule/Design/GotoStatement.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\Design;
 
+use PDepend\Source\AST\ASTGotoStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
@@ -35,7 +36,7 @@ class GotoStatement extends AbstractRule implements MethodAware, FunctionAware
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTGotoStatement') as $goto) {
+        foreach ($node->findChildrenOfType(ASTGotoStatement::class) as $goto) {
             $this->addViolation($goto, [$node->getType(), $node->getName()]);
         }
     }

--- a/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\Naming;
 
+use PDepend\Source\AST\ASTConstantDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
@@ -36,7 +37,7 @@ class ConstantNamingConventions extends AbstractRule implements ClassAware, Inte
      */
     public function apply(AbstractNode $node): void
     {
-        foreach ($node->findChildrenOfType('PDepend\Source\AST\ASTConstantDeclarator') as $declarator) {
+        foreach ($node->findChildrenOfType(ASTConstantDeclarator::class) as $declarator) {
             if ($declarator->getImage() !== strtoupper($declarator->getImage())) {
                 $this->addViolation($declarator, [$declarator->getImage()]);
             }

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -17,6 +17,9 @@
 
 namespace PHPMD\Rule\Naming;
 
+use PDepend\Source\AST\ASTFieldDeclaration;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
@@ -63,9 +66,9 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
         $this->resetProcessed();
 
         if ($node->getType() === 'class') {
-            $fields = $node->findChildrenOfType('PDepend\Source\AST\ASTFieldDeclaration');
+            $fields = $node->findChildrenOfType(ASTFieldDeclaration::class);
             foreach ($fields as $field) {
-                $declarators = $field->findChildrenOfType('PDepend\Source\AST\ASTVariableDeclarator');
+                $declarators = $field->findChildrenOfType(ASTVariableDeclarator::class);
                 foreach ($declarators as $declarator) {
                     $this->checkNodeImage($declarator);
                 }
@@ -74,7 +77,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
 
             return;
         }
-        $declarators = $node->findChildrenOfType('PDepend\Source\AST\ASTVariableDeclarator');
+        $declarators = $node->findChildrenOfType(ASTVariableDeclarator::class);
         foreach ($declarators as $declarator) {
             $this->checkNodeImage($declarator);
         }
@@ -130,7 +133,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      */
     protected function isNameAllowedInContext(AbstractNode $node)
     {
-        return $this->isChildOf($node, 'PDepend\Source\AST\ASTMemberPrimaryPrefix');
+        return $this->isChildOf($node, ASTMemberPrimaryPrefix::class);
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -17,6 +17,12 @@
 
 namespace PHPMD\Rule\Naming;
 
+use PDepend\Source\AST\ASTCatchStatement;
+use PDepend\Source\AST\ASTFieldDeclaration;
+use PDepend\Source\AST\ASTForeachStatement;
+use PDepend\Source\AST\ASTForInit;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
@@ -73,9 +79,9 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      */
     protected function applyClass(AbstractNode $node): void
     {
-        $fields = $node->findChildrenOfType('PDepend\Source\AST\ASTFieldDeclaration');
+        $fields = $node->findChildrenOfType(ASTFieldDeclaration::class);
         foreach ($fields as $field) {
-            $declarators = $field->findChildrenOfType('PDepend\Source\AST\ASTVariableDeclarator');
+            $declarators = $field->findChildrenOfType(ASTVariableDeclarator::class);
             foreach ($declarators as $declarator) {
                 $this->checkNodeImage($declarator);
             }
@@ -91,7 +97,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      */
     protected function applyNonClass(AbstractNode $node): void
     {
-        $declarators = $node->findChildrenOfType('PDepend\Source\AST\ASTVariableDeclarator');
+        $declarators = $node->findChildrenOfType(ASTVariableDeclarator::class);
         foreach ($declarators as $declarator) {
             $this->checkNodeImage($declarator);
         }
@@ -164,13 +170,13 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
     {
         $parent = $node->getParent();
 
-        if ($parent && $parent->isInstanceOf('PDepend\Source\AST\ASTForeachStatement')) {
+        if ($parent && $parent->isInstanceOf(ASTForeachStatement::class)) {
             return $this->isInitializedInLoop($node);
         }
 
-        return $this->isChildOf($node, 'PDepend\Source\AST\ASTCatchStatement')
-            || $this->isChildOf($node, 'PDepend\Source\AST\ASTForInit')
-            || $this->isChildOf($node, 'PDepend\Source\AST\ASTMemberPrimaryPrefix');
+        return $this->isChildOf($node, ASTCatchStatement::class)
+            || $this->isChildOf($node, ASTForInit::class)
+            || $this->isChildOf($node, ASTMemberPrimaryPrefix::class);
     }
 
     /**
@@ -186,7 +192,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
 
         $exceptionVariables = [];
 
-        $parentForeaches = $this->getParentsOfType($node, 'PDepend\Source\AST\ASTForeachStatement');
+        $parentForeaches = $this->getParentsOfType($node, ASTForeachStatement::class);
         foreach ($parentForeaches as $foreach) {
             foreach ($foreach->getChildren() as $foreachChild) {
                 $exceptionVariables[] = $foreachChild->getImage();

--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -17,6 +17,13 @@
 
 namespace PHPMD\Rule;
 
+use PDepend\Source\AST\ASTArray;
+use PDepend\Source\AST\ASTArrayElement;
+use PDepend\Source\AST\ASTLiteral;
+use PDepend\Source\AST\ASTMethodPostfix;
+use PDepend\Source\AST\ASTSelfReference;
+use PDepend\Source\AST\ASTStaticReference;
+use PDepend\Source\AST\ASTVariable;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
@@ -111,7 +118,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      */
     protected function removeExplicitCalls(ClassNode $class, array $methods)
     {
-        foreach ($class->findChildrenOfType('PDepend\Source\AST\ASTMethodPostfix') as $postfix) {
+        foreach ($class->findChildrenOfType(ASTMethodPostfix::class) as $postfix) {
             if ($this->isClassScope($class, $postfix)) {
                 unset($methods[strtolower($postfix->getImage())]);
             }
@@ -128,7 +135,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      */
     protected function removeCallableArrayRepresentations(ClassNode $class, array $methods)
     {
-        foreach ($class->findChildrenOfType('PDepend\Source\AST\ASTVariable') as $variable) {
+        foreach ($class->findChildrenOfType(ASTVariable::class) as $variable) {
             $parent = $variable->getParent();
             if ($parent && $this->isClassScope($class, $variable) && $variable->getImage() === '$this') {
                 $method = $this->getMethodNameFromArraySecondElement($parent);
@@ -150,15 +157,15 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      */
     protected function getMethodNameFromArraySecondElement(AbstractNode $parent)
     {
-        if ($parent->isInstanceOf('PDepend\Source\AST\ASTArrayElement')) {
+        if ($parent->isInstanceOf(ASTArrayElement::class)) {
             $array = $parent->getParent();
 
-            if ($array?->isInstanceOf('PDepend\Source\AST\ASTArray')
+            if ($array?->isInstanceOf(ASTArray::class)
                 && count($array->getChildren()) === 2
             ) {
                 $secondElement = $array->getChild(1)->getChild(0);
 
-                if ($secondElement->isInstanceOf('PDepend\Source\AST\ASTLiteral')) {
+                if ($secondElement->isInstanceOf(ASTLiteral::class)) {
                     return substr($secondElement->getImage(), 1, -1);
                 }
             }
@@ -178,9 +185,9 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
         $owner = $postfix->getParent()->getChild(0);
 
         return (
-            $owner->isInstanceOf('PDepend\Source\AST\ASTMethodPostfix') ||
-            $owner->isInstanceOf('PDepend\Source\AST\ASTSelfReference') ||
-            $owner->isInstanceOf('PDepend\Source\AST\ASTStaticReference') ||
+            $owner->isInstanceOf(ASTMethodPostfix::class) ||
+            $owner->isInstanceOf(ASTSelfReference::class) ||
+            $owner->isInstanceOf(ASTStaticReference::class) ||
             strcasecmp($owner->getImage(), '$this') === 0 ||
             strcasecmp($owner->getImage(), $class->getImage()) === 0
         );

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -100,7 +100,7 @@ class RuleSetFactory
      * Creates an array of rule-set instances for the given argument.
      *
      * @param string $ruleSetFileNames Comma-separated string of rule-set filenames or identifier.
-     * @return \PHPMD\RuleSet[]
+     * @return RuleSet[]
      */
     public function createRuleSets($ruleSetFileNames)
     {
@@ -351,7 +351,7 @@ class RuleSetFactory
             }
         }
 
-        /* @var $rule \PHPMD\Rule */
+        /* @var RuleSet $rule */
         $rule = new $className();
         $rule->setName((string) $ruleNode['name']);
         $rule->setMessage((string) $ruleNode['message']);

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -18,6 +18,7 @@
 namespace PHPMD\TextUI;
 
 use InvalidArgumentException;
+use PHPMD\AbstractRenderer;
 use PHPMD\Baseline\BaselineMode;
 use PHPMD\Cache\Model\ResultCacheStrategy;
 use PHPMD\Console\OutputInterface;
@@ -651,7 +652,7 @@ class CommandLineOptions
      *
      * @param string $reportFormat
      * @throws InvalidArgumentException When the specified renderer does not exist.
-     * @return \PHPMD\AbstractRenderer
+     * @return AbstractRenderer
      */
     public function createRenderer($reportFormat = null)
     {
@@ -671,7 +672,7 @@ class CommandLineOptions
     /**
      * @param string $reportFormat
      * @throws InvalidArgumentException When the specified renderer does not exist.
-     * @return \PHPMD\AbstractRenderer
+     * @return AbstractRenderer
      */
     protected function createRendererWithoutOptions($reportFormat = null)
     {
@@ -775,7 +776,7 @@ class CommandLineOptions
 
     /**
      * @throws InvalidArgumentException
-     * @return \PHPMD\AbstractRenderer
+     * @return AbstractRenderer
      */
     protected function createCustomRenderer()
     {


### PR DESCRIPTION
Type: documentation update
Breaking change: no

As promised in https://github.com/phpmd/phpmd/pull/1098 here is a PR to convert string to `::class` const as well as import classes. This helps to reduce line length and makes things more consistent. PHPMD at least seems to think so as it helped it discover 3 more violations in it self.