### PR TITLE
Clean up class import in tests

### DIFF
--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -267,9 +267,9 @@ abstract class AbstractRule implements Rule
      *
      * @param string $name The name of the property, e.g. "ignore-whitespace".
      * @param mixed $default An optional default value to fall back instead of throwing an exception.
+     * @return mixed The value of a configured property.
      * @throws OutOfBoundsException When no property for <b>$name</b> exists and
      * no default value to fall back was given.
-     * @return mixed The value of a configured property.
      */
     protected function getProperty(string $name, mixed $default = null): mixed
     {
@@ -292,9 +292,9 @@ abstract class AbstractRule implements Rule
      *
      * @param string $name The name of the property, e.g. "ignore-whitespace".
      * @param bool|null $default An optional default value to fall back instead of throwing an exception.
+     * @return bool The value of a configured property as a boolean.
      * @throws OutOfBoundsException When no property for <b>$name</b> exists and
      * no default value to fall back was given.
-     * @return bool The value of a configured property as a boolean.
      */
     public function getBooleanProperty(string $name, ?bool $default = null): bool
     {
@@ -309,9 +309,9 @@ abstract class AbstractRule implements Rule
      *
      * @param string $name The name of the property, e.g. "minimum".
      * @param int|null $default An optional default value to fall back instead of throwing an exception.
+     * @return int The value of a configured property as an integer.
      * @throws OutOfBoundsException When no property for <b>$name</b> exists and
      * no default value to fall back was given.
-     * @return int The value of a configured property as an integer.
      */
     public function getIntProperty(string $name, ?int $default = null): int
     {
@@ -326,9 +326,9 @@ abstract class AbstractRule implements Rule
      *
      * @param string $name The name of the property, e.g. "exceptions".
      * @param string|null $default An optional default value to fall back instead of throwing an exception.
+     * @return string The raw string value of a configured property.
      * @throws OutOfBoundsException When no property for <b>$name</b> exists and
      * no default value to fall back was given.
-     * @return string The raw string value of a configured property.
      */
     public function getStringProperty(string $name, ?string $default = null): string
     {

--- a/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
+++ b/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
@@ -46,8 +46,8 @@ class BaselineFileFinder
     /**
      * Find the violation baseline file
      *
-     * @throws RuntimeException
      * @return string|null
+     * @throws RuntimeException
      */
     public function find()
     {
@@ -83,8 +83,8 @@ class BaselineFileFinder
     /**
      * @param string $message
      *
-     * @throws RuntimeException
      * @return null
+     * @throws RuntimeException
      */
     private function nullOrThrow($message)
     {

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -11,8 +11,8 @@ class BaselineSetFactory
      * the baseline file.
      *
      * @param string $fileName
-     * @throws RuntimeException
      * @return BaselineSet
+     * @throws RuntimeException
      */
     public static function fromFile($fileName)
     {

--- a/src/main/php/PHPMD/Renderer/RendererFactory.php
+++ b/src/main/php/PHPMD/Renderer/RendererFactory.php
@@ -8,8 +8,8 @@ use RuntimeException;
 class RendererFactory
 {
     /**
-     * @throws RuntimeException
      * @return BaselineRenderer
+     * @throws RuntimeException
      */
     public static function createBaselineRenderer(StreamWriter $writer)
     {

--- a/src/main/php/PHPMD/Rule.php
+++ b/src/main/php/PHPMD/Rule.php
@@ -155,9 +155,9 @@ interface Rule
      *
      * @param string $name The name of the property, e.g. "exceptions".
      * @param string|null $default An optional default value to fall back instead of throwing an exception.
+     * @return string The raw string value of a configured property.
      * @throws OutOfBoundsException When no property for <b>$name</b> exists and
      * no non-null default value to fall back was given.
-     * @return string The raw string value of a configured property.
      */
     public function getStringProperty(string $name, ?string $default = null): string;
 

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -147,8 +147,8 @@ class RuleSetFactory
      * the input when it is already a filename.
      *
      * @param string $ruleSetOrFileName The rule-set filename or identifier.
-     * @throws RuleSetNotFoundException Thrown if no readable file found
      * @return string Path to rule set file name
+     * @throws RuleSetNotFoundException Thrown if no readable file found
      */
     private function createRuleSetFileName($ruleSetOrFileName)
     {
@@ -186,8 +186,8 @@ class RuleSetFactory
      * This method parses the rule-set definition in the given file.
      *
      * @param string $fileName
-     * @throws RuntimeException When loading the XML file fails.
      * @return RuleSet
+     * @throws RuntimeException When loading the XML file fails.
      */
     private function parseRuleSetNode($fileName)
     {
@@ -484,8 +484,8 @@ class RuleSetFactory
      * http://pmd.sourceforge.net/pmd-5.0.4/howtomakearuleset.html#Excluding_files_from_a_ruleset
      *
      * @param string $fileName The filename of a rule-set definition.
-     * @throws RuntimeException Thrown if file is not proper xml
      * @return array|null
+     * @throws RuntimeException Thrown if file is not proper xml
      */
     public function getIgnorePattern($fileName)
     {

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -651,8 +651,8 @@ class CommandLineOptions
      * </ul>
      *
      * @param string $reportFormat
-     * @throws InvalidArgumentException When the specified renderer does not exist.
      * @return AbstractRenderer
+     * @throws InvalidArgumentException When the specified renderer does not exist.
      */
     public function createRenderer($reportFormat = null)
     {
@@ -671,8 +671,8 @@ class CommandLineOptions
 
     /**
      * @param string $reportFormat
-     * @throws InvalidArgumentException When the specified renderer does not exist.
      * @return AbstractRenderer
+     * @throws InvalidArgumentException When the specified renderer does not exist.
      */
     protected function createRendererWithoutOptions($reportFormat = null)
     {
@@ -775,8 +775,8 @@ class CommandLineOptions
     }
 
     /**
-     * @throws InvalidArgumentException
      * @return AbstractRenderer
+     * @throws InvalidArgumentException
      */
     protected function createCustomRenderer()
     {
@@ -913,8 +913,8 @@ class CommandLineOptions
      * exception.
      *
      * @param string $inputFile Specified input file name.
-     * @throws InvalidArgumentException If the specified input file does not exist.
      * @return string
+     * @throws InvalidArgumentException If the specified input file does not exist.
      * @since 1.1.0
      */
     protected function readInputFile($inputFile)

--- a/src/main/php/PHPMD/Utility/Paths.php
+++ b/src/main/php/PHPMD/Utility/Paths.php
@@ -42,8 +42,8 @@ class Paths
     /**
      * Get the realpath of the given path or exception on failure
      * @param string $path
-     * @throws RuntimeException
      * @return string
+     * @throws RuntimeException
      */
     public static function getRealPath($path)
     {

--- a/src/main/php/PHPMD/Utility/Strings.php
+++ b/src/main/php/PHPMD/Utility/Strings.php
@@ -77,8 +77,8 @@ class Strings
      * @param string $listAsString The string to split.
      * @param string $separator The separator to split the string with, similar to explode.
      * @param string $trim Extra character to be trimmed off of each value.
-     * @throws InvalidArgumentException When the separator is an empty string.
      * @return array The list of trimmed and filtered parts of the string.
+     * @throws InvalidArgumentException When the separator is an empty string.
      */
     public static function splitToList($listAsString, $separator = ',', $trim = '')
     {

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -18,6 +18,7 @@
 namespace PHPMD;
 
 use Closure;
+use ErrorException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -189,8 +190,6 @@ abstract class AbstractStaticTestCase extends TestCase
     /**
      * This method initializes the test environment, it configures the files
      * directory and sets the include_path for svn versions.
-     *
-     * @return void
      */
     public static function setUpBeforeClass(): void
     {
@@ -260,7 +259,7 @@ abstract class AbstractStaticTestCase extends TestCase
      * Returns the trace frame of the calling test case.
      *
      * @return array
-     * @throws \ErrorException
+     * @throws ErrorException
      */
     protected static function getCallingTestCase()
     {
@@ -269,7 +268,7 @@ abstract class AbstractStaticTestCase extends TestCase
                 return $frame;
             }
         }
-        throw new \ErrorException('Cannot locate calling test case.');
+        throw new ErrorException('Cannot locate calling test case.');
     }
 
     protected static function getResourceFilePathFromClassName($className, $localPath)

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -102,8 +102,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
 
     /**
      * Resets a changed working directory.
-     *
-     * @return void
      */
     protected function tearDown(): void
     {
@@ -218,7 +216,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Returns the first method or function node for a given test file.
      *
      * @param string $file
-     * @return MethodNode|FunctionNode
+     * @return FunctionNode|MethodNode
      * @since 2.8.3
      */
     protected function getNodeForTestFile($file)
@@ -226,12 +224,12 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
         $source = $this->parseSource($file);
         $type = $source
             ->getTypes();
-        $nodeClassName = 'PHPMD\\Node\\FunctionNode';
+        $nodeClassName = FunctionNode::class;
         $getter = 'getFunctions';
 
         if ($type->count()) {
             $source = $type->current();
-            $nodeClassName = 'PHPMD\\Node\\MethodNode';
+            $nodeClassName = MethodNode::class;
             $getter = 'getMethods';
         }
 
@@ -310,7 +308,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
         }
 
         return implode("\n", array_map(function (RuleViolation $violation) {
-            $nodeExtractor = new ReflectionProperty('PHPMD\\RuleViolation', 'node');
+            $nodeExtractor = new ReflectionProperty(RuleViolation::class, 'node');
             $nodeExtractor->setAccessible(true);
             $node = $nodeExtractor->getValue($violation);
             $node = $node ? $node->getNode() : null;
@@ -378,13 +376,13 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Creates a mocked class node instance.
      *
      * @param string $metric
-     * @param integer $value
+     * @param int $value
      * @return ClassNode
      */
     protected function getClassMock($metric = null, $value = null)
     {
         $class = $this->getMockFromBuilder(
-            $this->getMockBuilder('PHPMD\\Node\\ClassNode')
+            $this->getMockBuilder(ClassNode::class)
                 ->setConstructorArgs([new ASTClass('FooBar')])
         );
 
@@ -402,12 +400,12 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Creates a mocked method node instance.
      *
      * @param string $metric
-     * @param integer $value
+     * @param int $value
      * @return MethodNode
      */
     protected function getMethodMock($metric = null, $value = null)
     {
-        return $this->createFunctionOrMethodMock('PHPMD\\Node\\MethodNode', new ASTMethod('fooBar'), $metric, $value);
+        return $this->createFunctionOrMethodMock(MethodNode::class, new ASTMethod('fooBar'), $metric, $value);
     }
 
     /**
@@ -420,7 +418,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     protected function createFunctionMock($metric = null, $value = null)
     {
         return $this->createFunctionOrMethodMock(
-            'PHPMD\\Node\\FunctionNode',
+            FunctionNode::class,
             new ASTFunction('fooBar'),
             $metric,
             $value
@@ -432,7 +430,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      *
      * @param FunctionNode|MethodNode|PHPUnit_Framework_MockObject_MockObject $mock
      * @param string $metric
-     * @param mixed $value
      * @return FunctionNode|MethodNode
      */
     protected function initFunctionOrMethod($mock, $metric, $value)
@@ -452,8 +449,8 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Creates a mocked report instance.
      *
-     * @param integer $expectedInvokes Number of expected invokes.
-     * @return Report|PHPUnit_Framework_MockObject_MockObject
+     * @param int $expectedInvokes Number of expected invokes.
+     * @return PHPUnit_Framework_MockObject_MockObject|Report
      */
     protected function getReportMock($expectedInvokes = -1)
     {
@@ -467,7 +464,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
             $expects = $this->exactly($expectedInvokes);
         }
 
-        $report = $this->getMockFromBuilder($this->getMockBuilder('PHPMD\\Report'));
+        $report = $this->getMockFromBuilder($this->getMockBuilder(Report::class));
         $report->expects($expects)
             ->method('addRuleViolation');
 
@@ -517,10 +514,10 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     protected function getRuleMock()
     {
         if (version_compare(PHP_VERSION, '7.4.0-dev', '<')) {
-            return $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+            return $this->getMockForAbstractClass(AbstractRule::class);
         }
 
-        return @$this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        return @$this->getMockForAbstractClass(AbstractRule::class);
     }
 
     /**
@@ -528,11 +525,11 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      *
      * @param string $expectedClass Optional class name for apply() expected at least once.
      * @param int|string $count How often should apply() be called?
-     * @return RuleSet|MockObject
+     * @return MockObject|RuleSet
      */
     protected function getRuleSetMock($expectedClass = null, $count = '*')
     {
-        $ruleSet = $this->getMockFromBuilder($this->getMockBuilder('PHPMD\RuleSet'));
+        $ruleSet = $this->getMockFromBuilder($this->getMockBuilder(RuleSet::class));
         if ($expectedClass === null) {
             $ruleSet->expects($this->never())->method('apply');
 
@@ -556,10 +553,10 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Creates a mocked rule violation instance.
      *
      * @param string $fileName The filename to use.
-     * @param integer $beginLine The begin of violation line number to use.
-     * @param integer $endLine The end of violation line number to use.
-     * @param null|object $rule The rule object to use.
-     * @param null|string $description The violation description to use.
+     * @param int $beginLine The begin of violation line number to use.
+     * @param int $endLine The end of violation line number to use.
+     * @param object|null $rule The rule object to use.
+     * @param string|null $description The violation description to use.
      * @return MockObject
      */
     protected function getRuleViolationMock(
@@ -570,7 +567,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
         $description = null
     ) {
         $ruleViolation = $this->getMockFromBuilder(
-            $this->getMockBuilder('PHPMD\\RuleViolation')
+            $this->getMockBuilder(RuleViolation::class)
                 ->setConstructorArgs(
                     [new TooManyFields(), new NodeInfo('fileName', 'namespace', null, null, null, 1, 2), 'Hello']
                 )
@@ -611,7 +608,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      *
      * @param string $file
      * @param string $message
-     * @return ProcessingError|MockObject
+     * @return MockObject|ProcessingError
      */
     protected function getErrorMock(
         $file = '/foo/baz.php',
@@ -619,7 +616,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     ) {
 
         $processingError = $this->getMockFromBuilder(
-            $this->getMockBuilder('PHPMD\\ProcessingError')
+            $this->getMockBuilder(ProcessingError::class)
                 ->setConstructorArgs([$message])
                 ->onlyMethods(['getFile', 'getMessage'])
         );
@@ -667,7 +664,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Returns the PHP_Depend node having the given name.
      *
-     * @param Iterator $nodes
      * @return PHP_Depend_Code_AbstractItem
      * @throws ErrorException
      */
@@ -684,7 +680,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Returns the PHP_Depend node for the calling test case.
      *
-     * @param Iterator $nodes
      * @return PHP_Depend_Code_AbstractItem
      * @throws ErrorException
      */

--- a/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
@@ -3,6 +3,8 @@
 namespace PHPMD\Baseline;
 
 use PHPMD\AbstractTestCase;
+use PHPMD\Rule\CleanCode\MissingImport;
+use PHPMD\Rule\CleanCode\UndefinedVariable;
 use RuntimeException;
 
 /**
@@ -19,9 +21,9 @@ class BaselineSetFactoryTest extends AbstractTestCase
         $baseDir  = dirname($filename);
         $set      = BaselineSetFactory::fromFile($filename);
 
-        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', $baseDir . '/src/foo/bar', null));
+        static::assertTrue($set->contains(MissingImport::class, $baseDir . '/src/foo/bar', null));
         static::assertTrue(
-            $set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', $baseDir . '/src/foo/bar', 'myMethod')
+            $set->contains(UndefinedVariable::class, $baseDir . '/src/foo/bar', 'myMethod')
         );
     }
 
@@ -34,9 +36,9 @@ class BaselineSetFactoryTest extends AbstractTestCase
         $baseDir  = dirname($filename);
         $set      = BaselineSetFactory::fromFile($filename);
 
-        static::assertTrue($set->contains('PHPMD\Rule\CleanCode\MissingImport', $baseDir . '/src\\foo/bar', null));
+        static::assertTrue($set->contains(MissingImport::class, $baseDir . '/src\\foo/bar', null));
         static::assertTrue(
-            $set->contains('PHPMD\Rule\CleanCode\UndefinedVariable', $baseDir . '/src\\foo/bar', 'myMethod')
+            $set->contains(UndefinedVariable::class, $baseDir . '/src\\foo/bar', 'myMethod')
         );
     }
 

--- a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -3,6 +3,7 @@
 namespace PHPMD\Baseline;
 
 use PHPMD\AbstractTestCase;
+use PHPMD\Rule;
 use PHPMD\RuleViolation;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -15,23 +16,23 @@ class BaselineValidatorTest extends AbstractTestCase
     /** @var BaselineSet|MockObject */
     private $baselineSet;
 
-    /** @var RuleViolation|MockObject */
+    /** @var MockObject|RuleViolation */
     private $violation;
 
     protected function setUp(): void
     {
         parent::setUp();
         $rule            = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Rule')->disableOriginalConstructor()
+            $this->getMockBuilder(Rule::class)->disableOriginalConstructor()
         );
         $this->violation = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\RuleViolation')->disableOriginalConstructor()
+            $this->getMockBuilder(RuleViolation::class)->disableOriginalConstructor()
         );
         $this->violation
             ->method('getRule')
             ->willReturn($rule);
         $this->baselineSet = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Baseline\BaselineSet')->disableOriginalConstructor()
+            $this->getMockBuilder(BaselineSet::class)->disableOriginalConstructor()
         );
     }
 

--- a/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
+++ b/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
@@ -69,7 +69,7 @@ class ResultCacheStateTest extends TestCase
 
         $expected = [
             [
-                'rule'          => 'PHPMD\Rule\CleanCode\BooleanArgumentFlag',
+                'rule'          => BooleanArgumentFlag::class,
                 'namespaceName' => 'namespace',
                 'className'     => 'className',
                 'methodName'    => 'methodName',
@@ -195,7 +195,7 @@ class ResultCacheStateTest extends TestCase
                         'hash'       => 'hash',
                         'violations' => [
                             [
-                                'rule'          => 'PHPMD\Rule\CleanCode\BooleanArgumentFlag',
+                                'rule'          => BooleanArgumentFlag::class,
                                 'namespaceName' => 'namespace',
                                 'className'     => 'className',
                                 'methodName'    => 'methodName',

--- a/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
@@ -20,10 +20,10 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
     /** @var CommandLineOptions&MockObject */
     private $options;
 
-    /** @var ResultCacheKeyFactory&MockObject */
+    /** @var MockObject&ResultCacheKeyFactory */
     private $keyFactory;
 
-    /** @var ResultCacheStateFactory&MockObject */
+    /** @var MockObject&ResultCacheStateFactory */
     private $stateFactory;
 
     /** @var ResultCacheUpdater */
@@ -32,13 +32,13 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
     protected function setUp(): void
     {
         $this->options      = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\TextUI\CommandLineOptions')->disableOriginalConstructor()
+            $this->getMockBuilder(CommandLineOptions::class)->disableOriginalConstructor()
         );
         $this->keyFactory   = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Cache\ResultCacheKeyFactory')->disableOriginalConstructor()
+            $this->getMockBuilder(ResultCacheKeyFactory::class)->disableOriginalConstructor()
         );
         $this->stateFactory = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Cache\ResultCacheStateFactory')->disableOriginalConstructor()
+            $this->getMockBuilder(ResultCacheStateFactory::class)->disableOriginalConstructor()
         );
 
         $this->engineFactory = new ResultCacheEngineFactory(new NullOutput(), $this->keyFactory, $this->stateFactory);

--- a/src/test/php/PHPMD/Cache/ResultCacheEngineTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheEngineTest.php
@@ -18,13 +18,13 @@ class ResultCacheEngineTest extends AbstractTestCase
     public function testGetters()
     {
         $filter  = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Cache\ResultCacheFileFilter')->disableOriginalConstructor()
+            $this->getMockBuilder(ResultCacheFileFilter::class)->disableOriginalConstructor()
         );
         $updater = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Cache\ResultCacheUpdater')->disableOriginalConstructor()
+            $this->getMockBuilder(ResultCacheUpdater::class)->disableOriginalConstructor()
         );
         $writer  = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Cache\ResultCacheWriter')->disableOriginalConstructor()
+            $this->getMockBuilder(ResultCacheWriter::class)->disableOriginalConstructor()
         );
 
         $engine = new ResultCacheEngine($filter, $updater, $writer);

--- a/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
@@ -17,19 +17,19 @@ class ResultCacheFileFilterTest extends AbstractTestCase
 {
     /** @var NullOutput */
     private $output;
-    /** @var ResultCacheKey&MockObject */
+    /** @var MockObject&ResultCacheKey */
     private $key;
-    /** @var ResultCacheState&MockObject */
+    /** @var MockObject&ResultCacheState */
     private $state;
 
     protected function setUp(): void
     {
         $this->output = new NullOutput();
         $this->key    = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Cache\Model\ResultCacheKey')->disableOriginalConstructor()
+            $this->getMockBuilder(ResultCacheKey::class)->disableOriginalConstructor()
         );
         $this->state  = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Cache\Model\ResultCacheState')->disableOriginalConstructor()
+            $this->getMockBuilder(ResultCacheState::class)->disableOriginalConstructor()
         );
     }
 

--- a/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
@@ -46,7 +46,7 @@ class ResultCacheKeyFactoryTest extends AbstractTestCase
 
         static::assertTrue($keyData['strict']);
         static::assertNotNull($keyData['baselineHash']);
-        static::assertSame(['PHPMD\Rule\CleanCode\DuplicatedArrayKey'], array_keys($keyData['rules']));
+        static::assertSame([DuplicatedArrayKey::class], array_keys($keyData['rules']));
         static::assertSame(['composer.json', 'composer.lock'], array_keys($keyData['composer']));
         static::assertSame(PHP_VERSION_ID, $keyData['phpVersion']);
     }

--- a/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
@@ -14,7 +14,7 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  */
 class ResultCacheUpdaterTest extends AbstractTestCase
 {
-    /** @var ResultCacheState&MockObject */
+    /** @var MockObject&ResultCacheState */
     private $state;
 
     /** @var ResultCacheUpdater */
@@ -23,7 +23,7 @@ class ResultCacheUpdaterTest extends AbstractTestCase
     protected function setUp(): void
     {
         $this->state = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Cache\Model\ResultCacheState')->disableOriginalConstructor()
+            $this->getMockBuilder(ResultCacheState::class)->disableOriginalConstructor()
         );
 
         $this->updater = new ResultCacheUpdater(new NullOutput(), '/base/path/');

--- a/src/test/php/PHPMD/Console/OutputTest.php
+++ b/src/test/php/PHPMD/Console/OutputTest.php
@@ -13,9 +13,6 @@ class OutputTest extends AbstractTestCase
     /** @var TestOutput */
     private $output;
 
-    /**
-     * @return void
-     */
     protected function setUp(): void
     {
         parent::setUp();

--- a/src/test/php/PHPMD/Node/ASTNodeTest.php
+++ b/src/test/php/PHPMD/Node/ASTNodeTest.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Node;
 
+use PDepend\Source\AST\ASTNode as PDependNode;
 use PHPMD\AbstractTestCase;
 
 /**
@@ -33,7 +34,7 @@ class ASTNodeTest extends AbstractTestCase
      */
     public function testGetImageDelegatesToGetImageMethodOfWrappedNode()
     {
-        $mock = $this->getMockFromBuilder($this->getMockBuilder('PDepend\Source\AST\ASTNode'));
+        $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $mock->expects($this->once())
             ->method('getImage');
 
@@ -48,7 +49,7 @@ class ASTNodeTest extends AbstractTestCase
      */
     public function testGetNameDelegatesToGetImageMethodOfWrappedNode()
     {
-        $mock = $this->getMockFromBuilder($this->getMockBuilder('PDepend\Source\AST\ASTNode'));
+        $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $mock->expects($this->once())
             ->method('getImage');
 
@@ -63,7 +64,7 @@ class ASTNodeTest extends AbstractTestCase
      */
     public function testHasSuppressWarningsAnnotationForAlwaysReturnsFalse()
     {
-        $mock = $this->getMockFromBuilder($this->getMockBuilder('PDepend\Source\AST\ASTNode'));
+        $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
 
         $node = new ASTNode($mock, __FILE__);
         $rule = $this->getRuleMock();
@@ -78,7 +79,7 @@ class ASTNodeTest extends AbstractTestCase
      */
     public function testGetParentNameReturnsNull()
     {
-        $mock = $this->getMockFromBuilder($this->getMockBuilder('PDepend\Source\AST\ASTNode'));
+        $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $node = new ASTNode($mock, __FILE__);
 
         $this->assertNull($node->getParentName());
@@ -91,7 +92,7 @@ class ASTNodeTest extends AbstractTestCase
      */
     public function testGetNamespaceNameReturnsNull()
     {
-        $mock = $this->getMockFromBuilder($this->getMockBuilder('PDepend\Source\AST\ASTNode'));
+        $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $node = new ASTNode($mock, __FILE__);
 
         $this->assertNull($node->getNamespaceName());
@@ -104,7 +105,7 @@ class ASTNodeTest extends AbstractTestCase
      */
     public function testGetFullQualifiedNameReturnsNull()
     {
-        $mock = $this->getMockFromBuilder($this->getMockBuilder('PDepend\Source\AST\ASTNode'));
+        $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $node = new ASTNode($mock, __FILE__);
 
         $this->assertNull($node->getFullQualifiedName());

--- a/src/test/php/PHPMD/Node/ClassNodeTest.php
+++ b/src/test/php/PHPMD/Node/ClassNodeTest.php
@@ -20,8 +20,10 @@ namespace PHPMD\Node;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
+use PHPMD\AbstractRule;
 use PHPMD\AbstractTestCase;
 use PHPMD\Rule\Design\CouplingBetweenObjects;
+use Sindelfingen\MyClass;
 
 /**
  * Test case for the class node implementation.
@@ -56,7 +58,7 @@ class ClassNodeTest extends AbstractTestCase
         $class = new ASTClass(null);
         $class->setComment('/** @SuppressWarnings("PMD") */');
 
-        $rule = $this->getMockFromBuilder($this->getMockBuilder('PHPMD\\AbstractRule'));
+        $rule = $this->getMockFromBuilder($this->getMockBuilder(AbstractRule::class));
 
         $node = new ClassNode($class);
 
@@ -103,7 +105,7 @@ class ClassNodeTest extends AbstractTestCase
 
         $node = new ClassNode($class);
 
-        $this->assertSame('Sindelfingen\\MyClass', $node->getFullQualifiedName());
+        $this->assertSame(MyClass::class, $node->getFullQualifiedName());
     }
 
     /**

--- a/src/test/php/PHPMD/Node/FunctionTest.php
+++ b/src/test/php/PHPMD/Node/FunctionTest.php
@@ -37,7 +37,7 @@ class FunctionTest extends AbstractTestCase
     public function testMagicCallDelegatesToWrappedPHPDependFunction()
     {
         $function = $this->getMockFromBuilder(
-            $this->getMockBuilder('PDepend\\Source\\AST\\ASTFunction')
+            $this->getMockBuilder(ASTFunction::class)
                 ->setConstructorArgs([null])
         );
         $function->expects($this->once())

--- a/src/test/php/PHPMD/Node/InterfaceNodeTest.php
+++ b/src/test/php/PHPMD/Node/InterfaceNodeTest.php
@@ -20,6 +20,7 @@ namespace PHPMD\Node;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTNamespace;
 use PHPMD\AbstractTestCase;
+use Sindelfingen\MyInterface;
 
 /**
  * Test case for the interface node implementation.
@@ -41,7 +42,7 @@ class InterfaceNodeTest extends AbstractTestCase
 
         $node = new InterfaceNode($interface);
 
-        $this->assertSame('Sindelfingen\\MyInterface', $node->getFullQualifiedName());
+        $this->assertSame(MyInterface::class, $node->getFullQualifiedName());
     }
 
     /**

--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -39,7 +39,7 @@ class MethodNodeTest extends AbstractTestCase
     public function testMagicCallDelegatesToWrappedPHPDependMethod()
     {
         $method = $this->getMockFromBuilder(
-            $this->getMockBuilder('PDepend\\Source\\AST\\ASTMethod')
+            $this->getMockBuilder(ASTMethod::class)
                 ->setConstructorArgs([null])
         );
         $method->expects($this->once())
@@ -70,7 +70,7 @@ class MethodNodeTest extends AbstractTestCase
     public function testGetParentTypeReturnsInterfaceForInterfaceMethod()
     {
         $this->assertInstanceOf(
-            'PHPMD\\Node\\InterfaceNode',
+            InterfaceNode::class,
             $this->getMethod()->getParentType()
         );
     }
@@ -83,7 +83,7 @@ class MethodNodeTest extends AbstractTestCase
     public function testGetParentTypeReturnsClassForClassMethod()
     {
         $this->assertInstanceOf(
-            'PHPMD\\Node\\ClassNode',
+            ClassNode::class,
             $this->getMethod()->getParentType()
         );
     }
@@ -94,7 +94,7 @@ class MethodNodeTest extends AbstractTestCase
     public function testGetParentTypeReturnsTrait()
     {
         $this->assertInstanceOf(
-            'PHPMD\\Node\\TraitNode',
+            TraitNode::class,
             $this->getMethod()->getParentType()
         );
     }

--- a/src/test/php/PHPMD/Node/NodeInfoFactoryTest.php
+++ b/src/test/php/PHPMD/Node/NodeInfoFactoryTest.php
@@ -17,7 +17,7 @@ class NodeInfoFactoryTest extends AbstractTestCase
     {
         /** @var AbstractTypeNode&MockObject $node */
         $node = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Node\AbstractTypeNode')->disableOriginalConstructor()
+            $this->getMockBuilder(AbstractTypeNode::class)->disableOriginalConstructor()
         );
         $node->method('getName')->willReturn('className');
         $node->method('getFileName')->willReturn('/file/path');
@@ -42,7 +42,7 @@ class NodeInfoFactoryTest extends AbstractTestCase
     {
         /** @var MethodNode&MockObject $node */
         $node = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Node\MethodNode')->disableOriginalConstructor()
+            $this->getMockBuilder(MethodNode::class)->disableOriginalConstructor()
         );
         $node->method('getName')->willReturn('methodName');
         $node->method('getParentName')->willReturn('className');
@@ -68,7 +68,7 @@ class NodeInfoFactoryTest extends AbstractTestCase
     {
         /** @var MethodNode&MockObject $node */
         $node = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Node\FunctionNode')->disableOriginalConstructor()
+            $this->getMockBuilder(FunctionNode::class)->disableOriginalConstructor()
         );
         $node->method('getName')->willReturn('functionName');
         $node->method('getFileName')->willReturn('/file/path');

--- a/src/test/php/PHPMD/Node/TraitNodeTest.php
+++ b/src/test/php/PHPMD/Node/TraitNodeTest.php
@@ -17,9 +17,10 @@
 
 namespace PHPMD\Node;
 
-use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTTrait;
 use PHPMD\AbstractTestCase;
+use Sindelfingen\MyTrait;
 
 /**
  * Test case for the trait node implementation.
@@ -41,7 +42,7 @@ class TraitNodeTest extends AbstractTestCase
 
         $node = new TraitNode($trait);
 
-        $this->assertSame('Sindelfingen\\MyTrait', $node->getFullQualifiedName());
+        $this->assertSame(MyTrait::class, $node->getFullQualifiedName());
     }
 
     /**

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -199,7 +199,7 @@ class PHPMDTest extends AbstractTestCase
 
         /** @var BaselineSet|PHPUnit_Framework_MockObject_MockObject $baselineSet */
         $baselineSet = $this->getMockFromBuilder(
-            $this->getMockBuilder('\PHPMD\Baseline\BaselineSet')->disableOriginalConstructor()
+            $this->getMockBuilder(BaselineSet::class)->disableOriginalConstructor()
         );
         $baselineSet->expects(static::exactly(2))->method('contains')->willReturn(true);
 

--- a/src/test/php/PHPMD/ParserFactoryTest.php
+++ b/src/test/php/PHPMD/ParserFactoryTest.php
@@ -17,6 +17,8 @@
 
 namespace PHPMD;
 
+use PHPMD\Node\ClassNode;
+
 /**
  * Test case for the parser factory class.
  *
@@ -36,14 +38,14 @@ class ParserFactoryTest extends AbstractTestCase
         $uri = $this->createFileUri('ParserFactory/Directory');
 
         $phpmd = $this->getMockFromBuilder(
-            $this->getMockBuilder('PHPMD\\PHPMD')
+            $this->getMockBuilder(PHPMD::class)
                 ->onlyMethods(['getInput'])
         );
         $phpmd->expects($this->once())
             ->method('getInput')
             ->willReturn($uri);
 
-        $ruleSet = $this->getRuleSetMock('PHPMD\\Node\\ClassNode');
+        $ruleSet = $this->getRuleSetMock(ClassNode::class);
 
         $parser = $factory->create($phpmd);
         $parser->addRuleSet($ruleSet);
@@ -62,14 +64,14 @@ class ParserFactoryTest extends AbstractTestCase
         $uri = $this->createFileUri('ParserFactory/File/Test.php');
 
         $phpmd = $this->getMockFromBuilder(
-            $this->getMockBuilder('PHPMD\\PHPMD')
+            $this->getMockBuilder(PHPMD::class)
                 ->onlyMethods(['getInput'])
         );
         $phpmd->expects($this->once())
             ->method('getInput')
             ->will($this->returnValue($uri));
 
-        $ruleSet = $this->getRuleSetMock('PHPMD\\Node\\ClassNode');
+        $ruleSet = $this->getRuleSetMock(ClassNode::class);
 
         $parser = $factory->create($phpmd);
         $parser->addRuleSet($ruleSet);
@@ -89,14 +91,14 @@ class ParserFactoryTest extends AbstractTestCase
         $uri2 = $this->createFileUri('ParserFactory/Directory');
 
         $phpmd = $this->getMockFromBuilder(
-            $this->getMockBuilder('PHPMD\\PHPMD')
+            $this->getMockBuilder(PHPMD::class)
                 ->onlyMethods(['getInput'])
         );
         $phpmd->expects($this->once())
             ->method('getInput')
             ->will($this->returnValue($uri1 . ',' . $uri2));
 
-        $ruleSet = $this->getRuleSetMock('PHPMD\\Node\\ClassNode', 2);
+        $ruleSet = $this->getRuleSetMock(ClassNode::class, 2);
 
         $parser = $factory->create($phpmd);
         $parser->addRuleSet($ruleSet);
@@ -115,12 +117,12 @@ class ParserFactoryTest extends AbstractTestCase
         $uri1 = $this->createFileUri('ParserFactory/File/Test.php');
         $uri2 = $this->createFileUri('ParserFactory/Directory');
 
-        $phpmd = $this->getMockFromBuilder($this->getMockBuilder('PHPMD\\PHPMD')->onlyMethods(['getInput']));
+        $phpmd = $this->getMockFromBuilder($this->getMockBuilder(PHPMD::class)->onlyMethods(['getInput']));
         $phpmd->expects($this->once())
             ->method('getInput')
             ->will($this->returnValue($uri1 . ',' . $uri2));
 
-        $ruleSet = $this->getRuleSetMock('PHPMD\\Node\\ClassNode', 2);
+        $ruleSet = $this->getRuleSetMock(ClassNode::class, 2);
 
         $parser = $factory->create($phpmd);
         $parser->addRuleSet($ruleSet);
@@ -139,7 +141,7 @@ class ParserFactoryTest extends AbstractTestCase
         $uri = $this->createFileUri('ParserFactory/File/Test.php');
 
         $phpmd = $this->getMockFromBuilder(
-            $this->getMockBuilder('PHPMD\\PHPMD')
+            $this->getMockBuilder(PHPMD::class)
                 ->onlyMethods(['getIgnorePatterns', 'getInput'])
         );
         $phpmd->expects($this->exactly(2))
@@ -164,7 +166,7 @@ class ParserFactoryTest extends AbstractTestCase
         $uri = $this->createFileUri('ParserFactory/File/Test.php');
 
         $phpmd = $this->getMockFromBuilder(
-            $this->getMockBuilder('PHPMD\\PHPMD')
+            $this->getMockBuilder(PHPMD::class)
                 ->onlyMethods(['getFileExtensions', 'getInput'])
         );
         $phpmd->expects($this->exactly(2))

--- a/src/test/php/PHPMD/ParserTest.php
+++ b/src/test/php/PHPMD/ParserTest.php
@@ -17,10 +17,19 @@
 
 namespace PHPMD;
 
+use ArrayIterator;
+use PDepend\Engine;
 use PDepend\Metrics\AnalyzerFactory;
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTCompilationUnit;
+use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\Parser\InvalidStateException;
 use PDepend\Util\Cache\CacheFactory;
 use PDepend\Util\Configuration;
+use PHPMD\Node\ClassNode;
+use PHPMD\Node\FunctionNode;
+use PHPMD\Node\MethodNode;
 use Symfony\Component\DependencyInjection\Container;
 
 /**
@@ -43,7 +52,7 @@ class ParserTest extends AbstractTestCase
             ->will($this->returnValue(true));
 
         $adapter = new Parser($this->getPHPDependMock());
-        $adapter->addRuleSet($this->getRuleSetMock('PHPMD\\Node\\ClassNode'));
+        $adapter->addRuleSet($this->getRuleSetMock(ClassNode::class));
         $adapter->setReport($this->getReportWithNoViolation());
         $adapter->visitClass($mock);
     }
@@ -75,7 +84,7 @@ class ParserTest extends AbstractTestCase
     public function testAdapterDelegatesMethodNodeToRuleSet()
     {
         $adapter = new Parser($this->getPHPDependMock());
-        $adapter->addRuleSet($this->getRuleSetMock('PHPMD\\Node\\MethodNode'));
+        $adapter->addRuleSet($this->getRuleSetMock(MethodNode::class));
         $adapter->setReport($this->getReportWithNoViolation());
         $adapter->visitMethod($this->getPHPDependMethodMock());
     }
@@ -102,7 +111,7 @@ class ParserTest extends AbstractTestCase
     public function testAdapterDelegatesFunctionNodeToRuleSet()
     {
         $adapter = new Parser($this->getPHPDependMock());
-        $adapter->addRuleSet($this->getRuleSetMock('PHPMD\\Node\\FunctionNode'));
+        $adapter->addRuleSet($this->getRuleSetMock(FunctionNode::class));
         $adapter->setReport($this->getReportWithNoViolation());
         $adapter->visitFunction($this->getPHPDependFunctionMock());
     }
@@ -147,7 +156,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Creates a mocked PDepend instance.
      *
-     * @return \PDepend\Engine
+     * @return Engine
      */
     private function getPHPDependMock()
     {
@@ -155,7 +164,7 @@ class ParserTest extends AbstractTestCase
         $config = new Configuration((object)[]);
 
         return $this->getMockFromBuilder(
-            $this->getMockBuilder('PDepend\Engine')
+            $this->getMockBuilder(Engine::class)
                 ->setConstructorArgs([
                     $config,
                     new CacheFactory($config),
@@ -167,12 +176,12 @@ class ParserTest extends AbstractTestCase
     /**
      * Creates a mocked PDepend class instance.
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
      */
     protected function getPHPDependClassMock()
     {
         $class = $this->getMockFromBuilder(
-            $this->getMockBuilder('PDepend\\Source\\AST\\ASTClass')
+            $this->getMockBuilder(ASTClass::class)
                 ->setConstructorArgs([null])
         );
         $class->expects($this->any())
@@ -180,13 +189,13 @@ class ParserTest extends AbstractTestCase
             ->will($this->returnValue($this->getPHPDependFileMock('foo.php')));
         $class->expects($this->any())
             ->method('getConstants')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
         $class->expects($this->any())
             ->method('getProperties')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
         $class->expects($this->any())
             ->method('getMethods')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
 
         return $class;
     }
@@ -200,7 +209,7 @@ class ParserTest extends AbstractTestCase
     protected function getPHPDependFunctionMock($fileName = '/foo/bar.php')
     {
         $function = $this->getMockFromBuilder(
-            $this->getMockBuilder('PDepend\Source\AST\ASTFunction')
+            $this->getMockBuilder(ASTFunction::class)
                 ->setConstructorArgs([null])
         );
         $function->expects($this->atLeastOnce())
@@ -219,7 +228,7 @@ class ParserTest extends AbstractTestCase
     protected function getPHPDependMethodMock($fileName = '/foo/bar.php')
     {
         $method = $this->getMockFromBuilder(
-            $this->getMockBuilder('PDepend\Source\AST\ASTMethod')
+            $this->getMockBuilder(ASTMethod::class)
                 ->setConstructorArgs([null])
         );
         $method->expects($this->atLeastOnce())
@@ -238,7 +247,7 @@ class ParserTest extends AbstractTestCase
     protected function getPHPDependFileMock($fileName)
     {
         $file = $this->getMockFromBuilder(
-            $this->getMockBuilder('PDepend\Source\AST\ASTCompilationUnit')
+            $this->getMockBuilder(ASTCompilationUnit::class)
                 ->setConstructorArgs([null])
         );
         $file->expects($this->any())

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
@@ -18,8 +18,10 @@
 namespace PHPMD\Regression;
 
 use PHPMD\PHPMD;
+use PHPMD\Renderer\TextRenderer;
 use PHPMD\Report;
 use PHPMD\RuleSetFactory;
+use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * Regression test for issue 409.
@@ -34,7 +36,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
     private const VIOLATION_MESSAGE = 'The class ExcessivePublicCountWorksForPublicStaticMethods has 71 public methods';
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\PHPMD\Renderer\TextRenderer
+     * @var PHPUnit_Framework_MockObject_MockObject|TextRenderer
      */
     private $renderer;
 
@@ -44,7 +46,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
     protected function setUp(): void
     {
         $this->renderer = $this->getMockFromBuilder(
-            $this->getMockBuilder('PHPMD\Renderer\TextRenderer')
+            $this->getMockBuilder(TextRenderer::class)
                 ->disableOriginalConstructor()
                 ->onlyMethods(['renderReport', 'start', 'end'])
         );

--- a/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Renderer;
 
+use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\Stubs\WriterStub;
 
@@ -49,7 +50,7 @@ class AnsiRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->atLeastOnce())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator($violations)));
+            ->will($this->returnValue(new ArrayIterator($violations)));
         $report->expects($this->atLeastOnce())
             ->method('isEmpty')
             ->will($this->returnValue(false));
@@ -58,7 +59,7 @@ class AnsiRendererTest extends AbstractTestCase
             ->will($this->returnValue(true));
         $report->expects($this->atLeastOnce())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator($errors)));
+            ->will($this->returnValue(new ArrayIterator($errors)));
         $report->expects($this->once())
             ->method('getElapsedTimeInMillis')
             ->will($this->returnValue(200));
@@ -104,7 +105,7 @@ class AnsiRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->atLeastOnce())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
         $report->expects($this->atLeastOnce())
             ->method('isEmpty')
             ->will($this->returnValue(true));
@@ -113,7 +114,7 @@ class AnsiRendererTest extends AbstractTestCase
             ->will($this->returnValue(false));
         $report->expects($this->atLeastOnce())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
         $report->expects($this->once())
             ->method('getElapsedTimeInMillis')
             ->will($this->returnValue(200));

--- a/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
@@ -25,7 +25,7 @@ class BaselineRendererTest extends AbstractTestCase
             $this->getRuleViolationMock('/src/php/foo.php'),
         ];
 
-        /** @var Report|MockObject $report */
+        /** @var MockObject|Report $report */
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
@@ -52,7 +52,7 @@ class BaselineRendererTest extends AbstractTestCase
         $violationMock = $this->getRuleViolationMock('/src/php/bar.php');
         $violationMock->expects(static::once())->method('getMethodName')->willReturn('foo');
 
-        /** @var Report|MockObject $report */
+        /** @var MockObject|Report $report */
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
@@ -80,7 +80,7 @@ class BaselineRendererTest extends AbstractTestCase
         $violationMock->expects(static::exactly(2))->method('getMethodName')->willReturn('foo');
 
         // add the same violation twice
-        /** @var Report|MockObject $report */
+        /** @var MockObject|Report $report */
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
@@ -109,7 +109,7 @@ class BaselineRendererTest extends AbstractTestCase
             ->method('getRuleViolations')
             ->willReturn(new ArrayIterator([]));
 
-        /** @var Report|MockObject $report */
+        /** @var MockObject|Report $report */
         $renderer = new BaselineRenderer('/src');
         $renderer->setWriter($writer);
         $renderer->start();

--- a/src/test/php/PHPMD/Renderer/CheckStyleRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/CheckStyleRendererTest.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Renderer;
 
+use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
@@ -47,10 +48,10 @@ class CheckStyleRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator($violations)));
+            ->will($this->returnValue(new ArrayIterator($violations)));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
 
         $renderer = new XMLRenderer();
         $renderer->setWriter($writer);
@@ -85,10 +86,10 @@ class CheckStyleRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator($processingErrors)));
+            ->will($this->returnValue(new ArrayIterator($processingErrors)));
 
         $renderer = new XMLRenderer();
         $renderer->setWriter($writer);

--- a/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Renderer;
 
+use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
@@ -47,10 +48,10 @@ class GitHubRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator($violations)));
+            ->will($this->returnValue(new ArrayIterator($violations)));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
 
         $renderer = new GitHubRenderer();
         $renderer->setWriter($writer);
@@ -86,10 +87,10 @@ class GitHubRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator($errors)));
+            ->will($this->returnValue(new ArrayIterator($errors)));
 
         $renderer = new GitHubRenderer();
         $renderer->setWriter($writer);

--- a/src/test/php/PHPMD/Renderer/GitLabRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/GitLabRendererTest.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Renderer;
 
+use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
@@ -46,10 +47,10 @@ class GitLabRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator($violations)));
+            ->will($this->returnValue(new ArrayIterator($violations)));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
 
         $renderer = new GitLabRenderer();
         $renderer->setWriter($writer);
@@ -83,10 +84,10 @@ class GitLabRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator($processingErrors)));
+            ->will($this->returnValue(new ArrayIterator($processingErrors)));
 
         $renderer = new GitLabRenderer();
         $renderer->setWriter($writer);

--- a/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -17,8 +17,8 @@
 
 namespace PHPMD\Renderer;
 
+use ArrayIterator;
 use PHPMD\AbstractTestCase;
-use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
 
 /**
@@ -47,7 +47,7 @@ class HTMLRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator($violations)));
+            ->will($this->returnValue(new ArrayIterator($violations)));
 
         $extraLineInExcerpt = 2;
         $renderer = new HTMLRenderer($extraLineInExcerpt);

--- a/src/test/php/PHPMD/Renderer/JSONRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/JSONRendererTest.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Renderer;
 
+use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
@@ -46,10 +47,10 @@ class JSONRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator($violations)));
+            ->will($this->returnValue(new ArrayIterator($violations)));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
 
         $renderer = new JSONRenderer();
         $renderer->setWriter($writer);
@@ -83,10 +84,10 @@ class JSONRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator($processingErrors)));
+            ->will($this->returnValue(new ArrayIterator($processingErrors)));
 
         $renderer = new JSONRenderer();
         $renderer->setWriter($writer);

--- a/src/test/php/PHPMD/Renderer/SARIFRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/SARIFRendererTest.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Renderer;
 
+use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\RuleStub;
@@ -57,10 +58,10 @@ class SARIFRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator($violations)));
+            ->will($this->returnValue(new ArrayIterator($violations)));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
 
         $renderer = new SARIFRenderer();
         $renderer->setWriter($writer);
@@ -100,10 +101,10 @@ class SARIFRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator($processingErrors)));
+            ->will($this->returnValue(new ArrayIterator($processingErrors)));
 
         $renderer = new SARIFRenderer();
         $renderer->setWriter($writer);
@@ -121,10 +122,10 @@ class SARIFRendererTest extends AbstractTestCase
         $flags = defined('JSON_PRETTY_PRINT') ? constant('JSON_PRETTY_PRINT') : 0;
 
         $this->assertSame(
-            json_encode($actual, $flags),
             json_encode(json_decode(file_get_contents(
                 __DIR__ . '/../../../resources/files/renderer/sarif_renderer_processing_errors.sarif'
-            )), $flags)
+            )), $flags),
+            json_encode($actual, $flags)
         );
     }
 }

--- a/src/test/php/PHPMD/Renderer/XMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/XMLRendererTest.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Renderer;
 
+use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
@@ -47,10 +48,10 @@ class XMLRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator($violations)));
+            ->will($this->returnValue(new ArrayIterator($violations)));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
 
         $renderer = new XMLRenderer();
         $renderer->setWriter($writer);
@@ -85,10 +86,10 @@ class XMLRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new \ArrayIterator([])));
+            ->will($this->returnValue(new ArrayIterator([])));
         $report->expects($this->once())
             ->method('getErrors')
-            ->will($this->returnValue(new \ArrayIterator($processingErrors)));
+            ->will($this->returnValue(new ArrayIterator($processingErrors)));
 
         $renderer = new XMLRenderer();
         $renderer->setWriter($writer);

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Rule\Controversial;
 
 use PHPMD\AbstractTestCase;
+use PHPMD\Node\MethodNode;
 
 /**
  * Test case for the camel case method name rule.
@@ -268,7 +269,7 @@ class CamelCaseMethodNameTest extends AbstractTestCase
      * Returns the first method found in a source file related to the calling
      * test method.
      *
-     * @return \PHPMD\Node\MethodNode
+     * @return MethodNode
      */
     protected function getMethod()
     {

--- a/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
@@ -18,6 +18,8 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPMD\Node\FunctionNode;
+use PHPMD\Node\MethodNode;
 
 /**
  * Test case for the excessive long parameter list rule.
@@ -107,8 +109,8 @@ class LongParameterListTest extends AbstractTestCase
     /**
      * Returns a mocked method instance.
      *
-     * @param integer $parameterCount
-     * @return \PHPMD\Node\MethodNode
+     * @param int $parameterCount
+     * @return MethodNode
      */
     private function createMethod($parameterCount)
     {
@@ -118,9 +120,9 @@ class LongParameterListTest extends AbstractTestCase
     /**
      * Creates a mocked function node instance.
      *
-     * @param integer $parameterCount Number of function parameters.
+     * @param int $parameterCount Number of function parameters.
      *
-     * @return \PHPMD\Node\FunctionNode
+     * @return FunctionNode
      */
     private function createFunction($parameterCount)
     {
@@ -130,9 +132,9 @@ class LongParameterListTest extends AbstractTestCase
     /**
      * Initializes the getParameterCount() method of the given callable.
      *
-     * @param \PHPMD\Node\FunctionNode|\PHPMD\Node\MethodNode $mock
-     * @param integer $parameterCount
-     * @return \PHPMD\Node\FunctionNode|\PHPMD\Node\MethodNode
+     * @param FunctionNode|MethodNode $mock
+     * @param int $parameterCount
+     * @return FunctionNode|MethodNode
      */
     private function initFunctionOrMethodMock($mock, $parameterCount)
     {

--- a/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPMD\Node\ClassNode;
 
 /**
  * Test case for the too many methods rule.
@@ -163,9 +164,9 @@ class TooManyMethodsTest extends AbstractTestCase
     /**
      * Creates a prepared class node mock
      *
-     * @param integer $numberOfMethods
+     * @param int $numberOfMethods
      * @param string[] $methodNames
-     * @return \PHPMD\Node\ClassNode
+     * @return ClassNode
      */
     private function createClassMock($numberOfMethods, array $methodNames = null)
     {

--- a/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -20,6 +20,7 @@ namespace PHPMD\Rule\Design;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\State;
 use PHPMD\AbstractTestCase;
+use PHPMD\Node\ClassNode;
 use PHPMD\Node\MethodNode;
 use PHPMD\Report;
 
@@ -181,10 +182,10 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     /**
      * Creates a prepared class node mock
      *
-     * @param integer $numberOfMethods
+     * @param int $numberOfMethods
      * @param array|null $publicMethods
      * @param array|null $privateMethods
-     * @return \PHPMD\Node\ClassNode
+     * @return ClassNode
      */
     private function createClassMock($numberOfMethods, array $publicMethods = [], array $privateMethods = [])
     {

--- a/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
+use PHPMD\Node\MethodNode;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Naming\BooleanGetMethodName} rule class.
@@ -138,7 +139,7 @@ class BooleanGetMethodNameTest extends AbstractTestCase
      * Returns the first method found in a source file related to the calling
      * test method.
      *
-     * @return \PHPMD\Node\MethodNode
+     * @return MethodNode
      */
     protected function getMethod()
     {

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -17,10 +17,13 @@
 
 namespace PHPMD;
 
+use Exception;
 use org\bovigo\vfs\vfsStream;
 use PHPMD\Exception\RuleClassFileNotFoundException;
 use PHPMD\Exception\RuleClassNotFoundException;
 use PHPMD\Exception\RuleSetNotFoundException;
+use PHPMD\Stubs\ClassFileNotFoundRule;
+use PHPMD\Stubs\ClassNotFoundRule;
 use RuntimeException;
 
 /**
@@ -95,7 +98,7 @@ class RuleSetFactoryTest extends AbstractTestCase
     public function testCreateRuleSetsForSingleFileReturnsOneRuleSetInstance()
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
-        $this->assertInstanceOf('PHPMD\\RuleSet', $ruleSets[0]);
+        $this->assertInstanceOf(RuleSet::class, $ruleSets[0]);
     }
 
     /**
@@ -145,8 +148,8 @@ class RuleSetFactoryTest extends AbstractTestCase
             'rulesets/set1.xml',
             'rulesets/set2.xml'
         );
-        $this->assertInstanceOf('PHPMD\\RuleSet', $ruleSets[0]);
-        $this->assertInstanceOf('PHPMD\\RuleSet', $ruleSets[1]);
+        $this->assertInstanceOf(RuleSet::class, $ruleSets[0]);
+        $this->assertInstanceOf(RuleSet::class, $ruleSets[1]);
     }
 
     /**
@@ -254,7 +257,7 @@ class RuleSetFactoryTest extends AbstractTestCase
         self::changeWorkingDirectory();
 
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/refset1.xml');
-        $this->assertInstanceOf('PHPMD\\AbstractRule', $ruleSets[0]->getRules()->current());
+        $this->assertInstanceOf(AbstractRule::class, $ruleSets[0]->getRules()->current());
     }
 
     /**
@@ -290,7 +293,7 @@ class RuleSetFactoryTest extends AbstractTestCase
         $factory = new RuleSetFactory();
         $ruleSet = $factory->createSingleRuleSet('set1');
 
-        $this->assertInstanceOf('PHPMD\\RuleSet', $ruleSet);
+        $this->assertInstanceOf(RuleSet::class, $ruleSet);
     }
 
     /**
@@ -582,7 +585,7 @@ class RuleSetFactoryTest extends AbstractTestCase
     public function testCreateRuleSetsThrowsExceptionWhenClassFileNotInIncludePath()
     {
         self::expectExceptionObject(new RuleClassFileNotFoundException(
-            'PHPMD\\Stubs\\ClassFileNotFoundRule',
+            ClassFileNotFoundRule::class,
         ));
 
         $fileName = self::createFileUri('rulesets/set-class-file-not-found.xml');
@@ -601,7 +604,7 @@ class RuleSetFactoryTest extends AbstractTestCase
     public function testCreateRuleSetThrowsExceptionWhenFileNotContainsClass()
     {
         self::expectExceptionObject(new RuleClassNotFoundException(
-            'PHPMD\\Stubs\\ClassNotFoundRule',
+            ClassNotFoundRule::class,
         ));
         $fileName = self::createFileUri('rulesets/set-class-not-found.xml');
         $factory = new RuleSetFactory();
@@ -649,7 +652,7 @@ class RuleSetFactoryTest extends AbstractTestCase
      * reference-by-includepath and explicit-classfile-declaration works.
      *
      * @return void
-     * @throws \Exception
+     * @throws Exception
      */
     public function testAddPHPIncludePath()
     {
@@ -665,7 +668,7 @@ class RuleSetFactoryTest extends AbstractTestCase
             $expectedIncludePath = "/foo/bar/baz";
             $actualIncludePaths = explode(PATH_SEPARATOR, get_include_path());
             $isIncludePathPresent = in_array($expectedIncludePath, $actualIncludePaths);
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             set_include_path($includePathBefore);
             throw $exception;
         }
@@ -702,7 +705,7 @@ class RuleSetFactoryTest extends AbstractTestCase
                 );
             } catch (RuleSetNotFoundException $e) {
                 $ruleSetNotFoundExceptionCount++;
-            } catch (\RuntimeException $e) {
+            } catch (RuntimeException $e) {
                 $runtimeExceptionCount++;
             }
         }
@@ -745,7 +748,7 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Invokes the <b>createRuleSets()</b> of the {@link RuleSetFactory}
      * class.
      *
-     * @param string $file At least one rule configuration file name. You can
+     * @param string $files At least one rule configuration file name. You can
      *        also pass multiple parameters with ruleset configuration files.
      * @return \PHPMD\RuleSet[]
      */

--- a/src/test/php/PHPMD/RuleSetTest.php
+++ b/src/test/php/PHPMD/RuleSetTest.php
@@ -24,7 +24,6 @@ use PDepend\Source\AST\ASTIfStatement;
 use PDepend\Source\AST\ASTScopeStatement;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\FunctionNode;
-use PHPMD\RuleByNameNotFoundException;
 use PHPMD\Rule\CleanCode\ElseExpression;
 use PHPMD\Stubs\RuleStub;
 

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -36,7 +36,7 @@ class RuleTest extends AbstractTestCase
     public function testGetBooleanPropertyReturnsTrueForStringValue1()
     {
         /** @var AbstractRule $rule */
-        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->addProperty(__FUNCTION__, '1');
 
         $this->assertTrue($rule->getBooleanProperty(__FUNCTION__));
@@ -52,7 +52,7 @@ class RuleTest extends AbstractTestCase
     public function testGetBooleanPropertyReturnsTrueForStringValueOn()
     {
         /** @var AbstractRule $rule */
-        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->addProperty(__FUNCTION__, 'on');
 
         $this->assertTrue($rule->getBooleanProperty(__FUNCTION__));
@@ -68,7 +68,7 @@ class RuleTest extends AbstractTestCase
     public function testGetBooleanPropertyReturnsTrueForStringValueTrue()
     {
         /** @var AbstractRule $rule */
-        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->addProperty(__FUNCTION__, 'true');
 
         $this->assertTrue($rule->getBooleanProperty(__FUNCTION__));
@@ -84,7 +84,7 @@ class RuleTest extends AbstractTestCase
     public function testGetBooleanPropertyReturnsTrueForDifferentStringValue()
     {
         /** @var AbstractRule $rule */
-        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->addProperty(__FUNCTION__, 'True');
 
         $this->assertFalse($rule->getBooleanProperty(__FUNCTION__));
@@ -100,7 +100,7 @@ class RuleTest extends AbstractTestCase
     public function testGetBooleanPropertyReturnsFallbackString()
     {
         /** @var AbstractRule $rule */
-        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        $rule = $this->getMockForAbstractClass(AbstractRule::class);
 
         $this->assertTrue($rule->getBooleanProperty(__FUNCTION__, true));
     }
@@ -115,7 +115,7 @@ class RuleTest extends AbstractTestCase
     public function testGetIntPropertyReturnsValueOfTypeInteger()
     {
         /** @var AbstractRule $rule */
-        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->addProperty(__FUNCTION__, '42.3');
 
         $this->assertSame(42, $rule->getIntProperty(__FUNCTION__));
@@ -133,7 +133,7 @@ class RuleTest extends AbstractTestCase
         self::expectException(OutOfBoundsException::class);
 
         /** @var AbstractRule $rule */
-        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->getIntProperty(__FUNCTION__);
     }
 
@@ -147,7 +147,7 @@ class RuleTest extends AbstractTestCase
     public function testGetIntPropertyReturnsFallbackString()
     {
         /** @var AbstractRule $rule */
-        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        $rule = $this->getMockForAbstractClass(AbstractRule::class);
 
         $this->assertSame(123, $rule->getIntProperty(__FUNCTION__, '123'));
     }
@@ -164,7 +164,7 @@ class RuleTest extends AbstractTestCase
         self::expectException(OutOfBoundsException::class);
 
         /** @var AbstractRule $rule */
-        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->getBooleanProperty(__FUNCTION__);
     }
 
@@ -180,7 +180,7 @@ class RuleTest extends AbstractTestCase
         self::expectException(OutOfBoundsException::class);
 
         /** @var AbstractRule $rule */
-        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->getStringProperty(__FUNCTION__);
     }
 
@@ -194,7 +194,7 @@ class RuleTest extends AbstractTestCase
     public function testGetStringPropertyReturnsString()
     {
         /** @var AbstractRule $rule */
-        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->addProperty(__FUNCTION__, 'Forty Two');
 
         $this->assertSame('Forty Two', $rule->getStringProperty(__FUNCTION__));
@@ -210,7 +210,7 @@ class RuleTest extends AbstractTestCase
     public function testGetStringPropertyReturnsFallbackString()
     {
         /** @var AbstractRule $rule */
-        $rule = $this->getMockForAbstractClass('PHPMD\\AbstractRule');
+        $rule = $this->getMockForAbstractClass(AbstractRule::class);
 
         $this->assertSame('fallback', $rule->getStringProperty(__FUNCTION__, 'fallback'));
     }

--- a/src/test/php/PHPMD/Stubs/RuleStub.php
+++ b/src/test/php/PHPMD/Stubs/RuleStub.php
@@ -47,8 +47,6 @@ class RuleStub extends AbstractRule implements ClassAware
     /**
      * This method should implement the violation analysis algorithm of concrete
      * rule implementations. All extending classes must implement this method.
-     *
-     * @param \PHPMD\AbstractNode $node
      */
     public function apply(AbstractNode $node): void
     {

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -23,7 +23,18 @@ use PHPMD\AbstractTestCase;
 use PHPMD\Baseline\BaselineMode;
 use PHPMD\Cache\Model\ResultCacheStrategy;
 use PHPMD\Console\OutputInterface;
+use PHPMD\Renderer\AnsiRenderer;
+use PHPMD\Renderer\CheckStyleRenderer;
+use PHPMD\Renderer\GitHubRenderer;
+use PHPMD\Renderer\GitLabRenderer;
+use PHPMD\Renderer\HtmlRenderer;
+use PHPMD\Renderer\JSONRenderer;
+use PHPMD\Renderer\SARIFRenderer;
+use PHPMD\Renderer\TextRenderer;
+use PHPMD\Renderer\XmlRenderer;
 use PHPMD\Rule;
+use PHPMD\Test\Renderer\NamespaceRenderer;
+use PHPMD\Test\Renderer\NotExistsRenderer;
 use ReflectionProperty;
 
 /**
@@ -57,7 +68,7 @@ class CommandLineOptionsTest extends AbstractTestCase
         $opts = new CommandLineOptions($args);
         $renbderer = $opts->createRenderer();
 
-        $verbosityExtractor = new ReflectionProperty('PHPMD\\Renderer\\TextRenderer', 'verbosityLevel');
+        $verbosityExtractor = new ReflectionProperty(TextRenderer::class, 'verbosityLevel');
         $verbosityExtractor->setAccessible(true);
 
         $verbosityLevel = $verbosityExtractor->getValue($renbderer);
@@ -75,7 +86,7 @@ class CommandLineOptionsTest extends AbstractTestCase
         $opts = new CommandLineOptions($args);
         $renderer = $opts->createRenderer();
 
-        $coloredExtractor = new ReflectionProperty('PHPMD\\Renderer\\TextRenderer', 'colored');
+        $coloredExtractor = new ReflectionProperty(TextRenderer::class, 'colored');
         $coloredExtractor->setAccessible(true);
 
         $colored = $coloredExtractor->getValue($renderer);
@@ -709,19 +720,19 @@ class CommandLineOptionsTest extends AbstractTestCase
     public static function dataProviderCreateRenderer(): array
     {
         return [
-            ['html', 'PHPMD\\Renderer\\HtmlRenderer'],
-            ['text', 'PHPMD\\Renderer\\TextRenderer'],
-            ['xml', 'PHPMD\\Renderer\\XmlRenderer'],
-            ['ansi', 'PHPMD\\Renderer\\AnsiRenderer'],
-            ['github', 'PHPMD\\Renderer\\GitHubRenderer'],
-            ['gitlab', 'PHPMD\\Renderer\\GitLabRenderer'],
-            ['json', 'PHPMD\\Renderer\\JSONRenderer'],
-            ['checkstyle', 'PHPMD\\Renderer\\CheckStyleRenderer'],
-            ['sarif', 'PHPMD\\Renderer\\SARIFRenderer'],
+            ['html', HtmlRenderer::class],
+            ['text', TextRenderer::class],
+            ['xml', XmlRenderer::class],
+            ['ansi', AnsiRenderer::class],
+            ['github', GitHubRenderer::class],
+            ['gitlab', GitLabRenderer::class],
+            ['json', JSONRenderer::class],
+            ['checkstyle', CheckStyleRenderer::class],
+            ['sarif', SARIFRenderer::class],
             ['PHPMD_Test_Renderer_PEARRenderer', 'PHPMD_Test_Renderer_PEARRenderer'],
-            ['PHPMD\\Test\\Renderer\\NamespaceRenderer', 'PHPMD\\Test\\Renderer\\NamespaceRenderer'],
+            [NamespaceRenderer::class, NamespaceRenderer::class],
             /* Test what happens when class already exists. */
-            ['PHPMD\\Test\\Renderer\\NamespaceRenderer', 'PHPMD\\Test\\Renderer\\NamespaceRenderer'],
+            [NamespaceRenderer::class, NamespaceRenderer::class],
         ];
     }
 
@@ -744,14 +755,13 @@ class CommandLineOptionsTest extends AbstractTestCase
     {
         return [
             [''],
-            ['PHPMD\\Test\\Renderer\\NotExistsRenderer'],
+            [NotExistsRenderer::class],
         ];
     }
 
     /**
      * @param string $deprecatedName
      * @param string $newName
-     * @param Closure $result
      * @dataProvider dataProviderDeprecatedCliOptions
      */
     public function testDeprecatedCliOptions($deprecatedName, $newName, Closure $result)
@@ -794,8 +804,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @param array $options
-     * @param array $expected
      * @return void
      * @dataProvider dataProviderGetReportFiles
      */

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -32,9 +32,6 @@ class CommandTest extends AbstractTestCase
      */
     private $stderrStreamFilter;
 
-    /**
-     * @return void
-     */
     protected function tearDown(): void
     {
         if (is_resource($this->stderrStreamFilter)) {
@@ -46,9 +43,6 @@ class CommandTest extends AbstractTestCase
     }
 
     /**
-     * @param            $sourceFile
-     * @param            $expectedExitCode
-     * @param array|null $options
      * @return void
      * @dataProvider dataProviderTestMainWithOption
      */
@@ -299,7 +293,7 @@ class CommandTest extends AbstractTestCase
 
     public function testMainWritesExceptionMessageToStderr()
     {
-        stream_filter_register('stderr_stream', 'PHPMD\\TextUI\\StreamFilter');
+        stream_filter_register('stderr_stream', StreamFilter::class);
 
         $this->stderrStreamFilter = stream_filter_prepend(STDERR, 'stderr_stream');
 
@@ -402,7 +396,7 @@ class CommandTest extends AbstractTestCase
 
     public function testMainPrintsVersionToStdout()
     {
-        stream_filter_register('stderr_stream', 'PHPMD\\TextUI\\StreamFilter');
+        stream_filter_register('stderr_stream', StreamFilter::class);
 
         $this->stderrStreamFilter = stream_filter_prepend(STDOUT, 'stderr_stream');
 

--- a/src/test/php/PHPMD/TextUI/StreamFilter.php
+++ b/src/test/php/PHPMD/TextUI/StreamFilter.php
@@ -17,10 +17,12 @@
 
 namespace PHPMD\TextUI;
 
+use php_user_filter;
+
 /**
  * Utility to test stream related stuff
  */
-class StreamFilter extends \php_user_filter
+class StreamFilter extends php_user_filter
 {
     public static $streamHandle;
 


### PR DESCRIPTION
Type: refactoring / documentation update
Breaking change: no

Similar class import cleanup as https://github.com/phpmd/phpmd/pull/1123, but this one is for tests and also applies the code style.