### PR TITLE
Backport: Fix Scrutinizer configuration

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,14 +15,15 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.3]
-        dependency-version: [prefer-stable]
+        php: ['8.3']
 
     name: PHP ${{ matrix.php }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -33,14 +34,14 @@ jobs:
 
       - name: Cache library packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-coverage-${{ matrix.php }}-${{ hashFiles('composer.json') }}
+          key: ${{ runner.os }}-coverage-v2-${{ matrix.php }}-${{ hashFiles('composer.json') }}
 
       - name: Cache test packages
         id: composer-test-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/test/vendor
           key: ${{ runner.os }}-coverage-test-${{ matrix.php }}-${{ hashFiles('src/test/composer.json') }}
@@ -48,6 +49,7 @@ jobs:
       - name: Upgrade PHPUnit
         run: |
           composer require symfony/config:^6.4 --no-update --no-interaction --dev
+          composer require scrutinizer/ocular --no-update --no-interaction --dev
           cd src/test && composer require phpunit/phpunit:^5.7.27 --no-update --no-interaction --dev
 
       - name: Install dependencies
@@ -63,6 +65,8 @@ jobs:
 
       - name: Execute Unit Tests
         run: src/test/vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
+        env:
+          XDEBUG_MODE: coverage
 
       - name: Archive code coverage results
         uses: codecov/codecov-action@v4
@@ -70,3 +74,6 @@ jobs:
           files: ./coverage.xml
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload Code Coverage To Scrutinizer
+        run: vendor/bin/ocular code-coverage:upload --format=php-clover coverage.xml

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,13 +1,18 @@
 build:
-  environment:
-    php:
-      version: 7.4.0
+    environment:
+        php:
+            version: 7.4
+    tests:
+        override:
+            - true
 
 checks:
-  php:
-    code_rating: true
-    duplication: true
+    php:
+        code_rating: true
+        duplication: true
 
 filter:
-  excluded_paths:
-    - src/test/resources/files/
+    paths: [ "src/main/php/*" ]
+
+tools:
+    external_code_coverage: true


### PR DESCRIPTION
Type: documentation update)
Breaking change: no

Finally we can get the "All checks have passed" instead of having forever an unfolded liste of pending checks on PRs.

Hasn't worked for 3 years, but looks like things have at least moved in the right direction :D
![image](https://github.com/phpmd/phpmd/assets/204594/3c3d741c-05cb-4541-a6cd-e66c246827cd)

- Upload coverage from our common test
- Allow wider range of PHP version to utilize build cache
- Narrow scanned files
- Align some GitHub Action settings