### PR TITLE
Document and check all exceptions

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -51,6 +51,9 @@
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore">
         <severity>0</severity>
     </rule>
+    <rule ref="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber">
+        <severity>0</severity>
+    </rule>
 
     <!-- Sniffs from Slevomat standard -->
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,9 @@ parameters:
         - src/main
     rememberPossiblyImpureFunctionValues: false
     level: 3
+    exceptions:
+        reportUncheckedExceptionDeadCatch: true
+        implicitThrows: false
+        check:
+            missingCheckedExceptionInThrows: true
+            tooWideThrowType: true

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -18,6 +18,7 @@
 namespace PHPMD;
 
 use BadMethodCallException;
+use OutOfBoundsException;
 use PDepend\Source\AST\AbstractASTArtifact;
 use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTArtifact;
@@ -98,6 +99,7 @@ abstract class AbstractNode
      *
      * @param int $index The child offset.
      * @return AbstractNode
+     * @throws OutOfBoundsException
      */
     public function getChild($index)
     {
@@ -316,7 +318,7 @@ abstract class AbstractNode
      * Returns the full qualified name of a class, an interface, a method or
      * a function.
      *
-     * @return string
+     * @return ?string
      */
     abstract public function getFullQualifiedName();
 

--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -17,6 +17,9 @@
 
 namespace PHPMD;
 
+use LogicException;
+use RuntimeException;
+
 /**
  * Abstract base class for PHPMD rendering engines.
  */
@@ -59,6 +62,9 @@ abstract class AbstractRenderer
     /**
      * This method will be called when the engine has finished the source analysis
      * phase.
+     *
+     * @throws RuntimeException
+     * @throws LogicException
      */
     abstract public function renderReport(Report $report): void;
 

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -17,7 +17,9 @@
 
 namespace PHPMD;
 
+use InvalidArgumentException;
 use OutOfBoundsException;
+use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PHPMD\Node\AbstractTypeNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\EnumNode;
@@ -362,6 +364,9 @@ abstract class AbstractRule implements Rule
      * Apply the current rule on each method of a class node.
      *
      * @param ClassNode|EnumNode|InterfaceNode|TraitNode $node class node containing methods.
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
+     * @throws OutOfBoundsException
+     * @throws InvalidArgumentException
      */
     protected function applyOnClassMethods(AbstractTypeNode $node): void
     {
@@ -377,6 +382,10 @@ abstract class AbstractRule implements Rule
     /**
      * This method should implement the violation analysis algorithm of concrete
      * rule implementations. All extending classes must implement this method.
+     *
+     * @throws OutOfBoundsException
+     * @throws InvalidArgumentException
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
      */
     abstract public function apply(AbstractNode $node): void;
 }

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Node;
 
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PDepend\Source\AST\ASTEnum;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTTrait;
@@ -134,6 +135,7 @@ class MethodNode extends AbstractCallableNode
      * Otherwise this method will return <b>false</b>.
      *
      * @return bool
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @since 1.2.1
      */
     public function isDeclaration()

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -17,7 +17,9 @@
 
 namespace PHPMD;
 
+use LogicException;
 use PHPMD\Cache\ResultCacheEngine;
+use RuntimeException;
 
 /**
  * This is the main facade of the PHP PMD application
@@ -211,6 +213,9 @@ class PHPMD
      * @param array|null         $ignorePattern
      * @param AbstractRenderer[] $renderers
      * @param RuleSet[]          $ruleSetList
+     *
+     * @throws LogicException
+     * @throws RuntimeException
      */
     public function processFiles(
         $inputPath,

--- a/src/main/php/PHPMD/Parser.php
+++ b/src/main/php/PHPMD/Parser.php
@@ -17,13 +17,16 @@
 
 namespace PHPMD;
 
+use InvalidArgumentException;
+use OutOfBoundsException;
 use PDepend\Engine;
 use PDepend\Metrics\Analyzer;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Report\CodeAwareGenerator;
-use PDepend\Report\NoLogOutputException;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
+use PDepend\Source\AST\ASTCompilationUnitNotFoundException;
 use PDepend\Source\AST\ASTEnum;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
@@ -137,8 +140,6 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
 
     /**
      * Closes the logger process and writes the output file.
-     *
-     * @throws NoLogOutputException If the no log target exists.
      */
     public function close(): void
     {
@@ -175,6 +176,10 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
 
     /**
      * Visits a class node.
+     *
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
      */
     public function visitClass(ASTClass $node): void
     {
@@ -188,6 +193,10 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
 
     /**
      * Visits a trait node.
+     *
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
      */
     public function visitTrait(ASTTrait $node): void
     {
@@ -201,6 +210,10 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
 
     /**
      * Visits a enum node.
+     *
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
      */
     public function visitEnum(ASTEnum $node): void
     {
@@ -214,6 +227,10 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
 
     /**
      * Visits a function node.
+     *
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
      */
     public function visitFunction(ASTFunction $node): void
     {
@@ -226,6 +243,10 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
 
     /**
      * Visits an interface node.
+     *
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
      */
     public function visitInterface(ASTInterface $node): void
     {
@@ -239,6 +260,11 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
 
     /**
      * Visits a method node.
+     *
+     * @throws ASTCompilationUnitNotFoundException
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
      */
     public function visitMethod(ASTMethod $node): void
     {
@@ -259,6 +285,10 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
 
     /**
      * Applies all rule-sets to the given <b>$node</b> instance.
+     *
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
+     * @throws OutOfBoundsException
+     * @throws InvalidArgumentException
      */
     private function apply(AbstractNode $node): void
     {

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -17,8 +17,10 @@
 
 namespace PHPMD\Renderer;
 
+use LogicException;
 use PHPMD\AbstractRenderer;
 use PHPMD\Report;
+use RuntimeException;
 use SplFileObject;
 
 /**
@@ -431,6 +433,8 @@ class HTMLRenderer extends AbstractRenderer
      * for additional cognitive context.
      *
      * @return array
+     * @throws RuntimeException
+     * @throws LogicException
      */
     protected static function getLineExcerpt($file, $lineNumber, $extra = 0)
     {
@@ -501,6 +505,8 @@ class HTMLRenderer extends AbstractRenderer
 
     /**
      * Render a pretty informational table and send the HTML to the writer.
+     *
+     * @param array<int, int> $items
      */
     protected function writeTable($title, $itemsTitle, $items): void
     {
@@ -541,7 +547,7 @@ class HTMLRenderer extends AbstractRenderer
     /**
      * Go through passed violations and count occurrences based on pre-specified conditions.
      *
-     * @return array
+     * @return array<string, array<int, int>>
      */
     protected static function sumUpViolations($violations)
     {

--- a/src/main/php/PHPMD/Renderer/RendererFactory.php
+++ b/src/main/php/PHPMD/Renderer/RendererFactory.php
@@ -3,13 +3,11 @@
 namespace PHPMD\Renderer;
 
 use PHPMD\Writer\StreamWriter;
-use RuntimeException;
 
 class RendererFactory
 {
     /**
      * @return BaselineRenderer
-     * @throws RuntimeException
      */
     public static function createBaselineRenderer(StreamWriter $writer)
     {

--- a/src/main/php/PHPMD/Rule.php
+++ b/src/main/php/PHPMD/Rule.php
@@ -17,7 +17,9 @@
 
 namespace PHPMD;
 
+use InvalidArgumentException;
 use OutOfBoundsException;
+use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 
 /**
  * Base interface for a PHPMD rule.
@@ -164,6 +166,10 @@ interface Rule
     /**
      * This method should implement the violation analysis algorithm of concrete
      * rule implementations. All extending classes must implement this method.
+     *
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
+     * @throws OutOfBoundsException
+     * @throws InvalidArgumentException
      */
     public function apply(AbstractNode $node): void;
 }

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule;
 
+use OutOfBoundsException;
 use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTArrayIndexExpression;
 use PDepend\Source\AST\ASTArtifact;
@@ -75,6 +76,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      *
      * @param ASTNode<ASTVariable> $variable The variable to check.
      * @return bool
+     * @throws OutOfBoundsException
      */
     protected function isLocal(ASTNode $variable)
     {
@@ -111,6 +113,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * or method postfix.
      *
      * @return bool
+     * @throws OutOfBoundsException
      */
     protected function isRegularVariable(ASTNode $variable)
     {
@@ -137,6 +140,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * instance.
      *
      * @return ASTNode
+     * @throws OutOfBoundsException
      */
     protected function stripWrappedIndexExpression(ASTNode $node)
     {
@@ -197,6 +201,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      *
      * @param ASTPropertyPostfix|ASTVariable|ASTVariableDeclarator $variable
      * @return string
+     * @throws OutOfBoundsException
      */
     protected function getVariableImage($variable)
     {
@@ -214,6 +219,9 @@ abstract class AbstractLocalVariable extends AbstractRule
         return $this->prependMemberPrimaryPrefix($image, $variable);
     }
 
+    /**
+     * @throws OutOfBoundsException
+     */
     protected function getParentMemberPrimaryPrefixImage($image, ASTPropertyPostfix $postfix)
     {
         do {
@@ -335,6 +343,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      *
      * @param ASTPropertyPostfix|ASTVariable|ASTVariableDeclarator $variable
      * @return string
+     * @throws OutOfBoundsException
      */
     private function prependMemberPrimaryPrefix($image, $variable)
     {

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\CleanCode;
 
+use OutOfBoundsException;
 use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTArray;
 use PDepend\Source\AST\ASTArrayElement;
@@ -53,6 +54,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      * with duplicated entries for any key and emits a rule violation if so.
      *
      * @param ASTNode $node Array node.
+     * @throws OutOfBoundsException
      */
     protected function checkForDuplicatedArrayKeys(ASTNode $node): void
     {
@@ -86,6 +88,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      * @param AbstractASTNode $node Array key to evaluate.
      * @param int $index Fallback in case of non-associative arrays
      * @return ?AbstractASTNode Key name
+     * @throws OutOfBoundsException
      */
     protected function normalizeKey(AbstractASTNode $node, $index)
     {

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\CleanCode;
 
+use OutOfBoundsException;
 use PDepend\Source\AST\ASTScopeStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -57,6 +58,7 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
      * Whether the given scope is an else clause
      *
      * @return bool
+     * @throws OutOfBoundsException
      */
     protected function isElseScope(AbstractNode $scope, ASTNode $parent)
     {

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\CleanCode;
 
+use OutOfBoundsException;
 use PDepend\Source\AST\ASTClassOrInterfaceReference;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTMethodPostfix;
@@ -70,6 +71,9 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
         }
     }
 
+    /**
+     * @throws OutOfBoundsException
+     */
     protected function isStaticMethodCall(AbstractNode $methodCall)
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTClassOrInterfaceReference &&
@@ -78,11 +82,17 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
             !$this->isCallingSelf($methodCall);
     }
 
+    /**
+     * @throws OutOfBoundsException
+     */
     protected function isCallingParent(AbstractNode $methodCall)
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTParentReference;
     }
 
+    /**
+     * @throws OutOfBoundsException
+     */
     protected function isCallingSelf(AbstractNode $methodCall)
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTSelfReference;

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\CleanCode;
 
+use OutOfBoundsException;
 use PDepend\Source\AST\ASTArray;
 use PDepend\Source\AST\ASTAssignmentExpression;
 use PDepend\Source\AST\ASTCatchStatement;
@@ -90,6 +91,8 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
     /**
      * Collect variables defined inside a PHPMD entry node (such as MethodNode).
+     *
+     * @throws OutOfBoundsException
      */
     protected function collect(AbstractNode $node): void
     {
@@ -118,6 +121,8 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
     /**
      * Stores the given literal node in an global of found variables.
+     *
+     * @throws OutOfBoundsException
      */
     protected function collectGlobalStatements(AbstractNode $node): void
     {
@@ -128,6 +133,8 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
     /**
      * Stores the given literal node in an catch of found variables.
+     *
+     * @throws OutOfBoundsException
      */
     protected function collectExceptionCatches(AbstractCallableNode $node): void
     {
@@ -140,6 +147,8 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
     /**
      * Stores the given literal node in an internal list of found variables.
+     *
+     * @throws OutOfBoundsException
      */
     protected function collectListExpressions(AbstractCallableNode $node): void
     {
@@ -150,6 +159,8 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
     /**
      * Stores the given literal node in an internal foreach of found variables.
+     *
+     * @throws OutOfBoundsException
      */
     protected function collectForeachStatements(AbstractCallableNode $node): void
     {
@@ -172,6 +183,8 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
     /**
      * Stores the given literal node in an internal closure of found variables.
+     *
+     * @throws OutOfBoundsException
      */
     protected function collectClosureParameters(AbstractCallableNode $node): void
     {
@@ -186,6 +199,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * Check if the given variable was defined in the current context before usage.
      *
      * @return bool
+     * @throws OutOfBoundsException
      */
     protected function checkVariableDefined(ASTNode $variable, AbstractCallableNode $parentNode)
     {
@@ -196,6 +210,8 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
     /**
      * Collect parameter names of method/function.
+     *
+     * @throws OutOfBoundsException
      */
     protected function collectParameters(AbstractNode $node): void
     {
@@ -212,6 +228,8 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
     /**
      * Collect assignments of variables.
+     *
+     * @throws OutOfBoundsException
      */
     protected function collectAssignments(AbstractCallableNode $node): void
     {
@@ -237,6 +255,8 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
     /**
      * Collect postfix property.
+     *
+     * @throws OutOfBoundsException
      */
     protected function collectPropertyPostfix(AbstractNode $node): void
     {
@@ -251,6 +271,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * Add the variable to images.
      *
      * @param ASTPropertyPostfix|ASTVariable|ASTVariableDeclarator $variable
+     * @throws OutOfBoundsException
      */
     protected function addVariableDefinition($variable): void
     {

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\Controversial;
 
+use OutOfBoundsException;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\MethodAware;
@@ -68,6 +69,9 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
         }
     }
 
+    /**
+     * @throws OutOfBoundsException
+     */
     protected function isValid($methodName)
     {
         // disallow any consecutive uppercase letters

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
@@ -14,6 +14,8 @@
 
 namespace PHPMD\Rule\Controversial;
 
+use InvalidArgumentException;
+use OutOfBoundsException;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
@@ -56,6 +58,8 @@ class CamelCaseNamespace extends AbstractRule implements ClassAware, InterfaceAw
     /**
      * Gets array of exceptions from property
      * @return array<string, int>
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
      */
     protected function getExceptionsList()
     {

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\Controversial;
 
+use OutOfBoundsException;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\FunctionNode;
@@ -54,6 +55,9 @@ class CamelCaseParameterName extends AbstractRule implements MethodAware, Functi
         }
     }
 
+    /**
+     * @throws OutOfBoundsException
+     */
     protected function isValid($parameterName)
     {
         // disallow any consecutive uppercase letters

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\Controversial;
 
+use OutOfBoundsException;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ClassNode;
@@ -56,6 +57,9 @@ class CamelCasePropertyName extends AbstractRule implements ClassAware, TraitAwa
         }
     }
 
+    /**
+     * @throws OutOfBoundsException
+     */
     private function isValid($propertyName)
     {
         // disallow any consecutive uppercase letters

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\Controversial;
 
+use OutOfBoundsException;
 use PDepend\Source\AST\ASTPropertyPostfix;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -68,6 +69,9 @@ class CamelCaseVariableName extends AbstractRule implements MethodAware, Functio
         }
     }
 
+    /**
+     * @throws OutOfBoundsException
+     */
     protected function isValid($variable)
     {
         $image = $variable->getImage();

--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\Design;
 
+use OutOfBoundsException;
 use PDepend\Source\AST\ASTFunctionPostfix;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -66,6 +67,7 @@ class DevelopmentCodeFragment extends AbstractRule implements MethodAware, Funct
      * development.
      *
      * @return array
+     * @throws OutOfBoundsException
      */
     protected function getSuspectImages()
     {

--- a/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule\Naming;
 
+use OutOfBoundsException;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\MethodNode;
@@ -46,6 +47,7 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
      * boolean get method.
      *
      * @return bool
+     * @throws OutOfBoundsException
      */
     protected function isBooleanGetMethod(MethodNode $node)
     {
@@ -84,6 +86,7 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
      * or has no parameters.
      *
      * @return bool
+     * @throws OutOfBoundsException
      */
     protected function isParameterizedOrIgnored(MethodNode $node)
     {

--- a/src/main/php/PHPMD/Rule/Naming/LongClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongClassName.php
@@ -17,6 +17,8 @@
 
 namespace PHPMD\Rule\Naming;
 
+use InvalidArgumentException;
+use OutOfBoundsException;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
@@ -68,6 +70,8 @@ class LongClassName extends AbstractRule implements ClassAware, InterfaceAware, 
      * Gets array of prefixes from property
      *
      * @return string[]
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
      */
     protected function getSubtractPrefixList()
     {
@@ -85,6 +89,8 @@ class LongClassName extends AbstractRule implements ClassAware, InterfaceAware, 
      * Gets array of suffixes from property
      *
      * @return string[]
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
      */
     protected function getSubtractSuffixList()
     {

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -17,6 +17,8 @@
 
 namespace PHPMD\Rule\Naming;
 
+use InvalidArgumentException;
+use OutOfBoundsException;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTVariableDeclarator;
@@ -93,6 +95,9 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
     /**
      * Checks if the variable name of the given node is smaller/equal to the
      * configured threshold.
+     *
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
      */
     protected function checkNodeImage(AbstractNode $node): void
     {
@@ -105,6 +110,8 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
     /**
      * Template method that performs the real node image check.
      *
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
      * @SuppressWarnings(PHPMD.LongVariable)
      */
     protected function checkMaximumLength(AbstractNode $node): void
@@ -186,6 +193,8 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * Gets array of suffixes from property
      *
      * @return string[]
+     * @throws OutOfBoundsException
+     * @throws InvalidArgumentException
      */
     protected function getSubtractPrefixList()
     {
@@ -200,6 +209,8 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * Gets array of suffixes from property
      *
      * @return string[]
+     * @throws OutOfBoundsException
+     * @throws InvalidArgumentException
      */
     protected function getSubtractSuffixList()
     {

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -17,6 +17,8 @@
 
 namespace PHPMD\Rule\Naming;
 
+use InvalidArgumentException;
+use OutOfBoundsException;
 use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTForeachStatement;
@@ -76,6 +78,9 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      *
      * Checks the variable name length against the configured minimum
      * length.
+     *
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
      */
     protected function applyClass(AbstractNode $node): void
     {
@@ -94,6 +99,9 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      *
      * Checks the variable name length against the configured minimum
      * length.
+     *
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
      */
     protected function applyNonClass(AbstractNode $node): void
     {
@@ -112,6 +120,9 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
     /**
      * Checks if the variable name of the given node is greater/equal to the
      * configured threshold or if the given node is an allowed context.
+     *
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
      */
     protected function checkNodeImage(AbstractNode $node): void
     {
@@ -123,6 +134,9 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
 
     /**
      * Template method that performs the real node image check.
+     *
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
      */
     protected function checkMinimumLength(AbstractNode $node): void
     {
@@ -165,6 +179,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * variable names in catch-statements.
      *
      * @return bool
+     * @throws OutOfBoundsException
      */
     protected function isNameAllowedInContext(AbstractNode $node)
     {
@@ -183,6 +198,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * Checks if a short name is initialized within a foreach loop statement
      *
      * @return bool
+     * @throws OutOfBoundsException
      */
     protected function isInitializedInLoop(AbstractNode $node)
     {

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -17,6 +17,8 @@
 
 namespace PHPMD\Rule;
 
+use OutOfBoundsException;
+use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PDepend\Source\AST\ASTCompoundVariable;
 use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTFormalParameter;
@@ -138,6 +140,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      * the initial declaration.
      *
      * @return bool
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @since 1.2.1
      */
     protected function isNotDeclaration(AbstractNode $node)
@@ -170,6 +173,8 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      * This method collects all local variables in the body of the currently
      * analyzed method or function and removes those parameters that are
      * referenced by one of the collected variables.
+     *
+     * @throws OutOfBoundsException
      */
     protected function removeUsedParameters(AbstractNode $node): void
     {
@@ -183,6 +188,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      * Removes all the regular variables from a given node
      *
      * @param AbstractNode $node The node to remove the regular variables from.
+     * @throws OutOfBoundsException
      */
     protected function removeRegularVariables(AbstractNode $node): void
     {

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -17,6 +17,8 @@
 
 namespace PHPMD\Rule;
 
+use InvalidArgumentException;
+use OutOfBoundsException;
 use PDepend\Source\AST\ASTAssignmentExpression;
 use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTCompoundVariable;
@@ -104,6 +106,8 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * This method removes all variables from the <b>$_images</b> property that
      * are also found in the formal parameters of the given method or/and
      * function node.
+     *
+     * @throws OutOfBoundsException
      */
     protected function removeParameters(AbstractCallableNode $node): void
     {
@@ -122,6 +126,8 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * This method collects all local variable instances from the given
      * method/function node and stores their image in the <b>$_images</b>
      * property.
+     *
+     * @throws OutOfBoundsException
      */
     protected function collectVariables(AbstractCallableNode $node): void
     {
@@ -150,6 +156,8 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
 
     /**
      * Stores the given compound variable node in an internal list of found variables.
+     *
+     * @throws OutOfBoundsException
      */
     protected function collectCompoundVariableInString(ASTNode $node): void
     {
@@ -170,6 +178,8 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
 
     /**
      * Stores the given variable node in an internal list of found variables.
+     *
+     * @throws OutOfBoundsException
      */
     protected function collectVariable(ASTNode $node): void
     {
@@ -207,6 +217,9 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
 
     /**
      * Template method that performs the real node image check.
+     *
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
      */
     protected function doCheckNodeImage(ASTNode $node): void
     {
@@ -253,6 +266,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      *
      * @param ASTNode $variable The variable to check.
      * @return bool True if allowed, else false.
+     * @throws OutOfBoundsException
      */
     protected function isUnusedForeachVariableAllowed(ASTNode $variable)
     {

--- a/src/main/php/PHPMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateField.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule;
 
+use OutOfBoundsException;
 use PDepend\Source\AST\ASTArrayIndexExpression;
 use PDepend\Source\AST\ASTCompoundVariable;
 use PDepend\Source\AST\ASTFieldDeclaration;
@@ -65,6 +66,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * method.
      *
      * @return AbstractNode[]
+     * @throws OutOfBoundsException
      */
     protected function collectUnusedPrivateFields(ClassNode $class)
     {
@@ -105,6 +107,8 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * This method extracts all property postfix nodes from the given class and
      * removes all fields from the <b>$_fields</b> property that are accessed by
      * one of the postfix nodes.
+     *
+     * @throws OutOfBoundsException
      */
     protected function removeUsedFields(ClassNode $class): void
     {
@@ -166,6 +170,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * instance or static reference to the given class.
      *
      * @return bool
+     * @throws OutOfBoundsException
      */
     protected function isInScopeOfClass(ClassNode $class, ASTNode $postfix)
     {
@@ -184,6 +189,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      *
      * @param ASTNode<ASTPropertyPostfix> $postfix
      * @return AbstractNode
+     * @throws OutOfBoundsException
      */
     protected function getOwner(ASTNode $postfix)
     {

--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Rule;
 
+use OutOfBoundsException;
 use PDepend\Source\AST\ASTArray;
 use PDepend\Source\AST\ASTArrayElement;
 use PDepend\Source\AST\ASTLiteral;
@@ -52,6 +53,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * as private and are not used in the same class' context.
      *
      * @return array<string, MethodNode>
+     * @throws OutOfBoundsException
      */
     protected function collectUnusedPrivateMethods(ClassNode $class)
     {
@@ -101,6 +103,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      *
      * @param array<string, MethodNode> $methods
      * @return array<string, MethodNode>
+     * @throws OutOfBoundsException
      */
     protected function removeUsedMethods(ClassNode $class, array $methods)
     {
@@ -115,6 +118,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      *
      * @param array<string, MethodNode> $methods
      * @return array<string, MethodNode>
+     * @throws OutOfBoundsException
      */
     protected function removeExplicitCalls(ClassNode $class, array $methods)
     {
@@ -132,6 +136,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      *
      * @param array<string, MethodNode> $methods
      * @return array<string, MethodNode>
+     * @throws OutOfBoundsException
      */
     protected function removeCallableArrayRepresentations(ClassNode $class, array $methods)
     {
@@ -154,6 +159,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * and that the second one is a literal static string.
      *
      * @return string|null
+     * @throws OutOfBoundsException
      */
     protected function getMethodNameFromArraySecondElement(AbstractNode $parent)
     {
@@ -179,6 +185,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * instance or static reference to the given class.
      *
      * @return bool
+     * @throws OutOfBoundsException
      */
     protected function isClassScope(ClassNode $class, ASTNode $postfix)
     {

--- a/src/main/php/PHPMD/RuleSet.php
+++ b/src/main/php/PHPMD/RuleSet.php
@@ -18,7 +18,10 @@
 namespace PHPMD;
 
 use ArrayIterator;
+use InvalidArgumentException;
 use IteratorAggregate;
+use OutOfBoundsException;
+use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PHPMD\Node\AbstractTypeNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\EnumNode;
@@ -230,6 +233,10 @@ class RuleSet implements IteratorAggregate
 
     /**
      * Applies all registered rules that match against the concrete node type.
+     *
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
+     * @throws OutOfBoundsException
+     * @throws InvalidArgumentException
      */
     public function apply(AbstractNode $node): void
     {

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -101,6 +101,7 @@ class RuleSetFactory
      *
      * @param string $ruleSetFileNames Comma-separated string of rule-set filenames or identifier.
      * @return RuleSet[]
+     * @throws RuntimeException
      */
     public function createRuleSets($ruleSetFileNames)
     {
@@ -121,6 +122,8 @@ class RuleSetFactory
      *
      * @param string $ruleSetOrFileName The rule-set filename or identifier.
      * @return RuleSet
+     * @throws RuleSetNotFoundException
+     * @throws RuntimeException
      */
     public function createSingleRuleSet($ruleSetOrFileName)
     {
@@ -239,6 +242,9 @@ class RuleSetFactory
      * This method parses a single rule xml node. Bases on the structure of the
      * xml node this method delegates the parsing process to another method in
      * this class.
+     *
+     * @throws RuleClassNotFoundException
+     * @throws RuntimeException
      */
     private function parseRuleNode(RuleSet $ruleSet, SimpleXMLElement $node): void
     {
@@ -262,6 +268,8 @@ class RuleSetFactory
     /**
      * This method parses a complete rule set that was includes a reference in
      * the currently parsed ruleset.
+     *
+     * @throws RuntimeException
      */
     private function parseRuleSetReferenceNode(RuleSet $ruleSet, SimpleXMLElement $ruleSetNode): void
     {
@@ -277,6 +285,7 @@ class RuleSetFactory
      * Parses a rule-set xml file referenced by the given rule-set xml element.
      *
      * @return RuleSet
+     * @throws RuntimeException
      * @since 0.2.3
      */
     private function parseRuleSetReference(SimpleXMLElement $ruleSetNode)
@@ -383,6 +392,10 @@ class RuleSetFactory
     /**
      * This method parses a single rule that was included from a different
      * rule-set.
+     *
+     * @throws RuleSetNotFoundException
+     * @throws RuleByNameNotFoundException
+     * @throws RuntimeException
      */
     private function parseRuleReferenceNode(RuleSet $ruleSet, SimpleXMLElement $ruleNode): void
     {

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -18,6 +18,8 @@
 namespace PHPMD\TextUI;
 
 use Exception;
+use InvalidArgumentException;
+use LogicException;
 use PHPMD\Baseline\BaselineFileFinder;
 use PHPMD\Baseline\BaselineMode;
 use PHPMD\Baseline\BaselineSetFactory;
@@ -34,6 +36,7 @@ use PHPMD\Report;
 use PHPMD\RuleSetFactory;
 use PHPMD\Utility\Paths;
 use PHPMD\Writer\StreamWriter;
+use RuntimeException;
 
 /**
  * This class provides a command line interface for PHPMD
@@ -70,6 +73,9 @@ class Command
      * even if any violation or error is found.
      *
      * @return int
+     * @throws InvalidArgumentException
+     * @throws RuntimeException
+     * @throws LogicException
      */
     public function run(CommandLineOptions $opts, RuleSetFactory $ruleSetFactory)
     {
@@ -200,6 +206,7 @@ class Command
      *
      * @param string[] $args The raw command line arguments array.
      * @return int
+     * @throws RuntimeException
      */
     public static function main(array $args)
     {

--- a/src/main/php/PHPMD/Utility/ExceptionsList.php
+++ b/src/main/php/PHPMD/Utility/ExceptionsList.php
@@ -19,6 +19,7 @@ namespace PHPMD\Utility;
 
 use ArrayAccess;
 use ArrayIterator;
+use InvalidArgumentException;
 use IteratorAggregate;
 use OutOfBoundsException;
 use PHPMD\Rule;
@@ -55,6 +56,10 @@ class ExceptionsList implements IteratorAggregate, ArrayAccess
         $this->separator = $separator;
     }
 
+    /**
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
+     */
     public function contains(string $value): bool
     {
         $exceptions = $this->getExceptionsList();
@@ -66,6 +71,8 @@ class ExceptionsList implements IteratorAggregate, ArrayAccess
      * Gets array of exceptions from property
      *
      * @return array<string, int>
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
      */
     protected function getExceptionsList(): array
     {
@@ -82,6 +89,10 @@ class ExceptionsList implements IteratorAggregate, ArrayAccess
         return $this->exceptions;
     }
 
+    /**
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
+     */
     public function getIterator(): ArrayIterator
     {
         $keys = array_keys($this->getExceptionsList());
@@ -89,12 +100,17 @@ class ExceptionsList implements IteratorAggregate, ArrayAccess
         return new ArrayIterator(array_combine($keys, $keys));
     }
 
+    /**
+     * @throws InvalidArgumentException
+     * @throws OutOfBoundsException
+     */
     public function offsetExists($offset): bool
     {
         return $this->contains($offset);
     }
 
     /**
+     * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
     public function offsetGet($offset): int


### PR DESCRIPTION
Type: documentation update
Breaking change: no

Enable settings in PHPStan for tracking exceptions. This will let us track where exceptions are leaking out. If we chose to handle some of them it will inform us where we need to then remove the notation as well so that things the docs and code are kept in sync.

A few types where also properly documented in order to make PHPStan able to determine correctly determine that correctly guard against dividing by zero (which would cause PHP to throw a `DivisionByZeroError` exception).