### PR TITLE
Apply code style to tests

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -63,6 +63,9 @@ return $config
     ])
     ->setFinder(PhpCsFixer\Finder::create()
         ->exclude('vendor')
-        ->in(__DIR__ . '/src/main/php/PHPMD')
+        ->in([
+            __DIR__ . '/src/main/php/PHPMD',
+            __DIR__ . '/src/test/php',
+        ])
     )
 ;

--- a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -37,11 +37,11 @@ class BaselineValidatorTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::isBaselined
-     * @dataProvider dataProvider
      * @param bool   $contains
      * @param string $baselineMode
      * @param bool   $isBaselined
+     * @dataProvider dataProvider
+     * @covers ::isBaselined
      */
     public function testIsBaselined($contains, $baselineMode, $isBaselined)
     {

--- a/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
+++ b/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
@@ -22,9 +22,9 @@ class ViolationBaselineTest extends TestCase
     /**
      * Test the give file matches the baseline correctly
      *
+     * @return void
      * @covers ::__construct
      * @covers ::matches
-     * @return void
      */
     public function testMatchesWithMethod()
     {
@@ -38,9 +38,9 @@ class ViolationBaselineTest extends TestCase
     /**
      * Test the give file matches the baseline correctly
      *
+     * @return void
      * @covers ::__construct
      * @covers ::matches
-     * @return void
      */
     public function testMatchesWithoutMethod()
     {

--- a/src/test/php/PHPMD/Console/OutputTest.php
+++ b/src/test/php/PHPMD/Console/OutputTest.php
@@ -20,9 +20,9 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
+     * @return void
      * @covers ::getVerbosity
      * @covers ::setVerbosity
-     * @return void
      */
     public function testSetGetVerbosity()
     {
@@ -34,8 +34,8 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::write
      * @return void
+     * @covers ::write
      */
     public function testWriteSingleMessage()
     {
@@ -46,8 +46,8 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::write
      * @return void
+     * @covers ::write
      */
     public function testWriteMultiMessageWithNewline()
     {
@@ -61,8 +61,8 @@ class OutputTest extends AbstractTestCase
      * @param int    $verbosity
      * @param string $expected
      * @param string $msg
-     * @covers ::write
      * @dataProvider verbosityProvider
+     * @covers ::write
      */
     public function testWriteWithVerbosityOption($verbosity, $expected, $msg)
     {
@@ -108,8 +108,8 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::writeln
      * @return void
+     * @covers ::writeln
      */
     public function testWritelnMessage()
     {

--- a/src/test/php/PHPMD/ProcessingErrorTest.php
+++ b/src/test/php/PHPMD/ProcessingErrorTest.php
@@ -20,9 +20,8 @@ namespace PHPMD;
 /**
  * Test case for the processing error class.
  *
- * @since 1.2.1
- *
  * @covers \PHPMD\ProcessingError
+ * @since 1.2.1
  */
 class ProcessingErrorTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
@@ -22,8 +22,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the {@link \PHPMD\Rule\Design\CouplingBetweenObjects} class.
  *
- * @link https://www.pivotaltracker.com/story/show/10474987
  * @covers \PHPMD\Rule\Design\CouplingBetweenObjects
+ * @link https://www.pivotaltracker.com/story/show/10474987
  */
 class CouplingBetweenObjectsTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -22,10 +22,9 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the {@link \PHPMD\Rule\Design\DevelopmentCodeFragment} class.
  *
+ * @covers \PHPMD\Rule\Design\DevelopmentCodeFragment
  * @link https://github.com/phpmd/phpmd/issues/265
  * @since 2.3.0
- *
- * @covers \PHPMD\Rule\Design\DevelopmentCodeFragment
  */
 class DevelopmentCodeFragmentTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
+++ b/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
@@ -22,9 +22,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the {@link \PHPMD\Rule\Design\GotoStatement} class.
  *
- * @link https://www.pivotaltracker.com/story/show/10474873
- *
  * @covers \PHPMD\Rule\Design\GotoStatement
+ * @link https://www.pivotaltracker.com/story/show/10474873
  */
 class GotoStatementTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
+++ b/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
@@ -22,9 +22,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the weighted method count rule.
  *
- * @since 0.2.5
- *
  * @covers \PHPMD\Rule\Design\WeightedMethodCount
+ * @since 0.2.5
  */
 class WeightedMethodCountTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
@@ -128,9 +128,9 @@ class ShortMethodNameTest extends AbstractTestCase
      * testRuleAlsoWorksWithoutExceptionListConfigured
      *
      * @return void
-     * @since 2.2.2
      * @link https://github.com/phpmd/phpmd/issues/80
      * @link https://github.com/phpmd/phpmd/issues/270
+     * @since 2.2.2
      */
     public function testRuleAppliesAlsoWithoutExceptionListConfiguredOnMock()
     {

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -363,8 +363,8 @@ class ShortVariableTest extends AbstractTestCase
     /**
      * testRuleAppliesToVariablesWithinForeach
      *
-     * @dataProvider provideClassWithShortForeachVariables
      * @return void
+     * @dataProvider provideClassWithShortForeachVariables
      */
     public function testRuleAppliesToVariablesWithinForeach($allowShortVarInLoop, $expectedErrorsCount)
     {

--- a/src/test/php/PHPMD/RuleViolationTest.php
+++ b/src/test/php/PHPMD/RuleViolationTest.php
@@ -22,9 +22,8 @@ use PHPMD\Node\NodeInfo;
 /**
  * Test case for the {@link \PHPMD\RuleViolation} class.
  *
- * @since 0.2.5
- *
  * @covers \PHPMD\RuleViolation
+ * @since 0.2.5
  */
 class RuleViolationTest extends AbstractTestCase
 {


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Simply apply the current code style to the tests as well. Just to go at this thing in slow increments and lower the diff of follow ups :)

(the failing test are fixed in https://github.com/phpmd/phpmd/pull/1135)