### PR TITLE
[3.x] PHP CS Fixer PHPCSFixer Ruleset

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -8,6 +8,7 @@
 $config = new PhpCsFixer\Config();
 return $config
     ->setRules([
+        '@PhpCsFixer' => true, // Gets overwritten by rules below
         '@PER-CS2.0' => true,
         'binary_operator_spaces' => true, // Going beyond PER CS v2
         'ordered_class_elements' => [
@@ -93,9 +94,268 @@ return $config
         'phpdoc_trim_consecutive_blank_line_separation' => true,
         'phpdoc_types_order' => ['null_adjustment' => 'always_last'],
         'phpdoc_var_annotation_correct_order' => true,
+
+        /*
+         * PHP CS Fixer rules
+         */
+
+        // Each line of multi-line DocComments must have an asterisk [PSR-5] and must be aligned with the first one.
+        'align_multiline_comment' => true,
+        // PHP arrays should be declared using the configured syntax.
+        'array_syntax' => true,
+        // Converts backtick operators to `shell_exec` calls.
+        'backtick_to_shell_exec' => true,
+        // An empty line feed must precede any configured statement.
+        'blank_line_before_statement' => [
+            'statements' => [
+                'break',
+                'case',
+                'continue',
+                'declare',
+                'default',
+                'exit',
+                'goto',
+                'include',
+                'include_once',
+                'phpdoc',
+                'require',
+                'require_once',
+                'return',
+                'switch',
+                'throw',
+                'try',
+                'yield',
+                'yield_from'
+            ]
+        ],
+        // Class, trait and interface elements must be separated with one or none blank line.
+        'class_attributes_separation' => ['elements' => ['method' => 'one']],
+        // When referencing an internal class it must be written using the correct casing.
+        'class_reference_name_casing' => true,
+        // Namespace must not contain spacing, comments or PHPDoc.
+        'clean_namespace' => true,
+        // Using `isset($var) &&` multiple times should be done in one call.
+        'combine_consecutive_issets' => true,
+        // Calling `unset` on multiple items should be done in one call.
+        'combine_consecutive_unsets' => true,
+        // There must not be spaces around `declare` statement parentheses.
+        'declare_parentheses' => true,
+        // Replaces short-echo `<?=` with long format `<?php echo`/`<?php print` syntax, or vice-versa.
+        'echo_tag_syntax' => ['format' => 'short', 'shorten_simple_statements_only' => true ],
+        // Empty loop-body must be in configured style.
+        'empty_loop_body' => true,
+        // Empty loop-condition must be in configured style.
+        'empty_loop_condition' => true,
+        // Add curly braces to indirect variables to make them clear to understand. Requires PHP >= 7.0.
+        'explicit_indirect_variable' => true,
+        // Converts implicit variables into explicit ones in double-quoted strings or heredoc syntax.
+        'explicit_string_variable' => false,
+        // Renames PHPDoc tags.
+        'general_phpdoc_tag_rename' => ['replacements' => ['inheritDocs' => 'inheritDoc']],
+        // Convert `heredoc` to `nowdoc` where possible.
+        'heredoc_to_nowdoc' => true,
+        // Include/Require and file path should be divided with a single space. File path should not be placed within parentheses.
+        'include' => true,
+        // Pre- or post-increment and decrement operators should be used if possible.
+        'increment_style' => false, // TODO Arguable
+        // Integer literals must be in correct case.
+        'integer_literal_case' => true,
+        // Lambda must not import variables it doesn't use.
+        'lambda_not_used_import' => true,
+        // Ensure there is no code on the same line as the PHP open tag.
+        'linebreak_after_opening_tag' => true,
+        // Magic constants should be referred to using the correct casing.
+        'magic_constant_casing' => true,
+        // Magic method definitions and calls must be using the correct casing.
+        'magic_method_casing' => true,
+        // Method chaining MUST be properly indented. Method chaining with different levels of indentation is not supported.
+        'method_chaining_indentation' => true,
+        // DocBlocks must start with two asterisks, multiline comments must start with a single asterisk, after the opening slash. Both must end with a single asterisk before the closing slash.
+        'multiline_comment_opening_closing' => true,
+        // Forbid multi-line whitespace before the closing semicolon or move the semicolon to the new line for chained calls.
+        'multiline_whitespace_before_semicolons' => false,
+        // Function defined by PHP should be called using the correct casing.
+        'native_function_casing' => true,
+        // Native type declarations should be used in the correct case.
+        'native_type_declaration_casing' => true,
+        // Master language constructs shall be used instead of aliases.
+        'no_alias_language_construct_call' => true,
+        // Replace control structure alternative syntax to use braces.
+        'no_alternative_syntax' => true,
+        // There should not be a binary flag before strings.
+        'no_binary_string' => true,
+        // There should not be blank lines between docblock and the documented element.
+        'no_blank_lines_after_phpdoc' => false,
+        // There should not be any empty comments.
+        'no_empty_comment' => true,
+        // Remove useless (semicolon) statements.
+        'no_empty_statement' => true,
+        // Removes extra blank lines and/or blank lines following configuration.
+        'no_extra_blank_lines' => [
+            'tokens' => [
+                'attribute',
+                'break',
+                'case',
+                'continue',
+                'curly_brace_block',
+                'default',
+                'extra',
+                'parenthesis_brace_block',
+                'return',
+                'square_brace_block',
+                'switch',
+                'throw',
+                'use'
+            ]
+        ],
+        // The namespace declaration line shouldn't contain leading whitespace.
+        'no_leading_namespace_whitespace' => true,
+        // Either language construct `print` or `echo` should be used.
+        'no_mixed_echo_print' => true,
+        // Operator `=>` should not be surrounded by multi-line whitespaces.
+        'no_multiline_whitespace_around_double_arrow' => true,
+        // Properties MUST not be explicitly initialized with `null` except when they have a type declaration (PHP 7.4).
+        'no_null_property_initialization' => true, // TODO Arguable, could remove info about nullability
+        // Short cast `bool` using double exclamation mark should not be used.
+        'no_short_bool_cast' => true,
+        // Single-line whitespace before closing semicolon are prohibited.
+        'no_singleline_whitespace_before_semicolons' => true,
+        // There MUST NOT be spaces around offset braces.
+        'no_spaces_around_offset' => true,
+        // Replaces superfluous `elseif` with `if`.
+        'no_superfluous_elseif' => true,
+        // If a list of values separated by a comma is contained on a single line, then the last item MUST NOT have a trailing comma.
+        'no_trailing_comma_in_singleline' => true,
+        // Removes unneeded braces that are superfluous and aren't part of a control structure's body.
+        'no_unneeded_braces' => ['namespaces' => true],
+        // Removes unneeded parentheses around control statements.
+        'no_unneeded_control_parentheses' => [
+            'statements' => [
+                'break',
+                'clone',
+                'continue',
+                'echo_print',
+                //'negative_instanceof',
+                'others',
+                //'return',
+                'switch_case',
+                'yield',
+                'yield_from'
+            ]
+        ],
+        // Imports should not be aliased as the same name.
+        'no_unneeded_import_alias' => true,
+        // Variables must be set `null` instead of using `(unset)` casting.
+        'no_unset_cast' => true,
+        // There should not be useless concat operations.
+        'no_useless_concat_operator' => true,
+        // There should not be useless `else` cases.
+        'no_useless_else' => true,
+        // There should not be useless Null-safe operator `?->` used.
+        'no_useless_nullsafe_operator' => true,
+        // There should not be an empty `return` statement at the end of a function.
+        'no_useless_return' => true,
+        // In array declaration, there MUST NOT be a whitespace before each comma.
+        'no_whitespace_before_comma_in_array' => ['after_heredoc' => true],
+        // Array index should always be written by using square braces.
+        'normalize_index_brace' => true,
+        // Nullable single type declaration should be standardised using configured syntax.
+        'nullable_type_declaration' => true,
+        // Adds or removes `?` before single type declarations or `|null` at the end of union types when parameters have a default `null` value.
+        'nullable_type_declaration_for_default_null_value' => true,
+        // There should not be space before or after object operators `->` and `?->`.
+        'object_operator_without_whitespace' => true,
+        // Operators - when multiline - must always be at the beginning or at the end of the line.
+        // TODO Decide whether to put boolean operators at the end or the beginning. Either way lead to 10 changed files.
+        'operator_linebreak' => false,
+        //'operator_linebreak' => ['only_booleans' => true, 'position' => 'beginning'],
+        //'operator_linebreak' => ['only_booleans' => true, 'position' => 'end'],
+        // Sort union types and intersection types using configured order.
+        'ordered_types' => true,
+        // PHPUnit annotations should be a FQCNs including a root namespace.
+        'php_unit_fqcn_annotation' => true,
+        // All PHPUnit test classes should be marked as internal.
+        'php_unit_internal_class' => false,
+        // Enforce camel (or snake) case for PHPUnit test methods, following configuration.
+        'php_unit_method_casing' => true,
+        // Adds a default `@coversNothing` annotation to PHPUnit test classes that have no `@covers*` annotation.
+        'php_unit_test_class_requires_covers' => false, // TODO We should enforce the opposite instead but not possible with PHP CS Fixer
+        // PHPDoc should contain `@param` for all params.
+        'phpdoc_add_missing_param_annotation' => false, // Can't be enabled due to "no_superfluous_phpdoc_tags" rule
+        // All items of the given PHPDoc tags must be either left-aligned or (by default) aligned vertically.
+        'phpdoc_align' => false,
+        // PHPDoc annotation descriptions should not be a sentence.
+        'phpdoc_annotation_without_dot' => false, // Also reduces the Casing of the First word of the description.
+        // Fixes PHPDoc inline tags.
+        'phpdoc_inline_tag_normalizer' => true,
+        // `@access` annotations should be omitted from PHPDoc.
+        'phpdoc_no_access' => true,
+        // No alias PHPDoc tags should be used.
+        'phpdoc_no_alias_tag' => false, // Changes @link to @see
+        // `@return void` and `@return null` annotations should be omitted from PHPDoc.
+        'phpdoc_no_empty_return' => false, // Removes a lot of return type hints that could be useful
+        // `@package` and `@subpackage` annotations should be omitted from PHPDoc.
+        'phpdoc_no_package' => true,
+        // Classy that does not inherit must not have `@inheritdoc` tags.
+        'phpdoc_no_useless_inheritdoc' => true,
+        // Order PHPDoc tags by value.
+        'phpdoc_order_by_value' => true,
+        // Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line.
+        'phpdoc_separation' => false,
+        // PHPDoc summary should end in either a full stop, exclamation mark, or question mark.
+        'phpdoc_summary' => false,
+        // Forces PHPDoc tags to be either regular annotations or inline.
+        'phpdoc_tag_type' => false,
+        // Docblocks should only be used on structural elements.
+        'phpdoc_to_comment' => false,
+        // The correct case must be used for standard PHP types in PHPDoc.
+        'phpdoc_types' => true,
+        // `@var` and `@type` annotations of classy properties should not contain the name.
+        'phpdoc_var_without_name' => true,
+        // Converts `protected` variables and methods to `private` where possible.
+        'protected_to_private' => true, // TODO Arguable, not a fan of
+        // Local, dynamic and directly referenced variables should not be assigned and directly returned by a function or method.
+        'return_assignment' => false, // Makes debugging more difficult
+        // Inside an enum or `final`/anonymous class, `self` should be preferred over `static`.
+        'self_static_accessor' => true,
+        // Instructions must be terminated with a semicolon.
+        'semicolon_after_instruction' => true,
+        // Converts explicit variables in double-quoted strings and heredoc syntax from simple to complex format (`${` to `{$`).
+        'simple_to_complex_string_variable' => true,
+        // Single-line comments must have proper spacing.
+        'single_line_comment_spacing' => true, // TODO Preferable for non-code, not so for actual code
+        // Single-line comments and multi-line comments with only one line of actual content should use the `//` syntax.
+        'single_line_comment_style' => true,
+        // Throwing exception must be done in single line.
+        'single_line_throw' => false,
+        // Convert double quotes to single quotes for simple strings.
+        'single_quote' => true,
+        // Ensures a single space after language constructs.
+        'single_space_around_construct' => true,
+        // Fix whitespace after a semicolon.
+        'space_after_semicolon' => ['remove_in_empty_for_expressions' => true],
+        // Increment and decrement operators should be used if possible.
+        'standardize_increment' => true,
+        // Replace all `<>` with `!=`.
+        'standardize_not_equals' => true,
+        // Handles implicit backslashes in strings and heredocs. Depending on the chosen strategy, it can escape implicit backslashes to ease the understanding of which are special chars interpreted by PHP and which not (`escape`), or it can remove these additional backslashes if you find them superfluous (`unescape`). You can also leave them as-is using `ignore` strategy.
+        'string_implicit_backslashes' => false,
+        // Switch case must not be ended with `continue` but with `break`.
+        'switch_continue_to_break' => true,
+        // Arrays should be formatted like function/method arguments, without leading or trailing single line space.
+        'trim_array_spaces' => true,
+        // Ensure single space between a variable and its type declaration in function arguments and properties.
+        'type_declaration_spaces' => true,
+        // A single space or none should be around union type and intersection type operators.
+        'types_spaces' => true,
+        // In array declaration, there MUST be a whitespace after each comma.
+        'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+        // Write conditions in Yoda style (`true`), non-Yoda style (`['equal' => false, 'identical' => false, 'less_and_greater' => false]`) or ignore those conditions (`null`) based on configuration.
+        'yoda_style' => false,
     ])
-    ->setFinder(PhpCsFixer\Finder::create()
-        ->exclude('vendor')
-        ->in(__DIR__ . '/src/main/php/PHPMD')
-        ->in(__DIR__ . '/src/test/php/')
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->exclude('vendor')
+            ->in(__DIR__ . '/src/main/php/PHPMD')
+            ->in(__DIR__ . '/src/test/php/')
     );

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
   "scripts": {
     "test": "paratest",
     "cs-check": "phpcs -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
+    "cs-fixer-check": "php-cs-fixer check",
     "cs-fixer": "php-cs-fixer fix",
     "cs-fix": "phpcbf -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
     "build-website": "easy-doc build src/site/config.php --verbose"

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -75,7 +75,7 @@ abstract class AbstractNode
             );
         }
 
-        return $node->$name(...$args);
+        return $node->{$name}(...$args);
     }
 
     /**

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -37,7 +37,7 @@ use PHPMD\Node\ASTNode;
 abstract class AbstractNode
 {
     /**
-     * @var TNode $node
+     * @var TNode
      */
     private $node;
 

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -39,14 +39,14 @@ abstract class AbstractNode
     /**
      * @var TNode $node
      */
-    private $node = null;
+    private $node;
 
     /**
      * The collected metrics for this node.
      *
      * @var array<string, mixed>
      */
-    private $metrics = null;
+    private $metrics;
 
     /**
      * Constructs a new PHPMD node.

--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -30,7 +30,7 @@ abstract class AbstractRenderer
      *
      * @var AbstractWriter
      */
-    private $writer = null;
+    private $writer;
 
     /**
      * Returns the associated output writer instance.

--- a/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
+++ b/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
@@ -30,6 +30,7 @@ class BaselineFileFinder
     public function existingFile()
     {
         $this->existingFile = true;
+
         return $this;
     }
 
@@ -40,6 +41,7 @@ class BaselineFileFinder
     public function notNull()
     {
         $this->notNull = true;
+
         return $this;
     }
 
@@ -91,6 +93,7 @@ class BaselineFileFinder
         if ($this->notNull) {
             throw new RuntimeException($message);
         }
+
         return null;
     }
 }

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -41,7 +41,7 @@ class BaselineSetFactory
 
             $methodName = null;
             if (isset($node['method']) && ((string) $node['method']) !== '') {
-                $methodName = (string) ($node['method']);
+                $methodName = (string) $node['method'];
             }
 
             $baselineSet->addEntry(new ViolationBaseline((string) $node['rule'], (string) $node['file'], $methodName));

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheKey.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheKey.php
@@ -6,12 +6,16 @@ class ResultCacheKey
 {
     /** @var bool */
     private $strict;
+
     /** @var string|null */
     private $baselineHash;
+
     /** @var array<string, string> */
     private $rules;
+
     /** @var array<string, string> */
     private $composer;
+
     /** @var int */
     private $phpVersion;
 

--- a/src/main/php/PHPMD/Cache/ResultCacheEngine.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngine.php
@@ -15,8 +15,8 @@ class ResultCacheEngine
 
     public function __construct(
         ResultCacheFileFilter $fileFilter,
-        ResultCacheUpdater    $updater,
-        ResultCacheWriter     $writer
+        ResultCacheUpdater $updater,
+        ResultCacheWriter $writer
     ) {
         $this->fileFilter = $fileFilter;
         $this->updater = $updater;

--- a/src/main/php/PHPMD/Cache/ResultCacheEngine.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngine.php
@@ -18,7 +18,6 @@ class ResultCacheEngine
         ResultCacheUpdater    $updater,
         ResultCacheWriter     $writer
     ) {
-
         $this->fileFilter = $fileFilter;
         $this->updater = $updater;
         $this->writer = $writer;

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -16,8 +16,8 @@ class ResultCacheEngineFactory
     private $cacheStateFactory;
 
     public function __construct(
-        OutputInterface         $output,
-        ResultCacheKeyFactory   $cacheKeyFactory,
+        OutputInterface $output,
+        ResultCacheKeyFactory $cacheKeyFactory,
         ResultCacheStateFactory $cacheStateFactory
     ) {
         $this->output = $output;

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -10,8 +10,10 @@ class ResultCacheEngineFactory
 {
     /** @var OutputInterface */
     private $output;
+
     /** @var ResultCacheKeyFactory */
     private $cacheKeyFactory;
+
     /** @var ResultCacheStateFactory */
     private $cacheStateFactory;
 
@@ -34,6 +36,7 @@ class ResultCacheEngineFactory
     {
         if (!$options->isCacheEnabled()) {
             $this->output->writeln('ResultCache is not enabled.', OutputInterface::VERBOSITY_VERY_VERBOSE);
+
             return null;
         }
 

--- a/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
@@ -28,7 +28,6 @@ class ResultCacheFileFilter implements Filter
     /** @var OutputInterface */
     private $output;
 
-
     /**
      * @param string                $basePath
      * @param string                $strategy

--- a/src/main/php/PHPMD/Cache/ResultCacheKeyFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheKeyFactory.php
@@ -11,6 +11,7 @@ class ResultCacheKeyFactory
 {
     /** @var string */
     private $basePath;
+
     /** @var string|null */
     private $baselineFile;
 

--- a/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
@@ -12,6 +12,7 @@ class ResultCacheUpdater
 {
     /** @var OutputInterface */
     private $output;
+
     /** @var string */
     private $basePath;
 

--- a/src/main/php/PHPMD/Console/Output.php
+++ b/src/main/php/PHPMD/Console/Output.php
@@ -39,7 +39,7 @@ abstract class Output implements OutputInterface
         }
 
         foreach ($messages as $message) {
-            $this->doWrite($message . ($newline ? "\n" : ""));
+            $this->doWrite($message . ($newline ? "\n" : ''));
         }
     }
 

--- a/src/main/php/PHPMD/Node/ASTNode.php
+++ b/src/main/php/PHPMD/Node/ASTNode.php
@@ -35,7 +35,7 @@ class ASTNode extends AbstractNode
      *
      * @var string
      */
-    private $fileName = null;
+    private $fileName;
 
     /**
      * Constructs a new ast node instance.

--- a/src/main/php/PHPMD/Node/AbstractNode.php
+++ b/src/main/php/PHPMD/Node/AbstractNode.php
@@ -35,7 +35,7 @@ abstract class AbstractNode extends BaseNode
      *
      * @var Annotations
      */
-    private $annotations = null;
+    private $annotations;
 
     /**
      * Checks if this node has a suppressed annotation for the given rule

--- a/src/main/php/PHPMD/Node/Annotation.php
+++ b/src/main/php/PHPMD/Node/Annotation.php
@@ -34,14 +34,14 @@ class Annotation
      *
      * @var string
      */
-    private $name = null;
+    private $name;
 
     /**
      * The annotation value.
      *
      * @var string
      */
-    private $value = null;
+    private $value;
 
     /**
      * Constructs a new annotation instance.

--- a/src/main/php/PHPMD/Node/Annotation.php
+++ b/src/main/php/PHPMD/Node/Annotation.php
@@ -78,7 +78,8 @@ class Annotation
     {
         if (in_array($this->value, ['PHPMD', 'PMD'])) {
             return true;
-        } elseif (preg_match(
+        }
+        if (preg_match(
             '/^(PH)?PMD\.' . preg_replace('/^.*\/([^\/]*)$/', '$1', $rule->getName()) . '/',
             $this->value
         )) {

--- a/src/main/php/PHPMD/Parser.php
+++ b/src/main/php/PHPMD/Parser.php
@@ -64,21 +64,21 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
      *
      * @var ASTArtifactList
      */
-    private $artifacts = null;
+    private $artifacts;
 
     /**
      * The violation report used by this PDepend adapter.
      *
      * @var Report
      */
-    private $report = null;
+    private $report;
 
     /**
      * The wrapped PDepend Engine instance.
      *
      * @var Engine
      */
-    private $pdepend = null;
+    private $pdepend;
 
     /**
      * Constructs a new parser adapter instance.

--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -99,6 +99,7 @@ class ParserFactory
             $trimmedPath = trim($path);
             if (is_dir($trimmedPath)) {
                 $pdepend->addDirectory($trimmedPath);
+
                 continue;
             }
             $pdepend->addFile($trimmedPath);

--- a/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
+++ b/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
@@ -80,7 +80,7 @@ class CheckStyleRenderer extends XMLRenderer
             $this->maybeAdd('function', $violation->getFunctionName());
             $this->maybeAdd('class', $violation->getClassName());
             $this->maybeAdd('method', $violation->getMethodName());
-            //$this->_maybeAdd('variable', $violation->getVariableName());
+            // $this->_maybeAdd('variable', $violation->getVariableName());
 
             $writer->write(' />' . \PHP_EOL);
         }

--- a/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
+++ b/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
@@ -37,6 +37,7 @@ class CheckStyleRenderer extends XMLRenderer
 
         return (int) $priority === 2 ? 'warning' : 'error';
     }
+
     /**
      * This method will be called when the engine has finished the source analysis
      * phase.

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -60,7 +60,7 @@ class GitLabRenderer extends AbstractRenderer
                 ],
                 'check_name' => $violation->getRule()->getName(),
                 'fingerprint' => sprintf(
-                    "%s:%s:%s",
+                    '%s:%s:%s',
                     $violation->getFileName(),
                     $violation->getBeginLine(),
                     $violation->getRule()->getName()

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -39,7 +39,6 @@ class GitLabRenderer extends AbstractRenderer
         $writer->write($jsonData . PHP_EOL);
     }
 
-
     /**
      * Add violations, if any, to GitLab Code Quality report format
      *

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -54,11 +54,10 @@ class GitLabRenderer extends AbstractRenderer
         foreach ($report->getRuleViolations() as $violation) {
             $violationResult = [
                 'type' => 'issue',
-                'categories' =>
-                    [
-                        'Style',
-                        'PHP',
-                    ],
+                'categories' => [
+                    'Style',
+                    'PHP',
+                ],
                 'check_name' => $violation->getRule()->getName(),
                 'fingerprint' => sprintf(
                     "%s:%s:%s",
@@ -68,15 +67,13 @@ class GitLabRenderer extends AbstractRenderer
                 ),
                 'description' => $violation->getDescription(),
                 'severity' => 'minor',
-                'location' =>
-                    [
-                        'path' => $violation->getFileName(),
-                        'lines' =>
-                            [
-                                'begin' => $violation->getBeginLine(),
-                                'end' => $violation->getEndLine(),
-                            ],
+                'location' => [
+                    'path' => $violation->getFileName(),
+                    'lines' => [
+                        'begin' => $violation->getBeginLine(),
+                        'end' => $violation->getEndLine(),
                     ],
+                ],
             ];
 
             $data[] = $violationResult;
@@ -101,14 +98,12 @@ class GitLabRenderer extends AbstractRenderer
                 'description' => $error->getMessage(),
                 'fingerprint' => $error->getFile() . ':0:MajorErrorInFile',
                 'severity' => 'major',
-                'location' =>
-                    [
-                        'path' => $error->getFile(),
-                        'lines' =>
-                            [
-                                'begin' => 0,
-                            ],
+                'location' => [
+                    'path' => $error->getFile(),
+                    'lines' => [
+                        'begin' => 0,
                     ],
+                ],
             ];
 
             $data[] = $errorResult;

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -88,7 +88,7 @@ class HTMLRenderer extends AbstractRenderer
     {
         $writer = $this->getWriter();
 
-        $mainColor = "#2f838a";
+        $mainColor = '#2f838a';
 
         // Avoid inlining styles.
         $style = "
@@ -319,7 +319,7 @@ class HTMLRenderer extends AbstractRenderer
                 on <em>PHP %s</em>
                 on <em>%s</em>
             </header>
-        ", date('Y-m-d H:i'), "https://phpmd.org", \PHP_VERSION, gethostname());
+        ", date('Y-m-d H:i'), 'https://phpmd.org', \PHP_VERSION, gethostname());
 
         $writer->write($header);
     }
@@ -344,7 +344,7 @@ class HTMLRenderer extends AbstractRenderer
         }
 
         // Render summary tables.
-        $writer->write("<h2>Summary</h2>");
+        $writer->write('<h2>Summary</h2>');
         $categorized = self::sumUpViolations($violations);
         $this->writeTable('By priority', 'Priority', $categorized[self::CATEGORY_PRIORITY]);
         $this->writeTable('By namespace', 'PHP Namespace', $categorized[self::CATEGORY_NAMESPACE]);
@@ -366,7 +366,7 @@ class HTMLRenderer extends AbstractRenderer
 
         foreach ($violations as $violation) {
             // This is going to be used as ID in HTML (deep anchoring).
-            $htmlId = "p-" . $index++;
+            $htmlId = 'p-' . $index++;
 
             // Get excerpt of the code from validated file.
             $excerptHtml = null;
@@ -384,7 +384,7 @@ class HTMLRenderer extends AbstractRenderer
 
             $descHtml = self::colorize(htmlentities($violation->getDescription()));
             $filePath = $violation->getFileName();
-            $fileHtml = "<a href='file://$filePath' target='_blank'>" . self::highlightFile($filePath) . "</a>";
+            $fileHtml = "<a href='file://$filePath' target='_blank'>" . self::highlightFile($filePath) . '</a>';
 
             // Create an external link to rule's help, if there's any provided.
             $linkHtml = null;
@@ -475,7 +475,7 @@ class HTMLRenderer extends AbstractRenderer
                 $value = "(?<{$key}>{$value['regex']})";
             });
 
-            self::$compiledHighlightRegex = "#(" . implode('|', $prepared) . ")#";
+            self::$compiledHighlightRegex = '#(' . implode('|', $prepared) . ')#';
         }
 
         $rules = self::$descHighlightRules;
@@ -497,7 +497,7 @@ class HTMLRenderer extends AbstractRenderer
      */
     protected static function highlightFile($path)
     {
-        $file = substr(strrchr($path, "/"), 1);
+        $file = substr(strrchr($path, '/'), 1);
         $dir = str_replace($file, '', $path);
 
         return $dir . "<span class='path-basename'>" . $file . '</span>';
@@ -596,6 +596,6 @@ class HTMLRenderer extends AbstractRenderer
      */
     protected static function reduceWhitespace($input, $eol = true)
     {
-        return preg_replace("#\s+#", " ", $input) . ($eol ? PHP_EOL : null);
+        return preg_replace("#\s+#", ' ', $input) . ($eol ? PHP_EOL : null);
     }
 }

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -64,7 +64,7 @@ class HTMLRenderer extends AbstractRenderer
         ],
     ];
 
-    protected static $compiledHighlightRegex = null;
+    protected static $compiledHighlightRegex;
 
     /**
      * Specify how many extra lines are added to a code snippet

--- a/src/main/php/PHPMD/Renderer/JSONRenderer.php
+++ b/src/main/php/PHPMD/Renderer/JSONRenderer.php
@@ -67,6 +67,7 @@ class JSONRenderer extends AbstractRenderer
     protected function addViolationsToReport(Report $report, array $data)
     {
         $filesList = [];
+
         /** @var RuleViolation $violation */
         foreach ($report->getRuleViolations() as $violation) {
             $fileName = $violation->getFileName();

--- a/src/main/php/PHPMD/Renderer/SARIFRenderer.php
+++ b/src/main/php/PHPMD/Renderer/SARIFRenderer.php
@@ -36,8 +36,7 @@ class SARIFRenderer extends JSONRenderer
     {
         $data = [
             'version' => '2.1.0',
-            '$schema' =>
-                'https://raw.githubusercontent.com/oasis-tcs/' .
+            '$schema' => 'https://raw.githubusercontent.com/oasis-tcs/' .
                 'sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
             'runs' => [
                 [

--- a/src/main/php/PHPMD/Renderer/XMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/XMLRenderer.php
@@ -83,7 +83,7 @@ class XMLRenderer extends AbstractRenderer
             $this->maybeAdd('function', $violation->getFunctionName());
             $this->maybeAdd('class', $violation->getClassName());
             $this->maybeAdd('method', $violation->getMethodName());
-            //$this->_maybeAdd('variable', $violation->getVariableName());
+            // $this->_maybeAdd('variable', $violation->getVariableName());
 
             $writer->write(' priority="' . $rule->getPriority() . '"');
             $writer->write('>' . PHP_EOL);

--- a/src/main/php/PHPMD/Renderer/XMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/XMLRenderer.php
@@ -32,7 +32,7 @@ class XMLRenderer extends AbstractRenderer
      *
      * @var string
      */
-    private $fileName = null;
+    private $fileName;
 
     /**
      * This method will be called on all renderers before the engine starts the

--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -59,7 +59,7 @@ class Report
     /** @var BaselineValidator|null */
     private $baselineValidator;
 
-    public function __construct(BaselineValidator $baselineValidator = null)
+    public function __construct(?BaselineValidator $baselineValidator = null)
     {
         $this->baselineValidator = $baselineValidator;
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -70,7 +70,7 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
         $this->scanFormalParameters($node);
     }
 
-    protected function isBooleanValue(ASTValue $value = null)
+    protected function isBooleanValue(?ASTValue $value = null)
     {
         return $value?->isValueAvailable() && is_bool($value->getValue());
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -128,10 +128,13 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
         switch ($value) {
             case 'false':
                 return '0';
+
             case 'true':
                 return '1';
+
             case 'null':
                 return '';
+
             default:
                 return trim($value, '\'""');
         }

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -59,6 +59,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
     protected function checkForDuplicatedArrayKeys(ASTNode $node): void
     {
         $keys = [];
+
         /** @var ASTArrayElement $arrayElement */
         foreach ($node->getChildren() as $index => $arrayElement) {
             $arrayElement = $this->normalizeKey($arrayElement, $index);
@@ -70,6 +71,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
             $key = $arrayElement->getImage();
             if (isset($keys[$key])) {
                 $this->addViolation($node, [$key, $arrayElement->getStartLine()]);
+
                 continue;
             }
             $keys[$key] = $arrayElement;
@@ -122,6 +124,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
     protected function castStringFromLiteral(PDependASTNode $key)
     {
         $value = $key->getImage();
+
         switch ($value) {
             case 'false':
                 return '0';

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -75,6 +75,6 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
      */
     protected function isIfOrElseIfStatement(ASTNode $parent)
     {
-        return ($parent->getName() === "if" || $parent->getName() === "elseif");
+        return ($parent->getName() === 'if' || $parent->getName() === 'elseif');
     }
 }

--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -45,10 +45,10 @@ class DevelopmentCodeFragment extends AbstractRule implements MethodAware, Funct
         foreach ($node->findChildrenOfType(ASTFunctionPostfix::class) as $postfix) {
             $fragment = $postfix->getImage();
             if ($ignoreNS) {
-                $fragment = str_replace("{$namespace}\\", "", $fragment);
+                $fragment = str_replace("{$namespace}\\", '', $fragment);
             }
             $fragment = strtolower($fragment);
-            $fragment = trim($fragment, "\\");
+            $fragment = trim($fragment, '\\');
             if (!in_array($fragment, $this->getSuspectImages())) {
                 continue;
             }

--- a/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
@@ -46,6 +46,7 @@ class TooManyMethods extends AbstractRule implements ClassAware
         if ($node->getMetric('nom') <= $threshold) {
             return;
         }
+
         /** @var AbstractTypeNode $node */
         $nom = $this->countMethods($node);
         if ($nom <= $threshold) {

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -121,7 +121,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
         static $magicMethodRegExp = null;
 
         if ($magicMethodRegExp === null) {
-            $magicMethodRegExp = '/__(?:' . implode("|", [
+            $magicMethodRegExp = '/__(?:' . implode('|', [
                 'call',
                 'callStatic',
                 'get',

--- a/src/main/php/PHPMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateField.php
@@ -145,7 +145,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * @return bool
      * @since 0.2.6
      */
-    protected function isValidPropertyNode(ASTNode $node = null)
+    protected function isValidPropertyNode(?ASTNode $node = null)
     {
         if ($node === null) {
             return false;

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -360,7 +360,7 @@ class RuleSetFactory
             }
         }
 
-        /* @var RuleSet $rule */
+        /** @var RuleSet $rule */
         $rule = new $className();
         $rule->setName((string) $ruleNode['name']);
         $rule->setMessage((string) $ruleNode['message']);

--- a/src/main/php/PHPMD/RuleViolation.php
+++ b/src/main/php/PHPMD/RuleViolation.php
@@ -52,7 +52,7 @@ class RuleViolation
      *
      * @var array|null
      */
-    private $args = null;
+    private $args;
 
     /**
      * The raw metric value which caused this rule violation.

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -251,107 +251,158 @@ class CommandLineOptions
                 case '--':
                     $this->refuseValue($equalChunk);
                     $listenOptions = false;
+
                     break;
+
                 case '--verbose':
                 case '-v':
                     $this->refuseValue($equalChunk);
                     $this->verbosity = OutputInterface::VERBOSITY_VERBOSE;
+
                     break;
+
                 case '-vv':
                     $this->refuseValue($equalChunk);
                     $this->verbosity = OutputInterface::VERBOSITY_VERY_VERBOSE;
+
                     break;
+
                 case '-vvv':
                     $this->refuseValue($equalChunk);
                     $this->verbosity = OutputInterface::VERBOSITY_DEBUG;
+
                     break;
+
                 case '--min-priority':
                 case '--minimum-priority':
                 case '--minimumpriority':
                     $this->minimumPriority = (int) $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--max-priority':
                 case '--maximum-priority':
                 case '--maximumpriority':
                     $this->maximumPriority = (int) $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--report-file':
                 case '--reportfile':
                     $this->reportFile = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--error-file':
                 case '--errorfile':
                     $this->errorFile = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--input-file':
                 case '--inputfile':
                     array_unshift($arguments, $this->readInputFile($this->readValue($equalChunk, $args)));
+
                     break;
+
                 case '--coverage':
                     $this->coverageReport = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--extensions':
                     $this->logDeprecated('extensions', 'suffixes');
                     // Deprecated: We use the suffixes option now
                     $this->extensions = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--suffixes':
                     $this->extensions = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--ignore':
                     $this->logDeprecated('ignore', 'exclude');
                     // Deprecated: We use the exclude option now
                     $this->ignore = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--exclude':
                     $this->ignore = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--color':
                     $this->refuseValue($equalChunk);
                     $this->colored = true;
+
                     break;
+
                 case '--version':
                     $this->refuseValue($equalChunk);
                     $this->version = true;
 
                     return;
+
                 case '--strict':
                     $this->refuseValue($equalChunk);
                     $this->strict = true;
+
                     break;
+
                 case '--not-strict':
                     $this->refuseValue($equalChunk);
                     $this->strict = false;
+
                     break;
+
                 case '--generate-baseline':
                     $this->refuseValue($equalChunk);
                     $this->generateBaseline = BaselineMode::GENERATE;
+
                     break;
+
                 case '--update-baseline':
                     $this->refuseValue($equalChunk);
                     $this->generateBaseline = BaselineMode::UPDATE;
+
                     break;
+
                 case '--baseline-file':
                     $this->baselineFile = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--cache':
                     $this->refuseValue($equalChunk);
                     $this->cacheEnabled = true;
+
                     break;
+
                 case '--cache-file':
                     $this->cacheFile = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--cache-strategy':
                     $this->cacheStrategy = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--ignore-errors-on-exit':
                     $this->refuseValue($equalChunk);
                     $this->ignoreErrorsOnExit = true;
+
                     break;
+
                 case '--ignore-violations-on-exit':
                     $this->refuseValue($equalChunk);
                     $this->ignoreViolationsOnExit = true;
+
                     break;
+
                 case '--reportfile-checkstyle':
                 case '--reportfile-github':
                 case '--reportfile-gitlab':
@@ -362,13 +413,18 @@ class CommandLineOptions
                 case '--reportfile-xml':
                     preg_match('(^\-\-reportfile\-(checkstyle|github|gitlab|html|json|sarif|text|xml)$)', $arg, $match);
                     $this->reportFiles[$match[1]] = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--extra-line-in-excerpt':
                     $this->extraLineInExcerpt = (int) $this->readValue($equalChunk, $args);
+
                     break;
+
                 default:
                     $hasImplicitArguments = true;
                     $arguments[] = $arg;
+
                     break;
             }
         }
@@ -603,6 +659,7 @@ class CommandLineOptions
             case ResultCacheStrategy::CONTENT:
             case ResultCacheStrategy::TIMESTAMP:
                 return $this->cacheStrategy;
+
             default:
                 return ResultCacheStrategy::CONTENT;
         }
@@ -682,22 +739,31 @@ class CommandLineOptions
         switch ($reportFormat) {
             case 'ansi':
                 return $this->createAnsiRenderer();
+
             case 'checkstyle':
                 return $this->createCheckStyleRenderer();
+
             case 'gitlab':
                 return $this->createGitLabRenderer();
+
             case 'github':
                 return $this->createGitHubRenderer();
+
             case 'html':
                 return $this->createHtmlRenderer();
+
             case 'json':
                 return $this->createJsonRenderer();
+
             case 'sarif':
                 return $this->createSarifRenderer();
+
             case 'text':
                 return $this->createTextRenderer();
+
             case 'xml':
                 return $this->createXmlRenderer();
+
             default:
                 return $this->createCustomRenderer();
         }

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -292,7 +292,7 @@ class CommandLineOptions
                     break;
                 case '--extensions':
                     $this->logDeprecated('extensions', 'suffixes');
-                    /* Deprecated: We use the suffixes option now */
+                    // Deprecated: We use the suffixes option now
                     $this->extensions = $this->readValue($equalChunk, $args);
                     break;
                 case '--suffixes':
@@ -300,7 +300,7 @@ class CommandLineOptions
                     break;
                 case '--ignore':
                     $this->logDeprecated('ignore', 'exclude');
-                    /* Deprecated: We use the exclude option now */
+                    // Deprecated: We use the exclude option now
                     $this->ignore = $this->readValue($equalChunk, $args);
                     break;
                 case '--exclude':

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -638,6 +638,7 @@ class CommandLineOptions
     {
         return $this->extraLineInExcerpt;
     }
+
     /**
      * Creates a report renderer instance based on the user's command line
      * argument.

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -923,6 +923,7 @@ class CommandLineOptions
         if (file_exists($inputFile)) {
             return implode(',', array_map(trim(...), file($inputFile)));
         }
+
         throw new InvalidArgumentException("Input file '{$inputFile}' not exists.");
     }
 

--- a/src/main/php/PHPMD/Utility/Strings.php
+++ b/src/main/php/PHPMD/Utility/Strings.php
@@ -49,7 +49,6 @@ class Strings
         array $subtractPrefixes,
         array $subtractSuffixes
     ) {
-
         $stringLength = strlen($stringName);
 
         foreach ($subtractSuffixes as $suffix) {

--- a/src/main/php/PHPMD/Utility/Strings.php
+++ b/src/main/php/PHPMD/Utility/Strings.php
@@ -55,6 +55,7 @@ class Strings
             $suffixLength = strlen($suffix);
             if (substr($stringName, -$suffixLength) === $suffix) {
                 $stringLength -= $suffixLength;
+
                 break;
             }
         }
@@ -63,6 +64,7 @@ class Strings
             $prefixLength = strlen($prefix);
             if (strncmp($stringName, $prefix, $prefixLength) === 0) {
                 $stringLength -= $prefixLength;
+
                 break;
             }
         }

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -51,6 +51,7 @@ class StreamWriter extends AbstractWriter
         }
         if (!file_exists($dirName)) {
             $message = 'Cannot find output directory "' . $dirName . '".';
+
             throw new RuntimeException($message);
         }
 

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -30,7 +30,7 @@ class StreamWriter extends AbstractWriter
      *
      * @var ?resource
      */
-    private $stream = null;
+    private $stream;
 
     /**
      * Constructs a new stream writer instance.

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -252,6 +252,7 @@ abstract class AbstractStaticTestCase extends TestCase
         } else {
             $filePath = tempnam(sys_get_temp_dir(), 'phpmd.');
         }
+
         return (self::$tempFiles[] = $filePath);
     }
 
@@ -268,6 +269,7 @@ abstract class AbstractStaticTestCase extends TestCase
                 return $frame;
             }
         }
+
         throw new ErrorException('Cannot locate calling test case.');
     }
 

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -31,14 +31,14 @@ abstract class AbstractStaticTestCase extends TestCase
      *
      * @var string $filesDirectory
      */
-    private static $filesDirectory = null;
+    private static $filesDirectory;
 
     /**
      * Original directory is used to reset a changed working directory.
      *
      * @return void
      */
-    private static $originalWorkingDirectory = null;
+    private static $originalWorkingDirectory;
 
     /**
      * Temporary files created by a test.

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -29,7 +29,7 @@ abstract class AbstractStaticTestCase extends TestCase
     /**
      * Directory with test files.
      *
-     * @var string $filesDirectory
+     * @var string
      */
     private static $filesDirectory;
 

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -614,7 +614,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
         $file = '/foo/baz.php',
         $message = 'Error in file "/foo/baz.php"'
     ) {
-
         $processingError = $this->getMockFromBuilder(
             $this->getMockBuilder(ProcessingError::class)
                 ->setConstructorArgs([$message])

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -235,7 +235,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
 
         return new $nodeClassName(
             $this->getNodeByName(
-                $source->$getter(),
+                $source->{$getter}(),
                 pathinfo($file, PATHINFO_FILENAME)
             )
         );

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -287,7 +287,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     {
         return basename($file) . " failed:\n" .
             "Expected $expectedInvokes violation" . ($expectedInvokes !== 1 ? 's' : '') . "\n" .
-            "But $actualInvokes violation" . ($actualInvokes !== 1 ? 's' : '') . " raised" .
+            "But $actualInvokes violation" . ($actualInvokes !== 1 ? 's' : '') . ' raised' .
             (
                 $actualInvokes > 0
                 ? ":\n" . $this->getViolationsSummary($violations)

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -673,6 +673,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
                 return $node;
             }
         }
+
         throw new ErrorException("Cannot locate node named $name.");
     }
 

--- a/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
@@ -23,8 +23,8 @@ class BaselineFileFinderTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::find
      * @covers ::existingFile
+     * @covers ::find
      */
     public function testShouldFindExistingFileNearRuleSet()
     {
@@ -65,9 +65,9 @@ class BaselineFileFinderTest extends AbstractTestCase
     }
 
     /**
+     * @covers ::existingFile
      * @covers ::find
      * @covers ::nullOrThrow
-     * @covers ::existingFile
      */
     public function testShouldOnlyFindExistingFile()
     {

--- a/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
@@ -32,8 +32,8 @@ class BaselineFileFinderTest extends AbstractTestCase
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
 
         // ensure consistent slashes
-        $expected = str_replace("\\", "/", realpath(static::createResourceUriForTest('testA/phpmd.baseline.xml')));
-        $actual = str_replace("\\", "/", $finder->existingFile()->find());
+        $expected = str_replace('\\', '/', realpath(static::createResourceUriForTest('testA/phpmd.baseline.xml')));
+        $actual = str_replace('\\', '/', $finder->existingFile()->find());
 
         static::assertSame($expected, $actual);
     }

--- a/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
+++ b/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
@@ -208,7 +208,6 @@ class ResultCacheStateTest extends TestCase
                             ],
                         ],
                     ],
-
                 ],
             ],
         ];

--- a/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
+++ b/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
@@ -35,8 +35,8 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @covers ::setViolations
      * @covers ::getViolations
+     * @covers ::setViolations
      */
     public function testGetSetViolations()
     {
@@ -87,8 +87,8 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @covers ::getRuleViolations
      * @covers ::findRuleIn
+     * @covers ::getRuleViolations
      */
     public function testGetRuleViolationsWithoutDescriptionArgs()
     {
@@ -114,8 +114,8 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @covers ::getRuleViolations
      * @covers ::findRuleIn
+     * @covers ::getRuleViolations
      */
     public function testGetRuleViolationsWithDescriptionArgs()
     {
@@ -146,8 +146,8 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @covers ::setFileState
      * @covers ::isFileModified
+     * @covers ::setFileState
      */
     public function testIsFileModified()
     {

--- a/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
@@ -17,8 +17,10 @@ class ResultCacheFileFilterTest extends AbstractTestCase
 {
     /** @var NullOutput */
     private $output;
+
     /** @var MockObject&ResultCacheKey */
     private $key;
+
     /** @var MockObject&ResultCacheState */
     private $state;
 

--- a/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
@@ -27,8 +27,8 @@ class ResultCacheKeyFactoryTest extends AbstractTestCase
 
     /**
      * @covers ::create
-     * @covers ::getBaselineHash
      * @covers ::createRuleHashes
+     * @covers ::getBaselineHash
      * @covers ::getComposerHashes
      */
     public function testCreate()

--- a/src/test/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
@@ -28,8 +28,8 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::fromFile
      * @covers ::createCacheKey
+     * @covers ::fromFile
      */
     public function testFromFileEmptyCache()
     {
@@ -38,8 +38,8 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::fromFile
      * @covers ::createCacheKey
+     * @covers ::fromFile
      */
     public function testFromFileIncompleteCacheKey()
     {
@@ -48,8 +48,8 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::fromFile
      * @covers ::createCacheKey
+     * @covers ::fromFile
      */
     public function testFromFileFullCache()
     {
@@ -73,8 +73,8 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::fromFile
      * @covers ::createCacheKey
+     * @covers ::fromFile
      */
     public function testFromFileWithCacheWithoutBaselineOrComposer()
     {

--- a/src/test/php/PHPMD/Console/OutputTest.php
+++ b/src/test/php/PHPMD/Console/OutputTest.php
@@ -40,7 +40,7 @@ class OutputTest extends AbstractTestCase
     public function testWriteSingleMessage()
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
-        $this->output->write("message", false, OutputInterface::VERBOSITY_VERBOSE);
+        $this->output->write('message', false, OutputInterface::VERBOSITY_VERBOSE);
 
         static::assertSame('message', $this->output->getOutput());
     }
@@ -52,7 +52,7 @@ class OutputTest extends AbstractTestCase
     public function testWriteMultiMessageWithNewline()
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
-        $this->output->write(["foo", "bar"], true, OutputInterface::VERBOSITY_VERBOSE);
+        $this->output->write(['foo', 'bar'], true, OutputInterface::VERBOSITY_VERBOSE);
 
         static::assertSame("foo\nbar\n", $this->output->getOutput());
     }
@@ -113,7 +113,7 @@ class OutputTest extends AbstractTestCase
      */
     public function testWritelnMessage()
     {
-        $this->output->writeln("message", OutputInterface::VERBOSITY_QUIET);
+        $this->output->writeln('message', OutputInterface::VERBOSITY_QUIET);
 
         static::assertSame("message\n", $this->output->getOutput());
     }

--- a/src/test/php/PHPMD/Console/TestOutput.php
+++ b/src/test/php/PHPMD/Console/TestOutput.php
@@ -24,6 +24,7 @@ class TestOutput extends Output
     public function getOutput()
     {
         fseek($this->stream, 0);
+
         return fread($this->stream, 1024);
     }
 }

--- a/src/test/php/PHPMD/Node/ClassNodeTest.php
+++ b/src/test/php/PHPMD/Node/ClassNodeTest.php
@@ -28,8 +28,8 @@ use Sindelfingen\MyClass;
 /**
  * Test case for the class node implementation.
  *
- * @covers \PHPMD\Node\ClassNode
  * @covers \PHPMD\Node\AbstractTypeNode
+ * @covers \PHPMD\Node\ClassNode
  */
 class ClassNodeTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Node/FunctionTest.php
+++ b/src/test/php/PHPMD/Node/FunctionTest.php
@@ -24,8 +24,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the function node implementation.
  *
- * @covers \PHPMD\Node\FunctionNode
  * @covers \PHPMD\Node\AbstractCallableNode
+ * @covers \PHPMD\Node\FunctionNode
  */
 class FunctionTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Node/InterfaceNodeTest.php
+++ b/src/test/php/PHPMD/Node/InterfaceNodeTest.php
@@ -25,8 +25,8 @@ use Sindelfingen\MyInterface;
 /**
  * Test case for the interface node implementation.
  *
- * @covers \PHPMD\Node\InterfaceNode
  * @covers \PHPMD\Node\AbstractTypeNode
+ * @covers \PHPMD\Node\InterfaceNode
  */
 class InterfaceNodeTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -26,8 +26,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the method node implementation.
  *
- * @covers \PHPMD\Node\MethodNode
  * @covers \PHPMD\Node\AbstractCallableNode
+ * @covers \PHPMD\Node\MethodNode
  */
 class MethodNodeTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Node/TraitNodeTest.php
+++ b/src/test/php/PHPMD/Node/TraitNodeTest.php
@@ -25,8 +25,8 @@ use Sindelfingen\MyTrait;
 /**
  * Test case for the trait node implementation.
  *
- * @covers \PHPMD\Node\TraitNode
  * @covers \PHPMD\Node\AbstractTypeNode
+ * @covers \PHPMD\Node\TraitNode
  */
 class TraitNodeTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
@@ -79,6 +79,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
                         foreach ($report->getRuleViolations() as $ruleViolation) {
                             if (str_starts_with($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE)) {
                                 $isViolating = true;
+
                                 break;
                             }
                         }
@@ -123,6 +124,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
                         foreach ($report->getRuleViolations() as $ruleViolation) {
                             if (str_starts_with($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE)) {
                                 $isViolating = true;
+
                                 break;
                             }
                         }

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
@@ -47,7 +47,6 @@ class MaximumNestingLevelTicket24975295RegressionTest extends AbstractRegression
         $renderers = [$renderer];
         $factory = new RuleSetFactory();
 
-
         $phpmd = new PHPMD();
         $phpmd->processFiles(
             $inputs,

--- a/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
@@ -72,16 +72,16 @@ class AnsiRendererTest extends AbstractTestCase
         $renderer->end();
 
         $expectedChunks = [
-            PHP_EOL . "FILE: /bar.php" . PHP_EOL . "--------------" . PHP_EOL,
+            PHP_EOL . 'FILE: /bar.php' . PHP_EOL . '--------------' . PHP_EOL,
             " 1 | \e[31mVIOLATION\e[0m | Test description" . PHP_EOL,
             PHP_EOL,
-            PHP_EOL . "FILE: /foo.php" . PHP_EOL . "--------------" . PHP_EOL,
+            PHP_EOL . 'FILE: /foo.php' . PHP_EOL . '--------------' . PHP_EOL,
             " 2 | \e[31mVIOLATION\e[0m | Test description" . PHP_EOL,
             " 3 | \e[31mVIOLATION\e[0m | Test description" . PHP_EOL,
-            PHP_EOL . "\e[33mERROR\e[0m while parsing /foo/baz.php" . PHP_EOL . "--------------------------------" .
+            PHP_EOL . "\e[33mERROR\e[0m while parsing /foo/baz.php" . PHP_EOL . '--------------------------------' .
             (version_compare(PHP_VERSION, '5.4.0-dev', '<') ? '--' : '') . PHP_EOL,
-            "Error in file \"/foo/baz.php\"" . PHP_EOL,
-            PHP_EOL . "Found 3 violations and 1 error in 200ms" . PHP_EOL,
+            'Error in file "/foo/baz.php"' . PHP_EOL,
+            PHP_EOL . 'Found 3 violations and 1 error in 200ms' . PHP_EOL,
         ];
 
         foreach ($writer->getChunks() as $i => $chunk) {
@@ -127,7 +127,7 @@ class AnsiRendererTest extends AbstractTestCase
         $renderer->end();
 
         $expectedChunks = [
-            PHP_EOL . "Found 0 violations and 0 errors in 200ms" . PHP_EOL,
+            PHP_EOL . 'Found 0 violations and 0 errors in 200ms' . PHP_EOL,
             PHP_EOL . "\e[32mNo mess detected\e[0m" . PHP_EOL,
         ];
 

--- a/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
@@ -61,9 +61,9 @@ class GitHubRendererTest extends AbstractTestCase
         $renderer->end();
 
         $this->assertEquals(
-            "::warning file=/bar.php,line=1::Test description" . PHP_EOL .
-            "::warning file=/foo.php,line=2::Test description" . PHP_EOL .
-            "::warning file=/foo.php,line=3::Test description" . PHP_EOL,
+            '::warning file=/bar.php,line=1::Test description' . PHP_EOL .
+            '::warning file=/foo.php,line=2::Test description' . PHP_EOL .
+            '::warning file=/foo.php,line=3::Test description' . PHP_EOL,
             $writer->getData()
         );
     }
@@ -100,9 +100,9 @@ class GitHubRendererTest extends AbstractTestCase
         $renderer->end();
 
         $this->assertEquals(
-            "::error file=/tmp/foo.php::Failed for file \"/tmp/foo.php\"." . PHP_EOL .
-            "::error file=/tmp/bar.php::Failed for file \"/tmp/bar.php\"." . PHP_EOL .
-            "::error file=/tmp/baz.php::Failed for file \"/tmp/baz.php\"." . PHP_EOL,
+            '::error file=/tmp/foo.php::Failed for file "/tmp/foo.php".' . PHP_EOL .
+            '::error file=/tmp/bar.php::Failed for file "/tmp/bar.php".' . PHP_EOL .
+            '::error file=/tmp/baz.php::Failed for file "/tmp/baz.php".' . PHP_EOL,
             $writer->getData()
         );
     }

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -66,9 +66,9 @@ class TextRendererTest extends AbstractTestCase
         $renderer->end();
 
         $this->assertEquals(
-            "/bar.php:1      LongerNamedRule  An other description for this rule" . PHP_EOL .
-            "/foo-biz.php:2  RuleStub         Test description" . PHP_EOL .
-            "/foo.php:34     RuleStub         Test description" . PHP_EOL,
+            '/bar.php:1      LongerNamedRule  An other description for this rule' . PHP_EOL .
+            '/foo-biz.php:2  RuleStub         Test description' . PHP_EOL .
+            '/foo.php:34     RuleStub         Test description' . PHP_EOL,
             $writer->getData()
         );
     }

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -198,6 +198,7 @@ class ReportTest extends AbstractTestCase
     {
         /** @var RuleViolation $ruleA */
         $ruleA = $this->getRuleViolationMock('foo.txt');
+
         /** @var RuleViolation $ruleB */
         $ruleB = $this->getRuleViolationMock('bar.txt', 1, 2);
 
@@ -224,6 +225,7 @@ class ReportTest extends AbstractTestCase
     {
         /** @var RuleViolation $ruleA */
         $ruleA = $this->getRuleViolationMock('foo.txt');
+
         /** @var RuleViolation $ruleB */
         $ruleB = $this->getRuleViolationMock('bar.txt', 1, 2);
 

--- a/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
@@ -35,6 +35,7 @@ class MissingImportTest extends AbstractTestCase
     {
         $rule = new MissingImport();
         $rule->addProperty('ignore-global', 'false');
+
         return $rule;
     }
 
@@ -95,6 +96,7 @@ class MissingImportTest extends AbstractTestCase
             // Covers case when the new property is set and the rule *should* apply.
             if (strpos($file, 'WithNotImportedDeepDependencies')) {
                 $this->expectRuleHasViolationsForFile($rule, static::ONE_VIOLATION, $file);
+
                 continue;
             }
             // Covers case when the new property is set and the rule *should not* apply.

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -34,7 +34,7 @@ class CamelCaseMethodNameTest extends AbstractTestCase
      */
     public function testRuleDoesNotApplyForValidMethodName()
     {
-        //$method = $this->getMethod();
+        // $method = $this->getMethod();
         $report = $this->getReportWithNoViolation();
 
         $rule = new CamelCaseMethodName();

--- a/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -168,7 +168,7 @@ class TooManyMethodsTest extends AbstractTestCase
      * @param string[] $methodNames
      * @return ClassNode
      */
-    private function createClassMock($numberOfMethods, array $methodNames = null)
+    private function createClassMock($numberOfMethods, ?array $methodNames = null)
     {
         $class = $this->getClassMock('nom', $numberOfMethods);
 

--- a/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -22,8 +22,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the unused formal parameter rule.
  *
- * @covers \PHPMD\Rule\UnusedFormalParameter
  * @covers \PHPMD\Rule\AbstractLocalVariable
+ * @covers \PHPMD\Rule\UnusedFormalParameter
  */
 class UnusedFormalParameterTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
@@ -22,8 +22,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the unused local variable rule.
  *
- * @covers \PHPMD\Rule\UnusedLocalVariable
  * @covers \PHPMD\Rule\AbstractLocalVariable
+ * @covers \PHPMD\Rule\UnusedLocalVariable
  */
 class UnusedLocalVariableTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -665,7 +665,7 @@ class RuleSetFactoryTest extends AbstractTestCase
             $factory = new RuleSetFactory();
             $factory->createRuleSets($fileName);
 
-            $expectedIncludePath = "/foo/bar/baz";
+            $expectedIncludePath = '/foo/bar/baz';
             $actualIncludePaths = explode(PATH_SEPARATOR, get_include_path());
             $isIncludePathPresent = in_array($expectedIncludePath, $actualIncludePaths);
         } catch (Exception $exception) {

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -670,6 +670,7 @@ class RuleSetFactoryTest extends AbstractTestCase
             $isIncludePathPresent = in_array($expectedIncludePath, $actualIncludePaths);
         } catch (Exception $exception) {
             set_include_path($includePathBefore);
+
             throw $exception;
         }
 
@@ -724,6 +725,7 @@ class RuleSetFactoryTest extends AbstractTestCase
     {
         $ruleSets = $this->createRuleSetsFromFiles($file);
         $ruleSet = $ruleSets[0];
+
         /** @var Rule $rule */
         foreach ($ruleSet->getRules() as $rule) {
             $message = sprintf(

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -172,8 +172,8 @@ class RuleTest extends AbstractTestCase
      * testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
-     * @covers ::getStringProperty
      * @covers ::getProperty
+     * @covers ::getStringProperty
      */
     public function testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
@@ -188,8 +188,8 @@ class RuleTest extends AbstractTestCase
      * testGetStringPropertyReturnsStringValue
      *
      * @return void
-     * @covers ::getStringProperty
      * @covers ::getProperty
+     * @covers ::getStringProperty
      */
     public function testGetStringPropertyReturnsString()
     {
@@ -204,8 +204,8 @@ class RuleTest extends AbstractTestCase
      * Tests the getStringProperty method with a fallback value
      *
      * @return void
-     * @covers ::getStringProperty
      * @covers ::getProperty
+     * @covers ::getStringProperty
      */
     public function testGetStringPropertyReturnsFallbackString()
     {

--- a/src/test/php/PHPMD/Stubs/RuleStub.php
+++ b/src/test/php/PHPMD/Stubs/RuleStub.php
@@ -26,7 +26,7 @@ use PHPMD\Rule\ClassAware;
  */
 class RuleStub extends AbstractRule implements ClassAware
 {
-    public $node = null;
+    public $node;
 
     /**
      * Constructs a new rule stub instance.

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -731,7 +731,7 @@ class CommandLineOptionsTest extends AbstractTestCase
             ['sarif', SARIFRenderer::class],
             ['PHPMD_Test_Renderer_PEARRenderer', 'PHPMD_Test_Renderer_PEARRenderer'],
             [NamespaceRenderer::class, NamespaceRenderer::class],
-            /* Test what happens when class already exists. */
+            // Test what happens when class already exists.
             [NamespaceRenderer::class, NamespaceRenderer::class],
         ];
     }

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -222,7 +222,7 @@ class CommandTest extends AbstractTestCase
 
     public function testMainGenerateBaseline()
     {
-        $uri = str_replace("\\", "/", realpath(self::createFileUri('source/source_with_anonymous_class.php')));
+        $uri = str_replace('\\', '/', realpath(self::createFileUri('source/source_with_anonymous_class.php')));
         $temp = self::createTempFileUri();
         $exitCode = Command::main([
             __FILE__,

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -46,7 +46,7 @@ class CommandTest extends AbstractTestCase
      * @return void
      * @dataProvider dataProviderTestMainWithOption
      */
-    public function testMainStrictOptionIsOfByDefault($sourceFile, $expectedExitCode, array $options = null)
+    public function testMainStrictOptionIsOfByDefault($sourceFile, $expectedExitCode, ?array $options = null)
     {
         $args = array_filter(
             array_merge(


### PR DESCRIPTION
Type: refactoring 
Issue: Resolves None
Breaking change: No

Depends on:
- https://github.com/phpmd/phpmd/pull/1139

This adds & applies the full "PHP CS  Fixer" ruleset but amends some rules.

Many rules are redundant and kept only for discussion & understandability, including their description line.

The config file contains a few TODOs. Some rules were applied already (see separte commits), for some we would need to make a decision.

Also, I added a Composer script for executing a PHP CS Fixer check just for conventience.
We don't need to keep them long term or can rename it.

@AJenbo this is not yet merged with your list. 
Will do that in a PR that is based on this one.