### PR TITLE
Fix Scrutinizer configuration

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,14 +15,16 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.3]
-        dependency-version: [prefer-stable]
+        php: ['8.3']
+        setup: ['stable']
 
     name: PHP ${{ matrix.php }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -33,17 +35,21 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
-          key: coverage-${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.dependency-version }}-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-coverage-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.json') }}
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
-        run: composer update --prefer-dist --no-progress --${{ matrix.dependency-version }}
+        run: |
+          composer require scrutinizer/ocular --no-update --no-interaction
+          composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
 
       - name: Execute Unit Tests
         run: vendor/bin/paratest --coverage-text --coverage-clover=coverage.xml
+        env:
+          XDEBUG_MODE: coverage
 
       - name: Archive code coverage results
         uses: codecov/codecov-action@v4
@@ -51,3 +57,6 @@ jobs:
           files: ./coverage.xml
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload Code Coverage To Scrutinizer
+        run: vendor/bin/ocular code-coverage:upload --format=php-clover coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,22 +37,22 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.json') }}
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php != '8.4'
-        run: composer update --no-progress --prefer-${{ matrix.setup }} --prefer-dist --no-progress
+        run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
 
       # For now we need to overwrite the PHP version check on the 8.4 beta as paratest has not been releasd for it yet
       - name: Install dependencies (PHP 8.4 beta)
         if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php == '8.4'
-        run: composer update --no-progress --prefer-${{ matrix.setup }} --prefer-dist --no-progress --ignore-platform-req=php
+        run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }} --ignore-platform-req=php
 
       - name: Execute Unit Tests
-        run: vendor/bin/paratest
+        run: composer test
 
       - name: Run PHPStan
         if: matrix.php != '8.4'

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,13 +1,18 @@
 build:
-  environment:
-    php:
-      version: 8.1.0
+    environment:
+        php:
+            version: 8.1
+    tests:
+        override:
+            - true
 
 checks:
-  php:
-    code_rating: true
-    duplication: true
+    php:
+        code_rating: true
+        duplication: true
 
 filter:
-  excluded_paths:
-    - src/test/resources/files/
+    paths: [ "src/main/php/*" ]
+
+tools:
+    external_code_coverage: true


### PR DESCRIPTION
Type: documentation update)
Breaking change: no

- Upload coverage from our common test
- Allow wider range of PHP version to utilize build cache
- Narrow scanned files
- Align some GitHub Action settings