### PR TITLE
PHP CS Fixer with PER CS v2 (amended)

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This document has been generated with
  * https://mlocati.github.io/php-cs-fixer-configurator/#version:3.54.0|configurator
@@ -7,8 +8,86 @@
 $config = new PhpCsFixer\Config();
 return $config
     ->setRules([
+        'array_indentation' => true,
+        'binary_operator_spaces' => true,
         'blank_line_after_namespace' => true,
+        'blank_line_after_opening_tag' => true,
+        'blank_line_between_import_groups' => true,
         'blank_lines_before_namespace' => true,
+        'braces_position' => ['allow_single_line_empty_anonymous_classes' => true],
+        'cast_spaces' => true,
+        'class_definition' => ['inline_constructor_arguments' => false, 'space_before_parenthesis' => true],
+        'compact_nullable_type_declaration' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'constant_case' => true,
+        'control_structure_braces' => true,
+        'control_structure_continuation_position' => true,
+        'declare_equal_normalize' => true,
+        'elseif' => true,
+        'encoding' => true,
+        'full_opening_tag' => true,
+        'function_declaration' => ['closure_fn_spacing' => 'none'],
+        'indentation_type' => true,
+        'line_ending' => true,
+        'lowercase_cast' => true,
+        'lowercase_keywords' => true,
+        'lowercase_static_reference' => true,
+        'method_argument_space' => true,
+        'new_with_parentheses' => true,
+        'no_blank_lines_after_class_opening' => true,
+        'no_break_comment' => true,
+        'no_closing_tag' => true,
+        'no_multiple_statements_per_line' => true,
+        'no_space_around_double_colon' => true,
+        'no_spaces_after_function_name' => true,
+        'no_trailing_whitespace' => true,
+        'no_trailing_whitespace_in_comment' => true,
+        'no_whitespace_in_blank_line' => true,
+        'ordered_class_elements' => [
+            'order' => [
+                'use_trait',
+                'case',
+                'constant_public',
+                'constant_protected',
+                'constant_private',
+                'property_public',
+                'property_protected',
+                'property_private',
+                'construct',
+                'destruct',
+                'magic',
+                'phpunit',
+                // We do not want to order methods
+//                'method_public',
+//                'method_protected',
+//                'method_private',
+            ]
+        ],
+        'return_type_declaration' => true,
+        'short_scalar_cast' => true,
+        'single_blank_line_at_eof' => true,
+        'single_class_element_per_statement' => ['elements' => ['property']],
+        'single_import_per_statement' => ['group_to_single_imports' => false],
+        'single_line_empty_body' => false, // Not adhering to PER CS v2
+        'single_trait_insert_per_statement' => true,
+        'spaces_inside_parentheses' => true,
+        'statement_indentation' => true,
+        'switch_case_semicolon_to_colon' => true,
+        'switch_case_space' => true,
+        'ternary_operator_spaces' => true,
+        'trailing_comma_in_multiline' => [
+            'after_heredoc' => true,
+            'elements' => [
+                // We don't want trailing commas for arguments
+//                'arguments',
+                'arrays',
+                'match',
+                // We don't want trailing commas for parameters
+//                'parameters'
+            ]
+        ],
+        'unary_operator_spaces' => ['only_dec_inc' => true],
+        'visibility_required' => true,
         'fully_qualified_strict_types' => true,
         'global_namespace_import' => true,
         'no_empty_phpdoc' => true,
@@ -64,5 +143,5 @@ return $config
     ->setFinder(PhpCsFixer\Finder::create()
         ->exclude('vendor')
         ->in(__DIR__ . '/src/main/php/PHPMD')
-    )
-;
+        ->in(__DIR__ . '/src/test/php/')
+    );

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -8,44 +8,12 @@
 $config = new PhpCsFixer\Config();
 return $config
     ->setRules([
-        'array_indentation' => true,
-        'binary_operator_spaces' => true,
-        'blank_line_after_namespace' => true,
-        'blank_line_after_opening_tag' => true,
-        'blank_line_between_import_groups' => true,
-        'blank_lines_before_namespace' => true,
-        'braces_position' => ['allow_single_line_empty_anonymous_classes' => true],
-        'cast_spaces' => true,
-        'class_definition' => ['inline_constructor_arguments' => false, 'space_before_parenthesis' => true],
-        'compact_nullable_type_declaration' => true,
-        'concat_space' => ['spacing' => 'one'],
-        'constant_case' => true,
-        'control_structure_braces' => true,
-        'control_structure_continuation_position' => true,
-        'declare_equal_normalize' => true,
-        'elseif' => true,
-        'encoding' => true,
-        'full_opening_tag' => true,
-        'function_declaration' => ['closure_fn_spacing' => 'none'],
-        'indentation_type' => true,
-        'line_ending' => true,
-        'lowercase_cast' => true,
-        'lowercase_keywords' => true,
-        'lowercase_static_reference' => true,
-        'method_argument_space' => true,
-        'new_with_parentheses' => true,
-        'no_blank_lines_after_class_opening' => true,
-        'no_break_comment' => true,
-        'no_closing_tag' => true,
-        'no_multiple_statements_per_line' => true,
-        'no_space_around_double_colon' => true,
-        'no_spaces_after_function_name' => true,
-        'no_trailing_whitespace' => true,
-        'no_trailing_whitespace_in_comment' => true,
-        'no_whitespace_in_blank_line' => true,
+        '@PER-CS2.0' => true,
+        'binary_operator_spaces' => true, // Going beyond PER CS v2
         'ordered_class_elements' => [
             'order' => [
                 'use_trait',
+                // Going beyond PER CS v2
                 'case',
                 'constant_public',
                 'constant_protected',
@@ -63,37 +31,24 @@ return $config
 //                'method_private',
             ]
         ],
-        'return_type_declaration' => true,
-        'short_scalar_cast' => true,
-        'single_blank_line_at_eof' => true,
-        'single_class_element_per_statement' => ['elements' => ['property']],
-        'single_import_per_statement' => ['group_to_single_imports' => false],
         'single_line_empty_body' => false, // Not adhering to PER CS v2
-        'single_trait_insert_per_statement' => true,
-        'spaces_inside_parentheses' => true,
-        'statement_indentation' => true,
-        'switch_case_semicolon_to_colon' => true,
-        'switch_case_space' => true,
-        'ternary_operator_spaces' => true,
         'trailing_comma_in_multiline' => [
             'after_heredoc' => true,
             'elements' => [
-                // We don't want trailing commas for arguments
+                // Not adhering to PER CS v2; we don't want trailing commas for arguments
 //                'arguments',
                 'arrays',
                 'match',
-                // We don't want trailing commas for parameters
+                // Not adhering to PER CS v2; we don't want trailing commas for parameters
 //                'parameters'
             ]
         ],
-        'unary_operator_spaces' => ['only_dec_inc' => true],
-        'visibility_required' => true,
         'fully_qualified_strict_types' => true,
         'global_namespace_import' => true,
         'no_empty_phpdoc' => true,
-        'no_leading_import_slash' => true,
         'no_superfluous_phpdoc_tags' => true,
         'no_unused_imports' => true,
+        // Using sorting algo "alpha" instead of "none" defined in PER CS v2
         'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
         'phpdoc_indent' => true,
         'phpdoc_order' => [
@@ -138,7 +93,6 @@ return $config
         'phpdoc_trim_consecutive_blank_line_separation' => true,
         'phpdoc_types_order' => ['null_adjustment' => 'always_last'],
         'phpdoc_var_annotation_correct_order' => true,
-        'single_line_after_imports' => true,
     ])
     ->setFinder(PhpCsFixer\Finder::create()
         ->exclude('vendor')

--- a/src/main/php/PHPMD/Baseline/BaselineValidator.php
+++ b/src/main/php/PHPMD/Baseline/BaselineValidator.php
@@ -18,7 +18,7 @@ class BaselineValidator
     public function __construct(BaselineSet $baselineSet, $baselineMode)
     {
         $this->baselineMode = $baselineMode;
-        $this->baselineSet  = $baselineSet;
+        $this->baselineSet = $baselineSet;
     }
 
     /**

--- a/src/main/php/PHPMD/Baseline/ViolationBaseline.php
+++ b/src/main/php/PHPMD/Baseline/ViolationBaseline.php
@@ -23,9 +23,9 @@ class ViolationBaseline
      */
     public function __construct($ruleName, $fileName, $methodName)
     {
-        $this->ruleName       = $ruleName;
-        $this->fileName       = $fileName;
-        $this->methodName     = $methodName;
+        $this->ruleName = $ruleName;
+        $this->fileName = $fileName;
+        $this->methodName = $methodName;
         $this->fileNameLength = strlen($fileName);
     }
 

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheKey.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheKey.php
@@ -24,11 +24,11 @@ class ResultCacheKey
      */
     public function __construct($strict, $baselineHash, $rules, $composer, $phpVersion)
     {
-        $this->strict       = $strict;
+        $this->strict = $strict;
         $this->baselineHash = $baselineHash;
-        $this->rules        = $rules;
-        $this->composer     = $composer;
-        $this->phpVersion   = $phpVersion;
+        $this->rules = $rules;
+        $this->composer = $composer;
+        $this->phpVersion = $phpVersion;
     }
 
     /**
@@ -37,11 +37,11 @@ class ResultCacheKey
     public function toArray()
     {
         return [
-            'strict'       => $this->strict,
+            'strict' => $this->strict,
             'baselineHash' => $this->baselineHash,
-            'rules'        => $this->rules,
-            'composer'     => $this->composer,
-            'phpVersion'   => $this->phpVersion,
+            'rules' => $this->rules,
+            'composer' => $this->composer,
+            'phpVersion' => $this->phpVersion,
         ];
     }
 

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
@@ -22,7 +22,7 @@ class ResultCacheState
     public function __construct(ResultCacheKey $cacheKey, $state = [])
     {
         $this->cacheKey = $cacheKey;
-        $this->state    = $state;
+        $this->state = $state;
     }
 
     /**
@@ -60,16 +60,16 @@ class ResultCacheState
     public function addRuleViolation($filePath, RuleViolation $violation): void
     {
         $this->state['files'][$filePath]['violations'][] = [
-            'rule'          => $violation->getRule()::class,
+            'rule' => $violation->getRule()::class,
             'namespaceName' => $violation->getNamespaceName(),
-            'className'     => $violation->getClassName(),
-            'methodName'    => $violation->getMethodName(),
-            'functionName'  => $violation->getFunctionName(),
-            'beginLine'     => $violation->getBeginLine(),
-            'endLine'       => $violation->getEndLine(),
-            'description'   => $violation->getDescription(),
-            'args'          => $violation->getArgs(),
-            'metric'        => $violation->getMetric(),
+            'className' => $violation->getClassName(),
+            'methodName' => $violation->getMethodName(),
+            'functionName' => $violation->getFunctionName(),
+            'beginLine' => $violation->getBeginLine(),
+            'endLine' => $violation->getEndLine(),
+            'description' => $violation->getDescription(),
+            'args' => $violation->getArgs(),
+            'metric' => $violation->getMetric(),
         ];
     }
 
@@ -90,7 +90,7 @@ class ResultCacheState
                 continue;
             }
             foreach ($violations['violations'] as $violation) {
-                $rule     = self::findRuleIn($violation['rule'], $ruleSetList);
+                $rule = self::findRuleIn($violation['rule'], $ruleSetList);
                 $nodeInfo = new NodeInfo(
                     Paths::concat($basePath, $filePath),
                     $violation['namespaceName'],
@@ -142,7 +142,7 @@ class ResultCacheState
     public function toArray()
     {
         return [
-            'key'   => $this->cacheKey->toArray(),
+            'key' => $this->cacheKey->toArray(),
             'state' => $this->state,
         ];
     }

--- a/src/main/php/PHPMD/Cache/ResultCacheEngine.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngine.php
@@ -20,8 +20,8 @@ class ResultCacheEngine
     ) {
 
         $this->fileFilter = $fileFilter;
-        $this->updater    = $updater;
-        $this->writer     = $writer;
+        $this->updater = $updater;
+        $this->writer = $writer;
     }
 
     /**

--- a/src/main/php/PHPMD/Cache/ResultCacheEngine.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngine.php
@@ -18,7 +18,7 @@ class ResultCacheEngine
         ResultCacheUpdater    $updater,
         ResultCacheWriter     $writer
     ) {
-    
+
         $this->fileFilter = $fileFilter;
         $this->updater    = $updater;
         $this->writer     = $writer;

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -20,8 +20,8 @@ class ResultCacheEngineFactory
         ResultCacheKeyFactory   $cacheKeyFactory,
         ResultCacheStateFactory $cacheStateFactory
     ) {
-        $this->output            = $output;
-        $this->cacheKeyFactory   = $cacheKeyFactory;
+        $this->output = $output;
+        $this->cacheKeyFactory = $cacheKeyFactory;
         $this->cacheStateFactory = $cacheStateFactory;
     }
 

--- a/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
@@ -36,10 +36,10 @@ class ResultCacheFileFilter implements Filter
      */
     public function __construct(OutputInterface $output, $basePath, $strategy, ResultCacheKey $cacheKey, $state)
     {
-        $this->output   = $output;
+        $this->output = $output;
         $this->basePath = $basePath;
         $this->strategy = $strategy;
-        $this->state    = $state;
+        $this->state = $state;
         $this->newState = new ResultCacheState($cacheKey);
     }
 

--- a/src/main/php/PHPMD/Cache/ResultCacheKeyFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheKeyFactory.php
@@ -20,7 +20,7 @@ class ResultCacheKeyFactory
      */
     public function __construct($basePath, $baselineFile)
     {
-        $this->basePath     = $basePath;
+        $this->basePath = $basePath;
         $this->baselineFile = $baselineFile;
     }
 

--- a/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
@@ -20,7 +20,7 @@ class ResultCacheUpdater
      */
     public function __construct(OutputInterface $output, $basePath)
     {
-        $this->output   = $output;
+        $this->output = $output;
         $this->basePath = $basePath;
     }
 

--- a/src/main/php/PHPMD/Console/Output.php
+++ b/src/main/php/PHPMD/Console/Output.php
@@ -32,7 +32,7 @@ abstract class Output implements OutputInterface
             | self::VERBOSITY_VERBOSE
             | self::VERBOSITY_VERY_VERBOSE
             | self::VERBOSITY_DEBUG;
-        $verbosity   = $verbosities & $options ?: self::VERBOSITY_NORMAL;
+        $verbosity = $verbosities & $options ?: self::VERBOSITY_NORMAL;
 
         if ($verbosity > $this->getVerbosity()) {
             return;

--- a/src/main/php/PHPMD/Console/OutputInterface.php
+++ b/src/main/php/PHPMD/Console/OutputInterface.php
@@ -8,11 +8,11 @@ namespace PHPMD\Console;
  */
 interface OutputInterface
 {
-    public const VERBOSITY_QUIET        = 16;
-    public const VERBOSITY_NORMAL       = 32;
-    public const VERBOSITY_VERBOSE      = 64;
+    public const VERBOSITY_QUIET = 16;
+    public const VERBOSITY_NORMAL = 32;
+    public const VERBOSITY_VERBOSE = 64;
     public const VERBOSITY_VERY_VERBOSE = 128;
-    public const VERBOSITY_DEBUG        = 256;
+    public const VERBOSITY_DEBUG = 256;
 
     /**
      * @param string|string[] $messages

--- a/src/main/php/PHPMD/Node/NodeInfo.php
+++ b/src/main/php/PHPMD/Node/NodeInfo.php
@@ -80,12 +80,12 @@ class NodeInfo
         $beginLine,
         $endLine
     ) {
-        $this->fileName      = $fileName;
+        $this->fileName = $fileName;
         $this->namespaceName = $namespaceName;
-        $this->className     = $className;
-        $this->methodName    = $methodName;
-        $this->functionName  = $functionName;
-        $this->beginLine     = $beginLine;
-        $this->endLine       = $endLine;
+        $this->className = $className;
+        $this->methodName = $methodName;
+        $this->functionName = $functionName;
+        $this->beginLine = $beginLine;
+        $this->endLine = $endLine;
     }
 }

--- a/src/main/php/PHPMD/Node/NodeInfoFactory.php
+++ b/src/main/php/PHPMD/Node/NodeInfoFactory.php
@@ -8,14 +8,14 @@ class NodeInfoFactory
 {
     public static function fromNode(PHPMDAbstractNode $node)
     {
-        $className    = null;
-        $methodName   = null;
+        $className = null;
+        $methodName = null;
         $functionName = null;
 
         if ($node instanceof AbstractTypeNode) {
             $className = $node->getName();
         } elseif ($node instanceof MethodNode) {
-            $className  = $node->getParentName();
+            $className = $node->getParentName();
             $methodName = $node->getName();
         } elseif ($node instanceof FunctionNode) {
             $functionName = $node->getName();

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -230,7 +230,7 @@ class PHPMD
         $this->input = $inputPath;
 
         $factory = new ParserFactory();
-        $parser  = $factory->create($this);
+        $parser = $factory->create($this);
 
         foreach ($ruleSetList as $ruleSet) {
             $parser->addRuleSet($ruleSet);
@@ -257,7 +257,7 @@ class PHPMD
             $renderer->end();
         }
 
-        $this->errors     = $report->hasErrors();
+        $this->errors = $report->hasErrors();
         $this->violations = !$report->isEmpty();
     }
 }

--- a/src/main/php/PHPMD/Renderer/AnsiRenderer.php
+++ b/src/main/php/PHPMD/Renderer/AnsiRenderer.php
@@ -13,7 +13,6 @@ use PHPMD\RuleViolation;
  */
 class AnsiRenderer extends AbstractRenderer
 {
-
     public function renderReport(Report $report): void
     {
         $this->writeViolationsReport($report);

--- a/src/main/php/PHPMD/Renderer/BaselineRenderer.php
+++ b/src/main/php/PHPMD/Renderer/BaselineRenderer.php
@@ -29,8 +29,8 @@ class BaselineRenderer extends AbstractRenderer
         $writer->write('<phpmd-baseline>' . PHP_EOL);
 
         foreach ($report->getRuleViolations() as $violation) {
-            $ruleName   = $violation->getRule()::class;
-            $filePath   = Paths::getRelativePath($this->basePath, $violation->getFileName());
+            $ruleName = $violation->getRule()::class;
+            $filePath = Paths::getRelativePath($this->basePath, $violation->getFileName());
             $methodName = $violation->getMethodName();
 
             // deduplicate similar violations

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -36,7 +36,7 @@ class GitLabRenderer extends AbstractRenderer
         $jsonData = $this->encodeReport($data);
 
         $writer = $this->getWriter();
-        $writer->write($jsonData.PHP_EOL);
+        $writer->write($jsonData . PHP_EOL);
     }
 
 
@@ -61,7 +61,7 @@ class GitLabRenderer extends AbstractRenderer
                         'PHP',
                     ],
                 'check_name' => $violation->getRule()->getName(),
-                'fingerprint' => $violation->getFileName().':'.$violation->getBeginLine().':'.$violation->getRule(
+                'fingerprint' => $violation->getFileName() . ':' . $violation->getBeginLine() . ':' . $violation->getRule(
                 )->getName(),
                 'description' => $violation->getDescription(),
                 'severity' => 'minor',
@@ -96,7 +96,7 @@ class GitLabRenderer extends AbstractRenderer
         foreach ($errors as $error) {
             $errorResult = [
                 'description' => $error->getMessage(),
-                'fingerprint' => $error->getFile().':0:MajorErrorInFile',
+                'fingerprint' => $error->getFile() . ':0:MajorErrorInFile',
                 'severity' => 'major',
                 'location' =>
                     [

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -61,8 +61,12 @@ class GitLabRenderer extends AbstractRenderer
                         'PHP',
                     ],
                 'check_name' => $violation->getRule()->getName(),
-                'fingerprint' => $violation->getFileName() . ':' . $violation->getBeginLine() . ':' . $violation->getRule(
-                )->getName(),
+                'fingerprint' => sprintf(
+                    "%s:%s:%s",
+                    $violation->getFileName(),
+                    $violation->getBeginLine(),
+                    $violation->getRule()->getName()
+                ),
                 'description' => $violation->getDescription(),
                 'severity' => 'minor',
                 'location' =>

--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -47,7 +47,7 @@ class TextRenderer extends AbstractRenderer implements Verbose, Color
         $violations = [];
 
         foreach ($report->getRuleViolations() as $violation) {
-            $location = $violation->getFileName().':'.$violation->getBeginLine();
+            $location = $violation->getFileName() . ':' . $violation->getBeginLine();
             $rule = $violation->getRule();
             $ruleName = $rule->getName();
             $ruleSet = $rule->getRuleSetName();

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -216,7 +216,7 @@ abstract class AbstractLocalVariable extends AbstractRule
 
         // If variable name is not in the node, it's in the second child
         if ($image === '::') {
-            return $image.$variable->getChild(1)->getImage();
+            return $image . $variable->getChild(1)->getImage();
         }
 
         return $this->prependMemberPrimaryPrefix($image, $variable);

--- a/src/main/php/PHPMD/Rule/ClassAware.php
+++ b/src/main/php/PHPMD/Rule/ClassAware.php
@@ -20,4 +20,6 @@ namespace PHPMD\Rule;
 /**
  * This interface is used to mark a rule implementation as class aware.
  */
-interface ClassAware {}
+interface ClassAware
+{
+}

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -114,7 +114,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
 
         foreach ($node->getProperties() as $property) {
             if ($property->isStatic()) {
-                $this->images['::'.$property->getName()] = $property;
+                $this->images['::' . $property->getName()] = $property;
             }
         }
     }

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
@@ -40,8 +40,8 @@ class CamelCaseNamespace extends AbstractRule implements ClassAware, InterfaceAw
             $pattern = '/^([A-Z][a-z0-9]+)*$/';
         }
 
-        $exceptions     = $this->getExceptionsList();
-        $fullNamespace  = $node->getNamespaceName();
+        $exceptions = $this->getExceptionsList();
+        $fullNamespace = $node->getNamespaceName();
         $namespaceNames = $fullNamespace === '' ? [] : explode('\\', $fullNamespace);
 
         foreach ($namespaceNames as $namespaceName) {

--- a/src/main/php/PHPMD/Rule/EnumAware.php
+++ b/src/main/php/PHPMD/Rule/EnumAware.php
@@ -20,4 +20,6 @@ namespace PHPMD\Rule;
 /**
  * This interface is used to mark a rule implementation as enum aware.
  */
-interface EnumAware {}
+interface EnumAware
+{
+}

--- a/src/main/php/PHPMD/Rule/FunctionAware.php
+++ b/src/main/php/PHPMD/Rule/FunctionAware.php
@@ -20,4 +20,6 @@ namespace PHPMD\Rule;
 /**
  * This interface is used to mark a rule implementation as function aware.
  */
-interface FunctionAware {}
+interface FunctionAware
+{
+}

--- a/src/main/php/PHPMD/Rule/InterfaceAware.php
+++ b/src/main/php/PHPMD/Rule/InterfaceAware.php
@@ -20,4 +20,6 @@ namespace PHPMD\Rule;
 /**
  * This interface marks a rule implementation as interface aware,
  */
-interface InterfaceAware {}
+interface InterfaceAware
+{
+}

--- a/src/main/php/PHPMD/Rule/MethodAware.php
+++ b/src/main/php/PHPMD/Rule/MethodAware.php
@@ -20,4 +20,6 @@ namespace PHPMD\Rule;
 /**
  * This interface marks a rule implementation as method aware,
  */
-interface MethodAware {}
+interface MethodAware
+{
+}

--- a/src/main/php/PHPMD/Rule/TraitAware.php
+++ b/src/main/php/PHPMD/Rule/TraitAware.php
@@ -20,4 +20,6 @@ namespace PHPMD\Rule;
 /**
  * This interface is used to mark a rule implementation as trait aware.
  */
-interface TraitAware {}
+interface TraitAware
+{
+}

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -122,14 +122,14 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
 
         if ($magicMethodRegExp === null) {
             $magicMethodRegExp = '/__(?:' . implode("|", [
-                    'call',
-                    'callStatic',
-                    'get',
-                    'set',
-                    'isset',
-                    'unset',
-                    'set_state',
-                ]) . ')/i';
+                'call',
+                'callStatic',
+                'get',
+                'set',
+                'isset',
+                'unset',
+                'set_state',
+            ]) . ')/i';
         }
 
         return preg_match($magicMethodRegExp, $node->getName()) === 1;

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -102,23 +102,23 @@ class Command
         }
 
         // Configure baseline violations
-        $report       = null;
-        $finder       = new BaselineFileFinder($opts);
+        $report = null;
+        $finder = new BaselineFileFinder($opts);
         $baselineFile = null;
         if ($opts->generateBaseline() === BaselineMode::GENERATE) {
             // overwrite any renderer with the baseline renderer
             $renderers = [RendererFactory::createBaselineRenderer(new StreamWriter($finder->notNull()->find()))];
         } elseif ($opts->generateBaseline() === BaselineMode::UPDATE) {
             $baselineFile = $finder->notNull()->existingFile()->find();
-            $baseline     = BaselineSetFactory::fromFile(Paths::getRealPath($baselineFile));
-            $renderers    = [RendererFactory::createBaselineRenderer(new StreamWriter($baselineFile))];
-            $report       = new Report(new BaselineValidator($baseline, BaselineMode::UPDATE));
+            $baseline = BaselineSetFactory::fromFile(Paths::getRealPath($baselineFile));
+            $renderers = [RendererFactory::createBaselineRenderer(new StreamWriter($baselineFile))];
+            $report = new Report(new BaselineValidator($baseline, BaselineMode::UPDATE));
         } else {
             // try to locate a baseline file and read it
             $baselineFile = $finder->existingFile()->find();
             if ($baselineFile !== null) {
                 $baseline = BaselineSetFactory::fromFile(Paths::getRealPath($baselineFile));
-                $report   = new Report(new BaselineValidator($baseline, BaselineMode::NONE));
+                $report = new Report(new BaselineValidator($baseline, BaselineMode::NONE));
             }
         }
 
@@ -149,7 +149,7 @@ class Command
         }
 
         $ignorePattern = $ruleSetFactory->getIgnorePattern($opts->getRuleSets());
-        $ruleSetList   = $ruleSetFactory->createRuleSets($opts->getRuleSets());
+        $ruleSetList = $ruleSetFactory->createRuleSets($opts->getRuleSets());
 
         // Configure Result Cache Engine
         if ($opts->generateBaseline() === BaselineMode::NONE) {
@@ -193,7 +193,7 @@ class Command
 
         $version = '@package_version@';
         if (file_exists($build)) {
-            $data    = @parse_ini_file($build);
+            $data = @parse_ini_file($build);
             $version = $data['project.version'];
         }
 
@@ -214,11 +214,11 @@ class Command
 
         try {
             $ruleSetFactory = new RuleSetFactory();
-            $options        = new CommandLineOptions($args, $ruleSetFactory->listAvailableRuleSets());
-            $errorFile      = $options->getErrorFile();
-            $errorStream    = new StreamWriter($errorFile ?: STDERR);
-            $output         = new StreamOutput($errorStream->getStream(), $options->getVerbosity());
-            $command        = new self($output);
+            $options = new CommandLineOptions($args, $ruleSetFactory->listAvailableRuleSets());
+            $errorFile = $options->getErrorFile();
+            $errorStream = new StreamWriter($errorFile ?: STDERR);
+            $output = new StreamOutput($errorStream->getStream(), $options->getVerbosity());
+            $command = new self($output);
 
             foreach ($options->getDeprecations() as $deprecation) {
                 $output->write($deprecation . PHP_EOL . PHP_EOL);

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -877,7 +877,7 @@ class CommandLineOptions
     protected function getListOfAvailableRenderers()
     {
         $renderersDirPathName = __DIR__ . '/../Renderer';
-        $renderers            = [];
+        $renderers = [];
 
         foreach (scandir($renderersDirPathName) as $rendererFileName) {
             $rendererName = [];

--- a/src/main/php/PHPMD/Utility/Strings.php
+++ b/src/main/php/PHPMD/Utility/Strings.php
@@ -88,10 +88,10 @@ class Strings
 
         return array_filter(
             array_map(
-                static fn ($value) => Strings::trim($value, $trim),
+                static fn($value) => Strings::trim($value, $trim),
                 explode($separator, $listAsString)
             ),
-            static fn ($value) => $value !== ''
+            static fn($value) => $value !== ''
         );
     }
 

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -48,6 +48,31 @@ abstract class AbstractStaticTestCase extends TestCase
     private static $tempFiles = [];
 
     /**
+     * This method initializes the test environment, it configures the files
+     * directory and sets the include_path for svn versions.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        self::$filesDirectory = realpath(__DIR__ . '/../../resources/files');
+
+        if (!str_contains(get_include_path(), self::$filesDirectory)) {
+            set_include_path(
+                sprintf(
+                    '%s%s%s%s%s',
+                    get_include_path(),
+                    PATH_SEPARATOR,
+                    self::$filesDirectory,
+                    PATH_SEPARATOR,
+                    realpath(__DIR__ . '/../')
+                )
+            );
+        }
+
+        // Prevent timezone warnings if no default TZ is set (PHP > 5.1.0)
+        date_default_timezone_set('UTC');
+    }
+
+    /**
      * Return to original working directory if changed.
      *
      * @return void
@@ -98,7 +123,7 @@ abstract class AbstractStaticTestCase extends TestCase
      */
     protected static function getValuesAsArrays($values)
     {
-        return array_map(static fn ($value) => [$value], $values);
+        return array_map(static fn($value) => [$value], $values);
     }
 
     /**
@@ -185,31 +210,6 @@ abstract class AbstractStaticTestCase extends TestCase
         $expected = str_replace('_DS_', DIRECTORY_SEPARATOR, $expected);
 
         self::assertJsonStringEqualsJsonString($expected, json_encode($actual));
-    }
-
-    /**
-     * This method initializes the test environment, it configures the files
-     * directory and sets the include_path for svn versions.
-     */
-    public static function setUpBeforeClass(): void
-    {
-        self::$filesDirectory = realpath(__DIR__ . '/../../resources/files');
-
-        if (!str_contains(get_include_path(), self::$filesDirectory)) {
-            set_include_path(
-                sprintf(
-                    '%s%s%s%s%s',
-                    get_include_path(),
-                    PATH_SEPARATOR,
-                    self::$filesDirectory,
-                    PATH_SEPARATOR,
-                    realpath(__DIR__ . '/../')
-                )
-            );
-        }
-
-        // Prevent timezone warnings if no default TZ is set (PHP > 5.1.0)
-        date_default_timezone_set('UTC');
     }
 
     /**

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -57,6 +57,17 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     protected const ONE_VIOLATION = 1;
 
     /**
+     * Resets a changed working directory.
+     */
+    protected function tearDown(): void
+    {
+        static::returnToOriginalWorkingDirectory();
+        static::cleanupTempFiles();
+
+        parent::tearDown();
+    }
+
+    /**
      * Get a list of files that should trigger a rule violation.
      *
      * By default, files named like "testRuleAppliesTo*", but it can be overridden in sub-classes.
@@ -98,17 +109,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     public static function getNotApplyingCases()
     {
         return static::getValuesAsArrays(static::getNotApplyingFiles());
-    }
-
-    /**
-     * Resets a changed working directory.
-     */
-    protected function tearDown(): void
-    {
-        static::returnToOriginalWorkingDirectory();
-        static::cleanupTempFiles();
-
-        parent::tearDown();
     }
 
     /**
@@ -285,12 +285,12 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      */
     protected function getViolationFailureMessage($file, $expectedInvokes, $actualInvokes, $violations)
     {
-        return basename($file)." failed:\n".
-            "Expected $expectedInvokes violation".($expectedInvokes !== 1 ? 's' : '')."\n".
-            "But $actualInvokes violation".($actualInvokes !== 1 ? 's' : '')." raised".
+        return basename($file) . " failed:\n" .
+            "Expected $expectedInvokes violation" . ($expectedInvokes !== 1 ? 's' : '') . "\n" .
+            "But $actualInvokes violation" . ($actualInvokes !== 1 ? 's' : '') . " raised" .
             (
                 $actualInvokes > 0
-                ? ":\n".$this->getViolationsSummary($violations)
+                ? ":\n" . $this->getViolationsSummary($violations)
                 : '.'
             );
     }
@@ -312,11 +312,11 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
             $nodeExtractor->setAccessible(true);
             $node = $nodeExtractor->getValue($violation);
             $node = $node ? $node->getNode() : null;
-            $message = '  - line '.$violation->getBeginLine();
+            $message = '  - line ' . $violation->getBeginLine();
 
             if ($node) {
                 $type = preg_replace('/^PDepend\\\\Source\\\\AST\\\\AST/', '', $node::class);
-                $message .= ' on '.$type.' '.$node->getImage();
+                $message .= ' on ' . $type . ' ' . $node->getImage();
             }
 
             return $message;

--- a/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
@@ -17,7 +17,7 @@ class BaselineFileFinderTest extends AbstractTestCase
      */
     public function testShouldFindFileFromCLI()
     {
-        $args   = ['script', 'source', 'xml', 'phpmd.xml', '--baseline-file', 'foobar.txt'];
+        $args = ['script', 'source', 'xml', 'phpmd.xml', '--baseline-file', 'foobar.txt'];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
         static::assertSame('foobar.txt', $finder->find());
     }
@@ -28,12 +28,12 @@ class BaselineFileFinderTest extends AbstractTestCase
      */
     public function testShouldFindExistingFileNearRuleSet()
     {
-        $args   = ['script', 'source', 'xml', static::createResourceUriForTest('testA/phpmd.xml')];
+        $args = ['script', 'source', 'xml', static::createResourceUriForTest('testA/phpmd.xml')];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
 
         // ensure consistent slashes
         $expected = str_replace("\\", "/", realpath(static::createResourceUriForTest('testA/phpmd.baseline.xml')));
-        $actual   = str_replace("\\", "/", $finder->existingFile()->find());
+        $actual = str_replace("\\", "/", $finder->existingFile()->find());
 
         static::assertSame($expected, $actual);
     }
@@ -48,7 +48,7 @@ class BaselineFileFinderTest extends AbstractTestCase
             'Unable to determine the baseline file location.',
         ));
 
-        $args   = ['script', 'source', 'xml', static::createResourceUriForTest('phpmd.xml')];
+        $args = ['script', 'source', 'xml', static::createResourceUriForTest('phpmd.xml')];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
         $finder->notNull()->find();
     }
@@ -59,7 +59,7 @@ class BaselineFileFinderTest extends AbstractTestCase
      */
     public function testShouldReturnNullForNonExistingRuleSet()
     {
-        $args   = ['script', 'source', 'xml', static::createResourceUriForTest('phpmd.xml')];
+        $args = ['script', 'source', 'xml', static::createResourceUriForTest('phpmd.xml')];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
         static::assertNull($finder->find());
     }
@@ -71,7 +71,7 @@ class BaselineFileFinderTest extends AbstractTestCase
      */
     public function testShouldOnlyFindExistingFile()
     {
-        $args   = ['script', 'source', 'xml', static::createResourceUriForTest('testB/phpmd.xml')];
+        $args = ['script', 'source', 'xml', static::createResourceUriForTest('testB/phpmd.xml')];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
         static::assertNull($finder->existingFile()->find());
     }
@@ -87,7 +87,7 @@ class BaselineFileFinderTest extends AbstractTestCase
             'Unable to find the baseline file',
         ));
 
-        $args   = ['script', 'source', 'xml', static::createResourceUriForTest('testB/phpmd.xml')];
+        $args = ['script', 'source', 'xml', static::createResourceUriForTest('testB/phpmd.xml')];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
         static::assertNull($finder->existingFile()->notNull()->find());
     }

--- a/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
@@ -18,8 +18,8 @@ class BaselineSetFactoryTest extends AbstractTestCase
     public function testFromFileShouldSucceed()
     {
         $filename = static::createResourceUriForTest('baseline.xml');
-        $baseDir  = dirname($filename);
-        $set      = BaselineSetFactory::fromFile($filename);
+        $baseDir = dirname($filename);
+        $set = BaselineSetFactory::fromFile($filename);
 
         static::assertTrue($set->contains(MissingImport::class, $baseDir . '/src/foo/bar', null));
         static::assertTrue(
@@ -33,8 +33,8 @@ class BaselineSetFactoryTest extends AbstractTestCase
     public function testFromFileShouldSucceedWithBackAndForwardSlashes()
     {
         $filename = static::createResourceUriForTest('baseline.xml');
-        $baseDir  = dirname($filename);
-        $set      = BaselineSetFactory::fromFile($filename);
+        $baseDir = dirname($filename);
+        $set = BaselineSetFactory::fromFile($filename);
 
         static::assertTrue($set->contains(MissingImport::class, $baseDir . '/src\\foo/bar', null));
         static::assertTrue(

--- a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -37,11 +37,11 @@ class BaselineValidatorTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::isBaselined
-     * @dataProvider dataProvider
      * @param bool   $contains
      * @param string $baselineMode
      * @param bool   $isBaselined
+     * @dataProvider dataProvider
+     * @covers ::isBaselined
      */
     public function testIsBaselined($contains, $baselineMode, $isBaselined)
     {

--- a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -22,7 +22,7 @@ class BaselineValidatorTest extends AbstractTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $rule            = $this->getMockFromBuilder(
+        $rule = $this->getMockFromBuilder(
             $this->getMockBuilder(Rule::class)->disableOriginalConstructor()
         );
         $this->violation = $this->getMockFromBuilder(
@@ -53,11 +53,11 @@ class BaselineValidatorTest extends AbstractTestCase
     public static function dataProvider(): array
     {
         return [
-            'contains: true, mode: none'      => [true, BaselineMode::NONE, true],
-            'contains: false, mode: none'     => [false, BaselineMode::NONE, false],
-            'contains: true, mode: update'    => [true, BaselineMode::UPDATE, false],
-            'contains: false, mode: update'   => [false, BaselineMode::UPDATE, true],
-            'contains: true, mode: generate'  => [true, BaselineMode::GENERATE, false],
+            'contains: true, mode: none' => [true, BaselineMode::NONE, true],
+            'contains: false, mode: none' => [false, BaselineMode::NONE, false],
+            'contains: true, mode: update' => [true, BaselineMode::UPDATE, false],
+            'contains: false, mode: update' => [false, BaselineMode::UPDATE, true],
+            'contains: true, mode: generate' => [true, BaselineMode::GENERATE, false],
             'contains: false, mode: generate' => [false, BaselineMode::GENERATE, false],
         ];
     }

--- a/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
+++ b/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
@@ -22,9 +22,9 @@ class ViolationBaselineTest extends TestCase
     /**
      * Test the give file matches the baseline correctly
      *
+     * @return void
      * @covers ::__construct
      * @covers ::matches
-     * @return void
      */
     public function testMatchesWithMethod()
     {
@@ -38,9 +38,9 @@ class ViolationBaselineTest extends TestCase
     /**
      * Test the give file matches the baseline correctly
      *
+     * @return void
      * @covers ::__construct
      * @covers ::matches
-     * @return void
      */
     public function testMatchesWithoutMethod()
     {

--- a/src/test/php/PHPMD/Cache/Model/ResultCacheKeyTest.php
+++ b/src/test/php/PHPMD/Cache/Model/ResultCacheKeyTest.php
@@ -15,7 +15,7 @@ class ResultCacheKeyTest extends AbstractTestCase
      */
     public function testToArray()
     {
-        $key      = new ResultCacheKey(
+        $key = new ResultCacheKey(
             true,
             'baselineHash',
             ['rule A' => 'hash1'],
@@ -23,11 +23,11 @@ class ResultCacheKeyTest extends AbstractTestCase
             12345
         );
         $expected = [
-            'strict'       => true,
+            'strict' => true,
             'baselineHash' => 'baselineHash',
-            'rules'        => ['rule A' => 'hash1'],
-            'composer'     => ['composer.json' => 'hash2'],
-            'phpVersion'   => 12345,
+            'rules' => ['rule A' => 'hash1'],
+            'composer' => ['composer.json' => 'hash2'],
+            'phpVersion' => 12345,
         ];
 
         static::assertSame($expected, $key->toArray());

--- a/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
+++ b/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
@@ -22,7 +22,7 @@ class ResultCacheStateTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->key   = new ResultCacheKey(true, 'baseline', [], [], 123);
+        $this->key = new ResultCacheKey(true, 'baseline', [], [], 123);
         $this->state = new ResultCacheState($this->key, []);
     }
 
@@ -53,7 +53,7 @@ class ResultCacheStateTest extends TestCase
      */
     public function testAddRuleViolation()
     {
-        $rule     = new BooleanArgumentFlag();
+        $rule = new BooleanArgumentFlag();
         $nodeInfo = new NodeInfo(
             'fileName',
             'namespace',
@@ -63,22 +63,22 @@ class ResultCacheStateTest extends TestCase
             123,
             456
         );
-        $metric   = ['line' => 100];
+        $metric = ['line' => 100];
 
         $ruleViolation = new RuleViolation($rule, $nodeInfo, 'violation', $metric);
 
         $expected = [
             [
-                'rule'          => BooleanArgumentFlag::class,
+                'rule' => BooleanArgumentFlag::class,
                 'namespaceName' => 'namespace',
-                'className'     => 'className',
-                'methodName'    => 'methodName',
-                'functionName'  => 'functionName',
-                'beginLine'     => 123,
-                'endLine'       => 456,
-                'description'   => 'violation',
-                'args'          => null,
-                'metric'        => $metric,
+                'className' => 'className',
+                'methodName' => 'methodName',
+                'functionName' => 'functionName',
+                'beginLine' => 123,
+                'endLine' => 456,
+                'description' => 'violation',
+                'args' => null,
+                'metric' => $metric,
             ],
         ];
 
@@ -94,7 +94,7 @@ class ResultCacheStateTest extends TestCase
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new BooleanArgumentFlag());
-        $rule     = new BooleanArgumentFlag();
+        $rule = new BooleanArgumentFlag();
         $nodeInfo = new NodeInfo(
             '/file/path',
             'namespace',
@@ -104,7 +104,7 @@ class ResultCacheStateTest extends TestCase
             123,
             456
         );
-        $metric   = ['line' => 100];
+        $metric = ['line' => 100];
 
         $ruleViolation = new RuleViolation($rule, $nodeInfo, 'violation', $metric);
 
@@ -121,7 +121,7 @@ class ResultCacheStateTest extends TestCase
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new BooleanArgumentFlag());
-        $rule     = new BooleanArgumentFlag();
+        $rule = new BooleanArgumentFlag();
         $nodeInfo = new NodeInfo(
             '/file/path',
             'namespace',
@@ -131,7 +131,7 @@ class ResultCacheStateTest extends TestCase
             123,
             456
         );
-        $metric   = ['line' => 100];
+        $metric = ['line' => 100];
 
         $ruleViolation = new RuleViolation(
             $rule,
@@ -165,7 +165,7 @@ class ResultCacheStateTest extends TestCase
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new BooleanArgumentFlag());
-        $rule     = new BooleanArgumentFlag();
+        $rule = new BooleanArgumentFlag();
         $nodeInfo = new NodeInfo(
             '/file/path',
             'namespace',
@@ -175,36 +175,36 @@ class ResultCacheStateTest extends TestCase
             123,
             456
         );
-        $metric   = ['line' => 100];
+        $metric = ['line' => 100];
 
         $ruleViolation = new RuleViolation($rule, $nodeInfo, 'violation', $metric);
         $this->state->setFileState('/file/path', 'hash');
         $this->state->addRuleViolation('/file/path', $ruleViolation);
 
         $expected = [
-            'key'   => [
-                'strict'       => true,
+            'key' => [
+                'strict' => true,
                 'baselineHash' => 'baseline',
-                'rules'        => [],
-                'composer'     => [],
-                'phpVersion'   => 123,
+                'rules' => [],
+                'composer' => [],
+                'phpVersion' => 123,
             ],
             'state' => [
                 'files' => [
                     '/file/path' => [
-                        'hash'       => 'hash',
+                        'hash' => 'hash',
                         'violations' => [
                             [
-                                'rule'          => BooleanArgumentFlag::class,
+                                'rule' => BooleanArgumentFlag::class,
                                 'namespaceName' => 'namespace',
-                                'className'     => 'className',
-                                'methodName'    => 'methodName',
-                                'functionName'  => 'functionName',
-                                'beginLine'     => 123,
-                                'endLine'       => 456,
-                                'description'   => 'violation',
-                                'args'          => null,
-                                'metric'        => $metric,
+                                'className' => 'className',
+                                'methodName' => 'methodName',
+                                'functionName' => 'functionName',
+                                'beginLine' => 123,
+                                'endLine' => 456,
+                                'description' => 'violation',
+                                'args' => null,
+                                'metric' => $metric,
                             ],
                         ],
                     ],

--- a/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
@@ -31,10 +31,10 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
 
     protected function setUp(): void
     {
-        $this->options      = $this->getMockFromBuilder(
+        $this->options = $this->getMockFromBuilder(
             $this->getMockBuilder(CommandLineOptions::class)->disableOriginalConstructor()
         );
-        $this->keyFactory   = $this->getMockFromBuilder(
+        $this->keyFactory = $this->getMockFromBuilder(
             $this->getMockBuilder(ResultCacheKeyFactory::class)->disableOriginalConstructor()
         );
         $this->stateFactory = $this->getMockFromBuilder(
@@ -61,9 +61,9 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
     public function testCreateCacheMissShouldHaveNoOriginalState()
     {
         $ruleSetList = [new RuleSet()];
-        $cacheKeyA   = new ResultCacheKey(true, 'baseline', [], [], 123);
-        $cacheKeyB   = new ResultCacheKey(false, 'baseline', [], [], 321);
-        $state       = new ResultCacheState($cacheKeyB, []);
+        $cacheKeyA = new ResultCacheKey(true, 'baseline', [], [], 123);
+        $cacheKeyB = new ResultCacheKey(false, 'baseline', [], [], 321);
+        $state = new ResultCacheState($cacheKeyB, []);
 
         $this->options->expects(self::once())->method('isCacheEnabled')->willReturn(true);
         $this->options->expects(self::once())->method('hasStrict')->willReturn(true);
@@ -83,8 +83,8 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
     public function testCreateCacheHitShouldHaveOriginalState()
     {
         $ruleSetList = [new RuleSet()];
-        $cacheKey    = new ResultCacheKey(true, 'baseline', [], [], 123);
-        $state       = new ResultCacheState($cacheKey, []);
+        $cacheKey = new ResultCacheKey(true, 'baseline', [], [], 123);
+        $state = new ResultCacheState($cacheKey, []);
 
         $this->options->expects(self::once())->method('isCacheEnabled')->willReturn(true);
         $this->options->expects(self::once())->method('hasStrict')->willReturn(true);

--- a/src/test/php/PHPMD/Cache/ResultCacheEngineTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheEngineTest.php
@@ -17,13 +17,13 @@ class ResultCacheEngineTest extends AbstractTestCase
      */
     public function testGetters()
     {
-        $filter  = $this->getMockFromBuilder(
+        $filter = $this->getMockFromBuilder(
             $this->getMockBuilder(ResultCacheFileFilter::class)->disableOriginalConstructor()
         );
         $updater = $this->getMockFromBuilder(
             $this->getMockBuilder(ResultCacheUpdater::class)->disableOriginalConstructor()
         );
-        $writer  = $this->getMockFromBuilder(
+        $writer = $this->getMockFromBuilder(
             $this->getMockBuilder(ResultCacheWriter::class)->disableOriginalConstructor()
         );
 

--- a/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
@@ -25,10 +25,10 @@ class ResultCacheFileFilterTest extends AbstractTestCase
     protected function setUp(): void
     {
         $this->output = new NullOutput();
-        $this->key    = $this->getMockFromBuilder(
+        $this->key = $this->getMockFromBuilder(
             $this->getMockBuilder(ResultCacheKey::class)->disableOriginalConstructor()
         );
-        $this->state  = $this->getMockFromBuilder(
+        $this->state = $this->getMockFromBuilder(
             $this->getMockBuilder(ResultCacheState::class)->disableOriginalConstructor()
         );
     }
@@ -70,8 +70,8 @@ class ResultCacheFileFilterTest extends AbstractTestCase
      */
     public function testAcceptStrategyTimestampModified()
     {
-        $timestamp = (string)filemtime(__FILE__);
-        $filter    = new ResultCacheFileFilter($this->output, __DIR__, Strategy::TIMESTAMP, $this->key, $this->state);
+        $timestamp = (string) filemtime(__FILE__);
+        $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::TIMESTAMP, $this->key, $this->state);
 
         $this->state->expects(self::once())->method('isFileModified')->willReturn(true);
 

--- a/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
@@ -33,7 +33,7 @@ class ResultCacheKeyFactoryTest extends AbstractTestCase
      */
     public function testCreate()
     {
-        $rule    = new DuplicatedArrayKey();
+        $rule = new DuplicatedArrayKey();
         $ruleSet = new RuleSet();
         $ruleSet->addRule($rule);
 

--- a/src/test/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
@@ -63,7 +63,7 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
             ['composer.json' => 'hash1', 'composer.lock' => 'hash2'],
             70000
         );
-        $cacheKey    = $state->getCacheKey();
+        $cacheKey = $state->getCacheKey();
         static::assertEquals($expectedKey, $cacheKey);
 
         // assert file state
@@ -89,7 +89,7 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
             [],
             70000
         );
-        $cacheKey    = $state->getCacheKey();
+        $cacheKey = $state->getCacheKey();
         static::assertEquals($expectedKey, $cacheKey);
     }
 }

--- a/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
@@ -34,8 +34,8 @@ class ResultCacheUpdaterTest extends AbstractTestCase
      */
     public function testUpdate()
     {
-        $ruleSet    = new RuleSet();
-        $report     = $this->getReportMock();
+        $ruleSet = new RuleSet();
+        $report = $this->getReportMock();
         $violationA = $this->getRuleViolationMock('/base/path/violation/a');
         $violationB = $this->getRuleViolationMock('/base/path/violation/b');
 

--- a/src/test/php/PHPMD/Cache/ResultCacheWriterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheWriterTest.php
@@ -22,7 +22,7 @@ class ResultCacheWriterTest extends AbstractTestCase
     protected function setUp(): void
     {
         $this->filePath = vfsStream::setup()->url() . '/.result-cache.php';
-        $this->writer   = new ResultCacheWriter($this->filePath);
+        $this->writer = new ResultCacheWriter($this->filePath);
     }
 
     /**
@@ -30,7 +30,7 @@ class ResultCacheWriterTest extends AbstractTestCase
      */
     public function testWrite()
     {
-        $cacheKey   = new ResultCacheKey(true, 'baseline', [], [], 70000);
+        $cacheKey = new ResultCacheKey(true, 'baseline', [], [], 70000);
         $cacheState = new ResultCacheState($cacheKey, []);
 
         $this->writer->write($cacheState);

--- a/src/test/php/PHPMD/Console/OutputTest.php
+++ b/src/test/php/PHPMD/Console/OutputTest.php
@@ -20,9 +20,9 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
+     * @return void
      * @covers ::getVerbosity
      * @covers ::setVerbosity
-     * @return void
      */
     public function testSetGetVerbosity()
     {
@@ -34,8 +34,8 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::write
      * @return void
+     * @covers ::write
      */
     public function testWriteSingleMessage()
     {
@@ -46,8 +46,8 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::write
      * @return void
+     * @covers ::write
      */
     public function testWriteMultiMessageWithNewline()
     {
@@ -61,8 +61,8 @@ class OutputTest extends AbstractTestCase
      * @param int    $verbosity
      * @param string $expected
      * @param string $msg
-     * @covers ::write
      * @dataProvider verbosityProvider
+     * @covers ::write
      */
     public function testWriteWithVerbosityOption($verbosity, $expected, $msg)
     {
@@ -108,8 +108,8 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::writeln
      * @return void
+     * @covers ::writeln
      */
     public function testWritelnMessage()
     {

--- a/src/test/php/PHPMD/ParserTest.php
+++ b/src/test/php/PHPMD/ParserTest.php
@@ -161,7 +161,7 @@ class ParserTest extends AbstractTestCase
     private function getPHPDependMock()
     {
         $container = new Container();
-        $config = new Configuration((object)[]);
+        $config = new Configuration((object) []);
 
         return $this->getMockFromBuilder(
             $this->getMockBuilder(Engine::class)

--- a/src/test/php/PHPMD/ProcessingErrorTest.php
+++ b/src/test/php/PHPMD/ProcessingErrorTest.php
@@ -20,9 +20,8 @@ namespace PHPMD;
 /**
  * Test case for the processing error class.
  *
- * @since 1.2.1
- *
  * @covers \PHPMD\ProcessingError
+ * @since 1.2.1
  */
 class ProcessingErrorTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
@@ -19,7 +19,7 @@ class BaselineRendererTest extends AbstractTestCase
      */
     public function testRenderReport()
     {
-        $writer     = new WriterStub();
+        $writer = new WriterStub();
         $violations = [
             $this->getRuleViolationMock('/src/php/bar.php'),
             $this->getRuleViolationMock('/src/php/foo.php'),
@@ -48,7 +48,7 @@ class BaselineRendererTest extends AbstractTestCase
      */
     public function testRenderReportShouldWriteMethodName()
     {
-        $writer        = new WriterStub();
+        $writer = new WriterStub();
         $violationMock = $this->getRuleViolationMock('/src/php/bar.php');
         $violationMock->expects(static::once())->method('getMethodName')->willReturn('foo');
 
@@ -75,7 +75,7 @@ class BaselineRendererTest extends AbstractTestCase
      */
     public function testRenderReportShouldDeduplicateSimilarViolations()
     {
-        $writer        = new WriterStub();
+        $writer = new WriterStub();
         $violationMock = $this->getRuleViolationMock('/src/php/bar.php');
         $violationMock->expects(static::exactly(2))->method('getMethodName')->willReturn('foo');
 

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -203,7 +203,7 @@ class ReportTest extends AbstractTestCase
 
         // setup baseline
         $violation = new ViolationBaseline($ruleA->getRule()::class, 'foo.txt', null);
-        $baseline  = new BaselineSet();
+        $baseline = new BaselineSet();
         $baseline->addEntry($violation);
 
         // setup report
@@ -229,7 +229,7 @@ class ReportTest extends AbstractTestCase
 
         // setup baseline
         $violation = new ViolationBaseline($ruleA->getRule()::class, 'foo.txt', null);
-        $baseline  = new BaselineSet();
+        $baseline = new BaselineSet();
         $baseline->addEntry($violation);
 
         // setup report

--- a/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
@@ -22,8 +22,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the {@link \PHPMD\Rule\Design\CouplingBetweenObjects} class.
  *
- * @link https://www.pivotaltracker.com/story/show/10474987
  * @covers \PHPMD\Rule\Design\CouplingBetweenObjects
+ * @link https://www.pivotaltracker.com/story/show/10474987
  */
 class CouplingBetweenObjectsTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -22,10 +22,9 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the {@link \PHPMD\Rule\Design\DevelopmentCodeFragment} class.
  *
+ * @covers \PHPMD\Rule\Design\DevelopmentCodeFragment
  * @link https://github.com/phpmd/phpmd/issues/265
  * @since 2.3.0
- *
- * @covers \PHPMD\Rule\Design\DevelopmentCodeFragment
  */
 class DevelopmentCodeFragmentTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
+++ b/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
@@ -22,9 +22,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the {@link \PHPMD\Rule\Design\GotoStatement} class.
  *
- * @link https://www.pivotaltracker.com/story/show/10474873
- *
  * @covers \PHPMD\Rule\Design\GotoStatement
+ * @link https://www.pivotaltracker.com/story/show/10474873
  */
 class GotoStatementTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
+++ b/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
@@ -22,9 +22,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the weighted method count rule.
  *
- * @since 0.2.5
- *
  * @covers \PHPMD\Rule\Design\WeightedMethodCount
+ * @since 0.2.5
  */
 class WeightedMethodCountTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
@@ -128,9 +128,9 @@ class ShortMethodNameTest extends AbstractTestCase
      * testRuleAlsoWorksWithoutExceptionListConfigured
      *
      * @return void
-     * @since 2.2.2
      * @link https://github.com/phpmd/phpmd/issues/80
      * @link https://github.com/phpmd/phpmd/issues/270
+     * @since 2.2.2
      */
     public function testRuleAppliesAlsoWithoutExceptionListConfiguredOnMock()
     {

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -26,7 +26,6 @@ use PHPMD\AbstractTestCase;
  */
 class ShortVariableTest extends AbstractTestCase
 {
-
     /**
      * testRuleAppliesToLocalVariableInFunctionWithNameShorterThanThreshold
      *

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -362,8 +362,8 @@ class ShortVariableTest extends AbstractTestCase
     /**
      * testRuleAppliesToVariablesWithinForeach
      *
-     * @dataProvider provideClassWithShortForeachVariables
      * @return void
+     * @dataProvider provideClassWithShortForeachVariables
      */
     public function testRuleAppliesToVariablesWithinForeach($allowShortVarInLoop, $expectedErrorsCount)
     {

--- a/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -373,7 +373,7 @@ class UnusedFormalParameterTest extends AbstractTestCase
     {
         $methods = array_filter(
             $this->getClass()->getMethods(),
-            static fn ($method) => $method->getName() === '__call',
+            static fn($method) => $method->getName() === '__call',
         );
 
         $rule = new UnusedFormalParameter();
@@ -532,7 +532,7 @@ class UnusedFormalParameterTest extends AbstractTestCase
     {
         $methods = array_filter(
             $this->getClass()->getMethods(),
-            static fn ($method) => $method->getImage() === '__construct',
+            static fn($method) => $method->getImage() === '__construct',
         );
 
         $rule = new UnusedFormalParameter();

--- a/src/test/php/PHPMD/RuleViolationTest.php
+++ b/src/test/php/PHPMD/RuleViolationTest.php
@@ -22,9 +22,8 @@ use PHPMD\Node\NodeInfo;
 /**
  * Test case for the {@link \PHPMD\RuleViolation} class.
  *
- * @since 0.2.5
- *
  * @covers \PHPMD\RuleViolation
+ * @since 0.2.5
  */
 class RuleViolationTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -58,7 +58,7 @@ class CommandTest extends AbstractTestCase
                     '--reportfile',
                     self::createTempFileUri(),
                 ],
-                (array)$options
+                (array) $options
             )
         );
 
@@ -170,8 +170,8 @@ class CommandTest extends AbstractTestCase
 
     public function testOutput()
     {
-        $uri      = realpath(self::createFileUri('source/source_with_anonymous_class.php'));
-        $temp     = self::createTempFileUri();
+        $uri = realpath(self::createFileUri('source/source_with_anonymous_class.php'));
+        $temp = self::createTempFileUri();
         $exitCode = Command::main([
             __FILE__,
             $uri,
@@ -222,8 +222,8 @@ class CommandTest extends AbstractTestCase
 
     public function testMainGenerateBaseline()
     {
-        $uri      = str_replace("\\", "/", realpath(self::createFileUri('source/source_with_anonymous_class.php')));
-        $temp     = self::createTempFileUri();
+        $uri = str_replace("\\", "/", realpath(self::createFileUri('source/source_with_anonymous_class.php')));
+        $temp = self::createTempFileUri();
         $exitCode = Command::main([
             __FILE__,
             $uri,
@@ -250,7 +250,7 @@ class CommandTest extends AbstractTestCase
      */
     public function testMainUpdateBaseline()
     {
-        $sourceTemp   = self::createTempFileUri('ClassWithMultipleViolations.php');
+        $sourceTemp = self::createTempFileUri('ClassWithMultipleViolations.php');
         $baselineTemp = self::createTempFileUri();
         // set work directory to the temp dir
         self::changeWorkingDirectory(dirname($baselineTemp));
@@ -277,9 +277,9 @@ class CommandTest extends AbstractTestCase
 
     public function testMainBaselineViolationShouldBeIgnored()
     {
-        $sourceFile   = realpath(static::createResourceUriForTest('Baseline/ClassWithShortVariable.php'));
+        $sourceFile = realpath(static::createResourceUriForTest('Baseline/ClassWithShortVariable.php'));
         $baselineFile = realpath(static::createResourceUriForTest('Baseline/phpmd.baseline.xml'));
-        $exitCode     = Command::main([
+        $exitCode = Command::main([
             __FILE__,
             $sourceFile,
             'text',
@@ -327,7 +327,7 @@ class CommandTest extends AbstractTestCase
             ]
         );
 
-        $errors = (string)file_get_contents($file);
+        $errors = (string) file_get_contents($file);
         unlink($file);
 
         $this->assertSame("Can't find the custom report class: ''" . PHP_EOL, $errors);
@@ -346,7 +346,7 @@ class CommandTest extends AbstractTestCase
             ]
         );
 
-        $errors = (string)file_get_contents($file);
+        $errors = (string) file_get_contents($file);
         unlink($file);
 
         $this->assertStringStartsWith("Can't find the custom report class: ''" . PHP_EOL, $errors);
@@ -385,7 +385,7 @@ class CommandTest extends AbstractTestCase
             ]
         );
 
-        $errors = (string)file_get_contents($file);
+        $errors = (string) file_get_contents($file);
         unlink($file);
 
         $this->assertSame(
@@ -407,7 +407,7 @@ class CommandTest extends AbstractTestCase
             ]
         );
 
-        $data    = @parse_ini_file(__DIR__ . '/../../../../../build.properties');
+        $data = @parse_ini_file(__DIR__ . '/../../../../../build.properties');
         $version = $data['project.version'];
 
         $this->assertEquals('PHPMD ' . $version, trim(StreamFilter::$streamHandle));


### PR DESCRIPTION
Type:  feature / refactoring / documentation update  
Issue: Resolves none
Breaking change: no

This is an extension to #1113 (but does not configure PHP CS Fixer for the GitHub workflow at the moment).

Not only does it include all rules of the other PR but adds the full list of rules from the PER CS v2 rule set (including PER CS v1, PSR-12, PSR-2 & PSR-1).

It does however deviate from PER CS v2 in some cases:

1. `ordered_class_elements` orders more than just trait imports
2. `single_line_empty_body` is disabled
3. `trailing_comma_in_multiline` does not add trailing commas for argument lists & parameters lists
4. `phpdoc_order` defines a clear order, which mostly reflects the existing order

Also, it deviates from the other PR for the `ordered_imports` & `single_import_per_statement` rules, as these have configuration through the PSR-12 rule set.

https://cs.symfony.com/doc/ruleSets/PSR12.html

https://cs.symfony.com/doc/rules/import/ordered_imports.html
https://cs.symfony.com/doc/rules/import/single_import_per_statement.html

Plus, it adds a Composer script for CS fixing with PHP CS Fixer [name is just a placeholder].

Lastly, it also applies the CS rules to showcase the consequences of the PHP CS Fixer configuration.