### PR TITLE
Use native hints for void returns in tests

### DIFF
--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -74,10 +74,8 @@ abstract class AbstractStaticTestCase extends TestCase
 
     /**
      * Return to original working directory if changed.
-     *
-     * @return void
      */
-    protected static function returnToOriginalWorkingDirectory()
+    protected static function returnToOriginalWorkingDirectory(): void
     {
         if (self::$originalWorkingDirectory !== null) {
             chdir(self::$originalWorkingDirectory);
@@ -88,10 +86,8 @@ abstract class AbstractStaticTestCase extends TestCase
 
     /**
      * Cleanup temporary files created for the test.
-     *
-     * @return void
      */
-    protected static function cleanupTempFiles()
+    protected static function cleanupTempFiles(): void
     {
         // cleanup any open resources on temp files
         gc_collect_cycles();
@@ -145,9 +141,8 @@ abstract class AbstractStaticTestCase extends TestCase
      *
      * @param string $actualOutput Generated xml output.
      * @param string $expectedFileName File with expected xml result.
-     * @return void
      */
-    public static function assertXmlEquals($actualOutput, $expectedFileName)
+    public static function assertXmlEquals($actualOutput, $expectedFileName): void
     {
         $actual = simplexml_load_string($actualOutput);
         // Remove dynamic timestamp and duration attribute
@@ -179,10 +174,8 @@ abstract class AbstractStaticTestCase extends TestCase
      * @param string $expectedFileName File with expected JSON result.
      * @param bool|Closure $removeDynamicValues If set to `false`, the actual output is not normalized,
      *                                          if set to a closure, the closure is applied on the actual output array.
-     *
-     * @return void
      */
-    public static function assertJsonEquals($actualOutput, $expectedFileName, $removeDynamicValues = true)
+    public static function assertJsonEquals($actualOutput, $expectedFileName, $removeDynamicValues = true): void
     {
         $actual = json_decode($actualOutput, true);
         // Remove dynamic timestamp and duration attribute
@@ -216,9 +209,8 @@ abstract class AbstractStaticTestCase extends TestCase
      * Changes the working directory for a single test.
      *
      * @param string $localPath The temporary working directory.
-     * @return void
      */
-    protected static function changeWorkingDirectory($localPath = '')
+    protected static function changeWorkingDirectory($localPath = ''): void
     {
         self::$originalWorkingDirectory = getcwd();
 

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -250,10 +250,9 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * @param Rule $rule Rule to test.
      * @param int $expectedInvokes Count of expected invocations.
      * @param string $file Test file containing a method with the same name to be tested.
-     * @return void
      * @throws ExpectationFailedException
      */
-    protected function expectRuleHasViolationsForFile(Rule $rule, $expectedInvokes, $file)
+    protected function expectRuleHasViolationsForFile(Rule $rule, $expectedInvokes, $file): void
     {
         $report = new Report();
         $rule->setReport($report);

--- a/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
@@ -15,7 +15,7 @@ class BaselineFileFinderTest extends AbstractTestCase
     /**
      * @covers ::find
      */
-    public function testShouldFindFileFromCLI()
+    public function testShouldFindFileFromCLI(): void
     {
         $args = ['script', 'source', 'xml', 'phpmd.xml', '--baseline-file', 'foobar.txt'];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
@@ -26,7 +26,7 @@ class BaselineFileFinderTest extends AbstractTestCase
      * @covers ::find
      * @covers ::existingFile
      */
-    public function testShouldFindExistingFileNearRuleSet()
+    public function testShouldFindExistingFileNearRuleSet(): void
     {
         $args = ['script', 'source', 'xml', static::createResourceUriForTest('testA/phpmd.xml')];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
@@ -42,7 +42,7 @@ class BaselineFileFinderTest extends AbstractTestCase
      * @covers ::find
      * @covers ::nullOrThrow
      */
-    public function testShouldThrowExceptionForNonExistingRuleSet()
+    public function testShouldThrowExceptionForNonExistingRuleSet(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Unable to determine the baseline file location.',
@@ -57,7 +57,7 @@ class BaselineFileFinderTest extends AbstractTestCase
      * @covers ::find
      * @covers ::nullOrThrow
      */
-    public function testShouldReturnNullForNonExistingRuleSet()
+    public function testShouldReturnNullForNonExistingRuleSet(): void
     {
         $args = ['script', 'source', 'xml', static::createResourceUriForTest('phpmd.xml')];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
@@ -69,7 +69,7 @@ class BaselineFileFinderTest extends AbstractTestCase
      * @covers ::nullOrThrow
      * @covers ::existingFile
      */
-    public function testShouldOnlyFindExistingFile()
+    public function testShouldOnlyFindExistingFile(): void
     {
         $args = ['script', 'source', 'xml', static::createResourceUriForTest('testB/phpmd.xml')];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
@@ -81,7 +81,7 @@ class BaselineFileFinderTest extends AbstractTestCase
      * @covers ::notNull
      * @covers ::nullOrThrow
      */
-    public function testShouldThrowExceptionWhenFileIsNull()
+    public function testShouldThrowExceptionWhenFileIsNull(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Unable to find the baseline file',

--- a/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
@@ -15,7 +15,7 @@ class BaselineSetFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileShouldSucceed()
+    public function testFromFileShouldSucceed(): void
     {
         $filename = static::createResourceUriForTest('baseline.xml');
         $baseDir = dirname($filename);
@@ -30,7 +30,7 @@ class BaselineSetFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileShouldSucceedWithBackAndForwardSlashes()
+    public function testFromFileShouldSucceedWithBackAndForwardSlashes(): void
     {
         $filename = static::createResourceUriForTest('baseline.xml');
         $baseDir = dirname($filename);
@@ -45,7 +45,7 @@ class BaselineSetFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileShouldThrowExceptionForMissingFile()
+    public function testFromFileShouldThrowExceptionForMissingFile(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Unable to locate the baseline file at',
@@ -57,7 +57,7 @@ class BaselineSetFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileShouldThrowExceptionForOnInvalidXML()
+    public function testFromFileShouldThrowExceptionForOnInvalidXML(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Unable to read xml from',
@@ -69,7 +69,7 @@ class BaselineSetFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileViolationMissingRuleShouldThrowException()
+    public function testFromFileViolationMissingRuleShouldThrowException(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Missing `rule` attribute in `violation`',
@@ -81,7 +81,7 @@ class BaselineSetFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileViolationMissingFileShouldThrowException()
+    public function testFromFileViolationMissingFileShouldThrowException(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Missing `file` attribute in `violation` in',

--- a/src/test/php/PHPMD/Baseline/BaselineSetTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetTest.php
@@ -13,7 +13,7 @@ class BaselineSetTest extends AbstractTestCase
      * @covers ::addEntry
      * @covers ::contains
      */
-    public function testSetContainsEntryWithoutMethodName()
+    public function testSetContainsEntryWithoutMethodName(): void
     {
         $set = new BaselineSet();
         $set->addEntry(new ViolationBaseline('rule', 'foobar', null));
@@ -25,7 +25,7 @@ class BaselineSetTest extends AbstractTestCase
      * @covers ::addEntry
      * @covers ::contains
      */
-    public function testSetContainsEntryWithMethodName()
+    public function testSetContainsEntryWithMethodName(): void
     {
         $set = new BaselineSet();
         $set->addEntry(new ViolationBaseline('rule', 'foobar', 'method'));
@@ -37,7 +37,7 @@ class BaselineSetTest extends AbstractTestCase
      * @covers ::addEntry
      * @covers ::contains
      */
-    public function testShouldFindEntryForIdenticalRules()
+    public function testShouldFindEntryForIdenticalRules(): void
     {
         $set = new BaselineSet();
         $set->addEntry(new ViolationBaseline('rule', 'foo', null));
@@ -54,7 +54,7 @@ class BaselineSetTest extends AbstractTestCase
      * @covers ::addEntry
      * @covers ::contains
      */
-    public function testShouldNotFindEntryForNonExistingRule()
+    public function testShouldNotFindEntryForNonExistingRule(): void
     {
         $set = new BaselineSet();
         $set->addEntry(new ViolationBaseline('rule', 'foo', null));
@@ -66,7 +66,7 @@ class BaselineSetTest extends AbstractTestCase
      * @covers ::addEntry
      * @covers ::contains
      */
-    public function testShouldNotFindEntryForNonExistingMethod()
+    public function testShouldNotFindEntryForNonExistingMethod(): void
     {
         $set = new BaselineSet();
         $set->addEntry(new ViolationBaseline('rule', 'foo', 'method'));

--- a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -43,7 +43,7 @@ class BaselineValidatorTest extends AbstractTestCase
      * @dataProvider dataProvider
      * @covers ::isBaselined
      */
-    public function testIsBaselined($contains, $baselineMode, $isBaselined)
+    public function testIsBaselined($contains, $baselineMode, $isBaselined): void
     {
         $this->baselineSet->method('contains')->willReturn($contains);
         $validator = new BaselineValidator($this->baselineSet, $baselineMode);

--- a/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
+++ b/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
@@ -13,7 +13,7 @@ class ViolationBaselineTest extends TestCase
      * @covers ::__construct
      * @covers ::getRuleName
      */
-    public function testGetRuleName()
+    public function testGetRuleName(): void
     {
         $violation = new ViolationBaseline('rule', 'foobar', null);
         static::assertSame('rule', $violation->getRuleName());
@@ -22,11 +22,10 @@ class ViolationBaselineTest extends TestCase
     /**
      * Test the give file matches the baseline correctly
      *
-     * @return void
      * @covers ::__construct
      * @covers ::matches
      */
-    public function testMatchesWithMethod()
+    public function testMatchesWithMethod(): void
     {
         $violation = new ViolationBaseline('sniff', 'foobar.txt', 'method');
         static::assertTrue($violation->matches('foobar.txt', 'method'));
@@ -38,11 +37,10 @@ class ViolationBaselineTest extends TestCase
     /**
      * Test the give file matches the baseline correctly
      *
-     * @return void
      * @covers ::__construct
      * @covers ::matches
      */
-    public function testMatchesWithoutMethod()
+    public function testMatchesWithoutMethod(): void
     {
         $violation = new ViolationBaseline('sniff', 'foobar.txt', null);
         static::assertTrue($violation->matches('foobar.txt', null));

--- a/src/test/php/PHPMD/Cache/Model/ResultCacheKeyTest.php
+++ b/src/test/php/PHPMD/Cache/Model/ResultCacheKeyTest.php
@@ -13,7 +13,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::toArray
      */
-    public function testToArray()
+    public function testToArray(): void
     {
         $key = new ResultCacheKey(
             true,
@@ -36,7 +36,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::isEqualTo
      */
-    public function testIsEqualTo()
+    public function testIsEqualTo(): void
     {
         $keyA = new ResultCacheKey(
             true,
@@ -60,7 +60,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::isEqualTo
      */
-    public function testIsEqualToDiffStrict()
+    public function testIsEqualToDiffStrict(): void
     {
         $keyA = new ResultCacheKey(
             true,
@@ -84,7 +84,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::isEqualTo
      */
-    public function testIsEqualToDiffRules()
+    public function testIsEqualToDiffRules(): void
     {
         $keyA = new ResultCacheKey(
             true,
@@ -108,7 +108,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::isEqualTo
      */
-    public function testIsEqualToDiffComposer()
+    public function testIsEqualToDiffComposer(): void
     {
         $keyA = new ResultCacheKey(
             true,
@@ -132,7 +132,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::isEqualTo
      */
-    public function testIsEqualToDiffPhpVersion()
+    public function testIsEqualToDiffPhpVersion(): void
     {
         $keyA = new ResultCacheKey(
             true,
@@ -156,7 +156,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::isEqualTo
      */
-    public function testIsEqualToDiffBaselineHash()
+    public function testIsEqualToDiffBaselineHash(): void
     {
         $keyA = new ResultCacheKey(
             true,

--- a/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
+++ b/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
@@ -29,7 +29,7 @@ class ResultCacheStateTest extends TestCase
     /**
      * @covers ::getCacheKey
      */
-    public function testGetCacheKey()
+    public function testGetCacheKey(): void
     {
         static::assertSame($this->key, $this->state->getCacheKey());
     }
@@ -38,7 +38,7 @@ class ResultCacheStateTest extends TestCase
      * @covers ::setViolations
      * @covers ::getViolations
      */
-    public function testGetSetViolations()
+    public function testGetSetViolations(): void
     {
         $violations = ['violations'];
 
@@ -51,7 +51,7 @@ class ResultCacheStateTest extends TestCase
     /**
      * @covers ::addRuleViolation
      */
-    public function testAddRuleViolation()
+    public function testAddRuleViolation(): void
     {
         $rule = new BooleanArgumentFlag();
         $nodeInfo = new NodeInfo(
@@ -90,7 +90,7 @@ class ResultCacheStateTest extends TestCase
      * @covers ::getRuleViolations
      * @covers ::findRuleIn
      */
-    public function testGetRuleViolationsWithoutDescriptionArgs()
+    public function testGetRuleViolationsWithoutDescriptionArgs(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new BooleanArgumentFlag());
@@ -117,7 +117,7 @@ class ResultCacheStateTest extends TestCase
      * @covers ::getRuleViolations
      * @covers ::findRuleIn
      */
-    public function testGetRuleViolationsWithDescriptionArgs()
+    public function testGetRuleViolationsWithDescriptionArgs(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new BooleanArgumentFlag());
@@ -149,7 +149,7 @@ class ResultCacheStateTest extends TestCase
      * @covers ::setFileState
      * @covers ::isFileModified
      */
-    public function testIsFileModified()
+    public function testIsFileModified(): void
     {
         $this->state->setFileState('/file/path', 'hash');
 
@@ -161,7 +161,7 @@ class ResultCacheStateTest extends TestCase
     /**
      * @covers ::toArray
      */
-    public function testToArray()
+    public function testToArray(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new BooleanArgumentFlag());

--- a/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
@@ -47,7 +47,7 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
     /**
      * @covers ::create
      */
-    public function testCreateNotEnabledShouldReturnNull()
+    public function testCreateNotEnabledShouldReturnNull(): void
     {
         $this->options->expects(self::once())->method('isCacheEnabled')->willReturn(false);
         $this->keyFactory->expects(self::never())->method('create');
@@ -58,7 +58,7 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
     /**
      * @covers ::create
      */
-    public function testCreateCacheMissShouldHaveNoOriginalState()
+    public function testCreateCacheMissShouldHaveNoOriginalState(): void
     {
         $ruleSetList = [new RuleSet()];
         $cacheKeyA = new ResultCacheKey(true, 'baseline', [], [], 123);
@@ -80,7 +80,7 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
     /**
      * @covers ::create
      */
-    public function testCreateCacheHitShouldHaveOriginalState()
+    public function testCreateCacheHitShouldHaveOriginalState(): void
     {
         $ruleSetList = [new RuleSet()];
         $cacheKey = new ResultCacheKey(true, 'baseline', [], [], 123);

--- a/src/test/php/PHPMD/Cache/ResultCacheEngineTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheEngineTest.php
@@ -15,7 +15,7 @@ class ResultCacheEngineTest extends AbstractTestCase
      * @covers ::getUpdater
      * @covers ::getWriter
      */
-    public function testGetters()
+    public function testGetters(): void
     {
         $filter = $this->getMockFromBuilder(
             $this->getMockBuilder(ResultCacheFileFilter::class)->disableOriginalConstructor()

--- a/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
@@ -37,7 +37,7 @@ class ResultCacheFileFilterTest extends AbstractTestCase
      * @covers ::accept
      * @covers ::getState
      */
-    public function testAcceptStrategyContentModified()
+    public function testAcceptStrategyContentModified(): void
     {
         $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::CONTENT, $this->key, $this->state);
 
@@ -52,7 +52,7 @@ class ResultCacheFileFilterTest extends AbstractTestCase
      * @covers ::accept
      * @covers ::getState
      */
-    public function testAcceptStrategyContentUnmodified()
+    public function testAcceptStrategyContentUnmodified(): void
     {
         $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::CONTENT, $this->key, $this->state);
 
@@ -68,7 +68,7 @@ class ResultCacheFileFilterTest extends AbstractTestCase
      * @covers ::accept
      * @covers ::getState
      */
-    public function testAcceptStrategyTimestampModified()
+    public function testAcceptStrategyTimestampModified(): void
     {
         $timestamp = (string) filemtime(__FILE__);
         $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::TIMESTAMP, $this->key, $this->state);
@@ -84,7 +84,7 @@ class ResultCacheFileFilterTest extends AbstractTestCase
      * @covers ::accept
      * @covers ::getState
      */
-    public function testAcceptWithoutState()
+    public function testAcceptWithoutState(): void
     {
         $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::CONTENT, $this->key, null);
 
@@ -98,7 +98,7 @@ class ResultCacheFileFilterTest extends AbstractTestCase
     /**
      * @covers ::accept
      */
-    public function testAcceptShouldCacheResults()
+    public function testAcceptShouldCacheResults(): void
     {
         $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::CONTENT, $this->key, $this->state);
 

--- a/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
@@ -31,7 +31,7 @@ class ResultCacheKeyFactoryTest extends AbstractTestCase
      * @covers ::createRuleHashes
      * @covers ::getComposerHashes
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $rule = new DuplicatedArrayKey();
         $ruleSet = new RuleSet();

--- a/src/test/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
@@ -21,7 +21,7 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileNonExisting()
+    public function testFromFileNonExisting(): void
     {
         $state = $this->factory->fromFile('foobar');
         static::assertNull($state);
@@ -31,7 +31,7 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
      * @covers ::fromFile
      * @covers ::createCacheKey
      */
-    public function testFromFileEmptyCache()
+    public function testFromFileEmptyCache(): void
     {
         $state = $this->factory->fromFile(static::createResourceUriForTest('.invalid-cache.php'));
         static::assertNull($state);
@@ -41,7 +41,7 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
      * @covers ::fromFile
      * @covers ::createCacheKey
      */
-    public function testFromFileIncompleteCacheKey()
+    public function testFromFileIncompleteCacheKey(): void
     {
         $state = $this->factory->fromFile(static::createResourceUriForTest('.incomplete-cache.php'));
         static::assertNull($state);
@@ -51,7 +51,7 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
      * @covers ::fromFile
      * @covers ::createCacheKey
      */
-    public function testFromFileFullCache()
+    public function testFromFileFullCache(): void
     {
         $state = $this->factory->fromFile(static::createResourceUriForTest('.result-cache.php'));
 
@@ -76,7 +76,7 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
      * @covers ::fromFile
      * @covers ::createCacheKey
      */
-    public function testFromFileWithCacheWithoutBaselineOrComposer()
+    public function testFromFileWithCacheWithoutBaselineOrComposer(): void
     {
         $state = $this->factory->fromFile(static::createResourceUriForTest('.minimal-cache.php'));
         static::assertNotNull($state);

--- a/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
@@ -32,7 +32,7 @@ class ResultCacheUpdaterTest extends AbstractTestCase
     /**
      * @covers ::update
      */
-    public function testUpdate()
+    public function testUpdate(): void
     {
         $ruleSet = new RuleSet();
         $report = $this->getReportMock();

--- a/src/test/php/PHPMD/Cache/ResultCacheWriterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheWriterTest.php
@@ -28,7 +28,7 @@ class ResultCacheWriterTest extends AbstractTestCase
     /**
      * @covers ::write
      */
-    public function testWrite()
+    public function testWrite(): void
     {
         $cacheKey = new ResultCacheKey(true, 'baseline', [], [], 70000);
         $cacheState = new ResultCacheState($cacheKey, []);

--- a/src/test/php/PHPMD/Console/OutputTest.php
+++ b/src/test/php/PHPMD/Console/OutputTest.php
@@ -20,11 +20,10 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @covers ::getVerbosity
      * @covers ::setVerbosity
      */
-    public function testSetGetVerbosity()
+    public function testSetGetVerbosity(): void
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
         static::assertSame(OutputInterface::VERBOSITY_VERBOSE, $this->output->getVerbosity());
@@ -34,10 +33,9 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @covers ::write
      */
-    public function testWriteSingleMessage()
+    public function testWriteSingleMessage(): void
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
         $this->output->write("message", false, OutputInterface::VERBOSITY_VERBOSE);
@@ -46,10 +44,9 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @covers ::write
      */
-    public function testWriteMultiMessageWithNewline()
+    public function testWriteMultiMessageWithNewline(): void
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
         $this->output->write(["foo", "bar"], true, OutputInterface::VERBOSITY_VERBOSE);
@@ -64,7 +61,7 @@ class OutputTest extends AbstractTestCase
      * @dataProvider verbosityProvider
      * @covers ::write
      */
-    public function testWriteWithVerbosityOption($verbosity, $expected, $msg)
+    public function testWriteWithVerbosityOption($verbosity, $expected, $msg): void
     {
         $this->output->setVerbosity($verbosity);
         $this->output->write('1', false);
@@ -108,10 +105,9 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @covers ::writeln
      */
-    public function testWritelnMessage()
+    public function testWritelnMessage(): void
     {
         $this->output->writeln("message", OutputInterface::VERBOSITY_QUIET);
 

--- a/src/test/php/PHPMD/Console/StreamOutputTest.php
+++ b/src/test/php/PHPMD/Console/StreamOutputTest.php
@@ -13,7 +13,7 @@ class StreamOutputTest extends TestCase
      * @covers ::__construct
      * @covers ::doWrite
      */
-    public function testDoWrite()
+    public function testDoWrite(): void
     {
         $stream = fopen('php://memory', 'w+b');
         $output = new StreamOutput($stream);

--- a/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
+++ b/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
@@ -30,10 +30,9 @@ class CommandLineInputFileOptionTest extends AbstractTestCase
     /**
      * testReportContainsExpectedRuleViolationWarning
      *
-     * @return void
      * @outputBuffering enabled
      */
-    public function testReportContainsExpectedRuleViolationWarning()
+    public function testReportContainsExpectedRuleViolationWarning(): void
     {
         self::assertStringContainsString(
             "Avoid unused local variables such as '\$foo'.",
@@ -44,10 +43,9 @@ class CommandLineInputFileOptionTest extends AbstractTestCase
     /**
      * testReportNotContainsRuleViolationWarningForFileNotInList
      *
-     * @return void
      * @outputBuffering enabled
      */
-    public function testReportNotContainsRuleViolationWarningForFileNotInList()
+    public function testReportNotContainsRuleViolationWarningForFileNotInList(): void
     {
         self::assertStringNotContainsString(
             "Avoid unused local variables such as '\$bar'.",

--- a/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
@@ -30,10 +30,9 @@ class CouplingBetweenObjectsIntegrationTest extends AbstractTestCase
     /**
      * testReportContainsCouplingBetweenObjectsWarning
      *
-     * @return void
      * @outputBuffering enabled
      */
-    public function testReportContainsCouplingBetweenObjectsWarning()
+    public function testReportContainsCouplingBetweenObjectsWarning(): void
     {
         $file = self::createTempFileUri();
 

--- a/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
@@ -30,10 +30,9 @@ class GotoStatementIntegrationTest extends AbstractTestCase
     /**
      * testReportContainsGotoStatementWarning
      *
-     * @return void
      * @outputBuffering enabled
      */
-    public function testReportContainsGotoStatementWarning()
+    public function testReportContainsGotoStatementWarning(): void
     {
         $file = self::createTempFileUri();
 

--- a/src/test/php/PHPMD/Node/ASTNodeTest.php
+++ b/src/test/php/PHPMD/Node/ASTNodeTest.php
@@ -29,10 +29,8 @@ class ASTNodeTest extends AbstractTestCase
 {
     /**
      * testGetImageDelegatesToGetImageMethodOfWrappedNode
-     *
-     * @return void
      */
-    public function testGetImageDelegatesToGetImageMethodOfWrappedNode()
+    public function testGetImageDelegatesToGetImageMethodOfWrappedNode(): void
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $mock->expects($this->once())
@@ -44,10 +42,8 @@ class ASTNodeTest extends AbstractTestCase
 
     /**
      * testGetNameDelegatesToGetImageMethodOfWrappedNode
-     *
-     * @return void
      */
-    public function testGetNameDelegatesToGetImageMethodOfWrappedNode()
+    public function testGetNameDelegatesToGetImageMethodOfWrappedNode(): void
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $mock->expects($this->once())
@@ -59,10 +55,8 @@ class ASTNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsAnnotationForAlwaysReturnsFalse
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsAnnotationForAlwaysReturnsFalse()
+    public function testHasSuppressWarningsAnnotationForAlwaysReturnsFalse(): void
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
 
@@ -74,10 +68,8 @@ class ASTNodeTest extends AbstractTestCase
 
     /**
      * testGetParentNameReturnsNull
-     *
-     * @return void
      */
-    public function testGetParentNameReturnsNull()
+    public function testGetParentNameReturnsNull(): void
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $node = new ASTNode($mock, __FILE__);
@@ -87,10 +79,8 @@ class ASTNodeTest extends AbstractTestCase
 
     /**
      * testGetNamespaceNameReturnsNull
-     *
-     * @return void
      */
-    public function testGetNamespaceNameReturnsNull()
+    public function testGetNamespaceNameReturnsNull(): void
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $node = new ASTNode($mock, __FILE__);
@@ -100,10 +90,8 @@ class ASTNodeTest extends AbstractTestCase
 
     /**
      * testGetFullQualifiedNameReturnsNull
-     *
-     * @return void
      */
-    public function testGetFullQualifiedNameReturnsNull()
+    public function testGetFullQualifiedNameReturnsNull(): void
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $node = new ASTNode($mock, __FILE__);

--- a/src/test/php/PHPMD/Node/AnnotationTest.php
+++ b/src/test/php/PHPMD/Node/AnnotationTest.php
@@ -28,10 +28,8 @@ class AnnotationTest extends AbstractTestCase
 {
     /**
      * testAnnotationReturnsFalseWhenNoSuppressWarningAnnotationExists
-     *
-     * @return void
      */
-    public function testAnnotationReturnsFalseWhenNoSuppressWarningAnnotationExists()
+    public function testAnnotationReturnsFalseWhenNoSuppressWarningAnnotationExists(): void
     {
         $annotation = new Annotation('NoSuppressWarning', 'PMD');
         $this->assertFalse($annotation->suppresses($this->getRuleMock()));
@@ -39,10 +37,8 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsFalseWhenSuppressWarningContainsInvalidValue
-     *
-     * @return void
      */
-    public function testAnnotationReturnsFalseWhenSuppressWarningContainsInvalidValue()
+    public function testAnnotationReturnsFalseWhenSuppressWarningContainsInvalidValue(): void
     {
         $annotation = new Annotation('SuppressWarnings', 'PHP');
         $this->assertFalse($annotation->suppresses($this->getRuleMock()));
@@ -50,10 +46,8 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsWithPMD
-     *
-     * @return void
      */
-    public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPMD()
+    public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPMD(): void
     {
         $annotation = new Annotation('SuppressWarnings', 'PMD');
         $this->assertTrue($annotation->suppresses($this->getRuleMock()));
@@ -61,10 +55,8 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMD
-     *
-     * @return void
      */
-    public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMD()
+    public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMD(): void
     {
         $annotation = new Annotation('SuppressWarnings', 'PHPMD');
         $this->assertTrue($annotation->suppresses($this->getRuleMock()));
@@ -72,10 +64,8 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMDLCFirst
-     *
-     * @return void
      */
-    public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMDLCFirst()
+    public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMDLCFirst(): void
     {
         $annotation = new Annotation('suppressWarnings', 'PHPMD');
         $this->assertTrue($annotation->suppresses($this->getRuleMock()));
@@ -83,10 +73,8 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsPMDPlusRuleName
-     *
-     * @return void
      */
-    public function testAnnotationReturnsTrueWhenSuppressWarningContainsPMDPlusRuleName()
+    public function testAnnotationReturnsTrueWhenSuppressWarningContainsPMDPlusRuleName(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('UnusedCodeRule');
@@ -97,10 +85,8 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsPHPMDPlusRuleName
-     *
-     * @return void
      */
-    public function testAnnotationReturnsTrueWhenSuppressWarningContainsPHPMDPlusRuleName()
+    public function testAnnotationReturnsTrueWhenSuppressWarningContainsPHPMDPlusRuleName(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('UnusedCodeRule');
@@ -111,10 +97,8 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsPartialRuleName
-     *
-     * @return void
      */
-    public function testAnnotationReturnsTrueWhenSuppressWarningContainsPartialRuleName()
+    public function testAnnotationReturnsTrueWhenSuppressWarningContainsPartialRuleName(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('UnusedCodeRule');

--- a/src/test/php/PHPMD/Node/AnnotationsTest.php
+++ b/src/test/php/PHPMD/Node/AnnotationsTest.php
@@ -28,10 +28,8 @@ class AnnotationsTest extends AbstractTestCase
 {
     /**
      * testCollectionReturnsFalseWhenNoAnnotationExists
-     *
-     * @return void
      */
-    public function testCollectionReturnsFalseWhenNoAnnotationExists()
+    public function testCollectionReturnsFalseWhenNoAnnotationExists(): void
     {
         $annotations = new Annotations($this->getClassMock());
         $this->assertFalse($annotations->suppresses($this->getRuleMock()));
@@ -39,10 +37,8 @@ class AnnotationsTest extends AbstractTestCase
 
     /**
      * testCollectionReturnsFalseWhenNoMatchingAnnotationExists
-     *
-     * @return void
      */
-    public function testCollectionReturnsFalseWhenNoMatchingAnnotationExists()
+    public function testCollectionReturnsFalseWhenNoMatchingAnnotationExists(): void
     {
         $class = $this->getClassMock();
         $class->expects($this->once())
@@ -64,10 +60,8 @@ class AnnotationsTest extends AbstractTestCase
 
     /**
      * testCollectionReturnsTrueWhenMatchingAnnotationExists
-     *
-     * @return void
      */
-    public function testCollectionReturnsTrueWhenMatchingAnnotationExists()
+    public function testCollectionReturnsTrueWhenMatchingAnnotationExists(): void
     {
         $class = $this->getClassMock();
         $class->expects($this->once())
@@ -81,10 +75,8 @@ class AnnotationsTest extends AbstractTestCase
 
     /**
      * testCollectionReturnsTrueWhenOneMatchingAnnotationExists
-     *
-     * @return void
      */
-    public function testCollectionReturnsTrueWhenOneMatchingAnnotationExists()
+    public function testCollectionReturnsTrueWhenOneMatchingAnnotationExists(): void
     {
         $class = $this->getClassMock();
         $class->expects($this->once())

--- a/src/test/php/PHPMD/Node/ClassNodeTest.php
+++ b/src/test/php/PHPMD/Node/ClassNodeTest.php
@@ -35,10 +35,8 @@ class ClassNodeTest extends AbstractTestCase
 {
     /**
      * testGetMethodNamesReturnsExpectedResult
-     *
-     * @return void
      */
-    public function testGetMethodNamesReturnsExpectedResult()
+    public function testGetMethodNamesReturnsExpectedResult(): void
     {
         $class = new ASTClass(null);
         $class->addMethod(new ASTMethod(__CLASS__));
@@ -50,10 +48,8 @@ class ClassNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsAnnotationForReturnsTrue
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsAnnotationForReturnsTrue()
+    public function testHasSuppressWarningsAnnotationForReturnsTrue(): void
     {
         $class = new ASTClass(null);
         $class->setComment('/** @SuppressWarnings("PMD") */');
@@ -67,10 +63,8 @@ class ClassNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsWithRuleNameContainingSlashes
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsWithRuleNameContainingSlashes()
+    public function testHasSuppressWarningsWithRuleNameContainingSlashes(): void
     {
         $class = new ASTClass(null);
         $class->setComment('/** @SuppressWarnings(PMD.CouplingBetweenObjects) */');
@@ -95,10 +89,8 @@ class ClassNodeTest extends AbstractTestCase
 
     /**
      * testGetFullQualifiedNameReturnsExpectedValue
-     *
-     * @return void
      */
-    public function testGetFullQualifiedNameReturnsExpectedValue()
+    public function testGetFullQualifiedNameReturnsExpectedValue(): void
     {
         $class = new ASTClass('MyClass');
         $class->setNamespace(new ASTNamespace('Sindelfingen'));
@@ -108,28 +100,19 @@ class ClassNodeTest extends AbstractTestCase
         $this->assertSame(MyClass::class, $node->getFullQualifiedName());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConstantCountReturnsZeroByDefault()
+    public function testGetConstantCountReturnsZeroByDefault(): void
     {
         $class = new ClassNode(new ASTClass('MyClass'));
         $this->assertSame(0, $class->getConstantCount());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConstantCount()
+    public function testGetConstantCount(): void
     {
         $class = $this->getClass();
         $this->assertSame(3, $class->getConstantCount());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetParentNameReturnsNull()
+    public function testGetParentNameReturnsNull(): void
     {
         $class = new ClassNode(new ASTClass('MyClass'));
         $this->assertNull($class->getParentName());

--- a/src/test/php/PHPMD/Node/FunctionTest.php
+++ b/src/test/php/PHPMD/Node/FunctionTest.php
@@ -31,10 +31,8 @@ class FunctionTest extends AbstractTestCase
 {
     /**
      * testMagicCallDelegatesToWrappedPHPDependFunction
-     *
-     * @return void
      */
-    public function testMagicCallDelegatesToWrappedPHPDependFunction()
+    public function testMagicCallDelegatesToWrappedPHPDependFunction(): void
     {
         $function = $this->getMockFromBuilder(
             $this->getMockBuilder(ASTFunction::class)
@@ -49,10 +47,8 @@ class FunctionTest extends AbstractTestCase
 
     /**
      * testMagicCallThrowsExceptionWhenNoMatchingMethodExists
-     *
-     * @return void
      */
-    public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists()
+    public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists(): void
     {
         self::expectException(BadMethodCallException::class);
 

--- a/src/test/php/PHPMD/Node/InterfaceNodeTest.php
+++ b/src/test/php/PHPMD/Node/InterfaceNodeTest.php
@@ -32,10 +32,8 @@ class InterfaceNodeTest extends AbstractTestCase
 {
     /**
      * testGetFullQualifiedNameReturnsExpectedValue
-     *
-     * @return void
      */
-    public function testGetFullQualifiedNameReturnsExpectedValue()
+    public function testGetFullQualifiedNameReturnsExpectedValue(): void
     {
         $interface = new ASTInterface('MyInterface');
         $interface->setNamespace(new ASTNamespace('Sindelfingen'));
@@ -45,28 +43,19 @@ class InterfaceNodeTest extends AbstractTestCase
         $this->assertSame(MyInterface::class, $node->getFullQualifiedName());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConstantCountReturnsZeroByDefault()
+    public function testGetConstantCountReturnsZeroByDefault(): void
     {
         $interface = new InterfaceNode(new ASTInterface('MyInterface'));
         $this->assertSame(0, $interface->getConstantCount());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConstantCount()
+    public function testGetConstantCount(): void
     {
         $class = $this->getInterface();
         $this->assertSame(3, $class->getConstantCount());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetParentNameReturnsNull()
+    public function testGetParentNameReturnsNull(): void
     {
         $interface = new InterfaceNode(new ASTInterface('MyInterface'));
         $this->assertNull($interface->getParentName());

--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -33,10 +33,8 @@ class MethodNodeTest extends AbstractTestCase
 {
     /**
      * testMagicCallDelegatesToWrappedPHPDependMethod
-     *
-     * @return void
      */
-    public function testMagicCallDelegatesToWrappedPHPDependMethod()
+    public function testMagicCallDelegatesToWrappedPHPDependMethod(): void
     {
         $method = $this->getMockFromBuilder(
             $this->getMockBuilder(ASTMethod::class)
@@ -51,10 +49,8 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testMagicCallThrowsExceptionWhenNoMatchingMethodExists
-     *
-     * @return void
      */
-    public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists()
+    public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists(): void
     {
         self::expectException(BadMethodCallException::class);
 
@@ -64,10 +60,8 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testGetParentTypeReturnsInterfaceForInterfaceMethod
-     *
-     * @return void
      */
-    public function testGetParentTypeReturnsInterfaceForInterfaceMethod()
+    public function testGetParentTypeReturnsInterfaceForInterfaceMethod(): void
     {
         $this->assertInstanceOf(
             InterfaceNode::class,
@@ -77,10 +71,8 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testGetParentTypeReturnsClassForClassMethod
-     *
-     * @return void
      */
-    public function testGetParentTypeReturnsClassForClassMethod()
+    public function testGetParentTypeReturnsClassForClassMethod(): void
     {
         $this->assertInstanceOf(
             ClassNode::class,
@@ -88,10 +80,7 @@ class MethodNodeTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testGetParentTypeReturnsTrait()
+    public function testGetParentTypeReturnsTrait(): void
     {
         $this->assertInstanceOf(
             TraitNode::class,
@@ -101,10 +90,8 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsExecutesDefaultImplementation
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsExecutesDefaultImplementation()
+    public function testHasSuppressWarningsExecutesDefaultImplementation(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('FooBar');
@@ -115,10 +102,8 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsDelegatesToParentClassMethod
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsDelegatesToParentClassMethod()
+    public function testHasSuppressWarningsDelegatesToParentClassMethod(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('FooBar');
@@ -129,10 +114,8 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsDelegatesToParentInterfaceMethod
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsDelegatesToParentInterfaceMethod()
+    public function testHasSuppressWarningsDelegatesToParentInterfaceMethod(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('FooBar');
@@ -143,10 +126,8 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsIgnoresCaseFirstLetter
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsIgnoresCaseFirstLetter()
+    public function testHasSuppressWarningsIgnoresCaseFirstLetter(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('FooBar');
@@ -158,10 +139,9 @@ class MethodNodeTest extends AbstractTestCase
     /**
      * testIsDeclarationReturnsTrueForMethodDeclaration
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testIsDeclarationReturnsTrueForMethodDeclaration()
+    public function testIsDeclarationReturnsTrueForMethodDeclaration(): void
     {
         $method = $this->getMethod();
         $this->assertTrue($method->isDeclaration());
@@ -170,10 +150,9 @@ class MethodNodeTest extends AbstractTestCase
     /**
      * testIsDeclarationReturnsTrueForMethodDeclarationWithParent
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testIsDeclarationReturnsTrueForMethodDeclarationWithParent()
+    public function testIsDeclarationReturnsTrueForMethodDeclarationWithParent(): void
     {
         $method = $this->getMethod();
         $this->assertTrue($method->isDeclaration());
@@ -182,10 +161,9 @@ class MethodNodeTest extends AbstractTestCase
     /**
      * testIsDeclarationReturnsFalseForInheritMethodDeclaration
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testIsDeclarationReturnsFalseForInheritMethodDeclaration()
+    public function testIsDeclarationReturnsFalseForInheritMethodDeclaration(): void
     {
         $method = $this->getMethod();
         $this->assertFalse($method->isDeclaration());
@@ -194,10 +172,9 @@ class MethodNodeTest extends AbstractTestCase
     /**
      * testIsDeclarationReturnsFalseForImplementedAbstractMethod
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testIsDeclarationReturnsFalseForImplementedAbstractMethod()
+    public function testIsDeclarationReturnsFalseForImplementedAbstractMethod(): void
     {
         $method = $this->getMethod();
         $this->assertFalse($method->isDeclaration());
@@ -206,19 +183,15 @@ class MethodNodeTest extends AbstractTestCase
     /**
      * testIsDeclarationReturnsFalseForImplementedInterfaceMethod
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testIsDeclarationReturnsFalseForImplementedInterfaceMethod()
+    public function testIsDeclarationReturnsFalseForImplementedInterfaceMethod(): void
     {
         $method = $this->getMethod();
         $this->assertFalse($method->isDeclaration());
     }
 
-    /**
-     * @return void
-     */
-    public function testIsDeclarationReturnsTrueForPrivateMethod()
+    public function testIsDeclarationReturnsTrueForPrivateMethod(): void
     {
         $method = $this->getMethod();
         $this->assertTrue($method->isDeclaration());
@@ -226,10 +199,8 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testGetFullQualifiedNameReturnsExpectedValue
-     *
-     * @return void
      */
-    public function testGetFullQualifiedNameReturnsExpectedValue()
+    public function testGetFullQualifiedNameReturnsExpectedValue(): void
     {
         $class = new ASTClass('MyClass');
         $class->setNamespace(new ASTNamespace('Sindelfingen'));

--- a/src/test/php/PHPMD/Node/NodeInfoFactoryTest.php
+++ b/src/test/php/PHPMD/Node/NodeInfoFactoryTest.php
@@ -13,7 +13,7 @@ class NodeInfoFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromNode
      */
-    public function testFromNodeForAbstractTypeNode()
+    public function testFromNodeForAbstractTypeNode(): void
     {
         /** @var AbstractTypeNode&MockObject $node */
         $node = $this->getMockFromBuilder(
@@ -38,7 +38,7 @@ class NodeInfoFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromNode
      */
-    public function testFromNodeForMethodNode()
+    public function testFromNodeForMethodNode(): void
     {
         /** @var MethodNode&MockObject $node */
         $node = $this->getMockFromBuilder(
@@ -64,7 +64,7 @@ class NodeInfoFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromNode
      */
-    public function testFromNodeForFunctionNode()
+    public function testFromNodeForFunctionNode(): void
     {
         /** @var MethodNode&MockObject $node */
         $node = $this->getMockFromBuilder(

--- a/src/test/php/PHPMD/Node/NodeInfoTest.php
+++ b/src/test/php/PHPMD/Node/NodeInfoTest.php
@@ -12,7 +12,7 @@ class NodeInfoTest extends AbstractTestCase
     /**
      * @covers ::__construct
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $nodeInfo = new NodeInfo(
             '/file/path',

--- a/src/test/php/PHPMD/Node/TraitNodeTest.php
+++ b/src/test/php/PHPMD/Node/TraitNodeTest.php
@@ -32,10 +32,8 @@ class TraitNodeTest extends AbstractTestCase
 {
     /**
      * testGetFullQualifiedNameReturnsExpectedValue
-     *
-     * @return void
      */
-    public function testGetFullQualifiedNameReturnsExpectedValue()
+    public function testGetFullQualifiedNameReturnsExpectedValue(): void
     {
         $trait = new ASTTrait('MyTrait');
         $trait->setNamespace(new ASTNamespace('Sindelfingen'));
@@ -45,19 +43,13 @@ class TraitNodeTest extends AbstractTestCase
         $this->assertSame(MyTrait::class, $node->getFullQualifiedName());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConstantCountReturnsZeroByDefault()
+    public function testGetConstantCountReturnsZeroByDefault(): void
     {
         $trait = new TraitNode(new ASTTrait('MyTrait'));
         $this->assertSame(0, $trait->getConstantCount());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetParentNameReturnsNull()
+    public function testGetParentNameReturnsNull(): void
     {
         $trait = new TraitNode(new ASTTrait('MyTrait'));
         $this->assertNull($trait->getParentName());

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -41,10 +41,8 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * Tests the main PHPMD interface with default settings an a xml-renderer.
-     *
-     * @return void
      */
-    public function testRunWithDefaultSettingsAndXmlRenderer()
+    public function testRunWithDefaultSettingsAndXmlRenderer(): void
     {
         self::changeWorkingDirectory();
 
@@ -68,10 +66,8 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testRunWithDefaultSettingsAndXmlRendererAgainstSingleFile
-     *
-     * @return void
      */
-    public function testRunWithDefaultSettingsAndXmlRendererAgainstDirectory()
+    public function testRunWithDefaultSettingsAndXmlRendererAgainstDirectory(): void
     {
         self::changeWorkingDirectory();
 
@@ -94,10 +90,8 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testRunWithDefaultSettingsAndXmlRendererAgainstSingleFile
-     *
-     * @return void
      */
-    public function testRunWithDefaultSettingsAndXmlRendererAgainstSingleFile()
+    public function testRunWithDefaultSettingsAndXmlRendererAgainstSingleFile(): void
     {
         self::changeWorkingDirectory();
 
@@ -120,10 +114,8 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testHasErrorsReturnsFalseByDefault
-     *
-     * @return void
      */
-    public function testHasErrorsReturnsFalseByDefault()
+    public function testHasErrorsReturnsFalseByDefault(): void
     {
         $phpmd = new PHPMD();
         $this->assertFalse($phpmd->hasErrors());
@@ -131,10 +123,8 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testHasViolationsReturnsFalseByDefault
-     *
-     * @return void
      */
-    public function testHasViolationsReturnsFalseByDefault()
+    public function testHasViolationsReturnsFalseByDefault(): void
     {
         $phpmd = new PHPMD();
         $this->assertFalse($phpmd->hasViolations());
@@ -142,10 +132,8 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testHasViolationsReturnsFalseForSourceWithoutViolations
-     *
-     * @return void
      */
-    public function testHasViolationsReturnsFalseForSourceWithoutViolations()
+    public function testHasViolationsReturnsFalseForSourceWithoutViolations(): void
     {
         self::changeWorkingDirectory();
 
@@ -167,10 +155,8 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testHasViolationsReturnsTrueForSourceWithViolation
-     *
-     * @return void
      */
-    public function testHasViolationsReturnsTrueForSourceWithViolation()
+    public function testHasViolationsReturnsTrueForSourceWithViolation(): void
     {
         self::changeWorkingDirectory();
 
@@ -190,10 +176,7 @@ class PHPMDTest extends AbstractTestCase
         $this->assertTrue($phpmd->hasViolations());
     }
 
-    /**
-     * @return void
-     */
-    public function testHasViolationsReturnsFalseWhenViolationIsBaselined()
+    public function testHasViolationsReturnsFalseWhenViolationIsBaselined(): void
     {
         self::changeWorkingDirectory();
 
@@ -220,10 +203,8 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testHasErrorsReturnsTrueForSourceWithError
-     *
-     * @return void
      */
-    public function testHasErrorsReturnsTrueForSourceWithError()
+    public function testHasErrorsReturnsTrueForSourceWithError(): void
     {
         self::changeWorkingDirectory();
 
@@ -245,10 +226,8 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testIgnorePattern
-     *
-     * @return void
      */
-    public function testIgnorePattern()
+    public function testIgnorePattern(): void
     {
         self::changeWorkingDirectory();
 

--- a/src/test/php/PHPMD/ParserFactoryTest.php
+++ b/src/test/php/PHPMD/ParserFactoryTest.php
@@ -28,10 +28,8 @@ class ParserFactoryTest extends AbstractTestCase
 {
     /**
      * testFactoryConfiguresInputDirectory
-     *
-     * @return void
      */
-    public function testFactoryConfiguresInputDirectory()
+    public function testFactoryConfiguresInputDirectory(): void
     {
         $factory = new ParserFactory();
 
@@ -54,10 +52,8 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresInputFile
-     *
-     * @return void
      */
-    public function testFactoryConfiguresInputFile()
+    public function testFactoryConfiguresInputFile(): void
     {
         $factory = new ParserFactory();
 
@@ -80,10 +76,8 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresMultipleInputDirectories
-     *
-     * @return void
      */
-    public function testFactoryConfiguresMultipleInputDirectories()
+    public function testFactoryConfiguresMultipleInputDirectories(): void
     {
         $factory = new ParserFactory();
 
@@ -107,10 +101,8 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresMultipleInputFilesAndDirectories
-     *
-     * @return void
      */
-    public function testFactoryConfiguresMultipleInputFilesAndDirectories()
+    public function testFactoryConfiguresMultipleInputFilesAndDirectories(): void
     {
         $factory = new ParserFactory();
 
@@ -131,10 +123,8 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresIgnorePattern
-     *
-     * @return void
      */
-    public function testFactoryConfiguresIgnorePattern()
+    public function testFactoryConfiguresIgnorePattern(): void
     {
         $factory = new ParserFactory();
 
@@ -156,10 +146,8 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresFileExtensions
-     *
-     * @return void
      */
-    public function testFactoryConfiguresFileExtensions()
+    public function testFactoryConfiguresFileExtensions(): void
     {
         $factory = new ParserFactory();
 

--- a/src/test/php/PHPMD/ParserTest.php
+++ b/src/test/php/PHPMD/ParserTest.php
@@ -41,10 +41,8 @@ class ParserTest extends AbstractTestCase
 {
     /**
      * Tests that the metrics adapter delegates a node to a registered rule-set.
-     *
-     * @return void
      */
-    public function testAdapterDelegatesClassNodeToRuleSet()
+    public function testAdapterDelegatesClassNodeToRuleSet(): void
     {
         $mock = $this->getPHPDependClassMock();
         $mock->expects($this->once())
@@ -60,10 +58,8 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the metrics adapter does not delegate a node without source
      * code file to a registered rule-set.
-     *
-     * @return void
      */
-    public function testAdapterDoesNotDelegateNonSourceClassNodeToRuleSet()
+    public function testAdapterDoesNotDelegateNonSourceClassNodeToRuleSet(): void
     {
         $mock = $this->getPHPDependClassMock();
         $mock->expects($this->once())
@@ -78,10 +74,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the metrics adapter delegates a node to a registered rule-set.
-     *
-     * @return void
      */
-    public function testAdapterDelegatesMethodNodeToRuleSet()
+    public function testAdapterDelegatesMethodNodeToRuleSet(): void
     {
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock(MethodNode::class));
@@ -92,10 +86,8 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the metrics adapter does not delegate a node without source
      * code file to a registered rule-set.
-     *
-     * @return void
      */
-    public function testAdapterDoesNotDelegateNonSourceMethodNodeToRuleSet()
+    public function testAdapterDoesNotDelegateNonSourceMethodNodeToRuleSet(): void
     {
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock());
@@ -105,10 +97,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the metrics adapter delegates a node to a registered rule-set.
-     *
-     * @return void
      */
-    public function testAdapterDelegatesFunctionNodeToRuleSet()
+    public function testAdapterDelegatesFunctionNodeToRuleSet(): void
     {
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock(FunctionNode::class));
@@ -119,10 +109,8 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the metrics adapter does not delegate a node without source
      * code file to a registered rule-set.
-     *
-     * @return void
      */
-    public function testAdapterDoesNotDelegateNonSourceFunctionNodeToRuleSet()
+    public function testAdapterDoesNotDelegateNonSourceFunctionNodeToRuleSet(): void
     {
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock());
@@ -133,10 +121,9 @@ class ParserTest extends AbstractTestCase
     /**
      * testParserStoreParsingExceptionsInReport
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testParserStoreParsingExceptionsInReport()
+    public function testParserStoreParsingExceptionsInReport(): void
     {
         $report = $this->getReportWithNoViolation();
         $report->expects($this->once())

--- a/src/test/php/PHPMD/ProcessingErrorTest.php
+++ b/src/test/php/PHPMD/ProcessingErrorTest.php
@@ -27,10 +27,8 @@ class ProcessingErrorTest extends AbstractTestCase
 {
     /**
      * testGetMessageReturnsTheExpectedValue
-     *
-     * @return void
      */
-    public function testGetMessageReturnsTheExpectedValue()
+    public function testGetMessageReturnsTheExpectedValue(): void
     {
         $processingError = new ProcessingError('Hello World.');
         $this->assertEquals('Hello World.', $processingError->getMessage());
@@ -41,10 +39,9 @@ class ProcessingErrorTest extends AbstractTestCase
      * a given exception message,
      *
      * @param string $message The original exception message
-     * @return void
      * @dataProvider getParserExceptionMessages
      */
-    public function testGetFileReturnsExpectedFileName($message)
+    public function testGetFileReturnsExpectedFileName($message): void
     {
         $processingError = new ProcessingError($message);
         $this->assertEquals('/tmp/foo.php', $processingError->getFile());

--- a/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
@@ -30,10 +30,8 @@ class AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest extends AbstractR
 {
     /**
      * testCliAcceptsDirectoryAsInput
-     *
-     * @return void
      */
-    public function testCliAcceptsDirectoryAsInput()
+    public function testCliAcceptsDirectoryAsInput(): void
     {
         self::changeWorkingDirectory();
 
@@ -54,10 +52,8 @@ class AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest extends AbstractR
 
     /**
      * testCliAcceptsSingleFileAsInput
-     *
-     * @return void
      */
-    public function testCliAcceptsSingleFileAsInput()
+    public function testCliAcceptsSingleFileAsInput(): void
     {
         self::changeWorkingDirectory();
 

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest.php
@@ -27,10 +27,8 @@ class ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest extends Abstr
 {
     /**
      * testRuleSetInvokesRuleForClassInstance
-     *
-     * @return void
      */
-    public function testRuleSetInvokesRuleForClassInstance()
+    public function testRuleSetInvokesRuleForClassInstance(): void
     {
         $rule = new ExcessivePublicCount();
         $rule->addProperty('minimum', 3);

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
@@ -60,10 +60,8 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
      * - TooManyMethods
      * - TooManyPublicMethods
      * - ExcessiveClassComplexity
-     *
-     * @return void
      */
-    public function testReportIsGeneratedIWithNoSuppression()
+    public function testReportIsGeneratedIWithNoSuppression(): void
     {
         self::changeWorkingDirectory();
         $phpmd = new PHPMD();
@@ -74,7 +72,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
             ->method('renderReport')
             ->will(
                 $this->returnCallback(
-                    function (Report $report) use ($self) {
+                    function (Report $report) use ($self): void {
                         $isViolating = false;
                         foreach ($report->getRuleViolations() as $ruleViolation) {
                             if (str_starts_with($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE)) {
@@ -104,10 +102,8 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
      * - TooManyMethods
      * - TooManyPublicMethods
      * - ExcessiveClassComplexity
-     *
-     * @return void
      */
-    public function testReportIsNotGeneratedIWithSuppression()
+    public function testReportIsNotGeneratedIWithSuppression(): void
     {
         self::changeWorkingDirectory();
         $phpmd = new PHPMD();
@@ -118,7 +114,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
             ->method('renderReport')
             ->will(
                 $this->returnCallback(
-                    function (Report $report) use ($self) {
+                    function (Report $report) use ($self): void {
                         $isViolating = false;
                         foreach ($report->getRuleViolations() as $ruleViolation) {
                             if (str_starts_with($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE)) {

--- a/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest.php
@@ -27,10 +27,8 @@ class InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest extend
 {
     /**
      * testLocalVariableUsedInDoubleQuoteStringGetsNotReported
-     *
-     * @return void
      */
-    public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported()
+    public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported(): void
     {
         $rule = new UnusedLocalVariable();
         $rule->setReport($this->getReportWithNoViolation());
@@ -39,10 +37,8 @@ class InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest extend
 
     /**
      * testFormalParameterUsedInDoubleQuoteStringGetsNotReported
-     *
-     * @return void
      */
-    public function testFormalParameterUsedInDoubleQuoteStringGetsNotReported()
+    public function testFormalParameterUsedInDoubleQuoteStringGetsNotReported(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
@@ -34,10 +34,9 @@ class MaximumNestingLevelTicket24975295RegressionTest extends AbstractRegression
     /**
      * testLocalVariableUsedInDoubleQuoteStringGetsNotReported
      *
-     * @return void
      * @outputBuffering enabled
      */
-    public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported()
+    public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported(): void
     {
         $renderer = new TextRenderer();
         $renderer->setWriter(new StreamWriter(self::createTempFileUri()));

--- a/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
+++ b/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
@@ -22,287 +22,287 @@ namespace PHPMD\Regression\Sources;
  */
 class ExcessivePublicCountSuppressionWorksForPublicStaticMethods
 {
-    public static function aMethod()
+    public static function aMethod(): void
     {
     }
 
-    public static function bMethod()
+    public static function bMethod(): void
     {
     }
 
-    public static function cMethod()
+    public static function cMethod(): void
     {
     }
 
-    public static function dMethod()
+    public static function dMethod(): void
     {
     }
 
-    public static function eMethod()
+    public static function eMethod(): void
     {
     }
 
-    public static function fMethod()
+    public static function fMethod(): void
     {
     }
 
-    public static function gMethod()
+    public static function gMethod(): void
     {
     }
 
-    public static function hMethod()
+    public static function hMethod(): void
     {
     }
 
-    public static function iMethod()
+    public static function iMethod(): void
     {
     }
 
-    public static function jMethod()
+    public static function jMethod(): void
     {
     }
 
-    public static function kMethod()
+    public static function kMethod(): void
     {
     }
 
-    public static function lMethod()
+    public static function lMethod(): void
     {
     }
 
-    public static function mMethod()
+    public static function mMethod(): void
     {
     }
 
-    public static function nMethod()
+    public static function nMethod(): void
     {
     }
 
-    public static function oMethod()
+    public static function oMethod(): void
     {
     }
 
-    public static function pMethod()
+    public static function pMethod(): void
     {
     }
 
-    public static function rMethod()
+    public static function rMethod(): void
     {
     }
 
-    public static function sMethod()
+    public static function sMethod(): void
     {
     }
 
-    public static function tMethod()
+    public static function tMethod(): void
     {
     }
 
-    public static function uMethod()
+    public static function uMethod(): void
     {
     }
 
-    public static function wMethod()
+    public static function wMethod(): void
     {
     }
 
-    public static function xMethod()
+    public static function xMethod(): void
     {
     }
 
-    public static function yMethod()
+    public static function yMethod(): void
     {
     }
 
-    public static function zMethod()
+    public static function zMethod(): void
     {
     }
 
-    public static function aaMethod()
+    public static function aaMethod(): void
     {
     }
 
-    public static function abMethod()
+    public static function abMethod(): void
     {
     }
 
-    public static function acMethod()
+    public static function acMethod(): void
     {
     }
 
-    public static function adMethod()
+    public static function adMethod(): void
     {
     }
 
-    public static function aeMethod()
+    public static function aeMethod(): void
     {
     }
 
-    public static function afMethod()
+    public static function afMethod(): void
     {
     }
 
-    public static function agMethod()
+    public static function agMethod(): void
     {
     }
 
-    public static function ahMethod()
+    public static function ahMethod(): void
     {
     }
 
-    public static function ajMethod()
+    public static function ajMethod(): void
     {
     }
 
-    public static function akMethod()
+    public static function akMethod(): void
     {
     }
 
-    public static function alMethod()
+    public static function alMethod(): void
     {
     }
 
-    public static function amMethod()
+    public static function amMethod(): void
     {
     }
 
-    public static function anMethod()
+    public static function anMethod(): void
     {
     }
 
-    public static function aoMethod()
+    public static function aoMethod(): void
     {
     }
 
-    public static function apMethod()
+    public static function apMethod(): void
     {
     }
 
-    public static function arMethod()
+    public static function arMethod(): void
     {
     }
 
-    public static function asMethod()
+    public static function asMethod(): void
     {
     }
 
-    public static function atMethod()
+    public static function atMethod(): void
     {
     }
 
-    public static function auMethod()
+    public static function auMethod(): void
     {
     }
 
-    public static function awMethod()
+    public static function awMethod(): void
     {
     }
 
-    public static function axMethod()
+    public static function axMethod(): void
     {
     }
 
-    public static function ayMethod()
+    public static function ayMethod(): void
     {
     }
 
-    public static function azMethod()
+    public static function azMethod(): void
     {
     }
 
-    public static function baMethod()
+    public static function baMethod(): void
     {
     }
 
-    public static function bbMethod()
+    public static function bbMethod(): void
     {
     }
 
-    public static function bcMethod()
+    public static function bcMethod(): void
     {
     }
 
-    public static function bdMethod()
+    public static function bdMethod(): void
     {
     }
 
-    public static function beMethod()
+    public static function beMethod(): void
     {
     }
 
-    public static function bfMethod()
+    public static function bfMethod(): void
     {
     }
 
-    public static function bgMethod()
+    public static function bgMethod(): void
     {
     }
 
-    public static function bhMethod()
+    public static function bhMethod(): void
     {
     }
 
-    public static function biMethod()
+    public static function biMethod(): void
     {
     }
 
-    public static function bjMethod()
+    public static function bjMethod(): void
     {
     }
 
-    public static function bkMethod()
+    public static function bkMethod(): void
     {
     }
 
-    public static function blmethod()
+    public static function blmethod(): void
     {
     }
 
-    public static function bmmethod()
+    public static function bmmethod(): void
     {
     }
 
-    public static function bnMethod()
+    public static function bnMethod(): void
     {
     }
 
-    public static function boMethod()
+    public static function boMethod(): void
     {
     }
 
-    public static function bpMethod()
+    public static function bpMethod(): void
     {
     }
 
-    public static function brMethod()
+    public static function brMethod(): void
     {
     }
 
-    public static function bsMethod()
+    public static function bsMethod(): void
     {
     }
 
-    public static function btMethod()
+    public static function btMethod(): void
     {
     }
 
-    public static function buMethod()
+    public static function buMethod(): void
     {
     }
 
-    public static function bwMethod()
+    public static function bwMethod(): void
     {
     }
 
-    public static function bxMethod()
+    public static function bxMethod(): void
     {
     }
 
-    public static function byMethod()
+    public static function byMethod(): void
     {
     }
 
-    public static function bzMethod()
+    public static function bzMethod(): void
     {
     }
 }

--- a/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php
+++ b/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php
@@ -19,287 +19,287 @@ namespace PHPMD\Regression\Sources;
 
 class ExcessivePublicCountWorksForPublicStaticMethods
 {
-    public static function aMethod()
+    public static function aMethod(): void
     {
     }
 
-    public static function bMethod()
+    public static function bMethod(): void
     {
     }
 
-    public static function cMethod()
+    public static function cMethod(): void
     {
     }
 
-    public static function dMethod()
+    public static function dMethod(): void
     {
     }
 
-    public static function eMethod()
+    public static function eMethod(): void
     {
     }
 
-    public static function fMethod()
+    public static function fMethod(): void
     {
     }
 
-    public static function gMethod()
+    public static function gMethod(): void
     {
     }
 
-    public static function hMethod()
+    public static function hMethod(): void
     {
     }
 
-    public static function iMethod()
+    public static function iMethod(): void
     {
     }
 
-    public static function jMethod()
+    public static function jMethod(): void
     {
     }
 
-    public static function kMethod()
+    public static function kMethod(): void
     {
     }
 
-    public static function lMethod()
+    public static function lMethod(): void
     {
     }
 
-    public static function mMethod()
+    public static function mMethod(): void
     {
     }
 
-    public static function nMethod()
+    public static function nMethod(): void
     {
     }
 
-    public static function oMethod()
+    public static function oMethod(): void
     {
     }
 
-    public static function pMethod()
+    public static function pMethod(): void
     {
     }
 
-    public static function rMethod()
+    public static function rMethod(): void
     {
     }
 
-    public static function sMethod()
+    public static function sMethod(): void
     {
     }
 
-    public static function tMethod()
+    public static function tMethod(): void
     {
     }
 
-    public static function uMethod()
+    public static function uMethod(): void
     {
     }
 
-    public static function wMethod()
+    public static function wMethod(): void
     {
     }
 
-    public static function xMethod()
+    public static function xMethod(): void
     {
     }
 
-    public static function yMethod()
+    public static function yMethod(): void
     {
     }
 
-    public static function zMethod()
+    public static function zMethod(): void
     {
     }
 
-    public static function aaMethod()
+    public static function aaMethod(): void
     {
     }
 
-    public static function abMethod()
+    public static function abMethod(): void
     {
     }
 
-    public static function acMethod()
+    public static function acMethod(): void
     {
     }
 
-    public static function adMethod()
+    public static function adMethod(): void
     {
     }
 
-    public static function aeMethod()
+    public static function aeMethod(): void
     {
     }
 
-    public static function afMethod()
+    public static function afMethod(): void
     {
     }
 
-    public static function agMethod()
+    public static function agMethod(): void
     {
     }
 
-    public static function ahMethod()
+    public static function ahMethod(): void
     {
     }
 
-    public static function ajMethod()
+    public static function ajMethod(): void
     {
     }
 
-    public static function akMethod()
+    public static function akMethod(): void
     {
     }
 
-    public static function alMethod()
+    public static function alMethod(): void
     {
     }
 
-    public static function amMethod()
+    public static function amMethod(): void
     {
     }
 
-    public static function anMethod()
+    public static function anMethod(): void
     {
     }
 
-    public static function aoMethod()
+    public static function aoMethod(): void
     {
     }
 
-    public static function apMethod()
+    public static function apMethod(): void
     {
     }
 
-    public static function arMethod()
+    public static function arMethod(): void
     {
     }
 
-    public static function asMethod()
+    public static function asMethod(): void
     {
     }
 
-    public static function atMethod()
+    public static function atMethod(): void
     {
     }
 
-    public static function auMethod()
+    public static function auMethod(): void
     {
     }
 
-    public static function awMethod()
+    public static function awMethod(): void
     {
     }
 
-    public static function axMethod()
+    public static function axMethod(): void
     {
     }
 
-    public static function ayMethod()
+    public static function ayMethod(): void
     {
     }
 
-    public static function azMethod()
+    public static function azMethod(): void
     {
     }
 
-    public static function baMethod()
+    public static function baMethod(): void
     {
     }
 
-    public static function bbMethod()
+    public static function bbMethod(): void
     {
     }
 
-    public static function bcMethod()
+    public static function bcMethod(): void
     {
     }
 
-    public static function bdMethod()
+    public static function bdMethod(): void
     {
     }
 
-    public static function beMethod()
+    public static function beMethod(): void
     {
     }
 
-    public static function bfMethod()
+    public static function bfMethod(): void
     {
     }
 
-    public static function bgMethod()
+    public static function bgMethod(): void
     {
     }
 
-    public static function bhMethod()
+    public static function bhMethod(): void
     {
     }
 
-    public static function biMethod()
+    public static function biMethod(): void
     {
     }
 
-    public static function bjMethod()
+    public static function bjMethod(): void
     {
     }
 
-    public static function bkMethod()
+    public static function bkMethod(): void
     {
     }
 
-    public static function blmethod()
+    public static function blmethod(): void
     {
     }
 
-    public static function bmmethod()
+    public static function bmmethod(): void
     {
     }
 
-    public static function bnMethod()
+    public static function bnMethod(): void
     {
     }
 
-    public static function boMethod()
+    public static function boMethod(): void
     {
     }
 
-    public static function bpMethod()
+    public static function bpMethod(): void
     {
     }
 
-    public static function brMethod()
+    public static function brMethod(): void
     {
     }
 
-    public static function bsMethod()
+    public static function bsMethod(): void
     {
     }
 
-    public static function btMethod()
+    public static function btMethod(): void
     {
     }
 
-    public static function buMethod()
+    public static function buMethod(): void
     {
     }
 
-    public static function bwMethod()
+    public static function bwMethod(): void
     {
     }
 
-    public static function bxMethod()
+    public static function bxMethod(): void
     {
     }
 
-    public static function byMethod()
+    public static function byMethod(): void
     {
     }
 
-    public static function bzMethod()
+    public static function bzMethod(): void
     {
     }
 }

--- a/src/test/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020RegressionTest.php
@@ -26,10 +26,8 @@ class StaticVariablesFlaggedAsUnusedTicket020RegressionTest extends AbstractRegr
 {
     /**
      * testRuleDoesNotApplyToAnySuperGlobalVariable
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToAnyStaticLocalVariable()
+    public function testRuleDoesNotApplyToAnyStaticLocalVariable(): void
     {
         $rule = new UnusedLocalVariable();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019RegressionTest.php
@@ -26,10 +26,8 @@ class SuperGlobalsFlaggedAsUnusedTicket019RegressionTest extends AbstractRegress
 {
     /**
      * testRuleDoesNotApplyToAnySuperGlobalVariable
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToAnySuperGlobalVariable()
+    public function testRuleDoesNotApplyToAnySuperGlobalVariable(): void
     {
         $rule = new UnusedLocalVariable();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036RegressionTest.php
@@ -27,10 +27,8 @@ class SuppressWarningsNotAppliesToUnusedPrivateMethod036RegressionTest extends A
 {
     /**
      * testRuleDoesNotApplyToPrivateMethodWithSuppressWarningsAnnotation
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateMethodWithSuppressWarningsAnnotation()
+    public function testRuleDoesNotApplyToPrivateMethodWithSuppressWarningsAnnotation(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new UnusedPrivateMethod());

--- a/src/test/php/PHPMD/Regression/UnusedParameterArgvTicket14990109RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/UnusedParameterArgvTicket14990109RegressionTest.php
@@ -30,10 +30,8 @@ class UnusedParameterArgvTicket14990109RegressionTest extends AbstractRegression
 {
     /**
      * testRuleDoesNotApplyToFunctionParameterNamedArgv
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToFunctionParameterNamedArgv()
+    public function testRuleDoesNotApplyToFunctionParameterNamedArgv(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new UnusedFormalParameter());
@@ -44,10 +42,8 @@ class UnusedParameterArgvTicket14990109RegressionTest extends AbstractRegression
 
     /**
      * testRuleDoesNotApplyToMethodParameterNamedArgv
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToMethodParameterNamedArgv()
+    public function testRuleDoesNotApplyToMethodParameterNamedArgv(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new UnusedFormalParameter());

--- a/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
@@ -30,10 +30,8 @@ class AnsiRendererTest extends AbstractTestCase
 {
     /**
      * testRendererOutputsForReportWithContents
-     *
-     * @return void
      */
-    public function testRendererOutputsForReportWithContents()
+    public function testRendererOutputsForReportWithContents(): void
     {
         $writer = new WriterStub();
 
@@ -95,10 +93,8 @@ class AnsiRendererTest extends AbstractTestCase
 
     /**
      * testRendererOutputsForReportWithoutContents
-     *
-     * @return void
      */
-    public function testRendererOutputsForReportWithoutContents()
+    public function testRendererOutputsForReportWithoutContents(): void
     {
         $writer = new WriterStub();
 

--- a/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
@@ -17,7 +17,7 @@ class BaselineRendererTest extends AbstractTestCase
     /**
      * @covers ::renderReport
      */
-    public function testRenderReport()
+    public function testRenderReport(): void
     {
         $writer = new WriterStub();
         $violations = [
@@ -46,7 +46,7 @@ class BaselineRendererTest extends AbstractTestCase
     /**
      * @covers ::renderReport
      */
-    public function testRenderReportShouldWriteMethodName()
+    public function testRenderReportShouldWriteMethodName(): void
     {
         $writer = new WriterStub();
         $violationMock = $this->getRuleViolationMock('/src/php/bar.php');
@@ -73,7 +73,7 @@ class BaselineRendererTest extends AbstractTestCase
     /**
      * @covers ::renderReport
      */
-    public function testRenderReportShouldDeduplicateSimilarViolations()
+    public function testRenderReportShouldDeduplicateSimilarViolations(): void
     {
         $writer = new WriterStub();
         $violationMock = $this->getRuleViolationMock('/src/php/bar.php');
@@ -101,7 +101,7 @@ class BaselineRendererTest extends AbstractTestCase
     /**
      * @covers ::renderReport
      */
-    public function testRenderEmptyReport()
+    public function testRenderEmptyReport(): void
     {
         $writer = new WriterStub();
         $report = $this->getReportWithNoViolation();

--- a/src/test/php/PHPMD/Renderer/CheckStyleRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/CheckStyleRendererTest.php
@@ -31,10 +31,8 @@ class CheckStyleRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfXmlElements
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfXmlElements()
+    public function testRendererCreatesExpectedNumberOfXmlElements(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -69,10 +67,9 @@ class CheckStyleRendererTest extends AbstractTestCase
     /**
      * testRendererAddsProcessingErrorsToXmlReport
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testRendererAddsProcessingErrorsToXmlReport()
+    public function testRendererAddsProcessingErrorsToXmlReport(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();

--- a/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
@@ -31,10 +31,8 @@ class GitHubRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfTextEntries
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfTextEntries()
+    public function testRendererCreatesExpectedNumberOfTextEntries(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -70,10 +68,8 @@ class GitHubRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToTextReport
-     *
-     * @return void
      */
-    public function testRendererAddsProcessingErrorsToTextReport()
+    public function testRendererAddsProcessingErrorsToTextReport(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();

--- a/src/test/php/PHPMD/Renderer/GitLabRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/GitLabRendererTest.php
@@ -31,10 +31,8 @@ class GitLabRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfGitLabElements
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfGitLabElements()
+    public function testRendererCreatesExpectedNumberOfGitLabElements(): void
     {
         $writer = new WriterStub();
 
@@ -67,10 +65,8 @@ class GitLabRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToGitLabReport
-     *
-     * @return void
      */
-    public function testRendererAddsProcessingErrorsToGitLabReport()
+    public function testRendererAddsProcessingErrorsToGitLabReport(): void
     {
         $writer = new WriterStub();
 

--- a/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -30,10 +30,8 @@ class HTMLRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfTextEntries
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedHtmlTableRow()
+    public function testRendererCreatesExpectedHtmlTableRow(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();

--- a/src/test/php/PHPMD/Renderer/JSONRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/JSONRendererTest.php
@@ -31,10 +31,8 @@ class JSONRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfJsonElements
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfJsonElements()
+    public function testRendererCreatesExpectedNumberOfJsonElements(): void
     {
         $writer = new WriterStub();
 
@@ -67,10 +65,8 @@ class JSONRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToJsonReport
-     *
-     * @return void
      */
-    public function testRendererAddsProcessingErrorsToJsonReport()
+    public function testRendererAddsProcessingErrorsToJsonReport(): void
     {
         $writer = new WriterStub();
 

--- a/src/test/php/PHPMD/Renderer/RendererFactoryTest.php
+++ b/src/test/php/PHPMD/Renderer/RendererFactoryTest.php
@@ -13,7 +13,7 @@ class RendererFactoryTest extends AbstractTestCase
     /**
      * @covers ::createBaselineRenderer
      */
-    public function testCreateBaselineRendererSuccessfully()
+    public function testCreateBaselineRendererSuccessfully(): void
     {
         $writer = new StreamWriter(tmpfile());
         $renderer = RendererFactory::createBaselineRenderer($writer);

--- a/src/test/php/PHPMD/Renderer/SARIFRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/SARIFRendererTest.php
@@ -32,10 +32,8 @@ class SARIFRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfJsonElements
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfJsonElements()
+    public function testRendererCreatesExpectedNumberOfJsonElements(): void
     {
         $writer = new WriterStub();
 
@@ -84,10 +82,8 @@ class SARIFRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToJsonReport
-     *
-     * @return void
      */
-    public function testRendererAddsProcessingErrorsToJsonReport()
+    public function testRendererAddsProcessingErrorsToJsonReport(): void
     {
         $writer = new WriterStub();
 

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -33,10 +33,8 @@ class TextRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfTextEntries
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfTextEntries()
+    public function testRendererCreatesExpectedNumberOfTextEntries(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -73,10 +71,7 @@ class TextRendererTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testRendererSupportVerbose()
+    public function testRendererSupportVerbose(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -112,10 +107,7 @@ class TextRendererTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testRendererSupportColor()
+    public function testRendererSupportColor(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -151,10 +143,8 @@ class TextRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToTextReport
-     *
-     * @return void
      */
-    public function testRendererAddsProcessingErrorsToTextReport()
+    public function testRendererAddsProcessingErrorsToTextReport(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();

--- a/src/test/php/PHPMD/Renderer/XMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/XMLRendererTest.php
@@ -31,10 +31,8 @@ class XMLRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfXmlElements
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfXmlElements()
+    public function testRendererCreatesExpectedNumberOfXmlElements(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -69,10 +67,9 @@ class XMLRendererTest extends AbstractTestCase
     /**
      * testRendererAddsProcessingErrorsToXmlReport
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testRendererAddsProcessingErrorsToXmlReport()
+    public function testRendererAddsProcessingErrorsToXmlReport(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -32,10 +32,8 @@ class ReportTest extends AbstractTestCase
     /**
      * Tests that the report returns a linear/sorted list of all rule violation
      * files.
-     *
-     * @return void
      */
-    public function testReportReturnsAListWithAllRuleViolations()
+    public function testReportReturnsAListWithAllRuleViolations(): void
     {
         $report = new Report();
 
@@ -57,10 +55,8 @@ class ReportTest extends AbstractTestCase
 
     /**
      * Tests that the report returns the result by the violation line number.
-     *
-     * @return void
      */
-    public function testReportSortsResultByLineNumber()
+    public function testReportSortsResultByLineNumber(): void
     {
         $report = new Report();
 
@@ -94,10 +90,8 @@ class ReportTest extends AbstractTestCase
 
     /**
      * Tests that the timer method returns the expected result.
-     *
-     * @return void
      */
-    public function testReportTimerReturnsMilliSeconds()
+    public function testReportTimerReturnsMilliSeconds(): void
     {
         $start = microtime(true);
 
@@ -117,10 +111,8 @@ class ReportTest extends AbstractTestCase
 
     /**
      * testIsEmptyReturnsTrueByDefault
-     *
-     * @return void
      */
-    public function testIsEmptyReturnsTrueByDefault()
+    public function testIsEmptyReturnsTrueByDefault(): void
     {
         $report = new Report();
         $this->assertTrue($report->isEmpty());
@@ -128,10 +120,8 @@ class ReportTest extends AbstractTestCase
 
     /**
      * testIsEmptyReturnsFalseWhenAtLeastOneViolationExists
-     *
-     * @return void
      */
-    public function testIsEmptyReturnsFalseWhenAtLeastOneViolationExists()
+    public function testIsEmptyReturnsFalseWhenAtLeastOneViolationExists(): void
     {
         $report = new Report();
         $report->addRuleViolation($this->getRuleViolationMock('foo.txt', 4, 5));
@@ -142,10 +132,9 @@ class ReportTest extends AbstractTestCase
     /**
      * testHasErrorsReturnsFalseByDefault
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testHasErrorsReturnsFalseByDefault()
+    public function testHasErrorsReturnsFalseByDefault(): void
     {
         $report = new Report();
         $this->assertFalse($report->hasErrors());
@@ -154,10 +143,9 @@ class ReportTest extends AbstractTestCase
     /**
      * testHasErrorsReturnsTrueWhenReportContainsAtLeastOneError
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testHasErrorsReturnsTrueWhenReportContainsAtLeastOneError()
+    public function testHasErrorsReturnsTrueWhenReportContainsAtLeastOneError(): void
     {
         $report = new Report();
         $report->addError(new ProcessingError('Failing file "/foo.php".'));
@@ -168,10 +156,9 @@ class ReportTest extends AbstractTestCase
     /**
      * testGetErrorsReturnsEmptyIteratorByDefault
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testGetErrorsReturnsEmptyIteratorByDefault()
+    public function testGetErrorsReturnsEmptyIteratorByDefault(): void
     {
         $report = new Report();
         $this->assertSame(0, iterator_count($report->getErrors()));
@@ -180,10 +167,9 @@ class ReportTest extends AbstractTestCase
     /**
      * testGetErrorsReturnsPreviousAddedProcessingError
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testGetErrorsReturnsPreviousAddedProcessingError()
+    public function testGetErrorsReturnsPreviousAddedProcessingError(): void
     {
         $report = new Report();
         $report->addError(new ProcessingError('Failing file "/foo.php".'));
@@ -191,10 +177,7 @@ class ReportTest extends AbstractTestCase
         $this->assertSame(1, iterator_count($report->getErrors()));
     }
 
-    /**
-     * @return void
-     */
-    public function testReportShouldIgnoreBaselineViolation()
+    public function testReportShouldIgnoreBaselineViolation(): void
     {
         /** @var RuleViolation $ruleA */
         $ruleA = $this->getRuleViolationMock('foo.txt');
@@ -217,10 +200,7 @@ class ReportTest extends AbstractTestCase
         static::assertSame($ruleB, $violations[0]);
     }
 
-    /**
-     * @return void
-     */
-    public function testReportShouldIgnoreNewViolationsOnBaselineUpdate()
+    public function testReportShouldIgnoreNewViolationsOnBaselineUpdate(): void
     {
         /** @var RuleViolation $ruleA */
         $ruleA = $this->getRuleViolationMock('foo.txt');

--- a/src/test/php/PHPMD/Rule/CleanCode/BooleanArgumentFlagTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/BooleanArgumentFlagTest.php
@@ -43,10 +43,9 @@ class BooleanArgumentFlagTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getApplyingCases
      */
-    public function testRuleAppliesTo($file)
+    public function testRuleAppliesTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::ONE_VIOLATION, $file);
     }
@@ -55,10 +54,9 @@ class BooleanArgumentFlagTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getNotApplyingCases
      */
-    public function testRuleDoesNotApplyTo($file)
+    public function testRuleDoesNotApplyTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::NO_VIOLATION, $file);
     }

--- a/src/test/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
@@ -29,10 +29,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutArrayDefinition
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithoutArrayDefinition()
+    public function testRuleNotAppliesToMethodWithoutArrayDefinition(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithNonAssotiativeArrayDefinition
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithNonAssotiativeArrayDefinition()
+    public function testRuleNotAppliesToMethodWithNonAssotiativeArrayDefinition(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithNoViolation());
@@ -53,10 +49,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithAssotiativeArrayDefinitionWithoutDuplicatedKeys
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithAssotiativeArrayDefinitionWithoutDuplicatedKeys()
+    public function testRuleNotAppliesToMethodWithAssotiativeArrayDefinitionWithoutDuplicatedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithNoViolation());
@@ -65,10 +59,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys()
+    public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithOneViolation());
@@ -77,10 +69,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys()
+    public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithOneViolation());
@@ -89,10 +79,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys()
+    public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithOneViolation());
@@ -101,10 +89,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesMultipleTimesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys()
+    public function testRuleAppliesMultipleTimesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportMock(3));
@@ -113,10 +99,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutArrayDefinition
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithoutArrayDefinition()
+    public function testRuleNotAppliesToFunctionWithoutArrayDefinition(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithNoViolation());
@@ -125,10 +109,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithNonAssotiativeArrayDefinition
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithNonAssotiativeArrayDefinition()
+    public function testRuleNotAppliesToFunctionWithNonAssotiativeArrayDefinition(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithNoViolation());
@@ -137,10 +119,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithAssotiativeArrayDefinitionWithoutDuplicatedKeys
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithAssotiativeArrayDefinitionWithoutDuplicatedKeys()
+    public function testRuleNotAppliesToFunctionWithAssotiativeArrayDefinitionWithoutDuplicatedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithNoViolation());
@@ -149,10 +129,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys()
+    public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithOneViolation());
@@ -161,10 +139,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys()
+    public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithOneViolation());
@@ -173,10 +149,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys()
+    public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithOneViolation());
@@ -185,10 +159,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesMultipleTimesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys()
+    public function testRuleAppliesMultipleTimesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportMock(3));
@@ -197,10 +169,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenKeyIsDeclaredInNonStandardWay
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenKeyIsDeclaredInNonStandardWay()
+    public function testRuleAppliesWhenKeyIsDeclaredInNonStandardWay(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportMock(4));
@@ -209,10 +179,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesCorrectlyWithNestedArrays
-     *
-     * @return void
      */
-    public function testRuleAppliesCorrectlyWithNestedArrays()
+    public function testRuleAppliesCorrectlyWithNestedArrays(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportMock(4));
@@ -221,10 +189,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesCorrectlyToMultipleArrays
-     *
-     * @return void
      */
-    public function testRuleAppliesCorrectlyToMultipleArrays()
+    public function testRuleAppliesCorrectlyToMultipleArrays(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportMock(4));

--- a/src/test/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
@@ -21,21 +21,21 @@ use PHPMD\AbstractTestCase;
 
 class ElseExpressionTest extends AbstractTestCase
 {
-    public function testRuleNotAppliesToMethodWithoutElseExpression()
+    public function testRuleNotAppliesToMethodWithoutElseExpression(): void
     {
         $rule = new ElseExpression();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleAppliesToMethodWithElseExpression()
+    public function testRuleAppliesToMethodWithElseExpression(): void
     {
         $rule = new ElseExpression();
         $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleAppliesMultipleTimesToMethodWithMultipleElseExpressions()
+    public function testRuleAppliesMultipleTimesToMethodWithMultipleElseExpressions(): void
     {
         $rule = new ElseExpression();
         $rule->setReport($this->getReportMock(3));

--- a/src/test/php/PHPMD/Rule/CleanCode/ErrorControlOperatorTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/ErrorControlOperatorTest.php
@@ -29,10 +29,9 @@ class ErrorControlOperatorTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply to unary operators in functions
      *
-     * @return void
      * @covers ::apply
      */
-    public function testDoesNotApplyToOtherUnaryOperatorsInFunction()
+    public function testDoesNotApplyToOtherUnaryOperatorsInFunction(): void
     {
         $rule = new ErrorControlOperator();
         $rule->setReport($this->getReportWithOneViolation());
@@ -42,10 +41,9 @@ class ErrorControlOperatorTest extends AbstractTestCase
     /**
      * Tests that the rule applies error control operators to functions
      *
-     * @return void
      * @covers ::apply
      */
-    public function testAppliesToErrorControlOperatorInFunction()
+    public function testAppliesToErrorControlOperatorInFunction(): void
     {
         $rule = new ErrorControlOperator();
         $rule->setReport($this->getReportMock(3));
@@ -55,10 +53,9 @@ class ErrorControlOperatorTest extends AbstractTestCase
     /**
      * Tests that the rule applies error control operators to classes and methods
      *
-     * @return void
      * @covers ::apply
      */
-    public function testAppliedToClassesAndMethods()
+    public function testAppliedToClassesAndMethods(): void
     {
         $rule = new ErrorControlOperator();
         $rule->setReport($this->getReportMock(6));

--- a/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
@@ -21,70 +21,70 @@ use PHPMD\AbstractTestCase;
 
 class IfStatementAssignmentTest extends AbstractTestCase
 {
-    public function testRuleNotAppliesInsideClosure()
+    public function testRuleNotAppliesInsideClosure(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesInsideClosureCallbacks()
+    public function testRuleNotAppliesInsideClosureCallbacks(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToIfsWithoutAssignment()
+    public function testRuleNotAppliesToIfsWithoutAssignment(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToIfsWithConditionsOnly()
+    public function testRuleNotAppliesToIfsWithConditionsOnly(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToLogicalOperators()
+    public function testRuleNotAppliesToLogicalOperators(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleWorksCorrectlyWhenExpressionContainsMath()
+    public function testRuleWorksCorrectlyWhenExpressionContainsMath(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportMock(3));
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleAppliesToFunctions()
+    public function testRuleAppliesToFunctions(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
-    public function testRuleAppliesMultipleIfConditions()
+    public function testRuleAppliesMultipleIfConditions(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
-    public function testRuleAppliesToMultilevelIfConditions()
+    public function testRuleAppliesToMultilevelIfConditions(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportMock(6));
         $rule->apply($this->getFunction());
     }
 
-    public function testRuleAppliesMultipleTimesInOneIfCondition()
+    public function testRuleAppliesMultipleTimesInOneIfCondition(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportMock(3));

--- a/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
@@ -42,10 +42,9 @@ class MissingImportTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getApplyingCases
      */
-    public function testRuleAppliesTo($file)
+    public function testRuleAppliesTo($file): void
     {
         $expectedInvokes = str_contains($file, 'testRuleAppliesTwice')
             ? 2
@@ -57,10 +56,9 @@ class MissingImportTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getNotApplyingCases
      */
-    public function testRuleDoesNotApplyTo($file)
+    public function testRuleDoesNotApplyTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::NO_VIOLATION, $file);
     }
@@ -68,11 +66,10 @@ class MissingImportTest extends AbstractTestCase
     /**
      * Tests that it applies to a class that has fully qualified class names
      *
-     * @return void
      * @covers ::apply
      * @covers ::isSelfReference
      */
-    public function testRuleAppliesTwiceToClassWithNotImportedDependencies()
+    public function testRuleAppliesTwiceToClassWithNotImportedDependencies(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportMock(2));
@@ -82,11 +79,10 @@ class MissingImportTest extends AbstractTestCase
     /**
      * Tests that it does not apply to a class in root namespace when configured.
      *
-     * @return void
      * @covers ::apply
      * @covers ::isGlobalNamespace
      */
-    public function testRuleDoesNotApplyWhenSuppressed()
+    public function testRuleDoesNotApplyWhenSuppressed(): void
     {
         $rule = new MissingImport();
         $rule->addProperty('ignore-global', 'true');

--- a/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
@@ -24,28 +24,28 @@ use PHPMD\AbstractTestCase;
  */
 class StaticAccessTest extends AbstractTestCase
 {
-    public function testRuleNotAppliesToParentStaticCall()
+    public function testRuleNotAppliesToParentStaticCall(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToSelfStaticCall()
+    public function testRuleNotAppliesToSelfStaticCall(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToDynamicMethodCall()
+    public function testRuleNotAppliesToDynamicMethodCall(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToStaticMethodAccessWhenExcluded()
+    public function testRuleNotAppliesToStaticMethodAccessWhenExcluded(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithNoViolation());
@@ -53,14 +53,14 @@ class StaticAccessTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleAppliesToStaticMethodAccess()
+    public function testRuleAppliesToStaticMethodAccess(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleAppliesToStaticMethodAccessWhenNotAllExcluded()
+    public function testRuleAppliesToStaticMethodAccessWhenNotAllExcluded(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithOneViolation());
@@ -68,7 +68,7 @@ class StaticAccessTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToConstantAccess()
+    public function testRuleNotAppliesToConstantAccess(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithNoViolation());
@@ -79,7 +79,7 @@ class StaticAccessTest extends AbstractTestCase
      * @covers ::apply
      * @covers ::isMethodIgnored
      */
-    public function testRuleNotAppliesToStaticMethodAccessWhenIgnored()
+    public function testRuleNotAppliesToStaticMethodAccessWhenIgnored(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithNoViolation());
@@ -91,7 +91,7 @@ class StaticAccessTest extends AbstractTestCase
      * @covers ::apply
      * @covers ::isMethodIgnored
      */
-    public function testRuleAppliesToStaticMethodAccessWhenNotIgnored()
+    public function testRuleAppliesToStaticMethodAccessWhenNotIgnored(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/CleanCode/UndefinedVariableTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/UndefinedVariableTest.php
@@ -40,10 +40,9 @@ class UndefinedVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getApplyingCases
      */
-    public function testRuleAppliesTo($file)
+    public function testRuleAppliesTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::ONE_VIOLATION, $file);
     }
@@ -52,10 +51,9 @@ class UndefinedVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getNotApplyingCases
      */
-    public function testRuleDoesNotApplyTo($file)
+    public function testRuleDoesNotApplyTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::NO_VIOLATION, $file);
     }

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
@@ -25,10 +25,7 @@ use PHPMD\Node\ClassNode;
  */
 class CamelCaseClassNameTest extends AbstractTestCase
 {
-    /**
-     * @return void
-     */
-    public function testRuleDoesNotApplyForValidClassName()
+    public function testRuleDoesNotApplyForValidClassName(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -38,10 +35,7 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('ValidClass'));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleDoesNotApplyForValidClassNameWithUppercaseAbbreviation()
+    public function testRuleDoesNotApplyForValidClassNameWithUppercaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -51,10 +45,7 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('ValidURLClass'));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleDoesApplyForClassNameWithUppercaseAbbreviation()
+    public function testRuleDoesApplyForClassNameWithUppercaseAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -64,10 +55,7 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('ValidURLClass'));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleDoesNotApplyForClassNameWithCamelcaseAbbreviation()
+    public function testRuleDoesNotApplyForClassNameWithCamelcaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -77,10 +65,7 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('ValidUrlClass'));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleAppliesForClassNameWithLowerCase()
+    public function testRuleAppliesForClassNameWithLowerCase(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -90,10 +75,7 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('invalidClass'));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleAppliesForClassNameWithLowerCaseAndCamelcaseAbbreviation()
+    public function testRuleAppliesForClassNameWithLowerCaseAndCamelcaseAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();
 

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -29,10 +29,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does not apply for a valid method name.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidMethodName()
+    public function testRuleDoesNotApplyForValidMethodName(): void
     {
         //$method = $this->getMethod();
         $report = $this->getReportWithNoViolation();
@@ -47,10 +45,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for method name
      * with all caps abbreviation.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForMethodNameWithAllCapsAbbreviation()
+    public function testRuleDoesApplyForMethodNameWithAllCapsAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -65,10 +61,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for method name
      * with camelcase abbreviation.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForMethodNameWithCamelcaseAbbreviation()
+    public function testRuleDoesNotApplyForMethodNameWithCamelcaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -83,10 +77,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for an method name
      * starting with a capital.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForMethodNameWithCapital()
+    public function testRuleDoesApplyForMethodNameWithCapital(): void
     {
         // Test method name with capital at the beginning
         $method = $this->getMethod();
@@ -102,10 +94,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a method name
      * with underscores.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForMethodNameWithUnderscores()
+    public function testRuleDoesApplyForMethodNameWithUnderscores(): void
     {
         // Test method name with underscores
         $method = $this->getMethod();
@@ -121,10 +111,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid method name
      * with an underscore at the beginning when it is allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForValidMethodNameWithUnderscoreWhenNotAllowed()
+    public function testRuleDoesApplyForValidMethodNameWithUnderscoreWhenNotAllowed(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithOneViolation();
@@ -139,10 +127,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid method name
      * with an underscore at the beginning when it is not allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidMethodNameWithUnderscoreWhenAllowed()
+    public function testRuleDoesNotApplyForValidMethodNameWithUnderscoreWhenAllowed(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithNoViolation();
@@ -157,10 +143,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid method name
      * with an underscore at the beginning when it is not allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForMagicMethods()
+    public function testRuleDoesNotApplyForMagicMethods(): void
     {
         $methods = $this->getClass()->getMethods();
 
@@ -178,10 +162,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid test method name
      * with an underscore.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForTestMethodWithUnderscoreWhenNotAllowed()
+    public function testRuleDoesApplyForTestMethodWithUnderscoreWhenNotAllowed(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithOneViolation();
@@ -196,10 +178,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid test method name
      * with an underscore when underscores are allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForTestMethodWithUnderscoreWhenAllowed()
+    public function testRuleDoesNotApplyForTestMethodWithUnderscoreWhenAllowed(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithNoViolation();
@@ -214,10 +194,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid test method name
      * with multiple underscores in different positions when underscores are allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForTestMethodWithMultipleUnderscoresWhenAllowed()
+    public function testRuleDoesNotApplyForTestMethodWithMultipleUnderscoresWhenAllowed(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithNoViolation();
@@ -232,10 +210,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a test method name
      * with consecutive underscores even when underscores are allowed.
-     *
-     * @return void
      */
-    public function testRuleAppliesToTestMethodWithTwoConsecutiveUnderscoresWhenAllowed()
+    public function testRuleAppliesToTestMethodWithTwoConsecutiveUnderscoresWhenAllowed(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithOneViolation();
@@ -250,10 +226,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply to for test method names that
      * have a capital after their single allowed underscore.
-     *
-     * @return void
      */
-    public function testRuleAppliesToTestMethodWithUnderscoreFollowedByCapital()
+    public function testRuleAppliesToTestMethodWithUnderscoreFollowedByCapital(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithOneViolation();

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
@@ -28,7 +28,7 @@ class CamelCaseNamespaceTest extends AbstractTestCase
     /**
      * Rule does not apply for valid namespace.
      */
-    public function testRuleDoesNotApplyForValidNamespace()
+    public function testRuleDoesNotApplyForValidNamespace(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -40,7 +40,7 @@ class CamelCaseNamespaceTest extends AbstractTestCase
     /**
      * Rule does apply for incorrect namespace.
      */
-    public function testRuleDoesApplyForIncorrectNamespace()
+    public function testRuleDoesApplyForIncorrectNamespace(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -52,7 +52,7 @@ class CamelCaseNamespaceTest extends AbstractTestCase
     /**
      * Rule does not apply for namespace with uppercase abbreviation.
      */
-    public function testRuleDoesNotApplyForNamespaceWithUppercaseAbbreviation()
+    public function testRuleDoesNotApplyForNamespaceWithUppercaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -64,7 +64,7 @@ class CamelCaseNamespaceTest extends AbstractTestCase
     /**
      * Rule does apply for namespace with uppercase abbreviation.
      */
-    public function testRuleDoesApplyForNamespaceWithUppercaseAbbreviation()
+    public function testRuleDoesApplyForNamespaceWithUppercaseAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -77,7 +77,7 @@ class CamelCaseNamespaceTest extends AbstractTestCase
     /**
      * Rule does not apply for invalid namespace in exception list.
      */
-    public function testRuleDoesNotApplyForNamespaceInException()
+    public function testRuleDoesNotApplyForNamespaceInException(): void
     {
         $report = $this->getReportWithNoViolation();
 

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
@@ -28,10 +28,8 @@ class CamelCaseParameterNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does apply for an invalid parameter name
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForInParameterNameWithUnderscore()
+    public function testRuleDoesApplyForInParameterNameWithUnderscore(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -45,10 +43,8 @@ class CamelCaseParameterNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does apply for all caps abbreviation when not allowed
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForAllCapsAbbreviation()
+    public function testRuleDoesApplyForAllCapsAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -63,10 +59,8 @@ class CamelCaseParameterNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does not apply for camelcase abbreviation
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForCamelcaseAbbreviation()
+    public function testRuleDoesNotApplyForCamelcaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -82,10 +76,8 @@ class CamelCaseParameterNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for an invalid parameter name
      * starting with a capital.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForParameterNameWithCapital()
+    public function testRuleDoesApplyForParameterNameWithCapital(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -99,10 +91,8 @@ class CamelCaseParameterNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does NOT apply for a valid parameter name
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidParameterName()
+    public function testRuleDoesNotApplyForValidParameterName(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -117,10 +107,8 @@ class CamelCaseParameterNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid parameter name
      * with an underscore at the beginning when it is allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidParameterNameWithUnderscoreWhenAllowed()
+    public function testRuleDoesNotApplyForValidParameterNameWithUnderscoreWhenAllowed(): void
     {
         $report = $this->getReportWithNoViolation();
 

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
@@ -28,10 +28,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does not apply for a valid property name.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidPropertyName()
+    public function testRuleDoesNotApplyForValidPropertyName(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -43,10 +41,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does apply for all caps abbreviation in property name.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForAllCapsAbbreviationInProperty()
+    public function testRuleDoesApplyForAllCapsAbbreviationInProperty(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -59,10 +55,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does not apply for a camelcase abbreviation in property name.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForCamelcaseAbbreviationInProperty()
+    public function testRuleDoesNotApplyForCamelcaseAbbreviationInProperty(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -76,10 +70,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a property name
      * starting with a capital.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForPropertyNameWithCapital()
+    public function testRuleDoesApplyForPropertyNameWithCapital(): void
     {
         // Test property name with capital at the beginning
         $report = $this->getReportWithOneViolation();
@@ -93,10 +85,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a property name
      * with underscores.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForPropertyNameWithUnderscores()
+    public function testRuleDoesApplyForPropertyNameWithUnderscores(): void
     {
         // Test property name with underscores
         $report = $this->getReportWithOneViolation();
@@ -110,10 +100,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid property name
      * with an underscore at the beginning when it is allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForValidPropertyNameWithUnderscoreWhenNotAllowed()
+    public function testRuleDoesApplyForValidPropertyNameWithUnderscoreWhenNotAllowed(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -126,10 +114,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid property name
      * with no underscore at the beginning when it is allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidPropertyNameWithNoUnderscoreWhenAllowed()
+    public function testRuleDoesNotApplyForValidPropertyNameWithNoUnderscoreWhenAllowed(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -142,10 +128,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid property name
      * with an underscore at the beginning when it is allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidPropertyNameWithUnderscoreWhenAllowed()
+    public function testRuleDoesNotApplyForValidPropertyNameWithUnderscoreWhenAllowed(): void
     {
         $report = $this->getReportWithNoViolation();
 

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
@@ -28,10 +28,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does apply for an invalid variable name
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForInvariableNameWithUnderscore()
+    public function testRuleDoesApplyForInvariableNameWithUnderscore(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -44,10 +42,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for variable name
      * with all caps abbreviation.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForAllCapsAbbreviation()
+    public function testRuleDoesApplyForAllCapsAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -61,10 +57,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for variable name
      * with camelcase abbreviation.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForCamelcaseAbbreviation()
+    public function testRuleDoesNotApplyForCamelcaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -78,10 +72,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for an invalid variable name
      * starting with a capital.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForVariableNameWithCapital()
+    public function testRuleDoesApplyForVariableNameWithCapital(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -93,10 +85,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does NOT apply for a valid variable name
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidVariableName()
+    public function testRuleDoesNotApplyForValidVariableName(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -108,10 +98,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does NOT apply for a statically accessed variable
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForStaticVariableAccess()
+    public function testRuleDoesNotApplyForStaticVariableAccess(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -123,10 +111,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does NOT apply if name allowed by config
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyIfExcluded()
+    public function testRuleDoesNotApplyIfExcluded(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -139,10 +125,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid variable name
      * with an underscore at the beginning when it is allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidVariableNameWithUnderscoreWhenAllowed()
+    public function testRuleDoesNotApplyForValidVariableNameWithUnderscoreWhenAllowed(): void
     {
         $report = $this->getReportWithNoViolation();
 

--- a/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
@@ -29,10 +29,8 @@ class CyclomaticComplexityTest extends AbstractTestCase
     /**
      * Tests that the rule applies for a value greater than the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueGreaterThanThreshold()
+    public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
         $method = $this->getMethodMock('ccn2', 42);
         $report = $this->getReportWithOneViolation();
@@ -46,10 +44,8 @@ class CyclomaticComplexityTest extends AbstractTestCase
     /**
      * Test that the rule applies for a value that is equal with the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueEqualToThreshold()
+    public function testRuleAppliesForValueEqualToThreshold(): void
     {
         $method = $this->getMethodMock('ccn2', 42);
         $report = $this->getReportWithOneViolation();
@@ -63,10 +59,8 @@ class CyclomaticComplexityTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply when the value is at least one lower
      * than the threshold.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValueLowerThanThreshold()
+    public function testRuleDoesNotApplyForValueLowerThanThreshold(): void
     {
         $method = $this->getMethodMock('ccn2', 22);
         $report = $this->getReportWithNoViolation();

--- a/src/test/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
@@ -28,10 +28,8 @@ class CountInLoopExpressionTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToAllTypesOfLoops
-     *
-     * @return void
      */
-    public function testRuleAppliesToAllTypesOfLoops()
+    public function testRuleAppliesToAllTypesOfLoops(): void
     {
         $rule = new CountInLoopExpression();
         $rule->setReport($this->getReportMock(3));
@@ -40,10 +38,8 @@ class CountInLoopExpressionTest extends AbstractTestCase
 
     /**
      * testRuleNotApplyToExpressionElsewhere
-     *
-     * @return void
      */
-    public function testRuleNotApplyToExpressionElsewhere()
+    public function testRuleNotApplyToExpressionElsewhere(): void
     {
         $rule = new CountInLoopExpression();
         $rule->setReport($this->getReportWithNoViolation());
@@ -52,10 +48,8 @@ class CountInLoopExpressionTest extends AbstractTestCase
 
     /**
      * testRuleApplyToNestedLoops
-     *
-     * @return void
      */
-    public function testRuleApplyToNestedLoops()
+    public function testRuleApplyToNestedLoops(): void
     {
         $rule = new CountInLoopExpression();
         $rule->setReport($this->getReportMock(8));
@@ -64,10 +58,8 @@ class CountInLoopExpressionTest extends AbstractTestCase
 
     /**
      * testMutedRuleAtClassLevel
-     *
-     * @return void
      */
-    public function testMutedRuleAtClassLevel()
+    public function testMutedRuleAtClassLevel(): void
     {
         $rule = new CountInLoopExpression();
         $rule->setReport($this->getReportWithNoViolation());
@@ -76,10 +68,8 @@ class CountInLoopExpressionTest extends AbstractTestCase
 
     /**
      * testMutedRuleAtMethodLevel
-     *
-     * @return void
      */
-    public function testMutedRuleAtMethodLevel()
+    public function testMutedRuleAtMethodLevel(): void
     {
         $rule = new CountInLoopExpression();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
@@ -29,10 +29,8 @@ class CouplingBetweenObjectsTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToClassWithCboLessThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassWithCboLessThanThreshold()
+    public function testRuleNotAppliesToClassWithCboLessThanThreshold(): void
     {
         $rule = new CouplingBetweenObjects();
         $rule->setReport($this->getReportWithNoViolation());
@@ -42,10 +40,8 @@ class CouplingBetweenObjectsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithCboEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassWithCboEqualToThreshold()
+    public function testRuleAppliesToClassWithCboEqualToThreshold(): void
     {
         $rule = new CouplingBetweenObjects();
         $rule->setReport($this->getReportWithOneViolation());
@@ -55,10 +51,8 @@ class CouplingBetweenObjectsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithCboGreaterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassWithCboGreaterThanThreshold()
+    public function testRuleAppliesToClassWithCboGreaterThanThreshold(): void
     {
         $rule = new CouplingBetweenObjects();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
@@ -28,10 +28,8 @@ class DepthOfInheritanceTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToClassWithNumberOfParentLessThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassWithNumberOfParentLessThanThreshold()
+    public function testRuleNotAppliesToClassWithNumberOfParentLessThanThreshold(): void
     {
         $rule = new DepthOfInheritance();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class DepthOfInheritanceTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithNumberOfParentIdenticalToThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassWithNumberOfParentIdenticalToThreshold()
+    public function testRuleAppliesToClassWithNumberOfParentIdenticalToThreshold(): void
     {
         $rule = new DepthOfInheritance();
         $rule->setReport($this->getReportWithOneViolation());
@@ -54,10 +50,8 @@ class DepthOfInheritanceTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithNumberOfParentGreaterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassWithNumberOfParentGreaterThanThreshold()
+    public function testRuleAppliesToClassWithNumberOfParentGreaterThanThreshold(): void
     {
         $rule = new DepthOfInheritance();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -30,10 +30,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutSuspectFunctionCall
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithoutSuspectFunctionCall()
+    public function testRuleNotAppliesToMethodWithoutSuspectFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithNoViolation());
@@ -42,10 +40,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithSuspectFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithSuspectFunctionCall()
+    public function testRuleAppliesToMethodWithSuspectFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithOneViolation());
@@ -54,10 +50,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithMultipleSuspectFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithMultipleSuspectFunctionCall()
+    public function testRuleAppliesToMethodWithMultipleSuspectFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportMock(3));
@@ -66,10 +60,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall()
+    public function testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithOneViolation());
@@ -78,10 +70,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall()
+    public function testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportMock(3));
@@ -90,10 +80,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutSuspectFunctionCall
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithoutSuspectFunctionCall()
+    public function testRuleNotAppliesToFunctionWithoutSuspectFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithNoViolation());
@@ -102,10 +90,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithSuspectFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithSuspectFunctionCall()
+    public function testRuleAppliesToFunctionWithSuspectFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithOneViolation());
@@ -114,10 +100,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithMultipleSuspectFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithMultipleSuspectFunctionCall()
+    public function testRuleAppliesToFunctionWithMultipleSuspectFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportMock(3));
@@ -126,10 +110,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithSuspectFullyQualifiedFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithSuspectFullyQualifiedFunctionCall()
+    public function testRuleAppliesToFunctionWithSuspectFullyQualifiedFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithOneViolation());
@@ -138,10 +120,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithMultipleSuspectFullyQualifiedFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithMultipleSuspectFullyQualifiedFunctionCall()
+    public function testRuleAppliesToFunctionWithMultipleSuspectFullyQualifiedFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportMock(3));
@@ -150,10 +130,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithinNamespace
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithinNamespace()
+    public function testRuleAppliesToMethodWithinNamespace(): void
     {
         $rule = $this->getRule();
         $rule->addProperty('ignore-namespaces', 'true');
@@ -163,10 +141,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithinNamespaceByDefault
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithinNamespaceByDefault()
+    public function testRuleNotAppliesToMethodWithinNamespaceByDefault(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
+++ b/src/test/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
@@ -29,10 +29,8 @@ class EmptyCatchBlockTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutTryCatchBlock
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithoutTryCatchBlock()
+    public function testRuleNotAppliesToMethodWithoutTryCatchBlock(): void
     {
         $rule = new EmptyCatchBlock();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class EmptyCatchBlockTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithEmptyCatchBlock
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithEmptyCatchBlock()
+    public function testRuleAppliesToFunctionWithEmptyCatchBlock(): void
     {
         $rule = new EmptyCatchBlock();
         $rule->setReport($this->getReportMock(3));
@@ -53,10 +49,8 @@ class EmptyCatchBlockTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithNonEmptyCatchBlock
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithNonEmptyCatchBlock()
+    public function testRuleNotAppliesToFunctionWithNonEmptyCatchBlock(): void
     {
         $rule = new EmptyCatchBlock();
         $rule->setReport($this->getReportWithNoViolation());
@@ -65,10 +59,8 @@ class EmptyCatchBlockTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToCatchBlockWithComments
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToCatchBlockWithComments()
+    public function testRuleNotAppliesToCatchBlockWithComments(): void
     {
         $rule = new EmptyCatchBlock();
         $rule->setReport($this->getReportWithNoViolation());
@@ -77,10 +69,8 @@ class EmptyCatchBlockTest extends AbstractTestCase
 
     /**
      * testRuleWorksWithNestedTryCatchBlocksAndNonSPLExceptions
-     *
-     * @return void
      */
-    public function testRuleWorksWithNestedTryCatchBlocksAndNonSPLExceptions()
+    public function testRuleWorksWithNestedTryCatchBlocksAndNonSPLExceptions(): void
     {
         $rule = new EmptyCatchBlock();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
@@ -28,10 +28,8 @@ class EvalExpressionTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutEvalExpression
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithoutEvalExpression()
+    public function testRuleNotAppliesToMethodWithoutEvalExpression(): void
     {
         $rule = new EvalExpression();
         $rule->setReport($this->getReportWithNoViolation());
@@ -40,10 +38,8 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithEvalExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithEvalExpression()
+    public function testRuleAppliesToMethodWithEvalExpression(): void
     {
         $rule = new EvalExpression();
         $rule->setReport($this->getReportWithOneViolation());
@@ -52,10 +48,8 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToMethodWithEvalExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesMultipleTimesToMethodWithEvalExpression()
+    public function testRuleAppliesMultipleTimesToMethodWithEvalExpression(): void
     {
         $rule = new EvalExpression();
         $rule->setReport($this->getReportMock(3));
@@ -64,10 +58,8 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutEvalExpression
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithoutEvalExpression()
+    public function testRuleNotAppliesToFunctionWithoutEvalExpression(): void
     {
         $rule = new EvalExpression();
         $rule->setReport($this->getReportWithNoViolation());
@@ -76,10 +68,8 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithEvalExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithEvalExpression()
+    public function testRuleAppliesToFunctionWithEvalExpression(): void
     {
         $rule = new EvalExpression();
         $rule->setReport($this->getReportWithOneViolation());
@@ -88,10 +78,8 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToFunctionWithEvalExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesMultipleTimesToFunctionWithEvalExpression()
+    public function testRuleAppliesMultipleTimesToFunctionWithEvalExpression(): void
     {
         $rule = new EvalExpression();
         $rule->setReport($this->getReportMock(3));

--- a/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
@@ -28,10 +28,8 @@ class ExitExpressionTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutExitExpression
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithoutExitExpression()
+    public function testRuleNotAppliesToMethodWithoutExitExpression(): void
     {
         $rule = new ExitExpression();
         $rule->setReport($this->getReportWithNoViolation());
@@ -40,10 +38,8 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithExitExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithExitExpression()
+    public function testRuleAppliesToMethodWithExitExpression(): void
     {
         $rule = new ExitExpression();
         $rule->setReport($this->getReportWithOneViolation());
@@ -52,10 +48,8 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToMethodWithExitExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesMultipleTimesToMethodWithExitExpression()
+    public function testRuleAppliesMultipleTimesToMethodWithExitExpression(): void
     {
         $rule = new ExitExpression();
         $rule->setReport($this->getReportMock(3));
@@ -64,10 +58,8 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutExitExpression
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithoutExitExpression()
+    public function testRuleNotAppliesToFunctionWithoutExitExpression(): void
     {
         $rule = new ExitExpression();
         $rule->setReport($this->getReportWithNoViolation());
@@ -76,10 +68,8 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithExitExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithExitExpression()
+    public function testRuleAppliesToFunctionWithExitExpression(): void
     {
         $rule = new ExitExpression();
         $rule->setReport($this->getReportWithOneViolation());
@@ -88,10 +78,8 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToFunctionWithExitExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesMultipleTimesToFunctionWithExitExpression()
+    public function testRuleAppliesMultipleTimesToFunctionWithExitExpression(): void
     {
         $rule = new ExitExpression();
         $rule->setReport($this->getReportMock(3));

--- a/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
+++ b/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
@@ -29,10 +29,8 @@ class GotoStatementTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutGotoStatement
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithoutGotoStatement()
+    public function testRuleNotAppliesToMethodWithoutGotoStatement(): void
     {
         $rule = new GotoStatement();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class GotoStatementTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithGotoStatement
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithGotoStatement()
+    public function testRuleAppliesToMethodWithGotoStatement(): void
     {
         $rule = new GotoStatement();
         $rule->setReport($this->getReportWithOneViolation());
@@ -53,10 +49,8 @@ class GotoStatementTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutGotoStatement
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithoutGotoStatement()
+    public function testRuleNotAppliesToFunctionWithoutGotoStatement(): void
     {
         $rule = new GotoStatement();
         $rule->setReport($this->getReportWithNoViolation());
@@ -65,10 +59,8 @@ class GotoStatementTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithGotoStatement
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithGotoStatement()
+    public function testRuleAppliesToFunctionWithGotoStatement(): void
     {
         $rule = new GotoStatement();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Design/LongClassTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongClassTest.php
@@ -29,10 +29,8 @@ class LongClassTest extends AbstractTestCase
     /**
      * Tests that the rule applies for a value greater than the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueGreaterThanThreshold()
+    public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
         $class = $this->getClassMock('loc', 42);
         $report = $this->getReportWithOneViolation();
@@ -47,10 +45,8 @@ class LongClassTest extends AbstractTestCase
     /**
      * Test that the rule applies for a value that is equal with the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueEqualToThreshold()
+    public function testRuleAppliesForValueEqualToThreshold(): void
     {
         $class = $this->getClassMock('loc', 42);
         $report = $this->getReportWithOneViolation();
@@ -65,10 +61,8 @@ class LongClassTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply when the value is at least one lower
      * than the threshold.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValueLowerThanThreshold()
+    public function testRuleDoesNotApplyForValueLowerThanThreshold(): void
     {
         $class = $this->getClassMock('loc', 22);
         $report = $this->getReportWithNoViolation();
@@ -82,10 +76,8 @@ class LongClassTest extends AbstractTestCase
 
     /**
      * Tests that the rule uses eloc when ignore whitespace is set
-     *
-     * @return void
      */
-    public function testRuleUsesElocWhenIgnoreWhitespaceSet()
+    public function testRuleUsesElocWhenIgnoreWhitespaceSet(): void
     {
         $class = $this->getClassMock('eloc', 22);
         $report = $this->getReportWithNoViolation();

--- a/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
@@ -29,10 +29,8 @@ class LongMethodTest extends AbstractTestCase
     /**
      * Tests that the rule applies for a value greater than the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueGreaterThanThreshold()
+    public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
         $method = $this->getMethodMock('loc', 42);
         $report = $this->getReportWithOneViolation();
@@ -47,10 +45,8 @@ class LongMethodTest extends AbstractTestCase
     /**
      * Test that the rule applies for a value that is equal with the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueEqualToThreshold()
+    public function testRuleAppliesForValueEqualToThreshold(): void
     {
         $method = $this->getMethodMock('loc', 42);
         $report = $this->getReportWithOneViolation();
@@ -65,10 +61,8 @@ class LongMethodTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply when the value is at least one lower
      * than the threshold.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValueLowerThanThreshold()
+    public function testRuleDoesNotApplyForValueLowerThanThreshold(): void
     {
         $method = $this->getMethodMock('loc', 22);
         $report = $this->getReportWithNoViolation();
@@ -82,10 +76,8 @@ class LongMethodTest extends AbstractTestCase
 
     /**
      * Tests that the rule uses eloc when ignore whitespace is set
-     *
-     * @return void
      */
-    public function testRuleUsesElocWhenIgnoreWhitespaceSet()
+    public function testRuleUsesElocWhenIgnoreWhitespaceSet(): void
     {
         $class = $this->getClassMock('eloc', 22);
         $report = $this->getReportWithNoViolation();

--- a/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
@@ -30,10 +30,8 @@ class LongParameterListTest extends AbstractTestCase
 {
     /**
      * testApplyIgnoresMethodsWithLessParametersThanMinimum
-     *
-     * @return void
      */
-    public function testApplyIgnoresMethodsWithLessParametersThanMinimum()
+    public function testApplyIgnoresMethodsWithLessParametersThanMinimum(): void
     {
         $rule = new LongParameterList();
         $rule->setReport($this->getReportWithNoViolation());
@@ -43,10 +41,8 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyReportsMethodsWithIdenticalParametersAndMinimum
-     *
-     * @return void
      */
-    public function testApplyReportsMethodsWithIdenticalParametersAndMinimum()
+    public function testApplyReportsMethodsWithIdenticalParametersAndMinimum(): void
     {
         $rule = new LongParameterList();
         $rule->setReport($this->getReportWithOneViolation());
@@ -56,10 +52,8 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyReportsMethodsWithMoreParametersThanMinimum
-     *
-     * @return void
      */
-    public function testApplyReportsMethodsWithMoreParametersThanMinimum()
+    public function testApplyReportsMethodsWithMoreParametersThanMinimum(): void
     {
         $rule = new LongParameterList();
         $rule->setReport($this->getReportWithOneViolation());
@@ -69,10 +63,8 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyIgnoresFunctionsWithLessParametersThanMinimum
-     *
-     * @return void
      */
-    public function testApplyIgnoresFunctionsWithLessParametersThanMinimum()
+    public function testApplyIgnoresFunctionsWithLessParametersThanMinimum(): void
     {
         $rule = new LongParameterList();
         $rule->setReport($this->getReportWithNoViolation());
@@ -82,10 +74,8 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyReportsFunctionsWithIdenticalParametersAndMinimum
-     *
-     * @return void
      */
-    public function testApplyReportsFunctionsWithIdenticalParametersAndMinimum()
+    public function testApplyReportsFunctionsWithIdenticalParametersAndMinimum(): void
     {
         $rule = new LongParameterList();
         $rule->setReport($this->getReportWithOneViolation());
@@ -95,10 +85,8 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyReportsFunctionsWithMoreParametersThanMinimum
-     *
-     * @return void
      */
-    public function testApplyReportsFunctionsWithMoreParametersThanMinimum()
+    public function testApplyReportsFunctionsWithMoreParametersThanMinimum(): void
     {
         $rule = new LongParameterList();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
@@ -29,10 +29,8 @@ class NpathComplexityTest extends AbstractTestCase
     /**
      * Tests that the rule applies for a value greater than the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueGreaterThanThreshold()
+    public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
         $method = $this->getMethodMock('npath', 42);
         $report = $this->getReportWithOneViolation();
@@ -46,10 +44,8 @@ class NpathComplexityTest extends AbstractTestCase
     /**
      * Test that the rule applies for a value that is equal with the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueEqualToThreshold()
+    public function testRuleAppliesForValueEqualToThreshold(): void
     {
         $method = $this->getMethodMock('npath', 42);
         $report = $this->getReportWithOneViolation();
@@ -63,10 +59,8 @@ class NpathComplexityTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply when the value is at least one lower
      * than the threshold.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValueLowerThanThreshold()
+    public function testRuleDoesNotApplyForValueLowerThanThreshold(): void
     {
         $method = $this->getMethodMock('npath', 22);
         $report = $this->getReportWithNoViolation();

--- a/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
@@ -28,10 +28,8 @@ class NumberOfChildrenTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToClassWithChildrenLessThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassWithChildrenLessThanThreshold()
+    public function testRuleNotAppliesToClassWithChildrenLessThanThreshold(): void
     {
         $rule = new NumberOfChildren();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class NumberOfChildrenTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithChildrenIdenticalToThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassWithChildrenIdenticalToThreshold()
+    public function testRuleAppliesToClassWithChildrenIdenticalToThreshold(): void
     {
         $rule = new NumberOfChildren();
         $rule->setReport($this->getReportWithOneViolation());
@@ -54,10 +50,8 @@ class NumberOfChildrenTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithChildrenGreaterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassWithChildrenGreaterThanThreshold()
+    public function testRuleAppliesToClassWithChildrenGreaterThanThreshold(): void
     {
         $rule = new NumberOfChildren();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
@@ -28,10 +28,8 @@ class TooManyFieldsTest extends AbstractTestCase
 {
     /**
      * testRuleDoesNotApplyToClassesWithLessFieldsThanThreshold
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassesWithLessFieldsThanThreshold()
+    public function testRuleDoesNotApplyToClassesWithLessFieldsThanThreshold(): void
     {
         $rule = new TooManyFields();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class TooManyFieldsTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToClassesWithSameNumberOfFieldsAsThreshold
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassesWithSameNumberOfFieldsAsThreshold()
+    public function testRuleDoesNotApplyToClassesWithSameNumberOfFieldsAsThreshold(): void
     {
         $rule = new TooManyFields();
         $rule->setReport($this->getReportWithNoViolation());
@@ -54,10 +50,8 @@ class TooManyFieldsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassesWithMoreFieldsThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassesWithMoreFieldsThanThreshold()
+    public function testRuleAppliesToClassesWithMoreFieldsThanThreshold(): void
     {
         $rule = new TooManyFields();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -29,10 +29,8 @@ class TooManyMethodsTest extends AbstractTestCase
 {
     /**
      * testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold()
+    public function testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -43,10 +41,8 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold()
+    public function testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -57,10 +53,8 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassesWithMoreMethodsThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassesWithMoreMethodsThanThreshold()
+    public function testRuleAppliesToClassesWithMoreMethodsThanThreshold(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithOneViolation());
@@ -71,10 +65,8 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresGetterMethodsInTest
-     *
-     * @return void
      */
-    public function testRuleIgnoresGetterMethodsInTest()
+    public function testRuleIgnoresGetterMethodsInTest(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -85,10 +77,8 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresSetterMethodsInTest
-     *
-     * @return void
      */
-    public function testRuleIgnoresSetterMethodsInTest()
+    public function testRuleIgnoresSetterMethodsInTest(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -99,10 +89,8 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven
-     *
-     * @return void
      */
-    public function testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven()
+    public function testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -113,10 +101,8 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresGetterAndSetterMethodsInTest
-     *
-     * @return void
      */
-    public function testRuleIgnoresGetterAndSetterMethodsInTest()
+    public function testRuleIgnoresGetterAndSetterMethodsInTest(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -125,10 +111,7 @@ class TooManyMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(3, ['invoke', 'getClass', 'setClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresHassers()
+    public function testRuleIgnoresHassers(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -137,10 +120,7 @@ class TooManyMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'hasClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresIssers()
+    public function testRuleIgnoresIssers(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -149,10 +129,7 @@ class TooManyMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'isClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresWithers()
+    public function testRuleIgnoresWithers(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -31,10 +31,7 @@ use PHPMD\Report;
  */
 class TooManyPublicMethodsTest extends AbstractTestCase
 {
-    /**
-     * @return void
-     */
-    public function testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold()
+    public function testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -43,10 +40,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(23));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold()
+    public function testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -55,10 +49,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(42));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleAppliesToClassesWithMoreMethodsThanThreshold()
+    public function testRuleAppliesToClassesWithMoreMethodsThanThreshold(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithOneViolation());
@@ -67,10 +58,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresGetterMethodsInTest()
+    public function testRuleIgnoresGetterMethodsInTest(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -79,10 +67,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'getClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresSetterMethodsInTest()
+    public function testRuleIgnoresSetterMethodsInTest(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -91,10 +76,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'setClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven()
+    public function testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -103,10 +85,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'injectClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresGetterAndSetterMethodsInTest()
+    public function testRuleIgnoresGetterAndSetterMethodsInTest(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -115,10 +94,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(3, ['foo', 'bar'], ['baz', 'bah']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresPrivateMethods()
+    public function testRuleIgnoresPrivateMethods(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -127,10 +103,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'getClass', 'setClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresHassers()
+    public function testRuleIgnoresHassers(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -139,10 +112,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'hasClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresIssers()
+    public function testRuleIgnoresIssers(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -151,10 +121,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'isClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresWithers()
+    public function testRuleIgnoresWithers(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -163,7 +130,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'withClass']));
     }
 
-    public function testRuleApplyToBasicClass()
+    public function testRuleApplyToBasicClass(): void
     {
         $class = $this->getClass();
         $rule = new TooManyPublicMethods();

--- a/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
+++ b/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
@@ -29,10 +29,8 @@ class WeightedMethodCountTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesForValueGreaterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueGreaterThanThreshold()
+    public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
         $class = $this->getClassMock('wmc', 42);
         $report = $this->getReportWithOneViolation();
@@ -45,10 +43,8 @@ class WeightedMethodCountTest extends AbstractTestCase
 
     /**
      * testRuleAppliesForValueEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueEqualToThreshold()
+    public function testRuleAppliesForValueEqualToThreshold(): void
     {
         $class = $this->getClassMock('wmc', 42);
         $report = $this->getReportWithOneViolation();
@@ -61,10 +57,8 @@ class WeightedMethodCountTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesForValueLowerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesForValueLowerThanThreshold()
+    public function testRuleNotAppliesForValueLowerThanThreshold(): void
     {
         $class = $this->getClassMock('wmc', 42);
         $report = $this->getReportWithNoViolation();

--- a/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
+++ b/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
@@ -28,10 +28,8 @@ class ExcessivePublicCountTest extends AbstractTestCase
 {
     /**
      * testRuleDoesNotApplyToClassesWithLessPublicMembersThanThreshold
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassesWithLessPublicMembersThanThreshold()
+    public function testRuleDoesNotApplyToClassesWithLessPublicMembersThanThreshold(): void
     {
         $rule = new ExcessivePublicCount();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class ExcessivePublicCountTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassesWithSameNumberOfPublicMembersAsThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassesWithSameNumberOfPublicMembersAsThreshold()
+    public function testRuleAppliesToClassesWithSameNumberOfPublicMembersAsThreshold(): void
     {
         $rule = new ExcessivePublicCount();
         $rule->setReport($this->getReportWithOneViolation());
@@ -54,10 +50,8 @@ class ExcessivePublicCountTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassesWithMorePublicMembersThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassesWithMorePublicMembersThanThreshold()
+    public function testRuleAppliesToClassesWithMorePublicMembersThanThreshold(): void
     {
         $rule = new ExcessivePublicCount();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
@@ -29,10 +29,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToMethodStartingWithGetAndReturningBoolean
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodStartingWithGetAndReturningBoolean()
+    public function testRuleAppliesToMethodStartingWithGetAndReturningBoolean(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
@@ -42,10 +40,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodStartingWithGetAndReturningBool
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodStartingWithGetAndReturningBool()
+    public function testRuleAppliesToMethodStartingWithGetAndReturningBool(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
@@ -55,10 +51,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToPearPrivateMethodStartingWithGetAndReturningBoolean
-     *
-     * @return void
      */
-    public function testRuleAppliesToPearPrivateMethodStartingWithGetAndReturningBoolean()
+    public function testRuleAppliesToPearPrivateMethodStartingWithGetAndReturningBoolean(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
@@ -68,10 +62,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresParametersWhenNotExplicitConfigured
-     *
-     * @return void
      */
-    public function testRuleIgnoresParametersWhenNotExplicitConfigured()
+    public function testRuleIgnoresParametersWhenNotExplicitConfigured(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
@@ -81,10 +73,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesWhenParametersAreExplicitEnabled
-     *
-     * @return void
      */
-    public function testRuleNotAppliesWhenParametersAreExplicitEnabled()
+    public function testRuleNotAppliesWhenParametersAreExplicitEnabled(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'true');
@@ -95,10 +85,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodStartingWithIs
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodStartingWithIs()
+    public function testRuleNotAppliesToMethodStartingWithIs(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
@@ -109,10 +97,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodStartingWithHas
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodStartingWithHas()
+    public function testRuleNotAppliesToMethodStartingWithHas(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
@@ -123,10 +109,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithReturnTypeNotBoolean
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithReturnTypeNotBoolean()
+    public function testRuleNotAppliesToMethodWithReturnTypeNotBoolean(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');

--- a/src/test/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
@@ -28,10 +28,8 @@ class ConstantNamingConventionsTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToClassConstantWithLowerCaseCharacters
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassConstantWithLowerCaseCharacters()
+    public function testRuleAppliesToClassConstantWithLowerCaseCharacters(): void
     {
         $rule = new ConstantNamingConventions();
         $rule->setReport($this->getReportMock(2));
@@ -40,10 +38,8 @@ class ConstantNamingConventionsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToInterfaceConstantWithLowerCaseCharacters
-     *
-     * @return void
      */
-    public function testRuleAppliesToInterfaceConstantWithLowerCaseCharacters()
+    public function testRuleAppliesToInterfaceConstantWithLowerCaseCharacters(): void
     {
         $rule = new ConstantNamingConventions();
         $rule->setReport($this->getReportMock(3));
@@ -52,10 +48,8 @@ class ConstantNamingConventionsTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToClassConstantWithUpperCaseCharacters
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassConstantWithUpperCaseCharacters()
+    public function testRuleNotAppliesToClassConstantWithUpperCaseCharacters(): void
     {
         $rule = new ConstantNamingConventions();
         $rule->setReport($this->getReportWithNoViolation());
@@ -64,10 +58,8 @@ class ConstantNamingConventionsTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToInterfaceConstantWithUpperCaseCharacters
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToInterfaceConstantWithUpperCaseCharacters()
+    public function testRuleNotAppliesToInterfaceConstantWithUpperCaseCharacters(): void
     {
         $rule = new ConstantNamingConventions();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
@@ -28,10 +28,8 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToConstructorMethodNamedAsEnclosingClass
-     *
-     * @return void
      */
-    public function testRuleAppliesToConstructorMethodNamedAsEnclosingClass()
+    public function testRuleAppliesToConstructorMethodNamedAsEnclosingClass(): void
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
         $rule->setReport($this->getReportWithOneViolation());
@@ -40,10 +38,8 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToConstructorMethodNamedAsEnclosingClassCaseInsensitive
-     *
-     * @return void
      */
-    public function testRuleAppliesToConstructorMethodNamedAsEnclosingClassCaseInsensitive()
+    public function testRuleAppliesToConstructorMethodNamedAsEnclosingClassCaseInsensitive(): void
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
         $rule->setReport($this->getReportWithOneViolation());
@@ -52,24 +48,22 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodNamedSimilarToEnclosingClass
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodNamedSimilarToEnclosingClass()
+    public function testRuleNotAppliesToMethodNamedSimilarToEnclosingClass(): void
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToMethodNamedAsEnclosingInterface()
+    public function testRuleNotAppliesToMethodNamedAsEnclosingInterface(): void
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToMethodInNamespaces()
+    public function testRuleNotAppliesToMethodInNamespaces(): void
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Rule/Naming/LongClassNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/LongClassNameTest.php
@@ -28,10 +28,8 @@ class LongClassNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does not apply to class name length (43) below threshold (44)
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassNameBelowThreshold()
+    public function testRuleNotAppliesToClassNameBelowThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 44);
@@ -41,10 +39,8 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to class name length (40) below threshold (39)
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassNameAboveThreshold()
+    public function testRuleAppliesToClassNameAboveThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 39);
@@ -54,10 +50,8 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does not apply to interface name length (47) below threshold (47)
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToInterfaceNameBelowThreshold()
+    public function testRuleNotAppliesToInterfaceNameBelowThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 47);
@@ -67,10 +61,8 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to class name length (44) above threshold (43)
-     *
-     * @return void
      */
-    public function testRuleAppliesToInterfaceNameAboveThreshold()
+    public function testRuleAppliesToInterfaceNameAboveThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 43);
@@ -80,10 +72,8 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to trait name length (40) above threshold (39)
-     *
-     * @return void
      */
-    public function testRuleAppliesToTraitNameAboveThreshold()
+    public function testRuleAppliesToTraitNameAboveThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 39);
@@ -93,10 +83,8 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to enum name length (39) above threshold (38)
-     *
-     * @return void
      */
-    public function testRuleAppliesToEnumNameAboveThreshold()
+    public function testRuleAppliesToEnumNameAboveThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 38);
@@ -107,10 +95,8 @@ class LongClassNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply to class name length (69) below threshold (60)
      * with configured suffix length (9)
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassNameLengthWithSuffixSubtractedBelowThreshold()
+    public function testRuleNotAppliesToClassNameLengthWithSuffixSubtractedBelowThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 60);
@@ -121,10 +107,8 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to class name length (66) above threshold (56) with configured suffix length (9)
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassNameLengthWithSuffixSubtractedAboveThreshold()
+    public function testRuleAppliesToClassNameLengthWithSuffixSubtractedAboveThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 56);
@@ -136,10 +120,8 @@ class LongClassNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply to class name length (55) below threshold (54)
      * not matching configured suffix length (9)
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassNameLengthWithoutSuffixSubtracted()
+    public function testRuleAppliesToClassNameLengthWithoutSuffixSubtracted(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 54);
@@ -151,10 +133,8 @@ class LongClassNameTest extends AbstractTestCase
     /**
      * Tests that the rule applies to class name length (43) below threshold (40)
      * not matching configured prefix length (15)
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassNameWithPrefixMatched()
+    public function testRuleAppliesToClassNameWithPrefixMatched(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 45);

--- a/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
@@ -28,10 +28,8 @@ class LongVariableTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToLocalVariableInFunctionWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToLocalVariableInFunctionWithNameLongerThanThreshold()
+    public function testRuleAppliesToLocalVariableInFunctionWithNameLongerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 21);
@@ -41,10 +39,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInFunctionWithNameSmallerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInFunctionWithNameSmallerThanThreshold()
+    public function testRuleNotAppliesToLocalVariableInFunctionWithNameSmallerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 6);
@@ -54,10 +50,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold()
+    public function testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 6);
@@ -67,10 +61,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionParameterWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionParameterWithNameLongerThanThreshold()
+    public function testRuleAppliesToFunctionParameterWithNameLongerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -80,10 +72,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionParameterWithNameSmallerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionParameterWithNameSmallerThanThreshold()
+    public function testRuleNotAppliesToFunctionParameterWithNameSmallerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -93,10 +83,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToLocalVariableInMethodWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToLocalVariableInMethodWithNameLongerThanThreshold()
+    public function testRuleAppliesToLocalVariableInMethodWithNameLongerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -112,10 +100,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold()
+    public function testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 6);
@@ -125,10 +111,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInMethodWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInMethodWithNameShorterThanThreshold()
+    public function testRuleNotAppliesToLocalVariableInMethodWithNameShorterThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -138,10 +122,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodParameterWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodParameterWithNameLongerThanThreshold()
+    public function testRuleAppliesToMethodParameterWithNameLongerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 3);
@@ -157,10 +139,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodParameterWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodParameterWithNameShorterThanThreshold()
+    public function testRuleNotAppliesToMethodParameterWithNameShorterThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -170,10 +150,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFieldWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFieldWithNameLongerThanThreshold()
+    public function testRuleAppliesToFieldWithNameLongerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -183,10 +161,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFieldWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFieldWithNameEqualToThreshold()
+    public function testRuleNotAppliesToFieldWithNameEqualToThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 6);
@@ -196,10 +172,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFieldWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFieldWithNameShorterThanThreshold()
+    public function testRuleNotAppliesToFieldWithNameShorterThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 8);
@@ -209,10 +183,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFieldAndParameterWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFieldAndParameterWithNameLongerThanThreshold()
+    public function testRuleAppliesToFieldAndParameterWithNameLongerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 3);
@@ -228,10 +200,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToStaticMembersAccessedInMethod
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToStaticMembersAccessedInMethod()
+    public function testRuleNotAppliesToStaticMembersAccessedInMethod(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 3);
@@ -241,10 +211,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToIdenticalVariableOnlyOneTime
-     *
-     * @return void
      */
-    public function testRuleAppliesToIdenticalVariableOnlyOneTime()
+    public function testRuleAppliesToIdenticalVariableOnlyOneTime(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -254,10 +222,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes
-     *
-     * @return void
      */
-    public function testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes()
+    public function testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -274,10 +240,9 @@ class LongVariableTest extends AbstractTestCase
     /**
      * testRuleAppliesForLongPrivateProperty
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testRuleAppliesForLongPrivateProperty()
+    public function testRuleAppliesForLongPrivateProperty(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -288,10 +253,9 @@ class LongVariableTest extends AbstractTestCase
     /**
      * testRuleAppliesForLongPrivateStaticProperty
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testRuleAppliesForLongPrivateStaticProperty()
+    public function testRuleAppliesForLongPrivateStaticProperty(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -301,10 +265,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToVariableNameSmallerThanThresholdWithSuffixSubtracted
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToVariableNameSmallerThanThresholdWithSuffixSubtracted()
+    public function testRuleNotAppliesToVariableNameSmallerThanThresholdWithSuffixSubtracted(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 10);
@@ -315,10 +277,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameLongerThanThresholdWithSuffixSubtracted
-     *
-     * @return void
      */
-    public function testRuleAppliesToVariableNameLongerThanThresholdWithSuffixSubtracted()
+    public function testRuleAppliesToVariableNameLongerThanThresholdWithSuffixSubtracted(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 9);
@@ -329,10 +289,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameLongerThanThresholdWithMultipleSuffixesDefined
-     *
-     * @return void
      */
-    public function testRuleAppliesToVariableNameLongerThanThresholdWithMultipleSuffixesDefined()
+    public function testRuleAppliesToVariableNameLongerThanThresholdWithMultipleSuffixesDefined(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 19);
@@ -343,10 +301,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameSuffixIsNotSubtractedWhenNotASuffix
-     *
-     * @return void
      */
-    public function testRuleAppliesToVariableNameSuffixIsNotSubtractedWhenNotASuffix()
+    public function testRuleAppliesToVariableNameSuffixIsNotSubtractedWhenNotASuffix(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 24);
@@ -357,10 +313,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameWithEmptySubtractSuffixes
-     *
-     * @return void
      */
-    public function testRuleAppliesToVariableNameWithEmptySubtractSuffixes()
+    public function testRuleAppliesToVariableNameWithEmptySubtractSuffixes(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 20);
@@ -371,10 +325,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameFollowingHungarianNotation
-     *
-     * @return void
      */
-    public function testRuleAppliesToVariableNameFollowingHungarianNotation()
+    public function testRuleAppliesToVariableNameFollowingHungarianNotation(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 12);

--- a/src/test/php/PHPMD/Rule/Naming/ShortClassNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortClassNameTest.php
@@ -28,10 +28,8 @@ class ShortClassNameTest extends AbstractTestCase
 {
     /**
      * Tests that rule does not apply to class name length (43) above threshold (43)
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassNameAboveThreshold()
+    public function testRuleNotAppliesToClassNameAboveThreshold(): void
     {
         $rule = new ShortClassName();
         $rule->addProperty('minimum', 43);
@@ -41,10 +39,8 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule applies to class name length (40) below threshold (41)
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassNameBelowThreshold()
+    public function testRuleAppliesToClassNameBelowThreshold(): void
     {
         $rule = new ShortClassName();
         $rule->addProperty('minimum', 41);
@@ -54,10 +50,8 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule does not apply to interface name length (47) above threshold (47)
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToInterfaceNameAboveThreshold()
+    public function testRuleNotAppliesToInterfaceNameAboveThreshold(): void
     {
         $rule = new ShortClassName();
         $rule->addProperty('minimum', 47);
@@ -67,10 +61,8 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule applies for interface name length (44) below threshold (45)
-     *
-     * @return void
      */
-    public function testRuleAppliesToInterfaceNameBelowThreshold()
+    public function testRuleAppliesToInterfaceNameBelowThreshold(): void
     {
         $rule = new ShortClassName();
         $rule->addProperty('minimum', 45);
@@ -80,10 +72,8 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule does not apply for class name length (55) below threshold (61) when set in exceptions
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassNameBelowThresholdInExceptions()
+    public function testRuleNotAppliesToClassNameBelowThresholdInExceptions(): void
     {
         $rule = new ShortClassName();
         $rule->addProperty('minimum', 61);
@@ -94,10 +84,8 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule applies to class name length (55) below threshold (56) when not set in exceptions
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassNameBelowThresholdNotInExceptions()
+    public function testRuleAppliesToClassNameBelowThresholdNotInExceptions(): void
     {
         $rule = new ShortClassName();
         $rule->addProperty('minimum', 56);

--- a/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
@@ -28,10 +28,8 @@ class ShortMethodNameTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToFunctionWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithNameShorterThanThreshold()
+    public function testRuleAppliesToFunctionWithNameShorterThanThreshold(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 54);
@@ -42,10 +40,8 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithNameEqualToThreshold()
+    public function testRuleNotAppliesToFunctionWithNameEqualToThreshold(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 52);
@@ -56,10 +52,8 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithNameLongerThanThreshold()
+    public function testRuleNotAppliesToFunctionWithNameLongerThanThreshold(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 54);
@@ -70,10 +64,8 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithNameShorterThanThreshold()
+    public function testRuleAppliesToMethodWithNameShorterThanThreshold(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 52);
@@ -84,10 +76,8 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithNameEqualToThreshold()
+    public function testRuleNotAppliesToMethodWithNameEqualToThreshold(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 50);
@@ -98,10 +88,8 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithNameLongerThanThreshold()
+    public function testRuleNotAppliesToMethodWithNameLongerThanThreshold(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 52);
@@ -112,10 +100,8 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithShortNameWhenException()
+    public function testRuleNotAppliesToMethodWithShortNameWhenException(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 100);
@@ -127,12 +113,11 @@ class ShortMethodNameTest extends AbstractTestCase
     /**
      * testRuleAlsoWorksWithoutExceptionListConfigured
      *
-     * @return void
      * @link https://github.com/phpmd/phpmd/issues/80
      * @link https://github.com/phpmd/phpmd/issues/270
      * @since 2.2.2
      */
-    public function testRuleAppliesAlsoWithoutExceptionListConfiguredOnMock()
+    public function testRuleAppliesAlsoWithoutExceptionListConfiguredOnMock(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 100);
@@ -140,7 +125,7 @@ class ShortMethodNameTest extends AbstractTestCase
         $rule->apply($this->getMethodMock());
     }
 
-    public function testRuleAppliesAlsoWithoutExceptionListConfigured()
+    public function testRuleAppliesAlsoWithoutExceptionListConfigured(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 100);

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -28,10 +28,8 @@ class ShortVariableTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToLocalVariableInFunctionWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToLocalVariableInFunctionWithNameShorterThanThreshold()
+    public function testRuleAppliesToLocalVariableInFunctionWithNameShorterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -42,10 +40,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToTryCatchBlocks
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToTryCatchBlocksInsideForeach()
+    public function testRuleNotAppliesToTryCatchBlocksInsideForeach(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -56,10 +52,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInFunctionWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInFunctionWithNameLongerThanThreshold()
+    public function testRuleNotAppliesToLocalVariableInFunctionWithNameLongerThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 2);
@@ -70,10 +64,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold()
+    public function testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -84,10 +76,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionParameterWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionParameterWithNameShorterThanThreshold()
+    public function testRuleAppliesToFunctionParameterWithNameShorterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -98,10 +88,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionParameterWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionParameterWithNameLongerThanThreshold()
+    public function testRuleNotAppliesToFunctionParameterWithNameLongerThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -112,10 +100,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToLocalVariableInMethodWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToLocalVariableInMethodWithNameShorterThanThreshold()
+    public function testRuleAppliesToLocalVariableInMethodWithNameShorterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -132,10 +118,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold()
+    public function testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -146,10 +130,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInMethodWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInMethodWithNameLongerThanThreshold()
+    public function testRuleNotAppliesToLocalVariableInMethodWithNameLongerThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 2);
@@ -160,10 +142,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodParameterWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodParameterWithNameShorterThanThreshold()
+    public function testRuleAppliesToMethodParameterWithNameShorterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -180,10 +160,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodParameterWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodParameterWithNameLongerThanThreshold()
+    public function testRuleNotAppliesToMethodParameterWithNameLongerThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 2);
@@ -194,10 +172,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFieldWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFieldWithNameShorterThanThreshold()
+    public function testRuleAppliesToFieldWithNameShorterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -208,10 +184,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFieldWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFieldWithNameEqualToThreshold()
+    public function testRuleNotAppliesToFieldWithNameEqualToThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -222,10 +196,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFieldWithNameGreaterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFieldWithNameGreaterThanThreshold()
+    public function testRuleNotAppliesToFieldWithNameGreaterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 2);
@@ -236,10 +208,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFieldAndParameterWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFieldAndParameterWithNameShorterThanThreshold()
+    public function testRuleAppliesToFieldAndParameterWithNameShorterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -256,10 +226,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToShortVariableNameAsForLoopIndex
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToShortVariableNameAsForLoopIndex()
+    public function testRuleNotAppliesToShortVariableNameAsForLoopIndex(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -270,10 +238,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToShortVariableNameAsForeachLoopIndex
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToShortVariableNameAsForeachLoopIndex()
+    public function testRuleNotAppliesToShortVariableNameAsForeachLoopIndex(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -284,10 +250,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToShortVariableNameInCatchStatement
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToShortVariableNameInCatchStatement()
+    public function testRuleNotAppliesToShortVariableNameInCatchStatement(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -298,10 +262,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToStaticMembersAccessedInMethod
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToStaticMembersAccessedInMethod()
+    public function testRuleNotAppliesToStaticMembersAccessedInMethod(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -312,10 +274,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToIdenticalVariableOnlyOneTime
-     *
-     * @return void
      */
-    public function testRuleAppliesToIdenticalVariableOnlyOneTime()
+    public function testRuleAppliesToIdenticalVariableOnlyOneTime(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -326,10 +286,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes
-     *
-     * @return void
      */
-    public function testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes()
+    public function testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -346,10 +304,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToVariablesFromExceptionsList
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToVariablesFromExceptionsList()
+    public function testRuleNotAppliesToVariablesFromExceptionsList(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -362,10 +318,9 @@ class ShortVariableTest extends AbstractTestCase
     /**
      * testRuleAppliesToVariablesWithinForeach
      *
-     * @return void
      * @dataProvider provideClassWithShortForeachVariables
      */
-    public function testRuleAppliesToVariablesWithinForeach($allowShortVarInLoop, $expectedErrorsCount)
+    public function testRuleAppliesToVariablesWithinForeach($allowShortVarInLoop, $expectedErrorsCount): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);

--- a/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -29,10 +29,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToFunctionUnusedFormalParameter
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionUnusedFormalParameter()
+    public function testRuleAppliesToFunctionUnusedFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithOneViolation());
@@ -41,10 +39,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMultipleFunctionUnusedFormalParameter
-     *
-     * @return void
      */
-    public function testRuleAppliesToMultipleFunctionUnusedFormalParameter()
+    public function testRuleAppliesToMultipleFunctionUnusedFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportMock(3));
@@ -53,10 +49,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodUnusedFormalParameter
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodUnusedFormalParameter()
+    public function testRuleAppliesToMethodUnusedFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithOneViolation());
@@ -65,10 +59,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToEnumMethodUnusedFormalParameter
-     *
-     * @return void
      */
-    public function testRuleAppliesToEnumMethodUnusedFormalParameter()
+    public function testRuleAppliesToEnumMethodUnusedFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithOneViolation());
@@ -77,10 +69,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClosureUnusedFormalParameter
-     *
-     * @return void
      */
-    public function testRuleAppliesToClosureUnusedFormalParameter()
+    public function testRuleAppliesToClosureUnusedFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithOneViolation());
@@ -89,10 +79,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMultipleMethodUnusedFormalParameter
-     *
-     * @return void
      */
-    public function testRuleAppliesToMultipleMethodUnusedFormalParameter()
+    public function testRuleAppliesToMultipleMethodUnusedFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportMock(2));
@@ -110,10 +98,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleAppliesToFormalParameterWhenSimilarStaticMemberIsAccessed()
+    public function testRuleAppliesToFormalParameterWhenSimilarStaticMemberIsAccessed(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithOneViolation());
@@ -130,10 +116,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFormalParameterUsedInPropertyCompoundVariable()
+    public function testRuleNotAppliesToFormalParameterUsedInPropertyCompoundVariable(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -150,10 +134,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFormalParameterUsedInMethodCompoundVariable()
+    public function testRuleNotAppliesToFormalParameterUsedInMethodCompoundVariable(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -162,10 +144,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToAbstractMethodFormalParameter
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToAbstractMethodFormalParameter()
+    public function testRuleDoesNotApplyToAbstractMethodFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -174,10 +154,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToInterfaceMethodFormalParameter
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToInterfaceMethodFormalParameter()
+    public function testRuleDoesNotApplyToInterfaceMethodFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -186,10 +164,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToInnerFunctionDeclaration
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToInnerFunctionDeclaration()
+    public function testRuleDoesNotApplyToInnerFunctionDeclaration(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -207,10 +183,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToFormalParameterUsedInCompoundExpression()
+    public function testRuleDoesNotApplyToFormalParameterUsedInCompoundExpression(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -227,10 +201,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToMethodArgument()
+    public function testRuleDoesNotApplyToMethodArgument(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -239,10 +211,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToMethodArgumentUsedAsArrayIndex
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToMethodArgumentUsedAsArrayIndex()
+    public function testRuleDoesNotApplyToMethodArgumentUsedAsArrayIndex(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -259,10 +229,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToParameterUsedAsArrayIndex()
+    public function testRuleDoesNotApplyToParameterUsedAsArrayIndex(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -279,10 +247,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToParameterUsedAsStringIndex()
+    public function testRuleDoesNotApplyToParameterUsedAsStringIndex(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -303,10 +269,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToMethodWithFuncGetArgs()
+    public function testRuleDoesNotApplyToMethodWithFuncGetArgs(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -315,10 +279,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
-     * @return void
      * @since 2.0.0
      */
-    public function testFuncGetArgsRuleWorksCaseInsensitive()
+    public function testFuncGetArgsRuleWorksCaseInsensitive(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -328,10 +291,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
     /**
      * testRuleDoesNotApplyToInheritMethod
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testRuleDoesNotApplyToInheritMethod()
+    public function testRuleDoesNotApplyToInheritMethod(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -341,10 +303,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
     /**
      * testRuleDoesNotApplyToImplementedAbstractMethod
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testRuleDoesNotApplyToImplementedAbstractMethod()
+    public function testRuleDoesNotApplyToImplementedAbstractMethod(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -354,10 +315,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
     /**
      * testRuleDoesNotApplyToImplementedInterfaceMethod
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testRuleDoesNotApplyToImplementedInterfaceMethod()
+    public function testRuleDoesNotApplyToImplementedInterfaceMethod(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -366,10 +326,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToMagicMethod
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToMagicMethod()
+    public function testRuleDoesNotApplyToMagicMethod(): void
     {
         $methods = array_filter(
             $this->getClass()->getMethods(),
@@ -384,7 +342,7 @@ class UnusedFormalParameterTest extends AbstractTestCase
     /**
      * testRuleDoesNotApplyToMethodWithInheritdocAnnotation
      */
-    public function testRuleDoesNotApplyToMethodWithInheritdocAnnotation()
+    public function testRuleDoesNotApplyToMethodWithInheritdocAnnotation(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -394,7 +352,7 @@ class UnusedFormalParameterTest extends AbstractTestCase
     /**
      * testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase
      */
-    public function testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase()
+    public function testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -403,10 +361,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
-     * @return void
      * @since 2.0.0
      */
-    public function testCompactFunctionRuleDoesNotApply()
+    public function testCompactFunctionRuleDoesNotApply(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -415,10 +372,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
-     * @return void
      * @since 2.0.0
      */
-    public function testCompactFunctionRuleOnlyAppliesToUsedParameters()
+    public function testCompactFunctionRuleOnlyAppliesToUsedParameters(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportMock(2));
@@ -427,10 +383,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
-     * @return void
      * @since 2.0.0
      */
-    public function testCompactFunctionRuleWorksCaseInsensitive()
+    public function testCompactFunctionRuleWorksCaseInsensitive(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -439,10 +394,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
-     * @return void
      * @since 2.0.1
      */
-    public function testNamespacedCompactFunctionRuleDoesNotApply()
+    public function testNamespacedCompactFunctionRuleDoesNotApply(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -451,10 +405,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
-     * @return void
      * @since 2.0.1
      */
-    public function testNamespacedCompactFunctionRuleOnlyAppliesToUsedParameters()
+    public function testNamespacedCompactFunctionRuleOnlyAppliesToUsedParameters(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportMock(2));
@@ -463,10 +416,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * @test
-     * @return void
      * @since 2.0.1
      */
-    public function testNamespacedCompactFunctionRuleWorksCaseInsensitive()
+    public function testNamespacedCompactFunctionRuleWorksCaseInsensitive(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -483,10 +435,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToFormalParameterUsedInStringCompoundVariable()
+    public function testRuleDoesNotApplyToFormalParameterUsedInStringCompoundVariable(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -507,10 +457,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToFormalParameterUsedAsParameterInStringCompoundVariable()
+    public function testRuleDoesNotApplyToFormalParameterUsedAsParameterInStringCompoundVariable(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -525,10 +473,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     public function __construct(private string $foo) {}
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPropertyPromotionParameters()
+    public function testRuleDoesNotApplyToPropertyPromotionParameters(): void
     {
         $methods = array_filter(
             $this->getClass()->getMethods(),

--- a/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
@@ -57,10 +57,9 @@ class UnusedLocalVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getApplyingCases
      */
-    public function testRuleAppliesTo($file)
+    public function testRuleAppliesTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule($file), static::ONE_VIOLATION, $file);
     }
@@ -69,10 +68,9 @@ class UnusedLocalVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getNotApplyingCases
      */
-    public function testRuleDoesNotApplyTo($file)
+    public function testRuleDoesNotApplyTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule($file), static::NO_VIOLATION, $file);
     }

--- a/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
@@ -28,10 +28,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToUnusedPrivateField
-     *
-     * @return void
      */
-    public function testRuleAppliesToUnusedPrivateField()
+    public function testRuleAppliesToUnusedPrivateField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -40,10 +38,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToUnusedPrivateStaticField
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenFieldWithSameNameIsAccessedOnDifferentObject()
+    public function testRuleAppliesWhenFieldWithSameNameIsAccessedOnDifferentObject(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -52,10 +48,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToUnusedPrivateStaticField
-     *
-     * @return void
      */
-    public function testRuleAppliesToUnusedPrivateStaticField()
+    public function testRuleAppliesToUnusedPrivateStaticField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -64,10 +58,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnDifferentClass
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnDifferentClass()
+    public function testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnDifferentClass(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -76,10 +68,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnParent
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnParent()
+    public function testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnParent(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -98,10 +88,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenLocalVariableIsUsedInStaticMemberPrefix()
+    public function testRuleAppliesWhenLocalVariableIsUsedInStaticMemberPrefix(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -120,10 +108,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotResultInFatalErrorByCallingNonObject()
+    public function testRuleDoesNotResultInFatalErrorByCallingNonObject(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -132,10 +118,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToUnusedPublicField
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToUnusedPublicField()
+    public function testRuleDoesNotApplyToUnusedPublicField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -144,10 +128,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToUnusedProtectedField
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToUnusedProtectedField()
+    public function testRuleDoesNotApplyToUnusedProtectedField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -156,10 +138,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToThisAccessedPrivateField
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToThisAccessedPrivateField()
+    public function testRuleDoesNotApplyToThisAccessedPrivateField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -168,10 +148,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToSelfAccessedPrivateField
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToSelfAccessedPrivateField()
+    public function testRuleDoesNotApplyToSelfAccessedPrivateField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -180,10 +158,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToStaticAccessedPrivateField
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToStaticAccessedPrivateField()
+    public function testRuleDoesNotApplyToStaticAccessedPrivateField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -192,10 +168,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToClassNameAccessedPrivateField
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassNameAccessedPrivateField()
+    public function testRuleDoesNotApplyToClassNameAccessedPrivateField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -214,10 +188,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateFieldInChainedMethodCall()
+    public function testRuleDoesNotApplyToPrivateFieldInChainedMethodCall(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -236,10 +208,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateArrayFieldAccess()
+    public function testRuleDoesNotApplyToPrivateArrayFieldAccess(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -258,10 +228,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateStringIndexFieldAccess()
+    public function testRuleDoesNotApplyToPrivateStringIndexFieldAccess(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -270,10 +238,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToFieldWithMethodsThatReturnArray
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToFieldWithMethodsThatReturnArray()
+    public function testRuleDoesNotApplyToFieldWithMethodsThatReturnArray(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
@@ -28,10 +28,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToUnusedPrivateMethod
-     *
-     * @return void
      */
-    public function testRuleAppliesToUnusedPrivateMethod()
+    public function testRuleAppliesToUnusedPrivateMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -40,10 +38,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToUnusedStaticPrivateMethod
-     *
-     * @return void
      */
-    public function testRuleAppliesToUnusedStaticPrivateMethod()
+    public function testRuleAppliesToUnusedStaticPrivateMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -52,10 +48,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToParentReferencedUnusedPrivateMethod
-     *
-     * @return void
      */
-    public function testRuleAppliesToParentReferencedUnusedPrivateMethod()
+    public function testRuleAppliesToParentReferencedUnusedPrivateMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -64,10 +58,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenMethodIsReferencedOnDifferentObject
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenMethodIsReferencedOnDifferentObject()
+    public function testRuleAppliesWhenMethodIsReferencedOnDifferentObject(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -76,10 +68,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenMethodIsReferencedOnDifferentClass
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenMethodIsReferencedOnDifferentClass()
+    public function testRuleAppliesWhenMethodIsReferencedOnDifferentClass(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -88,10 +78,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenPropertyWithSimilarNameIsReferenced
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenPropertyWithSimilarNameIsReferenced()
+    public function testRuleAppliesWhenPropertyWithSimilarNameIsReferenced(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -110,10 +98,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenMethodWithSimilarNameIsInInvocationChain()
+    public function testRuleAppliesWhenMethodWithSimilarNameIsInInvocationChain(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -122,10 +108,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToMethodUsedViaCallable
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToMethodUsedViaCallable()
+    public function testRuleDoesNotApplyToMethodUsedViaCallable(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -134,10 +118,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToPrivateConstructor
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateConstructor()
+    public function testRuleDoesNotApplyToPrivateConstructor(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -146,10 +128,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToPrivatePhp4Constructor
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivatePhp4Constructor()
+    public function testRuleDoesNotApplyToPrivatePhp4Constructor(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -158,10 +138,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToPrivateCloneMethod
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateCloneMethod()
+    public function testRuleDoesNotApplyToPrivateCloneMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -170,10 +148,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToThisReferencedMethod
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToThisReferencedMethod()
+    public function testRuleDoesNotApplyToThisReferencedMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -182,10 +158,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToSelfReferencedMethod
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToSelfReferencedMethod()
+    public function testRuleDoesNotApplyToSelfReferencedMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -194,10 +168,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToStaticReferencedMethod
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToStaticReferencedMethod()
+    public function testRuleDoesNotApplyToStaticReferencedMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -206,10 +178,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToClassNameReferencedMethod
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassNameReferencedMethod()
+    public function testRuleDoesNotApplyToClassNameReferencedMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -229,10 +199,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateMethodInChainedMethodCall()
+    public function testRuleDoesNotApplyToPrivateMethodInChainedMethodCall(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -241,10 +209,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo()
+    public function testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -42,10 +42,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetFileNameFindsXmlFileInBundledRuleSets
-     *
-     * @return void
      */
-    public function testCreateRuleSetFileNameFindsXmlFileInBundledRuleSets()
+    public function testCreateRuleSetFileNameFindsXmlFileInBundledRuleSets(): void
     {
         $factory = new RuleSetFactory();
         $ruleSet = $factory->createSingleRuleSet('codesize');
@@ -55,10 +53,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetFileNameFindsXmlFileInCurrentWorkingDirectory
-     *
-     * @return void
      */
-    public function testCreateRuleSetFileNameFindsXmlFileInCurrentWorkingDirectory()
+    public function testCreateRuleSetFileNameFindsXmlFileInCurrentWorkingDirectory(): void
     {
         self::changeWorkingDirectory('rulesets');
 
@@ -70,10 +66,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsReturnsArray
-     *
-     * @return void
      */
-    public function testCreateRuleSetsReturnsArray()
+    public function testCreateRuleSetsReturnsArray(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
         $this->assertIsArray($ruleSets);
@@ -81,10 +75,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForSingleFileReturnsArrayWithOneElement
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForSingleFileReturnsArrayWithOneElement()
+    public function testCreateRuleSetsForSingleFileReturnsArrayWithOneElement(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
         $this->assertEquals(1, count($ruleSets));
@@ -92,10 +84,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForSingleFileReturnsOneRuleSetInstance
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForSingleFileReturnsOneRuleSetInstance()
+    public function testCreateRuleSetsForSingleFileReturnsOneRuleSetInstance(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
         $this->assertInstanceOf(RuleSet::class, $ruleSets[0]);
@@ -103,10 +93,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsConfiguresExpectedRuleSetName
-     *
-     * @return void
      */
-    public function testCreateRuleSetsConfiguresExpectedRuleSetName()
+    public function testCreateRuleSetsConfiguresExpectedRuleSetName(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
         $this->assertEquals('First Test RuleSet', $ruleSets[0]->getName());
@@ -114,10 +102,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsConfiguresExpectedRuleSetName
-     *
-     * @return void
      */
-    public function testCreateRuleSetsConfiguresExpectedRuleSetDescription()
+    public function testCreateRuleSetsConfiguresExpectedRuleSetDescription(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
         $this->assertEquals('First description...', $ruleSets[0]->getDescription());
@@ -125,10 +111,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForTwoFilesReturnsArrayWithTwoElements
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForTwoFilesReturnsArrayWithTwoElements()
+    public function testCreateRuleSetsForTwoFilesReturnsArrayWithTwoElements(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles(
             'rulesets/set1.xml',
@@ -139,10 +123,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForTwoFilesReturnsExpectedRuleSetInstances
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForTwoFilesReturnsExpectedRuleSetInstances()
+    public function testCreateRuleSetsForTwoFilesReturnsExpectedRuleSetInstances(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles(
             'rulesets/set1.xml',
@@ -154,10 +136,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForTwoConfiguresExpectedRuleSetNames
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForTwoConfiguresExpectedRuleSetNames()
+    public function testCreateRuleSetsForTwoConfiguresExpectedRuleSetNames(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles(
             'rulesets/set1.xml',
@@ -169,10 +149,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForTwoConfiguresExpectedRuleSetDescriptions
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForTwoConfiguresExpectedRuleSetDescriptions()
+    public function testCreateRuleSetsForTwoConfiguresExpectedRuleSetDescriptions(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles(
             'rulesets/set1.xml',
@@ -184,10 +162,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForSingleLocalFileNameReturnsArray
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForLocalFileNameReturnsArray()
+    public function testCreateRuleSetsForLocalFileNameReturnsArray(): void
     {
         self::changeWorkingDirectory();
 
@@ -197,10 +173,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForSingleLocalFileNameReturnsArrayWithOneElement
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForLocalFileNameReturnsArrayWithOneElement()
+    public function testCreateRuleSetsForLocalFileNameReturnsArrayWithOneElement(): void
     {
         self::changeWorkingDirectory();
 
@@ -210,10 +184,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForSingleLocalFileNameConfiguresExpectedRuleSetName
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForLocalFileNameConfiguresExpectedRuleSetName()
+    public function testCreateRuleSetsForLocalFileNameConfiguresExpectedRuleSetName(): void
     {
         self::changeWorkingDirectory();
 
@@ -223,10 +195,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithReferenceContainsExpectedRuleSet
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithReferenceContainsExpectedRuleSet()
+    public function testCreateRuleSetsWithReferenceContainsExpectedRuleSet(): void
     {
         self::changeWorkingDirectory();
 
@@ -236,10 +206,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithReferenceContainsExpectedNumberOfRules
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithReferenceContainsExpectedNumberOfRules()
+    public function testCreateRuleSetsWithReferenceContainsExpectedNumberOfRules(): void
     {
         self::changeWorkingDirectory();
 
@@ -249,10 +217,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForLocalFileWithRuleSetReferenceNodes
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithReferenceContainsRuleInstances()
+    public function testCreateRuleSetsWithReferenceContainsRuleInstances(): void
     {
         self::changeWorkingDirectory();
 
@@ -262,10 +228,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithReferenceContainsExpectedRules
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithReferenceContainsExpectedRules()
+    public function testCreateRuleSetsWithReferenceContainsExpectedRules(): void
     {
         self::changeWorkingDirectory();
 
@@ -283,10 +247,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateSingleRuleSetReturnsRuleSetInstance
-     *
-     * @return void
      */
-    public function testCreateSingleRuleSetReturnsRuleSetInstance()
+    public function testCreateSingleRuleSetReturnsRuleSetInstance(): void
     {
         self::changeWorkingDirectory();
 
@@ -298,10 +260,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * Tests that the rule-set factory applies a set minimum priority filter correct.
-     *
-     * @return void
      */
-    public function testCreateRuleSetWithSpecifiedMinimumPriorityOnlyContainsMatchingRules()
+    public function testCreateRuleSetWithSpecifiedMinimumPriorityOnlyContainsMatchingRules(): void
     {
         self::changeWorkingDirectory();
 
@@ -314,10 +274,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * Tests that the rule-set factory applies a set maximum priority filter correct.
-     *
-     * @return void
      */
-    public function testCreateRuleSetWithSpecifiedMaximumPriorityOnlyContainsMatchingRules()
+    public function testCreateRuleSetWithSpecifiedMaximumPriorityOnlyContainsMatchingRules(): void
     {
         self::changeWorkingDirectory();
 
@@ -330,10 +288,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * Tests that the rule-set factory applies a set maximum priority filter correct.
-     *
-     * @return void
      */
-    public function testCreateRuleSetWithSpecifiedPrioritiesOnlyContainsMatchingRules()
+    public function testCreateRuleSetWithSpecifiedPrioritiesOnlyContainsMatchingRules(): void
     {
         self::changeWorkingDirectory();
 
@@ -347,10 +303,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleWithExcludePattern
-     *
-     * @return void
      */
-    public function testCreateRuleWithExcludePattern()
+    public function testCreateRuleWithExcludePattern(): void
     {
         self::changeWorkingDirectory();
 
@@ -367,10 +321,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesPrioritySetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesPrioritySetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesPrioritySetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -383,10 +335,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleWithExpectedExample
-     *
-     * @return void
      */
-    public function testCreateRuleWithExpectedExample()
+    public function testCreateRuleWithExpectedExample(): void
     {
         self::changeWorkingDirectory();
 
@@ -399,10 +349,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleWithExpectedMultipleExamples
-     *
-     * @return void
      */
-    public function testCreateRuleWithExpectedMultipleExamples()
+    public function testCreateRuleWithExpectedMultipleExamples(): void
     {
         self::changeWorkingDirectory();
 
@@ -415,10 +363,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesDescriptionSetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesDescriptionSetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesDescriptionSetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -431,10 +377,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesPropertySetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesPropertySetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesPropertySetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -447,10 +391,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testFactorySupportsAlternativeSyntaxForPropertyValue
-     *
-     * @return void
      */
-    public function testFactorySupportsAlternativeSyntaxForPropertyValue()
+    public function testFactorySupportsAlternativeSyntaxForPropertyValue(): void
     {
         self::changeWorkingDirectory();
 
@@ -463,10 +405,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesExamplesSetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesExamplesSetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesExamplesSetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -481,10 +421,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesExamplesSetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesNameSetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesNameSetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -497,10 +435,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesMessageSetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesMessageSetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesMessageSetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -513,10 +449,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesExtInfoUrlSetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesExtInfoUrlSetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesExtInfoUrlSetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -529,10 +463,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceNotContainsExcludedRule
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceNotContainsExcludedRule()
+    public function testCreateRuleSetsWithRuleReferenceNotContainsExcludedRule(): void
     {
         self::changeWorkingDirectory();
 
@@ -545,10 +477,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceNotContainsExcludedRules
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceNotContainsExcludedRules()
+    public function testCreateRuleSetsWithRuleReferenceNotContainsExcludedRules(): void
     {
         self::changeWorkingDirectory();
 
@@ -563,10 +493,9 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Tests that the factory throws the expected exception for an invalid ruleset
      * identifier.
      *
-     * @return void
      * @covers \PHPMD\Exception\RuleSetNotFoundException
      */
-    public function testCreateRuleSetsThrowsExceptionForInvalidIdentifier()
+    public function testCreateRuleSetsThrowsExceptionForInvalidIdentifier(): void
     {
         self::expectExceptionObject(new RuleSetNotFoundException('foo-bar-ruleset-23'));
 
@@ -579,10 +508,9 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Tests that the factory throws an exception when the source code filename
      * for the configured rule does not exist.
      *
-     * @return void
      * @covers \PHPMD\Exception\RuleClassFileNotFoundException
      */
-    public function testCreateRuleSetsThrowsExceptionWhenClassFileNotInIncludePath()
+    public function testCreateRuleSetsThrowsExceptionWhenClassFileNotInIncludePath(): void
     {
         self::expectExceptionObject(new RuleClassFileNotFoundException(
             ClassFileNotFoundRule::class,
@@ -598,10 +526,9 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Tests that the factory throws the expected exception when a rule class
      * cannot be found.
      *
-     * @return void
      * @covers \PHPMD\Exception\RuleClassNotFoundException
      */
-    public function testCreateRuleSetThrowsExceptionWhenFileNotContainsClass()
+    public function testCreateRuleSetThrowsExceptionWhenFileNotContainsClass(): void
     {
         self::expectExceptionObject(new RuleClassNotFoundException(
             ClassNotFoundRule::class,
@@ -616,10 +543,9 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Tests that the factory throws the expected exception when a rule class
      * cannot be found.
      *
-     * @return void
      * @covers \PHPMD\Exception\RuleClassNotFoundException
      */
-    public function testCreateRuleSetsThrowsExpectedExceptionForInvalidXmlFile()
+    public function testCreateRuleSetsThrowsExpectedExceptionForInvalidXmlFile(): void
     {
         self::expectException(RuntimeException::class);
 
@@ -631,10 +557,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsActivatesStrictModeOnRuleSet
-     *
-     * @return void
      */
-    public function testCreateRuleSetsActivatesStrictModeOnRuleSet()
+    public function testCreateRuleSetsActivatesStrictModeOnRuleSet(): void
     {
         $fileName = self::createFileUri('rulesets/set1.xml');
 
@@ -651,10 +575,9 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Also implicitly tests (by parsing the ruleset) that
      * reference-by-includepath and explicit-classfile-declaration works.
      *
-     * @return void
      * @throws Exception
      */
-    public function testAddPHPIncludePath()
+    public function testAddPHPIncludePath(): void
     {
         $includePathBefore = get_include_path();
 
@@ -684,10 +607,9 @@ class RuleSetFactoryTest extends AbstractTestCase
     /**
      * Checks if PHPMD doesn't treat directories named as code rule as files
      *
-     * @return void
      * @link https://github.com/phpmd/phpmd/issues/47
      */
-    public function testIfGettingRuleFilePathExcludeUnreadablePaths()
+    public function testIfGettingRuleFilePathExcludeUnreadablePaths(): void
     {
         self::changeWorkingDirectory(__DIR__);
         $factory = new RuleSetFactory();
@@ -717,10 +639,9 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Checks the ruleset XML files provided with PHPMD all provide externalInfoUrls
      *
      * @param string $file The path to the ruleset xml to test
-     * @return void
      * @dataProvider getDefaultRuleSets
      */
-    public function testDefaultRuleSetsProvideExternalInfoUrls($file)
+    public function testDefaultRuleSetsProvideExternalInfoUrls($file): void
     {
         $ruleSets = $this->createRuleSetsFromFiles($file);
         $ruleSet = $ruleSets[0];

--- a/src/test/php/PHPMD/RuleSetTest.php
+++ b/src/test/php/PHPMD/RuleSetTest.php
@@ -36,10 +36,8 @@ class RuleSetTest extends AbstractTestCase
 {
     /**
      * testGetRuleByNameReturnsNullWhenNoMatchingRuleExists
-     *
-     * @return void
      */
-    public function testGetRuleByNameThrowsExceptionWhenNoMatchingRuleExists()
+    public function testGetRuleByNameThrowsExceptionWhenNoMatchingRuleExists(): void
     {
         self::expectException(RuleByNameNotFoundException::class);
 
@@ -49,10 +47,8 @@ class RuleSetTest extends AbstractTestCase
 
     /**
      * testGetRuleByNameReturnsMatchingRuleInstance
-     *
-     * @return void
      */
-    public function testGetRuleByNameReturnsMatchingRuleInstance()
+    public function testGetRuleByNameReturnsMatchingRuleInstance(): void
     {
         $ruleSet = $this->createRuleSetFixture(__FUNCTION__, __CLASS__, __METHOD__);
         $rule = $ruleSet->getRuleByName(__CLASS__);
@@ -62,10 +58,8 @@ class RuleSetTest extends AbstractTestCase
 
     /**
      * testApplyNotInvokesRuleWhenSuppressAnnotationExists
-     *
-     * @return void
      */
-    public function testApplyNotInvokesRuleWhenSuppressAnnotationExists()
+    public function testApplyNotInvokesRuleWhenSuppressAnnotationExists(): void
     {
         $ruleSet = $this->createRuleSetFixture(__FUNCTION__);
         $ruleSet->setReport($this->getReportWithNoViolation());
@@ -76,10 +70,8 @@ class RuleSetTest extends AbstractTestCase
 
     /**
      * testApplyInvokesRuleWhenStrictModeIsSet
-     *
-     * @return void
      */
-    public function testApplyInvokesRuleWhenStrictModeIsSet()
+    public function testApplyInvokesRuleWhenStrictModeIsSet(): void
     {
         $ruleSet = $this->createRuleSetFixture(__FUNCTION__);
         $ruleSet->setReport($this->getReportWithNoViolation());
@@ -91,7 +83,7 @@ class RuleSetTest extends AbstractTestCase
         $this->assertSame($class, $ruleSet->getRuleByName(__FUNCTION__)->node);
     }
 
-    public function testDescriptionCanBeChanged()
+    public function testDescriptionCanBeChanged(): void
     {
         $ruleSet = new RuleSet();
 
@@ -102,7 +94,7 @@ class RuleSetTest extends AbstractTestCase
         $this->assertSame('foobar', $ruleSet->getDescription());
     }
 
-    public function testStrictnessCanBeEnabled()
+    public function testStrictnessCanBeEnabled(): void
     {
         $ruleSet = new RuleSet();
 
@@ -113,7 +105,7 @@ class RuleSetTest extends AbstractTestCase
         $this->assertTrue($ruleSet->isStrict());
     }
 
-    public function testReport()
+    public function testReport(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->setReport(new Report());

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -29,11 +29,10 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetBooleanPropertyReturnsTrueForStringValue1
      *
-     * @return void
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
-    public function testGetBooleanPropertyReturnsTrueForStringValue1()
+    public function testGetBooleanPropertyReturnsTrueForStringValue1(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
@@ -45,11 +44,10 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetBooleanPropertyReturnsTrueForStringValueOn
      *
-     * @return void
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
-    public function testGetBooleanPropertyReturnsTrueForStringValueOn()
+    public function testGetBooleanPropertyReturnsTrueForStringValueOn(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
@@ -61,11 +59,10 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetBooleanPropertyReturnsTrueForStringValueTrue
      *
-     * @return void
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
-    public function testGetBooleanPropertyReturnsTrueForStringValueTrue()
+    public function testGetBooleanPropertyReturnsTrueForStringValueTrue(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
@@ -77,11 +74,10 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetBooleanPropertyReturnsTrueForDifferentStringValue
      *
-     * @return void
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
-    public function testGetBooleanPropertyReturnsTrueForDifferentStringValue()
+    public function testGetBooleanPropertyReturnsTrueForDifferentStringValue(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
@@ -93,11 +89,10 @@ class RuleTest extends AbstractTestCase
     /**
      * Tests the getBooleanProperty method with a fallback value
      *
-     * @return void
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
-    public function testGetBooleanPropertyReturnsFallbackString()
+    public function testGetBooleanPropertyReturnsFallbackString(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
@@ -108,11 +103,10 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetIntPropertyReturnsValueOfTypeInteger
      *
-     * @return void
      * @covers ::getIntProperty
      * @covers ::getProperty
      */
-    public function testGetIntPropertyReturnsValueOfTypeInteger()
+    public function testGetIntPropertyReturnsValueOfTypeInteger(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
@@ -124,11 +118,10 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
-     * @return void
      * @covers ::getIntProperty
      * @covers ::getProperty
      */
-    public function testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists()
+    public function testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists(): void
     {
         self::expectException(OutOfBoundsException::class);
 
@@ -140,11 +133,10 @@ class RuleTest extends AbstractTestCase
     /**
      * Tests the getIntProperty method with a fallback value
      *
-     * @return void
      * @covers ::getIntProperty
      * @covers ::getProperty
      */
-    public function testGetIntPropertyReturnsFallbackString()
+    public function testGetIntPropertyReturnsFallbackString(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
@@ -155,11 +147,10 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
-     * @return void
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
-    public function testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists()
+    public function testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists(): void
     {
         self::expectException(OutOfBoundsException::class);
 
@@ -171,11 +162,10 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
-     * @return void
      * @covers ::getStringProperty
      * @covers ::getProperty
      */
-    public function testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists()
+    public function testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists(): void
     {
         self::expectException(OutOfBoundsException::class);
 
@@ -187,11 +177,10 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetStringPropertyReturnsStringValue
      *
-     * @return void
      * @covers ::getStringProperty
      * @covers ::getProperty
      */
-    public function testGetStringPropertyReturnsString()
+    public function testGetStringPropertyReturnsString(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
@@ -203,11 +192,10 @@ class RuleTest extends AbstractTestCase
     /**
      * Tests the getStringProperty method with a fallback value
      *
-     * @return void
      * @covers ::getStringProperty
      * @covers ::getProperty
      */
-    public function testGetStringPropertyReturnsFallbackString()
+    public function testGetStringPropertyReturnsFallbackString(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);

--- a/src/test/php/PHPMD/RuleViolationTest.php
+++ b/src/test/php/PHPMD/RuleViolationTest.php
@@ -27,10 +27,7 @@ use PHPMD\Node\NodeInfo;
  */
 class RuleViolationTest extends AbstractTestCase
 {
-    /**
-     * @return void
-     */
-    public function testNodeInfoGetters()
+    public function testNodeInfoGetters(): void
     {
         $rule = $this->getRuleMock();
 

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -47,10 +47,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testAssignsInputArgumentToInputProperty
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testAssignsInputArgumentToInputProperty()
+    public function testAssignsInputArgumentToInputProperty(): void
     {
         $args = ['foo.php', __FILE__, 'text', 'design'];
         $opts = new CommandLineOptions($args);
@@ -59,10 +58,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @since 2.14.0
      */
-    public function testVerbose()
+    public function testVerbose(): void
     {
         $args = ['foo.php', __FILE__, 'text', 'design', '-vvv'];
         $opts = new CommandLineOptions($args);
@@ -77,10 +75,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @since 2.14.0
      */
-    public function testColored()
+    public function testColored(): void
     {
         $args = ['foo.php', __FILE__, 'text', 'design', '--color'];
         $opts = new CommandLineOptions($args);
@@ -95,10 +92,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @since 2.14.0
      */
-    public function testStdInDashShortCut()
+    public function testStdInDashShortCut(): void
     {
         $args = ['foo.php', '-', 'text', 'design'];
         $opts = new CommandLineOptions($args);
@@ -107,10 +103,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @since 2.14.0
      */
-    public function testMultipleFiles()
+    public function testMultipleFiles(): void
     {
         // What happen when calling: phpmd src/*Service.php text design
         $args = ['foo.php', 'src/FooService.php', 'src/BarService.php', 'text', 'design'];
@@ -124,10 +119,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testAssignsFormatArgumentToReportFormatProperty
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testAssignsFormatArgumentToReportFormatProperty()
+    public function testAssignsFormatArgumentToReportFormatProperty(): void
     {
         $args = ['foo.php', __FILE__, 'text', 'design'];
         $opts = new CommandLineOptions($args);
@@ -138,10 +132,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testAssignsRuleSetsArgumentToRuleSetProperty
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testAssignsRuleSetsArgumentToRuleSetProperty()
+    public function testAssignsRuleSetsArgumentToRuleSetProperty(): void
     {
         $args = ['foo.php', __FILE__, 'text', 'design'];
         $opts = new CommandLineOptions($args);
@@ -152,10 +145,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testThrowsExpectedExceptionWhenRequiredArgumentsNotSet
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testThrowsExpectedExceptionWhenRequiredArgumentsNotSet()
+    public function testThrowsExpectedExceptionWhenRequiredArgumentsNotSet(): void
     {
         self::expectException(InvalidArgumentException::class);
 
@@ -166,7 +158,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
-    public function testThrowsExpectedExceptionWhenOptionNotFound()
+    public function testThrowsExpectedExceptionWhenOptionNotFound(): void
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage(
@@ -183,7 +175,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
-    public function testThrowsExpectedExceptionWhenOptionNotFoundInFront()
+    public function testThrowsExpectedExceptionWhenOptionNotFoundInFront(): void
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage(
@@ -200,7 +192,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
-    public function testThrowsExpectedExceptionWhenOptionNotFoundUsingArgumentSeparator()
+    public function testThrowsExpectedExceptionWhenOptionNotFoundUsingArgumentSeparator(): void
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage(
@@ -217,7 +209,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
-    public function testThrowsExpectedExceptionWhenBooleanOptionReceiveValue()
+    public function testThrowsExpectedExceptionWhenBooleanOptionReceiveValue(): void
     {
         self::expectExceptionObject(new InvalidArgumentException(
             '--color option does not accept a value',
@@ -230,7 +222,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
-    public function testOptionEqualSyntax()
+    public function testOptionEqualSyntax(): void
     {
         $args = [__FILE__, '--exclude=*/vendor/*', '-', 'text', 'design'];
         $opts = new CommandLineOptions($args);
@@ -241,7 +233,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
-    public function testArgumentSeparatorEnforced()
+    public function testArgumentSeparatorEnforced(): void
     {
         $args = [__FILE__, '--', '--help', 'text', 'design'];
         $opts = new CommandLineOptions($args);
@@ -252,10 +244,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testAssignsInputFileOptionToInputPathProperty
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testAssignsInputFileOptionToInputPathProperty()
+    public function testAssignsInputFileOptionToInputPathProperty(): void
     {
         $uri = self::createResourceUriForTest('inputfile.txt');
 
@@ -268,10 +259,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testAssignsFormatArgumentCorrectWhenCalledWithInputFile
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testAssignsFormatArgumentCorrectWhenCalledWithInputFile()
+    public function testAssignsFormatArgumentCorrectWhenCalledWithInputFile(): void
     {
         $uri = self::createResourceUriForTest('inputfile.txt');
 
@@ -284,10 +274,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testAssignsRuleSetsArgumentCorrectWhenCalledWithInputFile
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testAssignsRuleSetsArgumentCorrectWhenCalledWithInputFile()
+    public function testAssignsRuleSetsArgumentCorrectWhenCalledWithInputFile(): void
     {
         $uri = self::createResourceUriForTest('inputfile.txt');
 
@@ -300,10 +289,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testThrowsExpectedExceptionWhenInputFileNotExists
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testThrowsExpectedExceptionWhenInputFileNotExists()
+    public function testThrowsExpectedExceptionWhenInputFileNotExists(): void
     {
         self::expectExceptionObject(new InvalidArgumentException(
             "Input file 'inputfail.txt' not exists.",
@@ -315,10 +303,8 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * testHasVersionReturnsFalseByDefault
-     *
-     * @return void
      */
-    public function testHasVersionReturnsFalseByDefault()
+    public function testHasVersionReturnsFalseByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'unusedcode'];
         $opts = new CommandLineOptions($args);
@@ -328,10 +314,8 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * testCliOptionsAcceptsVersionArgument
-     *
-     * @return void
      */
-    public function testCliOptionsAcceptsVersionArgument()
+    public function testCliOptionsAcceptsVersionArgument(): void
     {
         $args = [__FILE__, '--version'];
         $opts = new CommandLineOptions($args);
@@ -341,10 +325,8 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if ignoreErrorsOnExit returns false by default
-     *
-     * @return void
      */
-    public function testIgnoreErrorsOnExitReturnsFalseByDefault()
+    public function testIgnoreErrorsOnExitReturnsFalseByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'unusedcode'];
         $opts = new CommandLineOptions($args);
@@ -354,10 +336,8 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if CLI options accepts ignoreErrorsOnExit argument
-     *
-     * @return void
      */
-    public function testCliOptionsAcceptsIgnoreErrorsOnExitArgument()
+    public function testCliOptionsAcceptsIgnoreErrorsOnExitArgument(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'unusedcode', '--ignore-errors-on-exit'];
         $opts = new CommandLineOptions($args);
@@ -367,10 +347,8 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if CLI usage contains ignoreErrorsOnExit option
-     *
-     * @return void
      */
-    public function testCliUsageContainsIgnoreErrorsOnExitOption()
+    public function testCliUsageContainsIgnoreErrorsOnExitOption(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
@@ -380,10 +358,8 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if ignoreViolationsOnExit returns false by default
-     *
-     * @return void
      */
-    public function testIgnoreViolationsOnExitReturnsFalseByDefault()
+    public function testIgnoreViolationsOnExitReturnsFalseByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'unusedcode'];
         $opts = new CommandLineOptions($args);
@@ -393,10 +369,8 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if CLI options accepts ignoreViolationsOnExit argument
-     *
-     * @return void
      */
-    public function testCliOptionsAcceptsIgnoreViolationsOnExitArgument()
+    public function testCliOptionsAcceptsIgnoreViolationsOnExitArgument(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'unusedcode', '--ignore-violations-on-exit'];
         $opts = new CommandLineOptions($args);
@@ -406,10 +380,8 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if CLI usage contains ignoreViolationsOnExit option
-     *
-     * @return void
      */
-    public function testCliUsageContainsIgnoreViolationsOnExitOption()
+    public function testCliUsageContainsIgnoreViolationsOnExitOption(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
@@ -419,10 +391,8 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if CLI usage contains the auto-discovered renderers
-     *
-     * @return void
      */
-    public function testCliUsageContainsAutoDiscoveredRenderers()
+    public function testCliUsageContainsAutoDiscoveredRenderers(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
@@ -435,10 +405,8 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * testCliUsageContainsStrictOption
-     *
-     * @return void
      */
-    public function testCliUsageContainsStrictOption()
+    public function testCliUsageContainsStrictOption(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
@@ -449,10 +417,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testCliOptionsIsStrictReturnsFalseByDefault
      *
-     * @return void
      * @since 1.2.0
      */
-    public function testCliOptionsIsStrictReturnsFalseByDefault()
+    public function testCliOptionsIsStrictReturnsFalseByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
@@ -463,10 +430,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testCliOptionsAcceptsStrictArgument
      *
-     * @return void
      * @since 1.2.0
      */
-    public function testCliOptionsAcceptsStrictArgument()
+    public function testCliOptionsAcceptsStrictArgument(): void
     {
         $args = [__FILE__, '--strict', __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
@@ -479,10 +445,7 @@ class CommandLineOptionsTest extends AbstractTestCase
         self::assertFalse($opts->hasStrict());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionsAcceptsMinimumpriorityArgument()
+    public function testCliOptionsAcceptsMinimumpriorityArgument(): void
     {
         $args = [__FILE__, '--minimumpriority', 42, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
@@ -490,10 +453,7 @@ class CommandLineOptionsTest extends AbstractTestCase
         self::assertSame(42, $opts->getMinimumPriority());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionsAcceptsMaximumpriorityArgument()
+    public function testCliOptionsAcceptsMaximumpriorityArgument(): void
     {
         $args = [__FILE__, '--maximumpriority', 42, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
@@ -501,100 +461,70 @@ class CommandLineOptionsTest extends AbstractTestCase
         self::assertSame(42, $opts->getMaximumPriority());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionGenerateBaselineFalseByDefault()
+    public function testCliOptionGenerateBaselineFalseByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
         static::assertSame(BaselineMode::NONE, $opts->generateBaseline());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionVerbosityNormal()
+    public function testCliOptionVerbosityNormal(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
         static::assertSame(OutputInterface::VERBOSITY_NORMAL, $opts->getVerbosity());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionVerbosityVerbose()
+    public function testCliOptionVerbosityVerbose(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '-v'];
         $opts = new CommandLineOptions($args);
         static::assertSame(OutputInterface::VERBOSITY_VERBOSE, $opts->getVerbosity());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionVerbosityVeryVerbose()
+    public function testCliOptionVerbosityVeryVerbose(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '-vv'];
         $opts = new CommandLineOptions($args);
         static::assertSame(OutputInterface::VERBOSITY_VERY_VERBOSE, $opts->getVerbosity());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionVerbosityDebug()
+    public function testCliOptionVerbosityDebug(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '-vvv'];
         $opts = new CommandLineOptions($args);
         static::assertSame(OutputInterface::VERBOSITY_DEBUG, $opts->getVerbosity());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionGenerateBaselineShouldBeSet()
+    public function testCliOptionGenerateBaselineShouldBeSet(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--generate-baseline'];
         $opts = new CommandLineOptions($args);
         static::assertSame(BaselineMode::GENERATE, $opts->generateBaseline());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionUpdateBaselineShouldBeSet()
+    public function testCliOptionUpdateBaselineShouldBeSet(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--update-baseline'];
         $opts = new CommandLineOptions($args);
         static::assertSame(BaselineMode::UPDATE, $opts->generateBaseline());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionBaselineFileShouldBeNullByDefault()
+    public function testCliOptionBaselineFileShouldBeNullByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
         static::assertNull($opts->baselineFile());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionBaselineFileShouldBeWithFilename()
+    public function testCliOptionBaselineFileShouldBeWithFilename(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--baseline-file', 'foobar.txt'];
         $opts = new CommandLineOptions($args);
         static::assertSame('foobar.txt', $opts->baselineFile());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetMinimumPriorityReturnsLowestValueByDefault()
+    public function testGetMinimumPriorityReturnsLowestValueByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
@@ -602,10 +532,7 @@ class CommandLineOptionsTest extends AbstractTestCase
         self::assertSame(Rule::LOWEST_PRIORITY, $opts->getMinimumPriority());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetCoverageReportReturnsNullByDefault()
+    public function testGetCoverageReportReturnsNullByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
@@ -613,10 +540,7 @@ class CommandLineOptionsTest extends AbstractTestCase
         self::assertNull($opts->getCoverageReport());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetCoverageReportWithCliOption()
+    public function testGetCoverageReportWithCliOption(): void
     {
         $opts = new CommandLineOptions(
             [
@@ -632,10 +556,7 @@ class CommandLineOptionsTest extends AbstractTestCase
         self::assertSame(__METHOD__, $opts->getCoverageReport());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetCacheWithCliOption()
+    public function testGetCacheWithCliOption(): void
     {
         $opts = new CommandLineOptions(
             [
@@ -683,10 +604,7 @@ class CommandLineOptionsTest extends AbstractTestCase
         self::assertTrue($opts->isCacheEnabled());
     }
 
-    /**
-     * @return void
-     */
-    public function testExcludeOption()
+    public function testExcludeOption(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--ignore', 'foo/bar', '--error-file', 'abc'];
         $opts = new CommandLineOptions($args);
@@ -706,10 +624,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @param string $reportFormat
      * @param string $expectedClass
-     * @return void
      * @dataProvider dataProviderCreateRenderer
      */
-    public function testCreateRenderer($reportFormat, $expectedClass)
+    public function testCreateRenderer($reportFormat, $expectedClass): void
     {
         $args = [__FILE__, __FILE__, $reportFormat, 'codesize'];
         $opts = new CommandLineOptions($args);
@@ -764,7 +681,7 @@ class CommandLineOptionsTest extends AbstractTestCase
      * @param string $newName
      * @dataProvider dataProviderDeprecatedCliOptions
      */
-    public function testDeprecatedCliOptions($deprecatedName, $newName, Closure $result)
+    public function testDeprecatedCliOptions($deprecatedName, $newName, Closure $result): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', sprintf('--%s', $deprecatedName), '42'];
         $opts = new CommandLineOptions($args);
@@ -794,20 +711,19 @@ class CommandLineOptionsTest extends AbstractTestCase
     public static function dataProviderDeprecatedCliOptions(): array
     {
         return [
-            ['extensions', 'suffixes', static function (CommandLineOptions $opts) {
+            ['extensions', 'suffixes', static function (CommandLineOptions $opts): void {
                 self::assertSame('42', $opts->getExtensions());
             }],
-            ['ignore', 'exclude', static function (CommandLineOptions $opts) {
+            ['ignore', 'exclude', static function (CommandLineOptions $opts): void {
                 self::assertSame('42', $opts->getIgnore());
             }],
         ];
     }
 
     /**
-     * @return void
      * @dataProvider dataProviderGetReportFiles
      */
-    public function testGetReportFiles(array $options, array $expected)
+    public function testGetReportFiles(array $options, array $expected): void
     {
         $args = array_merge([__FILE__, __FILE__, 'text', 'codesize'], $options);
         $opts = new CommandLineOptions($args);
@@ -815,10 +731,7 @@ class CommandLineOptionsTest extends AbstractTestCase
         self::assertEquals($expected, $opts->getReportFiles());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionExtraLineInExcerptShouldBeWithNumber()
+    public function testCliOptionExtraLineInExcerptShouldBeWithNumber(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--extra-line-in-excerpt', '5'];
         $opts = new CommandLineOptions($args);

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -43,10 +43,9 @@ class CommandTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @dataProvider dataProviderTestMainWithOption
      */
-    public function testMainStrictOptionIsOfByDefault($sourceFile, $expectedExitCode, array $options = null)
+    public function testMainStrictOptionIsOfByDefault($sourceFile, $expectedExitCode, array $options = null): void
     {
         $args = array_filter(
             array_merge(
@@ -132,10 +131,7 @@ class CommandTest extends AbstractTestCase
         ];
     }
 
-    /**
-     * @return void
-     */
-    public function testWithMultipleReportFiles()
+    public function testWithMultipleReportFiles(): void
     {
         $args = [
             __FILE__,
@@ -168,7 +164,7 @@ class CommandTest extends AbstractTestCase
         $this->assertFileExists($sarif);
     }
 
-    public function testOutput()
+    public function testOutput(): void
     {
         $uri = realpath(self::createFileUri('source/source_with_anonymous_class.php'));
         $temp = self::createTempFileUri();
@@ -192,10 +188,9 @@ class CommandTest extends AbstractTestCase
     /**
      * @param string $option
      * @param string $value
-     * @return void
      * @dataProvider dataProviderWithFilter
      */
-    public function testWithFilter($option, $value)
+    public function testWithFilter($option, $value): void
     {
         $args = [
             __FILE__,
@@ -220,7 +215,7 @@ class CommandTest extends AbstractTestCase
         ];
     }
 
-    public function testMainGenerateBaseline()
+    public function testMainGenerateBaseline(): void
     {
         $uri = str_replace("\\", "/", realpath(self::createFileUri('source/source_with_anonymous_class.php')));
         $temp = self::createTempFileUri();
@@ -248,7 +243,7 @@ class CommandTest extends AbstractTestCase
      * - ShortVariable violation should still exist
      * - BooleanGetMethodName shouldn't be added
      */
-    public function testMainUpdateBaseline()
+    public function testMainUpdateBaseline(): void
     {
         $sourceTemp = self::createTempFileUri('ClassWithMultipleViolations.php');
         $baselineTemp = self::createTempFileUri();
@@ -275,7 +270,7 @@ class CommandTest extends AbstractTestCase
         );
     }
 
-    public function testMainBaselineViolationShouldBeIgnored()
+    public function testMainBaselineViolationShouldBeIgnored(): void
     {
         $sourceFile = realpath(static::createResourceUriForTest('Baseline/ClassWithShortVariable.php'));
         $baselineFile = realpath(static::createResourceUriForTest('Baseline/phpmd.baseline.xml'));
@@ -291,7 +286,7 @@ class CommandTest extends AbstractTestCase
         static::assertSame(Command::EXIT_SUCCESS, $exitCode);
     }
 
-    public function testMainWritesExceptionMessageToStderr()
+    public function testMainWritesExceptionMessageToStderr(): void
     {
         stream_filter_register('stderr_stream', StreamFilter::class);
 
@@ -312,7 +307,7 @@ class CommandTest extends AbstractTestCase
         );
     }
 
-    public function testMainWritesExceptionMessageToErrorFileIfSpecified()
+    public function testMainWritesExceptionMessageToErrorFileIfSpecified(): void
     {
         $file = tempnam(sys_get_temp_dir(), 'err');
 
@@ -368,7 +363,7 @@ class CommandTest extends AbstractTestCase
         );
     }
 
-    public function testOutputDeprecation()
+    public function testOutputDeprecation(): void
     {
         $file = tempnam(sys_get_temp_dir(), 'err');
 
@@ -394,7 +389,7 @@ class CommandTest extends AbstractTestCase
         );
     }
 
-    public function testMainPrintsVersionToStdout()
+    public function testMainPrintsVersionToStdout(): void
     {
         stream_filter_register('stderr_stream', StreamFilter::class);
 

--- a/src/test/php/PHPMD/Utility/PathsTest.php
+++ b/src/test/php/PHPMD/Utility/PathsTest.php
@@ -13,7 +13,7 @@ class PathsTest extends AbstractTestCase
     /**
      * @covers ::getRelativePath
      */
-    public function testGetRelativePathShouldSubtractBasePath()
+    public function testGetRelativePathShouldSubtractBasePath(): void
     {
         static::assertSame('bar/', Paths::getRelativePath('/foo', '/foo/bar/'));
     }
@@ -21,7 +21,7 @@ class PathsTest extends AbstractTestCase
     /**
      * @covers ::getRelativePath
      */
-    public function testGetRelativePathShouldTreatForwardAndBackwardSlashes()
+    public function testGetRelativePathShouldTreatForwardAndBackwardSlashes(): void
     {
         static::assertSame('text.txt', Paths::getRelativePath('\\foo/bar\\', '/foo\\bar/text.txt'));
     }
@@ -29,7 +29,7 @@ class PathsTest extends AbstractTestCase
     /**
      * @covers ::getRelativePath
      */
-    public function testGetRelativePathShouldNotSubtractOnInfixPath()
+    public function testGetRelativePathShouldNotSubtractOnInfixPath(): void
     {
         static::assertSame('/foo/bar/text.txt', Paths::getRelativePath('/bar', '/foo/bar/text.txt'));
     }
@@ -37,7 +37,7 @@ class PathsTest extends AbstractTestCase
     /**
      * @covers ::concat
      */
-    public function testConcat()
+    public function testConcat(): void
     {
         static::assertSame('pathA/pathB', Paths::concat('pathA', 'pathB'));
         static::assertSame('pathA/pathB', Paths::concat('pathA', '/pathB'));
@@ -48,7 +48,7 @@ class PathsTest extends AbstractTestCase
     /**
      * @covers ::getRealPath
      */
-    public function testGetRealPathShouldReturnTheRealPath()
+    public function testGetRealPathShouldReturnTheRealPath(): void
     {
         $path = static::createResourceUriForTest('resource.txt');
         static::assertSame(realpath($path), Paths::getRealPath($path));
@@ -57,7 +57,7 @@ class PathsTest extends AbstractTestCase
     /**
      * @covers ::getRealPath
      */
-    public function testGetRealPathShouldThrowExceptionOnFailure()
+    public function testGetRealPathShouldThrowExceptionOnFailure(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Unable to determine the realpath for: unknown/path',

--- a/src/test/php/PHPMD/Utility/StringsTest.php
+++ b/src/test/php/PHPMD/Utility/StringsTest.php
@@ -29,70 +29,56 @@ class StringsTest extends AbstractTestCase
 {
     /**
      * Tests the lengthWithoutSuffixes() method with an empty string
-     *
-     * @return void
      */
-    public function testLengthWithoutSuffixesEmptyString()
+    public function testLengthWithoutSuffixesEmptyString(): void
     {
         static::assertSame(0, Strings::lengthWithoutSuffixes('', []));
     }
 
     /**
      * Tests the lengthWithoutSuffixes() method with an empty string with list of suffixes
-     *
-     * @return void
      */
-    public function testLengthWithoutSuffixesEmptyStringWithConfiguredSubtractSuffix()
+    public function testLengthWithoutSuffixesEmptyStringWithConfiguredSubtractSuffix(): void
     {
         static::assertSame(0, Strings::lengthWithoutSuffixes('', ['Foo', 'Bar']));
     }
 
     /**
      * Tests the lengthWithoutSuffixes() method with a string not in the list of suffixes
-     *
-     * @return void
      */
-    public function testLengthWithoutSuffixesStringWithoutSubtractSuffixMatch()
+    public function testLengthWithoutSuffixesStringWithoutSubtractSuffixMatch(): void
     {
         static::assertSame(8, Strings::lengthWithoutSuffixes('UnitTest', ['Foo', 'Bar']));
     }
 
     /**
      * Tests the lengthWithoutSuffixes() method with a string in the list of suffixes
-     *
-     * @return void
      */
-    public function testLengthWithoutSuffixesStringWithSubtractSuffixMatch()
+    public function testLengthWithoutSuffixesStringWithSubtractSuffixMatch(): void
     {
         static::assertSame(4, Strings::lengthWithoutSuffixes('UnitBar', ['Foo', 'Bar']));
     }
 
     /**
      * Tests the lengthWithoutSuffixes() method with a string that should match only once for two potential matches
-     *
-     * @return void
      */
-    public function testLengthWithoutSuffixesStringWithDoubleSuffixMatchSubtractOnce()
+    public function testLengthWithoutSuffixesStringWithDoubleSuffixMatchSubtractOnce(): void
     {
         static::assertSame(7, Strings::lengthWithoutSuffixes('UnitFooBar', ['Foo', 'Bar']));
     }
 
     /**
      * Tests the lengthWithoutSuffixes() method that a Prefix should not be matched
-     *
-     * @return void
      */
-    public function testLengthWithoutSuffixesStringWithPrefixMatchShouldNotSubtract()
+    public function testLengthWithoutSuffixesStringWithPrefixMatchShouldNotSubtract(): void
     {
         static::assertSame(11, Strings::lengthWithoutSuffixes('FooUnitTest', ['Foo', 'Bar']));
     }
 
     /**
      * Tests the lengthWithoutSuffixes() method that a Prefix should be matched
-     *
-     * @return void
      */
-    public function testlengthWithPrefixesAndSuffixesStringWithPrefixMatchShouldSubtract()
+    public function testlengthWithPrefixesAndSuffixesStringWithPrefixMatchShouldSubtract(): void
     {
         static::assertSame(11, Strings::lengthWithoutSuffixes('FooUnitTest', ['Foo', 'Bar']));
         static::assertSame(8, Strings::lengthWithoutSuffixes('UnitTestFoo', ['Foo', 'Bar']));
@@ -100,10 +86,8 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the lengthWithoutPrefixesAndSuffixes() method that a Prefix should not be matched in order
-     *
-     * @return void
      */
-    public function testlengthWithPrefixesAndSuffixesStringWithPrefixesMatchShouldSubtractInOrder()
+    public function testlengthWithPrefixesAndSuffixesStringWithPrefixesMatchShouldSubtractInOrder(): void
     {
         $prefixes = ['Foo', 'Bar'];
         $suffixes = ['Foo', 'FooUnit'];
@@ -113,10 +97,8 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the splitToList() method with an empty separator
-     *
-     * @return void
      */
-    public function testSplitToListEmptySeparatorThrowsException()
+    public function testSplitToListEmptySeparatorThrowsException(): void
     {
         self::expectExceptionObject(new InvalidArgumentException(
             "Separator can't be empty string",
@@ -127,60 +109,48 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the splitToList() method with an empty string
-     *
-     * @return void
      */
-    public function testSplitToListEmptyString()
+    public function testSplitToListEmptyString(): void
     {
         static::assertSame([], Strings::splitToList('', ','));
     }
 
     /**
      * Tests the splitToList() method with a non-matching separator
-     *
-     * @return void
      */
-    public function testSplitToListStringWithoutMatchingSeparator()
+    public function testSplitToListStringWithoutMatchingSeparator(): void
     {
         static::assertSame(['UnitTest'], Strings::splitToList('UnitTest', ','));
     }
 
     /**
      * Tests the splitToList() method with a matching separator
-     *
-     * @return void
      */
-    public function testSplitToListStringWithMatchingSeparator()
+    public function testSplitToListStringWithMatchingSeparator(): void
     {
         static::assertSame(['Unit', 'Test'], Strings::splitToList('Unit,Test', ','));
     }
 
     /**
      * Tests the splitToList() method with trailing whitespace
-     *
-     * @return void
      */
-    public function testSplitToListStringTrimsLeadingAndTrailingWhitespace()
+    public function testSplitToListStringTrimsLeadingAndTrailingWhitespace(): void
     {
         static::assertSame(['Unit', 'Test'], Strings::splitToList('Unit , Test', ','));
     }
 
     /**
      * Tests the splitToList() method that it removes empty strings from list
-     *
-     * @return void
      */
-    public function testSplitToListStringRemoveEmptyStringValues()
+    public function testSplitToListStringRemoveEmptyStringValues(): void
     {
         static::assertSame(['Foo'], Strings::splitToList('Foo,,,', ','));
     }
 
     /**
      * Tests the splitToList() method that it does not remove zero values from list
-     *
-     * @return void
      */
-    public function testSplitToListStringShouldNotRemoveAZeroValue()
+    public function testSplitToListStringShouldNotRemoveAZeroValue(): void
     {
         static::assertSame(['0', '1', '2'], Strings::splitToList('0,1,2', ','));
     }

--- a/src/test/php/PHPMD/Writer/StreamWriterTest.php
+++ b/src/test/php/PHPMD/Writer/StreamWriterTest.php
@@ -13,7 +13,7 @@ class StreamWriterTest extends TestCase
     /**
      * @covers ::getStream
      */
-    public function testGetStream()
+    public function testGetStream(): void
     {
         $writer = new StreamWriter(STDOUT);
         static::assertSame(STDOUT, $writer->getStream());

--- a/src/test/php/bootstrap.php
+++ b/src/test/php/bootstrap.php
@@ -18,7 +18,7 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
 spl_autoload_register(
-    function ($class) {
+    function ($class): void {
         $file = __DIR__ . '/' . strtr($class, '\\', '/') . '.php';
         if (file_exists($file)) {
             include $file;


### PR DESCRIPTION
Type: documentation update
Breaking change: no

Depends on:
- https://github.com/phpmd/phpmd/pull/1135