### PR TITLE
[3.x] PHP CS Fixer Rules from Anders

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -7,6 +7,7 @@
  */
 $config = new PhpCsFixer\Config();
 return $config
+    ->setRiskyAllowed(true)
     ->setRules([
         '@PhpCsFixer' => true, // Gets overwritten by rules below
         '@PER-CS2.0' => true,

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -381,7 +381,7 @@ return $config
         'is_null' => false, // Risky // Uses yoda-style
         'logical_operators' => true, // Risky
         'long_to_shorthand_operator' => true, // Risky
-        'mb_str_functions' => true, // Risky
+        'mb_str_functions' => false, // Risky, leads to test suite errors
         'modernize_types_casting' => true, // Risky
         'no_unset_on_property' => true, // Risky
         'no_useless_sprintf' => true, // Risky

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -83,6 +83,8 @@ return $config
                 'since', // Source & version
                 'filesource', // phpDocumentor specific
                 'ignore', // phpDocumentor specific
+                'SuppressWarnings', // PHPMD specific (Current format "@SuppressWarnings(*)" not supported)
+                'phpcsSuppress', // PHPCS specific
                 'deprecated', // Should be to the end to better notice them
                 'todo', // Should be last to better notice them
             ],

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -217,7 +217,7 @@ return $config
         // Operator `=>` should not be surrounded by multi-line whitespaces.
         'no_multiline_whitespace_around_double_arrow' => true,
         // Properties MUST not be explicitly initialized with `null` except when they have a type declaration (PHP 7.4).
-        'no_null_property_initialization' => true, // TODO Arguable, could remove info about nullability
+        'no_null_property_initialization' => false, // TODO Arguable, could remove info about nullability
         // Short cast `bool` using double exclamation mark should not be used.
         'no_short_bool_cast' => true,
         // Single-line whitespace before closing semicolon are prohibited.

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -8,6 +8,7 @@
 $config = new PhpCsFixer\Config();
 return $config
     ->setRules([
+        '@PhpCsFixer' => true, // Gets overwritten by rules below
         '@PER-CS2.0' => true,
         'binary_operator_spaces' => true, // Going beyond PER CS v2
         'ordered_class_elements' => [
@@ -93,9 +94,268 @@ return $config
         'phpdoc_trim_consecutive_blank_line_separation' => true,
         'phpdoc_types_order' => ['null_adjustment' => 'always_last'],
         'phpdoc_var_annotation_correct_order' => true,
+
+        /*
+         * PHP CS Fixer rules
+         */
+
+        // Each line of multi-line DocComments must have an asterisk [PSR-5] and must be aligned with the first one.
+        'align_multiline_comment' => true,
+        // PHP arrays should be declared using the configured syntax.
+        'array_syntax' => true,
+        // Converts backtick operators to `shell_exec` calls.
+        'backtick_to_shell_exec' => true,
+        // An empty line feed must precede any configured statement.
+        'blank_line_before_statement' => [
+            'statements' => [
+                'break',
+                'case',
+                'continue',
+                'declare',
+                'default',
+                'exit',
+                'goto',
+                'include',
+                'include_once',
+                'phpdoc',
+                'require',
+                'require_once',
+                'return',
+                'switch',
+                'throw',
+                'try',
+                'yield',
+                'yield_from'
+            ]
+        ],
+        // Class, trait and interface elements must be separated with one or none blank line.
+        'class_attributes_separation' => ['elements' => ['method' => 'one']],
+        // When referencing an internal class it must be written using the correct casing.
+        'class_reference_name_casing' => true,
+        // Namespace must not contain spacing, comments or PHPDoc.
+        'clean_namespace' => true,
+        // Using `isset($var) &&` multiple times should be done in one call.
+        'combine_consecutive_issets' => true,
+        // Calling `unset` on multiple items should be done in one call.
+        'combine_consecutive_unsets' => true,
+        // There must not be spaces around `declare` statement parentheses.
+        'declare_parentheses' => true,
+        // Replaces short-echo `<?=` with long format `<?php echo`/`<?php print` syntax, or vice-versa.
+        'echo_tag_syntax' => ['format' => 'short', 'shorten_simple_statements_only' => true ],
+        // Empty loop-body must be in configured style.
+        'empty_loop_body' => true,
+        // Empty loop-condition must be in configured style.
+        'empty_loop_condition' => true,
+        // Add curly braces to indirect variables to make them clear to understand. Requires PHP >= 7.0.
+        'explicit_indirect_variable' => true,
+        // Converts implicit variables into explicit ones in double-quoted strings or heredoc syntax.
+        'explicit_string_variable' => false,
+        // Renames PHPDoc tags.
+        'general_phpdoc_tag_rename' => ['replacements' => ['inheritDocs' => 'inheritDoc']],
+        // Convert `heredoc` to `nowdoc` where possible.
+        'heredoc_to_nowdoc' => true,
+        // Include/Require and file path should be divided with a single space. File path should not be placed within parentheses.
+        'include' => true,
+        // Pre- or post-increment and decrement operators should be used if possible.
+        'increment_style' => false, // TODO Arguable
+        // Integer literals must be in correct case.
+        'integer_literal_case' => true,
+        // Lambda must not import variables it doesn't use.
+        'lambda_not_used_import' => true,
+        // Ensure there is no code on the same line as the PHP open tag.
+        'linebreak_after_opening_tag' => true,
+        // Magic constants should be referred to using the correct casing.
+        'magic_constant_casing' => true,
+        // Magic method definitions and calls must be using the correct casing.
+        'magic_method_casing' => true,
+        // Method chaining MUST be properly indented. Method chaining with different levels of indentation is not supported.
+        'method_chaining_indentation' => true,
+        // DocBlocks must start with two asterisks, multiline comments must start with a single asterisk, after the opening slash. Both must end with a single asterisk before the closing slash.
+        'multiline_comment_opening_closing' => true,
+        // Forbid multi-line whitespace before the closing semicolon or move the semicolon to the new line for chained calls.
+        'multiline_whitespace_before_semicolons' => false,
+        // Function defined by PHP should be called using the correct casing.
+        'native_function_casing' => true,
+        // Native type declarations should be used in the correct case.
+        'native_type_declaration_casing' => true,
+        // Master language constructs shall be used instead of aliases.
+        'no_alias_language_construct_call' => true,
+        // Replace control structure alternative syntax to use braces.
+        'no_alternative_syntax' => true,
+        // There should not be a binary flag before strings.
+        'no_binary_string' => true,
+        // There should not be blank lines between docblock and the documented element.
+        'no_blank_lines_after_phpdoc' => false,
+        // There should not be any empty comments.
+        'no_empty_comment' => true,
+        // Remove useless (semicolon) statements.
+        'no_empty_statement' => true,
+        // Removes extra blank lines and/or blank lines following configuration.
+        'no_extra_blank_lines' => [
+            'tokens' => [
+                'attribute',
+                'break',
+                'case',
+                'continue',
+                'curly_brace_block',
+                'default',
+                'extra',
+                'parenthesis_brace_block',
+                'return',
+                'square_brace_block',
+                'switch',
+                'throw',
+                'use'
+            ]
+        ],
+        // The namespace declaration line shouldn't contain leading whitespace.
+        'no_leading_namespace_whitespace' => true,
+        // Either language construct `print` or `echo` should be used.
+        'no_mixed_echo_print' => true,
+        // Operator `=>` should not be surrounded by multi-line whitespaces.
+        'no_multiline_whitespace_around_double_arrow' => true,
+        // Properties MUST not be explicitly initialized with `null` except when they have a type declaration (PHP 7.4).
+        'no_null_property_initialization' => true, // TODO Arguable, could remove info about nullability
+        // Short cast `bool` using double exclamation mark should not be used.
+        'no_short_bool_cast' => true,
+        // Single-line whitespace before closing semicolon are prohibited.
+        'no_singleline_whitespace_before_semicolons' => true,
+        // There MUST NOT be spaces around offset braces.
+        'no_spaces_around_offset' => true,
+        // Replaces superfluous `elseif` with `if`.
+        'no_superfluous_elseif' => true,
+        // If a list of values separated by a comma is contained on a single line, then the last item MUST NOT have a trailing comma.
+        'no_trailing_comma_in_singleline' => true,
+        // Removes unneeded braces that are superfluous and aren't part of a control structure's body.
+        'no_unneeded_braces' => ['namespaces' => true],
+        // Removes unneeded parentheses around control statements.
+        'no_unneeded_control_parentheses' => [
+            'statements' => [
+                'break',
+                'clone',
+                'continue',
+                'echo_print',
+                //'negative_instanceof',
+                'others',
+                //'return',
+                'switch_case',
+                'yield',
+                'yield_from'
+            ]
+        ],
+        // Imports should not be aliased as the same name.
+        'no_unneeded_import_alias' => true,
+        // Variables must be set `null` instead of using `(unset)` casting.
+        'no_unset_cast' => true,
+        // There should not be useless concat operations.
+        'no_useless_concat_operator' => true,
+        // There should not be useless `else` cases.
+        'no_useless_else' => true,
+        // There should not be useless Null-safe operator `?->` used.
+        'no_useless_nullsafe_operator' => true,
+        // There should not be an empty `return` statement at the end of a function.
+        'no_useless_return' => true,
+        // In array declaration, there MUST NOT be a whitespace before each comma.
+        'no_whitespace_before_comma_in_array' => ['after_heredoc' => true],
+        // Array index should always be written by using square braces.
+        'normalize_index_brace' => true,
+        // Nullable single type declaration should be standardised using configured syntax.
+        'nullable_type_declaration' => true,
+        // Adds or removes `?` before single type declarations or `|null` at the end of union types when parameters have a default `null` value.
+        'nullable_type_declaration_for_default_null_value' => true,
+        // There should not be space before or after object operators `->` and `?->`.
+        'object_operator_without_whitespace' => true,
+        // Operators - when multiline - must always be at the beginning or at the end of the line.
+        // TODO Decide whether to put boolean operators at the end or the beginning. Either way lead to 10 changed files.
+        'operator_linebreak' => false,
+        //'operator_linebreak' => ['only_booleans' => true, 'position' => 'beginning'],
+        //'operator_linebreak' => ['only_booleans' => true, 'position' => 'end'],
+        // Sort union types and intersection types using configured order.
+        'ordered_types' => true,
+        // PHPUnit annotations should be a FQCNs including a root namespace.
+        'php_unit_fqcn_annotation' => true,
+        // All PHPUnit test classes should be marked as internal.
+        'php_unit_internal_class' => false,
+        // Enforce camel (or snake) case for PHPUnit test methods, following configuration.
+        'php_unit_method_casing' => true,
+        // Adds a default `@coversNothing` annotation to PHPUnit test classes that have no `@covers*` annotation.
+        'php_unit_test_class_requires_covers' => false, // TODO We should enforce the opposite instead but not possible with PHP CS Fixer
+        // PHPDoc should contain `@param` for all params.
+        'phpdoc_add_missing_param_annotation' => false, // Can't be enabled due to "no_superfluous_phpdoc_tags" rule
+        // All items of the given PHPDoc tags must be either left-aligned or (by default) aligned vertically.
+        'phpdoc_align' => false,
+        // PHPDoc annotation descriptions should not be a sentence.
+        'phpdoc_annotation_without_dot' => false, // Also reduces the Casing of the First word of the description.
+        // Fixes PHPDoc inline tags.
+        'phpdoc_inline_tag_normalizer' => true,
+        // `@access` annotations should be omitted from PHPDoc.
+        'phpdoc_no_access' => true,
+        // No alias PHPDoc tags should be used.
+        'phpdoc_no_alias_tag' => false, // Changes @link to @see
+        // `@return void` and `@return null` annotations should be omitted from PHPDoc.
+        'phpdoc_no_empty_return' => false, // Removes a lot of return type hints that could be useful
+        // `@package` and `@subpackage` annotations should be omitted from PHPDoc.
+        'phpdoc_no_package' => true,
+        // Classy that does not inherit must not have `@inheritdoc` tags.
+        'phpdoc_no_useless_inheritdoc' => true,
+        // Order PHPDoc tags by value.
+        'phpdoc_order_by_value' => true,
+        // Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line.
+        'phpdoc_separation' => false,
+        // PHPDoc summary should end in either a full stop, exclamation mark, or question mark.
+        'phpdoc_summary' => false,
+        // Forces PHPDoc tags to be either regular annotations or inline.
+        'phpdoc_tag_type' => false,
+        // Docblocks should only be used on structural elements.
+        'phpdoc_to_comment' => false,
+        // The correct case must be used for standard PHP types in PHPDoc.
+        'phpdoc_types' => true,
+        // `@var` and `@type` annotations of classy properties should not contain the name.
+        'phpdoc_var_without_name' => true,
+        // Converts `protected` variables and methods to `private` where possible.
+        'protected_to_private' => true, // TODO Arguable, not a fan of
+        // Local, dynamic and directly referenced variables should not be assigned and directly returned by a function or method.
+        'return_assignment' => false, // Makes debugging more difficult
+        // Inside an enum or `final`/anonymous class, `self` should be preferred over `static`.
+        'self_static_accessor' => true,
+        // Instructions must be terminated with a semicolon.
+        'semicolon_after_instruction' => true,
+        // Converts explicit variables in double-quoted strings and heredoc syntax from simple to complex format (`${` to `{$`).
+        'simple_to_complex_string_variable' => true,
+        // Single-line comments must have proper spacing.
+        'single_line_comment_spacing' => true, // TODO Preferable for non-code, not so for actual code
+        // Single-line comments and multi-line comments with only one line of actual content should use the `//` syntax.
+        'single_line_comment_style' => true,
+        // Throwing exception must be done in single line.
+        'single_line_throw' => false,
+        // Convert double quotes to single quotes for simple strings.
+        'single_quote' => true,
+        // Ensures a single space after language constructs.
+        'single_space_around_construct' => true,
+        // Fix whitespace after a semicolon.
+        'space_after_semicolon' => ['remove_in_empty_for_expressions' => true],
+        // Increment and decrement operators should be used if possible.
+        'standardize_increment' => true,
+        // Replace all `<>` with `!=`.
+        'standardize_not_equals' => true,
+        // Handles implicit backslashes in strings and heredocs. Depending on the chosen strategy, it can escape implicit backslashes to ease the understanding of which are special chars interpreted by PHP and which not (`escape`), or it can remove these additional backslashes if you find them superfluous (`unescape`). You can also leave them as-is using `ignore` strategy.
+        'string_implicit_backslashes' => false,
+        // Switch case must not be ended with `continue` but with `break`.
+        'switch_continue_to_break' => true,
+        // Arrays should be formatted like function/method arguments, without leading or trailing single line space.
+        'trim_array_spaces' => true,
+        // Ensure single space between a variable and its type declaration in function arguments and properties.
+        'type_declaration_spaces' => true,
+        // A single space or none should be around union type and intersection type operators.
+        'types_spaces' => true,
+        // In array declaration, there MUST be a whitespace after each comma.
+        'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+        // Write conditions in Yoda style (`true`), non-Yoda style (`['equal' => false, 'identical' => false, 'less_and_greater' => false]`) or ignore those conditions (`null`) based on configuration.
+        'yoda_style' => false,
     ])
-    ->setFinder(PhpCsFixer\Finder::create()
-        ->exclude('vendor')
-        ->in(__DIR__ . '/src/main/php/PHPMD')
-        ->in(__DIR__ . '/src/test/php/')
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->exclude('vendor')
+            ->in(__DIR__ . '/src/main/php/PHPMD')
+            ->in(__DIR__ . '/src/test/php/')
     );

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -37,11 +37,11 @@ return $config
             'after_heredoc' => true,
             'elements' => [
                 // Not adhering to PER CS v2; we don't want trailing commas for arguments
-//                'arguments',
+                //'arguments',
                 'arrays',
                 'match',
                 // Not adhering to PER CS v2; we don't want trailing commas for parameters
-//                'parameters'
+                //'parameters'
             ]
         ],
         'fully_qualified_strict_types' => true,

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -354,6 +354,55 @@ return $config
         'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
         // Write conditions in Yoda style (`true`), non-Yoda style (`['equal' => false, 'identical' => false, 'less_and_greater' => false]`) or ignore those conditions (`null`) based on configuration.
         'yoda_style' => false,
+
+        /*
+         * Additional rules, mostly risky ones
+         */
+
+        '@PHPUnit100Migration:risky' => true,
+        '@PER-CS2.0:risky' => true,
+        '@PHP81Migration' => true,
+        '@PHP80Migration:risky' => true,
+
+        'declare_strict_types' => false, // Not yet
+        'pow_to_exponentiation' => false, // Risky
+
+        'array_push' => true, // Risky
+        'comment_to_phpdoc' => true, // Risky
+        'date_time_create_from_format_call' => true, // Risky
+        'dir_constant' => true, // Risky
+        'ereg_to_preg' => true, // Risky
+        'fopen_flag_order' => true, // Risky
+        'fopen_flags' => true, // Risky
+        'function_to_constant' => true, // Risky
+        'general_phpdoc_annotation_remove' => false, // We do not want to remove any in general
+        'heredoc_closing_marker' => true,
+        'is_null' => false, // Risky // Uses yoda-style
+        'logical_operators' => true, // Risky
+        'long_to_shorthand_operator' => true, // Risky
+        'mb_str_functions' => true, // Risky
+        'modernize_types_casting' => true, // Risky
+        'no_unset_on_property' => true, // Risky
+        'no_useless_sprintf' => true, // Risky
+        'ordered_interfaces' => true,
+        'ordered_traits' => true, // Risky
+        'php_unit_construct' => true, // Risky
+        'php_unit_set_up_tear_down_visibility' => true, // Risky
+         'php_unit_strict' => false, // Risky
+        'php_unit_test_annotation' => true, // Risky
+        'php_unit_test_case_static_method_calls' => true, // Risky
+        'phpdoc_line_span' => ['const' => 'single','property' => 'single'],
+        'phpdoc_param_order' => true,
+        'phpdoc_tag_casing' => true,
+        'regular_callable_call' => true, // Risky
+        'self_accessor' => true, // Risky
+        'set_type_to_cast' => true, // Risky
+        'simplified_if_return' => false, // TODO Arguable, can make it less readable
+        'strict_comparison' => true, // Risky
+        'strict_param' => true, // Risky
+        'string_length_to_empty' => true, // Risky
+        'string_line_ending' => true, // Risky
+        'ternary_to_elvis_operator' => true, // Risky
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -185,7 +185,7 @@ return $config
         // There should not be a binary flag before strings.
         'no_binary_string' => true,
         // There should not be blank lines between docblock and the documented element.
-        'no_blank_lines_after_phpdoc' => false,
+        'no_blank_lines_after_phpdoc' => true,
         // There should not be any empty comments.
         'no_empty_comment' => true,
         // Remove useless (semicolon) statements.

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -28,9 +28,9 @@ return $config
                 'magic',
                 'phpunit',
                 // We do not want to order methods
-//                'method_public',
-//                'method_protected',
-//                'method_private',
+                //'method_public',
+                //'method_protected',
+                //'method_private',
             ]
         ],
         'single_line_empty_body' => false, // Not adhering to PER CS v2

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
   "scripts": {
     "test": "paratest",
     "cs-check": "phpcs -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
+    "cs-fixer-check": "php-cs-fixer check",
     "cs-fixer": "php-cs-fixer fix",
     "cs-fix": "phpcbf -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
     "build-website": "easy-doc build src/site/config.php --verbose"

--- a/composer.json
+++ b/composer.json
@@ -64,8 +64,8 @@
   "scripts": {
     "test": "paratest",
     "cs-check": "phpcs -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
-    "cs-fixer-check": "php-cs-fixer check --allow-risky=yes",
-    "cs-fixer": "php-cs-fixer fix --allow-risky=yes",
+    "cs-fixer-check": "php-cs-fixer check",
+    "cs-fixer": "php-cs-fixer fix",
     "cs-fix": "phpcbf -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
     "build-website": "easy-doc build src/site/config.php --verbose"
   },

--- a/composer.json
+++ b/composer.json
@@ -64,8 +64,8 @@
   "scripts": {
     "test": "paratest",
     "cs-check": "phpcs -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
-    "cs-fixer-check": "php-cs-fixer check",
-    "cs-fixer": "php-cs-fixer fix",
+    "cs-fixer-check": "php-cs-fixer check --allow-risky=yes",
+    "cs-fixer": "php-cs-fixer fix --allow-risky=yes",
     "cs-fix": "phpcbf -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
     "build-website": "easy-doc build src/site/config.php --verbose"
   },

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -34,9 +34,7 @@ use PHPMD\Node\ASTNode;
  */
 abstract class AbstractNode
 {
-    /**
-     * @var TNode
-     */
+    /** @var TNode */
     private $node = null;
 
     /**

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -35,7 +35,7 @@ use PHPMD\Node\ASTNode;
 abstract class AbstractNode
 {
     /**
-     * @var TNode $node
+     * @var TNode
      */
     private $node = null;
 

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -74,7 +74,7 @@ abstract class AbstractNode
             );
         }
 
-        return $node->$name(...$args);
+        return $node->{$name}(...$args);
     }
 
     /**

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -36,29 +36,19 @@ use RuntimeException;
  */
 abstract class AbstractRule implements Rule
 {
-    /**
-     * The name for this rule instance.
-     */
+    /** The name for this rule instance. */
     private string $name = '';
 
-    /**
-     * The violation message text for this rule.
-     */
+    /** The violation message text for this rule. */
     private string $message = '';
 
-    /**
-     * The version since when this rule is available.
-     */
+    /** The version since when this rule is available. */
     private ?string $since = null;
 
-    /**
-     * An url will external information for this rule.
-     */
+    /** An url will external information for this rule. */
     private string $externalInfoUrl = '';
 
-    /**
-     * An optional description for this rule.
-     */
+    /** An optional description for this rule. */
     private string $description = '';
 
     /**
@@ -68,14 +58,10 @@ abstract class AbstractRule implements Rule
      */
     private array $examples = [];
 
-    /**
-     * The name of the parent rule-set instance.
-     */
+    /** The name of the parent rule-set instance. */
     private string $ruleSetName = '';
 
-    /**
-     * The priority of this rule.
-     */
+    /** The priority of this rule. */
     private int $priority = self::LOWEST_PRIORITY;
 
     /**
@@ -85,14 +71,10 @@ abstract class AbstractRule implements Rule
      */
     private array $properties = [];
 
-    /**
-     * The report for object for this rule.
-     */
+    /** The report for object for this rule. */
     private ?Report $report = null;
 
-    /**
-     * Should this rule force the strict mode.
-     */
+    /** Should this rule force the strict mode. */
     private bool $strict = false;
 
     /**

--- a/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
+++ b/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
@@ -30,6 +30,7 @@ class BaselineFileFinder
     public function existingFile()
     {
         $this->existingFile = true;
+
         return $this;
     }
 
@@ -40,6 +41,7 @@ class BaselineFileFinder
     public function notNull()
     {
         $this->notNull = true;
+
         return $this;
     }
 
@@ -91,6 +93,7 @@ class BaselineFileFinder
         if ($this->notNull) {
             throw new RuntimeException($message);
         }
+
         return null;
     }
 }

--- a/src/main/php/PHPMD/Baseline/BaselineMode.php
+++ b/src/main/php/PHPMD/Baseline/BaselineMode.php
@@ -4,18 +4,12 @@ namespace PHPMD\Baseline;
 
 class BaselineMode
 {
-    /**
-     * Do not generate or update any baseline file
-     */
+    /** Do not generate or update any baseline file */
     public const NONE = 'none';
 
-    /**
-     * Generate a baseline file for _all_ current violations
-     */
+    /** Generate a baseline file for _all_ current violations */
     public const GENERATE = 'generate';
 
-    /**
-     * Remove any non existing violations from the baseline file. Do not baseline any new violations.
-     */
+    /** Remove any non existing violations from the baseline file. Do not baseline any new violations. */
     public const UPDATE = 'update';
 }

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -41,7 +41,7 @@ class BaselineSetFactory
 
             $methodName = null;
             if (isset($node['method']) && ((string) $node['method']) !== '') {
-                $methodName = (string) ($node['method']);
+                $methodName = (string) $node['method'];
             }
 
             $baselineSet->addEntry(new ViolationBaseline((string) $node['rule'], (string) $node['file'], $methodName));

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheKey.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheKey.php
@@ -6,12 +6,16 @@ class ResultCacheKey
 {
     /** @var bool */
     private $strict;
+
     /** @var string|null */
     private $baselineHash;
+
     /** @var array<string, string> */
     private $rules;
+
     /** @var array<string, string> */
     private $composer;
+
     /** @var int */
     private $phpVersion;
 

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheKey.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheKey.php
@@ -48,7 +48,7 @@ class ResultCacheKey
     /**
      * @return bool
      */
-    public function isEqualTo(ResultCacheKey $other)
+    public function isEqualTo(self $other)
     {
         return $this->strict === $other->strict
             && $this->baselineHash === $other->baselineHash

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
@@ -132,9 +132,8 @@ class ResultCacheState
     /**
      * @param string $filePath
      * @param string $hash
-     * @return void
      */
-    public function setFileState($filePath, $hash)
+    public function setFileState($filePath, $hash): void
     {
         $this->state['files'][$filePath]['hash'] = $hash;
     }

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheStrategy.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheStrategy.php
@@ -4,13 +4,9 @@ namespace PHPMD\Cache\Model;
 
 class ResultCacheStrategy
 {
-    /**
-     * Determine the file cache freshness based on sha hash of the contents of the file
-     */
+    /** Determine the file cache freshness based on sha hash of the contents of the file */
     public const CONTENT = 'content';
 
-    /**
-     * Determine the file cache freshness based on the file modified timestamp
-     */
+    /** Determine the file cache freshness based on the file modified timestamp */
     public const TIMESTAMP = 'timestamp';
 }

--- a/src/main/php/PHPMD/Cache/ResultCacheEngine.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngine.php
@@ -15,8 +15,8 @@ class ResultCacheEngine
 
     public function __construct(
         ResultCacheFileFilter $fileFilter,
-        ResultCacheUpdater    $updater,
-        ResultCacheWriter     $writer
+        ResultCacheUpdater $updater,
+        ResultCacheWriter $writer
     ) {
         $this->fileFilter = $fileFilter;
         $this->updater = $updater;

--- a/src/main/php/PHPMD/Cache/ResultCacheEngine.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngine.php
@@ -18,7 +18,6 @@ class ResultCacheEngine
         ResultCacheUpdater    $updater,
         ResultCacheWriter     $writer
     ) {
-
         $this->fileFilter = $fileFilter;
         $this->updater = $updater;
         $this->writer = $writer;

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -16,8 +16,8 @@ class ResultCacheEngineFactory
     private $cacheStateFactory;
 
     public function __construct(
-        OutputInterface         $output,
-        ResultCacheKeyFactory   $cacheKeyFactory,
+        OutputInterface $output,
+        ResultCacheKeyFactory $cacheKeyFactory,
         ResultCacheStateFactory $cacheStateFactory
     ) {
         $this->output = $output;

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -10,8 +10,10 @@ class ResultCacheEngineFactory
 {
     /** @var OutputInterface */
     private $output;
+
     /** @var ResultCacheKeyFactory */
     private $cacheKeyFactory;
+
     /** @var ResultCacheStateFactory */
     private $cacheStateFactory;
 
@@ -34,6 +36,7 @@ class ResultCacheEngineFactory
     {
         if (!$options->isCacheEnabled()) {
             $this->output->writeln('ResultCache is not enabled.', OutputInterface::VERBOSITY_VERY_VERBOSE);
+
             return null;
         }
 

--- a/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
@@ -28,7 +28,6 @@ class ResultCacheFileFilter implements Filter
     /** @var OutputInterface */
     private $output;
 
-
     /**
      * @param string                $basePath
      * @param string                $strategy

--- a/src/main/php/PHPMD/Cache/ResultCacheKeyFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheKeyFactory.php
@@ -10,6 +10,7 @@ class ResultCacheKeyFactory
 {
     /** @var string */
     private $basePath;
+
     /** @var string|null */
     private $baselineFile;
 

--- a/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
@@ -12,6 +12,7 @@ class ResultCacheUpdater
 {
     /** @var OutputInterface */
     private $output;
+
     /** @var string */
     private $basePath;
 

--- a/src/main/php/PHPMD/Console/Output.php
+++ b/src/main/php/PHPMD/Console/Output.php
@@ -39,7 +39,7 @@ abstract class Output implements OutputInterface
         }
 
         foreach ($messages as $message) {
-            $this->doWrite($message . ($newline ? "\n" : ""));
+            $this->doWrite($message . ($newline ? "\n" : ''));
         }
     }
 

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -28,9 +28,7 @@ use PDepend\Source\AST\AbstractASTClassOrInterface;
  */
 abstract class AbstractTypeNode extends AbstractNode
 {
-    /**
-     * @var TNode
-     */
+    /** @var TNode */
     private $node;
 
     /**

--- a/src/main/php/PHPMD/Node/Annotation.php
+++ b/src/main/php/PHPMD/Node/Annotation.php
@@ -24,9 +24,7 @@ use PHPMD\Rule;
  */
 class Annotation
 {
-    /**
-     * Name of the suppress warnings annotation.
-     */
+    /** Name of the suppress warnings annotation. */
     private const SUPPRESS_ANNOTATION = 'suppressWarnings';
 
     /**
@@ -76,7 +74,7 @@ class Annotation
      */
     private function isSuppressed(Rule $rule)
     {
-        if (in_array($this->value, ['PHPMD', 'PMD'])) {
+        if (in_array($this->value, ['PHPMD', 'PMD'], true)) {
             return true;
         }
         if (preg_match(

--- a/src/main/php/PHPMD/Node/Annotation.php
+++ b/src/main/php/PHPMD/Node/Annotation.php
@@ -78,7 +78,8 @@ class Annotation
     {
         if (in_array($this->value, ['PHPMD', 'PMD'])) {
             return true;
-        } elseif (preg_match(
+        }
+        if (preg_match(
             '/^(PH)?PMD\.' . preg_replace('/^.*\/([^\/]*)$/', '$1', $rule->getName()) . '/',
             $this->value
         )) {

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -25,9 +25,7 @@ use PHPMD\Cache\ResultCacheEngine;
  */
 class PHPMD
 {
-    /**
-     * The current PHPMD version.
-     */
+    /** The current PHPMD version. */
     public const VERSION = '@package_version@';
 
     /**

--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -106,6 +106,7 @@ class ParserFactory
             $trimmedPath = trim($path);
             if (is_dir($trimmedPath)) {
                 $pdepend->addDirectory($trimmedPath);
+
                 continue;
             }
             $pdepend->addFile($trimmedPath);

--- a/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
+++ b/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
@@ -80,7 +80,7 @@ class CheckStyleRenderer extends XMLRenderer
             $this->maybeAdd('function', $violation->getFunctionName());
             $this->maybeAdd('class', $violation->getClassName());
             $this->maybeAdd('method', $violation->getMethodName());
-            //$this->_maybeAdd('variable', $violation->getVariableName());
+            // $this->_maybeAdd('variable', $violation->getVariableName());
 
             $writer->write(' />' . \PHP_EOL);
         }

--- a/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
+++ b/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
@@ -37,6 +37,7 @@ class CheckStyleRenderer extends XMLRenderer
 
         return (int) $priority === 2 ? 'warning' : 'error';
     }
+
     /**
      * This method will be called when the engine has finished the source analysis
      * phase.

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -59,7 +59,7 @@ class GitLabRenderer extends AbstractRenderer
                 ],
                 'check_name' => $violation->getRule()->getName(),
                 'fingerprint' => sprintf(
-                    "%s:%s:%s",
+                    '%s:%s:%s',
                     $violation->getFileName(),
                     $violation->getBeginLine(),
                     $violation->getRule()->getName()

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -39,7 +39,6 @@ class GitLabRenderer extends AbstractRenderer
         $writer->write($jsonData . PHP_EOL);
     }
 
-
     /**
      * Add violations, if any, to GitLab Code Quality report format
      *

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -53,11 +53,10 @@ class GitLabRenderer extends AbstractRenderer
         foreach ($report->getRuleViolations() as $violation) {
             $violationResult = [
                 'type' => 'issue',
-                'categories' =>
-                    [
-                        'Style',
-                        'PHP',
-                    ],
+                'categories' => [
+                    'Style',
+                    'PHP',
+                ],
                 'check_name' => $violation->getRule()->getName(),
                 'fingerprint' => sprintf(
                     "%s:%s:%s",
@@ -67,15 +66,13 @@ class GitLabRenderer extends AbstractRenderer
                 ),
                 'description' => $violation->getDescription(),
                 'severity' => 'minor',
-                'location' =>
-                    [
-                        'path' => $violation->getFileName(),
-                        'lines' =>
-                            [
-                                'begin' => $violation->getBeginLine(),
-                                'end' => $violation->getEndLine(),
-                            ],
+                'location' => [
+                    'path' => $violation->getFileName(),
+                    'lines' => [
+                        'begin' => $violation->getBeginLine(),
+                        'end' => $violation->getEndLine(),
                     ],
+                ],
             ];
 
             $data[] = $violationResult;
@@ -99,14 +96,12 @@ class GitLabRenderer extends AbstractRenderer
                 'description' => $error->getMessage(),
                 'fingerprint' => $error->getFile() . ':0:MajorErrorInFile',
                 'severity' => 'major',
-                'location' =>
-                    [
-                        'path' => $error->getFile(),
-                        'lines' =>
-                            [
-                                'begin' => 0,
-                            ],
+                'location' => [
+                    'path' => $error->getFile(),
+                    'lines' => [
+                        'begin' => 0,
                     ],
+                ],
             ];
 
             $data[] = $errorResult;

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -41,9 +41,7 @@ class HTMLRenderer extends AbstractRenderer
 
     private const CATEGORY_RULE = 'category_rule';
 
-    /**
-     * @var array<int, string>
-     */
+    /** @var array<int, string> */
     private static array $priorityTitles = [
         1 => 'Top (1)',
         2 => 'High (2)',
@@ -99,7 +97,7 @@ class HTMLRenderer extends AbstractRenderer
     {
         $writer = $this->getWriter();
 
-        $mainColor = "#2f838a";
+        $mainColor = '#2f838a';
 
         // Avoid inlining styles.
         $style = "
@@ -330,7 +328,7 @@ class HTMLRenderer extends AbstractRenderer
                 on <em>PHP %s</em>
                 on <em>%s</em>
             </header>
-        ", date('Y-m-d H:i'), "https://phpmd.org", \PHP_VERSION, gethostname());
+        ", date('Y-m-d H:i'), 'https://phpmd.org', \PHP_VERSION, gethostname());
 
         $writer->write($header);
     }
@@ -355,7 +353,7 @@ class HTMLRenderer extends AbstractRenderer
         }
 
         // Render summary tables.
-        $writer->write("<h2>Summary</h2>");
+        $writer->write('<h2>Summary</h2>');
         $categorized = self::sumUpViolations($violations);
         $this->writeTable('By priority', 'Priority', $categorized[self::CATEGORY_PRIORITY]);
         $this->writeTable('By namespace', 'PHP Namespace', $categorized[self::CATEGORY_NAMESPACE]);
@@ -377,7 +375,7 @@ class HTMLRenderer extends AbstractRenderer
 
         foreach ($violations as $violation) {
             // This is going to be used as ID in HTML (deep anchoring).
-            $htmlId = "p-" . $index++;
+            $htmlId = 'p-' . $index++;
 
             // Get excerpt of the code from validated file.
             $excerptHtml = null;
@@ -395,7 +393,7 @@ class HTMLRenderer extends AbstractRenderer
 
             $descHtml = self::colorize(htmlentities($violation->getDescription()));
             $filePath = $violation->getFileName();
-            $fileHtml = "<a href='file://$filePath' target='_blank'>" . self::highlightFile($filePath) . "</a>";
+            $fileHtml = "<a href='file://$filePath' target='_blank'>" . self::highlightFile($filePath) . '</a>';
 
             // Create an external link to rule's help, if there's any provided.
             $linkHtml = null;
@@ -493,7 +491,7 @@ class HTMLRenderer extends AbstractRenderer
                 $prepared[] = "(?<{$key}>{$value['regex']})";
             }
 
-            self::$compiledHighlightRegex = "#(" . implode('|', $prepared) . ")#";
+            self::$compiledHighlightRegex = '#(' . implode('|', $prepared) . ')#';
         }
 
         $rules = self::$descHighlightRules;
@@ -516,7 +514,7 @@ class HTMLRenderer extends AbstractRenderer
      */
     private static function highlightFile($path)
     {
-        $file = substr(strrchr($path, "/") ?: '', 1);
+        $file = substr(strrchr($path, '/') ?: '', 1);
         $dir = str_replace($file, '', $path);
 
         return $dir . "<span class='path-basename'>" . $file . '</span>';
@@ -620,6 +618,6 @@ class HTMLRenderer extends AbstractRenderer
      */
     private static function reduceWhitespace($input, $eol = true)
     {
-        return preg_replace("#\s+#", " ", $input) . ($eol ? PHP_EOL : null);
+        return preg_replace("#\s+#", ' ', $input) . ($eol ? PHP_EOL : null);
     }
 }

--- a/src/main/php/PHPMD/Renderer/SARIFRenderer.php
+++ b/src/main/php/PHPMD/Renderer/SARIFRenderer.php
@@ -35,8 +35,7 @@ class SARIFRenderer extends JSONRenderer
     {
         $data = [
             'version' => '2.1.0',
-            '$schema' =>
-                'https://raw.githubusercontent.com/oasis-tcs/' .
+            '$schema' => 'https://raw.githubusercontent.com/oasis-tcs/' .
                 'sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
             'runs' => [
                 [

--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -27,7 +27,7 @@ use PHPMD\Report;
  * This renderer output a textual log with all found violations and suspect
  * software artifacts.
  */
-class TextRenderer extends AbstractRenderer implements Verbose, Color
+class TextRenderer extends AbstractRenderer implements Color, Verbose
 {
     private int $columnSpacing = 2;
 

--- a/src/main/php/PHPMD/Renderer/XMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/XMLRenderer.php
@@ -83,7 +83,7 @@ class XMLRenderer extends AbstractRenderer
             $this->maybeAdd('function', $violation->getFunctionName());
             $this->maybeAdd('class', $violation->getClassName());
             $this->maybeAdd('method', $violation->getMethodName());
-            //$this->_maybeAdd('variable', $violation->getVariableName());
+            // $this->_maybeAdd('variable', $violation->getVariableName());
 
             $writer->write(' priority="' . $rule->getPriority() . '"');
             $writer->write('>' . PHP_EOL);

--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -59,7 +59,7 @@ class Report
     /** @var BaselineValidator|null */
     private $baselineValidator;
 
-    public function __construct(BaselineValidator $baselineValidator = null)
+    public function __construct(?BaselineValidator $baselineValidator = null)
     {
         $this->baselineValidator = $baselineValidator;
     }

--- a/src/main/php/PHPMD/Rule.php
+++ b/src/main/php/PHPMD/Rule.php
@@ -29,14 +29,10 @@ use PDepend\Source\AST\ASTNode;
  */
 interface Rule
 {
-    /**
-     * The default lowest rule priority.
-     */
+    /** The default lowest rule priority. */
     public const LOWEST_PRIORITY = 5;
 
-    /**
-     * The default highest rule priority.
-     */
+    /** The default highest rule priority. */
     public const HIGHEST_PRIORITY = 1;
 
     /**

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -39,9 +39,7 @@ use ReflectionFunction;
  */
 abstract class AbstractLocalVariable extends AbstractRule
 {
-    /**
-     * @var list<string> Self reference class names.
-     */
+    /** @var list<string> Self reference class names. */
     private $selfReferences = ['self', 'static'];
 
     /**
@@ -241,7 +239,7 @@ abstract class AbstractLocalVariable extends AbstractRule
         $previousChildImage = $postfix->getChild(0)->getImage();
 
         if ($postfix instanceof ASTMemberPrimaryPrefix &&
-            in_array($previousChildImage, $this->selfReferences)
+            in_array($previousChildImage, $this->selfReferences, true)
         ) {
             return $previousChildImage;
         }
@@ -307,7 +305,7 @@ abstract class AbstractLocalVariable extends AbstractRule
             return false;
         }
 
-        $argumentPosition = array_search($variable, $parent->getChildren());
+        $argumentPosition = array_search($variable, $parent->getChildren(), true);
         $parentParent = $parent->getParent();
         if ($parentParent === null) {
             return false;

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -33,7 +33,7 @@ use PHPMD\Utility\ExceptionsList;
  *
  * Boolean flags are signs for single responsibility principle violations.
  */
-class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionAware
+class BooleanArgumentFlag extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * Temporary cache of configured exceptions.
@@ -71,7 +71,7 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
         $this->scanFormalParameters($node);
     }
 
-    protected function isBooleanValue(ASTValue $value = null): bool
+    protected function isBooleanValue(?ASTValue $value = null): bool
     {
         return $value?->isValueAvailable() && is_bool($value->getValue());
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -126,10 +126,13 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
         switch ($value) {
             case 'false':
                 return '0';
+
             case 'true':
                 return '1';
+
             case 'null':
                 return '';
+
             default:
                 return trim($value, '\'""');
         }

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -36,7 +36,7 @@ use PHPMD\Rule\MethodAware;
  * @author Rafał Wrzeszcz <rafal.wrzeszcz@wrzasq.pl>
  * @author Kamil Szymanaski <kamil.szymanski@gmail.com>
  */
-class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAware
+class DuplicatedArrayKey extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * Retrieves all arrays from single node and performs comparison logic on it
@@ -71,6 +71,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
             $key = $arrayElement->getImage();
             if (isset($keys[$key])) {
                 $this->addViolation($node, [$key, (string) $arrayElement->getStartLine()]);
+
                 continue;
             }
             $keys[$key] = $arrayElement;
@@ -123,6 +124,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
     private function castStringFromLiteral(PDependASTNode $key)
     {
         $value = $key->getImage();
+
         switch ($value) {
             case 'false':
                 return '0';

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -33,7 +33,7 @@ use PHPMD\Rule\MethodAware;
  * Object Calisthenics teaches us, that an else expression can always be
  * avoided by simple guard clause or return statements.
  */
-class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
+class ElseExpression extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if a method/function uses an else expression and add a violation for each one found.
@@ -83,6 +83,6 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
      */
     private function isIfOrElseIfStatement(ASTNode $parent)
     {
-        return ($parent->getName() === "if" || $parent->getName() === "elseif");
+        return ($parent->getName() === 'if' || $parent->getName() === 'elseif');
     }
 }

--- a/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
@@ -31,7 +31,7 @@ use PHPMD\Rule\MethodAware;
  * @author Kamil Szymanaski <kamil.szymanski@gmail.com>
  * @link http://php.net/manual/en/language.operators.errorcontrol.php
  */
-class ErrorControlOperator extends AbstractRule implements MethodAware, FunctionAware
+class ErrorControlOperator extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * Loops trough all class or function nodes and looks for '@' sign.

--- a/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
@@ -44,7 +44,7 @@ use PHPMD\Rule\MethodAware;
  *
  * Empty if clauses are skipped
  */
-class IfStatementAssignment extends AbstractRule implements MethodAware, FunctionAware
+class IfStatementAssignment extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if method/function has if clauses
@@ -132,7 +132,7 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
             }
 
             $uniqueHash = $assignment->getStartColumn() . ':' . $assignment->getStartLine();
-            if (!in_array($uniqueHash, $processesViolations)) {
+            if (!in_array($uniqueHash, $processesViolations, true)) {
                 $processesViolations[] = $uniqueHash;
                 $this->addViolation(
                     $node,

--- a/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
@@ -30,11 +30,9 @@ use PHPMD\Rule\MethodAware;
  *
  * This rule can be used to prevent use of fully qualified class names.
  */
-class MissingImport extends AbstractRule implements MethodAware, FunctionAware
+class MissingImport extends AbstractRule implements FunctionAware, MethodAware
 {
-    /**
-     * @var list<string> Self reference class names.
-     */
+    /** @var list<string> Self reference class names. */
     private $selfReferences = ['self', 'static'];
 
     /**

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -35,7 +35,7 @@ use PHPMD\Utility\ExceptionsList;
  * Static access is known to cause hard dependencies between classes
  * and is a bad practice.
  */
-class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
+class StaticAccess extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * Temporary cache of configured exceptions.

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseClassName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseClassName.php
@@ -30,7 +30,7 @@ use PHPMD\Rule\TraitAware;
  * @author Francis Besset <francis.besset@gmail.com>
  * @since 1.1.0
  */
-class CamelCaseClassName extends AbstractRule implements ClassAware, InterfaceAware, TraitAware, EnumAware
+class CamelCaseClassName extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
 {
     /**
      * This method checks if a class is not named in CamelCase

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -30,9 +30,7 @@ use PHPMD\Rule\MethodAware;
  */
 class CamelCaseMethodName extends AbstractRule implements MethodAware
 {
-    /**
-     * @var list<string>
-     */
+    /** @var list<string> */
     private $ignoredMethods = [
         '__construct',
         '__destruct',
@@ -60,7 +58,7 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
     public function apply(AbstractNode $node): void
     {
         $methodName = $node->getName();
-        if (!in_array($methodName, $this->ignoredMethods)) {
+        if (!in_array($methodName, $this->ignoredMethods, true)) {
             if (!$this->isValid($methodName)) {
                 $this->addViolation(
                     $node,

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
@@ -27,7 +27,7 @@ use PHPMD\Utility\Strings;
 /**
  * This rule class detects namespace parts that are not named in CamelCase.
  */
-class CamelCaseNamespace extends AbstractRule implements ClassAware, InterfaceAware, TraitAware, EnumAware
+class CamelCaseNamespace extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
 {
     /** @var array<string, int>|null */
     private $exceptions;

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -30,7 +30,7 @@ use PHPMD\Rule\MethodAware;
  * @author Francis Besset <francis.besset@gmail.com>
  * @since 1.1.0
  */
-class CamelCaseParameterName extends AbstractRule implements MethodAware, FunctionAware
+class CamelCaseParameterName extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if a parameter is not named in camelCase

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
@@ -31,11 +31,9 @@ use PHPMD\Rule\MethodAware;
  * @author Francis Besset <francis.besset@gmail.com>
  * @since 1.1.0
  */
-class CamelCaseVariableName extends AbstractRule implements MethodAware, FunctionAware
+class CamelCaseVariableName extends AbstractRule implements FunctionAware, MethodAware
 {
-    /**
-     * @var list<string>
-     */
+    /** @var list<string> */
     private $exceptions = [
         '$php_errormsg',
         '$http_response_header',
@@ -78,7 +76,7 @@ class CamelCaseVariableName extends AbstractRule implements MethodAware, Functio
     {
         $image = $variable->getImage();
 
-        if (in_array($image, $this->exceptions)) {
+        if (in_array($image, $this->exceptions, true)) {
             return true;
         }
 

--- a/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
+++ b/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
@@ -28,11 +28,9 @@ use PHPMD\Rule\MethodAware;
  * @author Francis Besset <francis.besset@gmail.com>
  * @since 1.1.0
  */
-class Superglobals extends AbstractRule implements MethodAware, FunctionAware
+class Superglobals extends AbstractRule implements FunctionAware, MethodAware
 {
-    /**
-     * @var list<string>
-     */
+    /** @var list<string> */
     private $superglobals = [
         '$GLOBALS',
         '$_SERVER',
@@ -59,7 +57,7 @@ class Superglobals extends AbstractRule implements MethodAware, FunctionAware
     public function apply(AbstractNode $node): void
     {
         foreach ($node->findChildrenOfTypeVariable() as $variable) {
-            if (in_array($variable->getImage(), $this->superglobals)) {
+            if (in_array($variable->getImage(), $this->superglobals, true)) {
                 $this->addViolation(
                     $node,
                     [

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -50,7 +50,7 @@ use RuntimeException;
  * @author Kamil Szymanski <kamilszymanski@gmail.com>
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAware, EnumAware
+class CountInLoopExpression extends AbstractRule implements ClassAware, EnumAware, TraitAware
 {
     /**
      * List of functions to search against
@@ -175,6 +175,6 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
     {
         $functionName = str_replace($this->currentNamespace, '', $function->getImage());
 
-        return in_array($functionName, $this->unwantedFunctions);
+        return in_array($functionName, $this->unwantedFunctions, true);
     }
 }

--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -32,7 +32,7 @@ use PHPMD\Rule\MethodAware;
  * @link https://github.com/phpmd/phpmd/issues/265
  * @since 2.3.0
  */
-class DevelopmentCodeFragment extends AbstractRule implements MethodAware, FunctionAware
+class DevelopmentCodeFragment extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if a given function or method contains an eval-expression
@@ -45,11 +45,11 @@ class DevelopmentCodeFragment extends AbstractRule implements MethodAware, Funct
         foreach ($node->findChildrenOfType(ASTFunctionPostfix::class) as $postfix) {
             $fragment = $postfix->getImage();
             if ($ignoreNS) {
-                $fragment = str_replace("{$namespace}\\", "", $fragment);
+                $fragment = str_replace("{$namespace}\\", '', $fragment);
             }
             $fragment = strtolower($fragment);
-            $fragment = trim($fragment, "\\");
-            if (!in_array($fragment, $this->getSuspectImages())) {
+            $fragment = trim($fragment, '\\');
+            if (!in_array($fragment, $this->getSuspectImages(), true)) {
                 continue;
             }
 

--- a/src/main/php/PHPMD/Rule/Design/EmptyCatchBlock.php
+++ b/src/main/php/PHPMD/Rule/Design/EmptyCatchBlock.php
@@ -30,7 +30,7 @@ use PHPMD\Rule\MethodAware;
  * @author Grégoire Paris <postmaster@greg0ire.fr>
  * @author Kamil Szymanski <kamilszymanski@gmail.com>
  */
-class EmptyCatchBlock extends AbstractRule implements MethodAware, FunctionAware
+class EmptyCatchBlock extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if a given function or method contains an empty catch block

--- a/src/main/php/PHPMD/Rule/Design/EvalExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/EvalExpression.php
@@ -26,7 +26,7 @@ use PHPMD\Rule\MethodAware;
 /**
  * This rule class detects the usage of PHP's eval-expression.
  */
-class EvalExpression extends AbstractRule implements MethodAware, FunctionAware
+class EvalExpression extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if a given function or method contains an eval-expression

--- a/src/main/php/PHPMD/Rule/Design/ExitExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/ExitExpression.php
@@ -26,7 +26,7 @@ use PHPMD\Rule\MethodAware;
 /**
  * This rule class detects the usage of PHP's exit statement.
  */
-class ExitExpression extends AbstractRule implements MethodAware, FunctionAware
+class ExitExpression extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if a given function or method contains an exit-expression

--- a/src/main/php/PHPMD/Rule/Design/GotoStatement.php
+++ b/src/main/php/PHPMD/Rule/Design/GotoStatement.php
@@ -28,7 +28,7 @@ use PHPMD\Rule\MethodAware;
  *
  * @since 1.1.0
  */
-class GotoStatement extends AbstractRule implements MethodAware, FunctionAware
+class GotoStatement extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method should implement the violation analysis algorithm of concrete

--- a/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
@@ -29,7 +29,7 @@ use PHPMD\Rule\TraitAware;
  * This rule detects class/interface constants that do not follow the upper
  * case convention.
  */
-class ConstantNamingConventions extends AbstractRule implements ClassAware, InterfaceAware, TraitAware, EnumAware
+class ConstantNamingConventions extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
 {
     /**
      * Extracts all constant declarations from the given node and tests that

--- a/src/main/php/PHPMD/Rule/Naming/LongClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongClassName.php
@@ -31,7 +31,7 @@ use PHPMD\Utility\Strings;
  * This rule checks if an interface or class name exceeds the configured length
  * excluding certain configured prefixes and suffixes
  */
-class LongClassName extends AbstractRule implements ClassAware, InterfaceAware, TraitAware, EnumAware
+class LongClassName extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
 {
     /**
      * Temporary cache of configured prefixes to subtract

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -35,7 +35,7 @@ use PHPMD\Utility\Strings;
  * This rule class will detect variables, parameters and properties with really
  * long names.
  */
-class LongVariable extends AbstractRule implements ClassAware, MethodAware, FunctionAware, TraitAware
+class LongVariable extends AbstractRule implements ClassAware, FunctionAware, MethodAware, TraitAware
 {
     /**
      * Temporary cache of configured prefixes to subtract

--- a/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
@@ -28,7 +28,7 @@ use PHPMD\Utility\ExceptionsList;
 /**
  * This rule will detect classes and interfaces with names that are too short.
  */
-class ShortClassName extends AbstractRule implements ClassAware, InterfaceAware, TraitAware, EnumAware
+class ShortClassName extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
 {
     /**
      * Temporary cache of configured exceptions. Have name as key

--- a/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
@@ -26,7 +26,7 @@ use PHPMD\Utility\ExceptionsList;
 /**
  * This rule class will detect methods and functions with very short names.
  */
-class ShortMethodName extends AbstractRule implements MethodAware, FunctionAware
+class ShortMethodName extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * Temporary cache of configured exceptions.

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -38,7 +38,7 @@ use PHPMD\Utility\ExceptionsList;
  * This rule class will detect variables, parameters and properties with short
  * names.
  */
-class ShortVariable extends AbstractRule implements ClassAware, MethodAware, FunctionAware, TraitAware
+class ShortVariable extends AbstractRule implements ClassAware, FunctionAware, MethodAware, TraitAware
 {
     /**
      * Temporary map holding variables that were already processed in the

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -101,7 +101,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
 
     /**
      * Returns <b>true</b> when the given node is method with signature declared as inherited using
-     * {@inheritdoc} annotation.
+     * {@inheritDoc} annotation.
      *
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @return bool

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -132,7 +132,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
         static $magicMethodRegExp = null;
 
         if ($magicMethodRegExp === null) {
-            $magicMethodRegExp = '/__(?:' . implode("|", [
+            $magicMethodRegExp = '/__(?:' . implode('|', [
                 'call',
                 'callStatic',
                 'get',

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -100,7 +100,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
                 return true;
             }
 
-            if (in_array($node->getNode(), array_slice($parent->getChildren(), 1))) {
+            if (in_array($node->getNode(), array_slice($parent->getChildren(), 1), true)) {
                 return true;
             }
         }
@@ -176,7 +176,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
         $parentNode = $node->getParent()->getNode();
         $candidateParentNodes = $node->getParentsOfType(ASTString::class);
 
-        if (in_array($parentNode, $candidateParentNodes)) {
+        if (in_array($parentNode, $candidateParentNodes, true)) {
             $variablePrefix = $node->getImage();
 
             foreach ($node->findChildrenOfType(ASTExpression::class) as $child) {

--- a/src/main/php/PHPMD/RuleSet.php
+++ b/src/main/php/PHPMD/RuleSet.php
@@ -51,24 +51,16 @@ class RuleSet implements IteratorAggregate
      */
     private bool $strict = false;
 
-    /**
-     * The name of the file where this set is specified.
-     */
+    /** The name of the file where this set is specified. */
     private string $fileName = '';
 
-    /**
-     * The name of this rule-set.
-     */
+    /** The name of this rule-set. */
     private string $name = '';
 
-    /**
-     * An optional description for this rule-set.
-     */
+    /** An optional description for this rule-set. */
     private string $description = '';
 
-    /**
-     * The violation report used by the rule-set.
-     */
+    /** The violation report used by the rule-set. */
     private ?Report $report = null;
 
     /**

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -357,7 +357,7 @@ class RuleSetFactory
         }
 
         if (!class_exists($className)) {
-            $handle = @fopen($fileName, 'r', true);
+            $handle = @fopen($fileName, 'rb', true);
             if (!$handle) {
                 throw new RuleClassFileNotFoundException($className);
             }

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -299,7 +299,7 @@ class RuleSetFactory
      */
     private function parseRuleSetReference(SimpleXMLElement $ruleSetNode)
     {
-        $ruleSetFactory = new RuleSetFactory();
+        $ruleSetFactory = new self();
         $ruleSetFactory->setMinimumPriority($this->minimumPriority);
         $ruleSetFactory->setMaximumPriority($this->maximumPriority);
 
@@ -415,7 +415,7 @@ class RuleSetFactory
 
         $ruleName = substr($ref, strpos($ref, '.xml/') + 5);
 
-        $ruleSetFactory = new RuleSetFactory();
+        $ruleSetFactory = new self();
 
         $ruleSetRef = $ruleSetFactory->createSingleRuleSet($fileName);
         $rule = $ruleSetRef->getRuleByName($ruleName);

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -41,9 +41,7 @@ use RuntimeException;
  */
 class Command
 {
-    /**
-     * Exit codes used by the phpmd command line tool.
-     */
+    /** Exit codes used by the phpmd command line tool. */
     public const EXIT_SUCCESS = 0,
         EXIT_EXCEPTION = 1,
         EXIT_VIOLATION = 2,

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -251,107 +251,158 @@ class CommandLineOptions
                 case '--':
                     $this->refuseValue($equalChunk);
                     $listenOptions = false;
+
                     break;
+
                 case '--verbose':
                 case '-v':
                     $this->refuseValue($equalChunk);
                     $this->verbosity = OutputInterface::VERBOSITY_VERBOSE;
+
                     break;
+
                 case '-vv':
                     $this->refuseValue($equalChunk);
                     $this->verbosity = OutputInterface::VERBOSITY_VERY_VERBOSE;
+
                     break;
+
                 case '-vvv':
                     $this->refuseValue($equalChunk);
                     $this->verbosity = OutputInterface::VERBOSITY_DEBUG;
+
                     break;
+
                 case '--min-priority':
                 case '--minimum-priority':
                 case '--minimumpriority':
                     $this->minimumPriority = (int) $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--max-priority':
                 case '--maximum-priority':
                 case '--maximumpriority':
                     $this->maximumPriority = (int) $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--report-file':
                 case '--reportfile':
                     $this->reportFile = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--error-file':
                 case '--errorfile':
                     $this->errorFile = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--input-file':
                 case '--inputfile':
                     array_unshift($arguments, $this->readInputFile($this->readValue($equalChunk, $args)));
+
                     break;
+
                 case '--coverage':
                     $this->coverageReport = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--extensions':
                     $this->logDeprecated('extensions', 'suffixes');
                     // Deprecated: We use the suffixes option now
                     $this->extensions = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--suffixes':
                     $this->extensions = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--ignore':
                     $this->logDeprecated('ignore', 'exclude');
                     // Deprecated: We use the exclude option now
                     $this->ignore = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--exclude':
                     $this->ignore = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--color':
                     $this->refuseValue($equalChunk);
                     $this->colored = true;
+
                     break;
+
                 case '--version':
                     $this->refuseValue($equalChunk);
                     $this->version = true;
 
                     return;
+
                 case '--strict':
                     $this->refuseValue($equalChunk);
                     $this->strict = true;
+
                     break;
+
                 case '--not-strict':
                     $this->refuseValue($equalChunk);
                     $this->strict = false;
+
                     break;
+
                 case '--generate-baseline':
                     $this->refuseValue($equalChunk);
                     $this->generateBaseline = BaselineMode::GENERATE;
+
                     break;
+
                 case '--update-baseline':
                     $this->refuseValue($equalChunk);
                     $this->generateBaseline = BaselineMode::UPDATE;
+
                     break;
+
                 case '--baseline-file':
                     $this->baselineFile = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--cache':
                     $this->refuseValue($equalChunk);
                     $this->cacheEnabled = true;
+
                     break;
+
                 case '--cache-file':
                     $this->cacheFile = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--cache-strategy':
                     $this->cacheStrategy = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--ignore-errors-on-exit':
                     $this->refuseValue($equalChunk);
                     $this->ignoreErrorsOnExit = true;
+
                     break;
+
                 case '--ignore-violations-on-exit':
                     $this->refuseValue($equalChunk);
                     $this->ignoreViolationsOnExit = true;
+
                     break;
+
                 case '--reportfile-checkstyle':
                 case '--reportfile-github':
                 case '--reportfile-gitlab':
@@ -362,13 +413,18 @@ class CommandLineOptions
                 case '--reportfile-xml':
                     preg_match('(^\-\-reportfile\-(checkstyle|github|gitlab|html|json|sarif|text|xml)$)', $arg, $match);
                     $this->reportFiles[$match[1]] = $this->readValue($equalChunk, $args);
+
                     break;
+
                 case '--extra-line-in-excerpt':
                     $this->extraLineInExcerpt = (int) $this->readValue($equalChunk, $args);
+
                     break;
+
                 default:
                     $hasImplicitArguments = true;
                     $arguments[] = $arg;
+
                     break;
             }
         }
@@ -603,6 +659,7 @@ class CommandLineOptions
             case ResultCacheStrategy::CONTENT:
             case ResultCacheStrategy::TIMESTAMP:
                 return $this->cacheStrategy;
+
             default:
                 return ResultCacheStrategy::CONTENT;
         }
@@ -682,22 +739,31 @@ class CommandLineOptions
         switch ($reportFormat) {
             case 'ansi':
                 return $this->createAnsiRenderer();
+
             case 'checkstyle':
                 return $this->createCheckStyleRenderer();
+
             case 'gitlab':
                 return $this->createGitLabRenderer();
+
             case 'github':
                 return $this->createGitHubRenderer();
+
             case 'html':
                 return $this->createHtmlRenderer();
+
             case 'json':
                 return $this->createJsonRenderer();
+
             case 'sarif':
                 return $this->createSarifRenderer();
+
             case 'text':
                 return $this->createTextRenderer();
+
             case 'xml':
                 return $this->createXmlRenderer();
+
             default:
                 return $this->createCustomRenderer();
         }

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -861,7 +861,7 @@ class CommandLineOptions
         // Try to load a custom renderer
         $fileName = strtr($this->reportFormat, '_\\', '//') . '.php';
 
-        $fileHandle = @fopen($fileName, 'r', true);
+        $fileHandle = @fopen($fileName, 'rb', true);
         if (!is_resource($fileHandle)) {
             throw new InvalidArgumentException(
                 sprintf(

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -292,7 +292,7 @@ class CommandLineOptions
                     break;
                 case '--extensions':
                     $this->logDeprecated('extensions', 'suffixes');
-                    /* Deprecated: We use the suffixes option now */
+                    // Deprecated: We use the suffixes option now
                     $this->extensions = $this->readValue($equalChunk, $args);
                     break;
                 case '--suffixes':
@@ -300,7 +300,7 @@ class CommandLineOptions
                     break;
                 case '--ignore':
                     $this->logDeprecated('ignore', 'exclude');
-                    /* Deprecated: We use the exclude option now */
+                    // Deprecated: We use the exclude option now
                     $this->ignore = $this->readValue($equalChunk, $args);
                     break;
                 case '--exclude':

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -44,9 +44,7 @@ use PHPMD\Utility\ArgumentsValidator;
  */
 class CommandLineOptions
 {
-    /**
-     * Error code for invalid input
-     */
+    /** Error code for invalid input */
     private const INPUT_ERROR = 23;
 
     /**

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -638,6 +638,7 @@ class CommandLineOptions
     {
         return $this->extraLineInExcerpt;
     }
+
     /**
      * Creates a report renderer instance based on the user's command line
      * argument.

--- a/src/main/php/PHPMD/Utility/ExceptionsList.php
+++ b/src/main/php/PHPMD/Utility/ExceptionsList.php
@@ -29,12 +29,11 @@ use RuntimeException;
  * @implements IteratorAggregate<string, string>
  * @implements ArrayAccess<string, string>
  */
-class ExceptionsList implements IteratorAggregate, ArrayAccess
+class ExceptionsList implements ArrayAccess, IteratorAggregate
 {
-    /**
-     * Separator used to join exception in the property string.
-     */
+    /** Separator used to join exception in the property string. */
     protected string $separator;
+
     /**
      * Temporary cache of configured exceptions. Have name as key
      *
@@ -42,14 +41,10 @@ class ExceptionsList implements IteratorAggregate, ArrayAccess
      */
     private array $exceptions;
 
-    /**
-     * Rule to which the exception list apply.
-     */
+    /** Rule to which the exception list apply. */
     private Rule $rule;
 
-    /**
-     * Extra characters to be trimmed with whitespace at beginning and ending of each exception.
-     */
+    /** Extra characters to be trimmed with whitespace at beginning and ending of each exception. */
     private string $trim;
 
     public function __construct(Rule $rule, string $trim = '', string $separator = ',')

--- a/src/main/php/PHPMD/Utility/Strings.php
+++ b/src/main/php/PHPMD/Utility/Strings.php
@@ -49,7 +49,6 @@ class Strings
         array $subtractPrefixes,
         array $subtractSuffixes
     ) {
-
         $stringLength = strlen($stringName);
 
         foreach ($subtractSuffixes as $suffix) {

--- a/src/main/php/PHPMD/Utility/Strings.php
+++ b/src/main/php/PHPMD/Utility/Strings.php
@@ -55,6 +55,7 @@ class Strings
             $suffixLength = strlen($suffix);
             if (substr($stringName, -$suffixLength) === $suffix) {
                 $stringLength -= $suffixLength;
+
                 break;
             }
         }
@@ -63,6 +64,7 @@ class Strings
             $prefixLength = strlen($prefix);
             if (strncmp($stringName, $prefix, $prefixLength) === 0) {
                 $stringLength -= $prefixLength;
+
                 break;
             }
         }

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -51,6 +51,7 @@ class StreamWriter extends AbstractWriter
         }
         if (!file_exists($dirName)) {
             $message = 'Cannot find output directory "' . $dirName . '".';
+
             throw new RuntimeException($message);
         }
 

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -74,10 +74,8 @@ abstract class AbstractStaticTestCase extends TestCase
 
     /**
      * Return to original working directory if changed.
-     *
-     * @return void
      */
-    protected static function returnToOriginalWorkingDirectory()
+    protected static function returnToOriginalWorkingDirectory(): void
     {
         if (self::$originalWorkingDirectory !== null) {
             chdir(self::$originalWorkingDirectory);
@@ -88,10 +86,8 @@ abstract class AbstractStaticTestCase extends TestCase
 
     /**
      * Cleanup temporary files created for the test.
-     *
-     * @return void
      */
-    protected static function cleanupTempFiles()
+    protected static function cleanupTempFiles(): void
     {
         // cleanup any open resources on temp files
         gc_collect_cycles();
@@ -145,9 +141,8 @@ abstract class AbstractStaticTestCase extends TestCase
      *
      * @param string $actualOutput Generated xml output.
      * @param string $expectedFileName File with expected xml result.
-     * @return void
      */
-    public static function assertXmlEquals($actualOutput, $expectedFileName)
+    public static function assertXmlEquals($actualOutput, $expectedFileName): void
     {
         $actual = simplexml_load_string($actualOutput);
         // Remove dynamic timestamp and duration attribute
@@ -169,7 +164,7 @@ abstract class AbstractStaticTestCase extends TestCase
 
         $expected = str_replace('_DS_', DIRECTORY_SEPARATOR, $expected);
 
-        self::assertXmlStringEqualsXmlString($expected, $actual->saveXML());
+        static::assertXmlStringEqualsXmlString($expected, $actual->saveXML());
     }
 
     /**
@@ -179,10 +174,8 @@ abstract class AbstractStaticTestCase extends TestCase
      * @param string $expectedFileName File with expected JSON result.
      * @param bool|Closure $removeDynamicValues If set to `false`, the actual output is not normalized,
      *                                          if set to a closure, the closure is applied on the actual output array.
-     *
-     * @return void
      */
-    public static function assertJsonEquals($actualOutput, $expectedFileName, $removeDynamicValues = true)
+    public static function assertJsonEquals($actualOutput, $expectedFileName, $removeDynamicValues = true): void
     {
         $actual = json_decode($actualOutput, true);
         // Remove dynamic timestamp and duration attribute
@@ -209,16 +202,15 @@ abstract class AbstractStaticTestCase extends TestCase
         $expected = str_replace('#{workingDirectory}', getcwd(), $expected);
         $expected = str_replace('_DS_', DIRECTORY_SEPARATOR, $expected);
 
-        self::assertJsonStringEqualsJsonString($expected, json_encode($actual));
+        static::assertJsonStringEqualsJsonString($expected, json_encode($actual));
     }
 
     /**
      * Changes the working directory for a single test.
      *
      * @param string $localPath The temporary working directory.
-     * @return void
      */
-    protected static function changeWorkingDirectory($localPath = '')
+    protected static function changeWorkingDirectory($localPath = ''): void
     {
         self::$originalWorkingDirectory = getcwd();
 
@@ -252,6 +244,7 @@ abstract class AbstractStaticTestCase extends TestCase
         } else {
             $filePath = tempnam(sys_get_temp_dir(), 'phpmd.');
         }
+
         return (self::$tempFiles[] = $filePath);
     }
 
@@ -268,6 +261,7 @@ abstract class AbstractStaticTestCase extends TestCase
                 return $frame;
             }
         }
+
         throw new ErrorException('Cannot locate calling test case.');
     }
 

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -293,7 +293,7 @@ abstract class AbstractStaticTestCase extends TestCase
     {
         return sprintf(
             '%s/../../resources/files/%s/%s',
-            dirname(__FILE__),
+            __DIR__,
             $directory,
             $file
         );

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -29,7 +29,7 @@ abstract class AbstractStaticTestCase extends TestCase
     /**
      * Directory with test files.
      *
-     * @var string $filesDirectory
+     * @var string
      */
     private static $filesDirectory = null;
 

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -236,7 +236,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
 
         return new $nodeClassName(
             $this->getNodeByName(
-                $source->$getter(),
+                $source->{$getter}(),
                 pathinfo($file, PATHINFO_FILENAME)
             )
         );

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -615,7 +615,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
         $file = '/foo/baz.php',
         $message = 'Error in file "/foo/baz.php"'
     ) {
-
         $processingError = $this->getMockFromBuilder(
             $this->getMockBuilder(ProcessingError::class)
                 ->setConstructorArgs([$message])

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -251,10 +251,9 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * @param Rule $rule Rule to test.
      * @param int $expectedInvokes Count of expected invocations.
      * @param string $file Test file containing a method with the same name to be tested.
-     * @return void
      * @throws ExpectationFailedException
      */
-    protected function expectRuleHasViolationsForFile(Rule $rule, $expectedInvokes, $file)
+    protected function expectRuleHasViolationsForFile(Rule $rule, $expectedInvokes, $file): void
     {
         $report = new Report();
         $rule->setReport($report);
@@ -271,7 +270,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
             );
         }
 
-        $this->assertTrue($assertion);
+        static::assertTrue($assertion);
     }
 
     /**
@@ -288,7 +287,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     {
         return basename($file) . " failed:\n" .
             "Expected $expectedInvokes violation" . ($expectedInvokes !== 1 ? 's' : '') . "\n" .
-            "But $actualInvokes violation" . ($actualInvokes !== 1 ? 's' : '') . " raised" .
+            "But $actualInvokes violation" . ($actualInvokes !== 1 ? 's' : '') . ' raised' .
             (
                 $actualInvokes > 0
                 ? ":\n" . $this->getViolationsSummary($violations)
@@ -388,9 +387,9 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
         );
 
         if ($metric !== null) {
-            $class->expects($this->atLeastOnce())
+            $class->expects(static::atLeastOnce())
                 ->method('getMetric')
-                ->with($this->equalTo($metric))
+                ->with(static::equalTo($metric))
                 ->willReturn($value);
         }
 
@@ -439,9 +438,9 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
             return $mock;
         }
 
-        $mock->expects($this->atLeastOnce())
+        $mock->expects(static::atLeastOnce())
             ->method('getMetric')
-            ->with($this->equalTo($metric))
+            ->with(static::equalTo($metric))
             ->willReturn($value);
 
         return $mock;
@@ -456,13 +455,13 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     protected function getReportMock($expectedInvokes = -1)
     {
         if ($expectedInvokes === self::AL_LEAST_ONE_VIOLATION) {
-            $expects = $this->atLeastOnce();
+            $expects = static::atLeastOnce();
         } elseif ($expectedInvokes === self::NO_VIOLATION) {
-            $expects = $this->never();
+            $expects = static::never();
         } elseif ($expectedInvokes === self::ONE_VIOLATION) {
-            $expects = $this->once();
+            $expects = static::once();
         } else {
-            $expects = $this->exactly($expectedInvokes);
+            $expects = static::exactly($expectedInvokes);
         }
 
         $report = $this->getMockFromBuilder($this->getMockBuilder(Report::class));
@@ -532,20 +531,20 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     {
         $ruleSet = $this->getMockFromBuilder($this->getMockBuilder(RuleSet::class));
         if ($expectedClass === null) {
-            $ruleSet->expects($this->never())->method('apply');
+            $ruleSet->expects(static::never())->method('apply');
 
             return $ruleSet;
         }
 
         if ($count === '*') {
-            $count = $this->atLeastOnce();
+            $count = static::atLeastOnce();
         } else {
-            $count = $this->exactly($count);
+            $count = static::exactly($count);
         }
 
         $ruleSet->expects($count)
             ->method('apply')
-            ->with($this->isInstanceOf($expectedClass));
+            ->with(static::isInstanceOf($expectedClass));
 
         return $ruleSet;
     }
@@ -674,6 +673,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
                 return $node;
             }
         }
+
         throw new ErrorException("Cannot locate node named $name.");
     }
 

--- a/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
@@ -23,8 +23,8 @@ class BaselineFileFinderTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::find
      * @covers ::existingFile
+     * @covers ::find
      */
     public function testShouldFindExistingFileNearRuleSet()
     {
@@ -65,9 +65,9 @@ class BaselineFileFinderTest extends AbstractTestCase
     }
 
     /**
+     * @covers ::existingFile
      * @covers ::find
      * @covers ::nullOrThrow
-     * @covers ::existingFile
      */
     public function testShouldOnlyFindExistingFile()
     {

--- a/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineFileFinderTest.php
@@ -15,7 +15,7 @@ class BaselineFileFinderTest extends AbstractTestCase
     /**
      * @covers ::find
      */
-    public function testShouldFindFileFromCLI()
+    public function testShouldFindFileFromCLI(): void
     {
         $args = ['script', 'source', 'xml', 'phpmd.xml', '--baseline-file', 'foobar.txt'];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
@@ -26,14 +26,14 @@ class BaselineFileFinderTest extends AbstractTestCase
      * @covers ::existingFile
      * @covers ::find
      */
-    public function testShouldFindExistingFileNearRuleSet()
+    public function testShouldFindExistingFileNearRuleSet(): void
     {
         $args = ['script', 'source', 'xml', static::createResourceUriForTest('testA/phpmd.xml')];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
 
         // ensure consistent slashes
-        $expected = str_replace("\\", "/", realpath(static::createResourceUriForTest('testA/phpmd.baseline.xml')));
-        $actual = str_replace("\\", "/", $finder->existingFile()->find());
+        $expected = str_replace('\\', '/', realpath(static::createResourceUriForTest('testA/phpmd.baseline.xml')));
+        $actual = str_replace('\\', '/', $finder->existingFile()->find());
 
         static::assertSame($expected, $actual);
     }
@@ -42,7 +42,7 @@ class BaselineFileFinderTest extends AbstractTestCase
      * @covers ::find
      * @covers ::nullOrThrow
      */
-    public function testShouldThrowExceptionForNonExistingRuleSet()
+    public function testShouldThrowExceptionForNonExistingRuleSet(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Unable to determine the baseline file location.',
@@ -57,7 +57,7 @@ class BaselineFileFinderTest extends AbstractTestCase
      * @covers ::find
      * @covers ::nullOrThrow
      */
-    public function testShouldReturnNullForNonExistingRuleSet()
+    public function testShouldReturnNullForNonExistingRuleSet(): void
     {
         $args = ['script', 'source', 'xml', static::createResourceUriForTest('phpmd.xml')];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
@@ -69,7 +69,7 @@ class BaselineFileFinderTest extends AbstractTestCase
      * @covers ::find
      * @covers ::nullOrThrow
      */
-    public function testShouldOnlyFindExistingFile()
+    public function testShouldOnlyFindExistingFile(): void
     {
         $args = ['script', 'source', 'xml', static::createResourceUriForTest('testB/phpmd.xml')];
         $finder = new BaselineFileFinder(new CommandLineOptions($args));
@@ -81,7 +81,7 @@ class BaselineFileFinderTest extends AbstractTestCase
      * @covers ::notNull
      * @covers ::nullOrThrow
      */
-    public function testShouldThrowExceptionWhenFileIsNull()
+    public function testShouldThrowExceptionWhenFileIsNull(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Unable to find the baseline file',

--- a/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
@@ -15,7 +15,7 @@ class BaselineSetFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileShouldSucceed()
+    public function testFromFileShouldSucceed(): void
     {
         $filename = static::createResourceUriForTest('baseline.xml');
         $baseDir = dirname($filename);
@@ -30,7 +30,7 @@ class BaselineSetFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileShouldSucceedWithBackAndForwardSlashes()
+    public function testFromFileShouldSucceedWithBackAndForwardSlashes(): void
     {
         $filename = static::createResourceUriForTest('baseline.xml');
         $baseDir = dirname($filename);
@@ -45,7 +45,7 @@ class BaselineSetFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileShouldThrowExceptionForMissingFile()
+    public function testFromFileShouldThrowExceptionForMissingFile(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Unable to load the baseline file at: ',
@@ -57,7 +57,7 @@ class BaselineSetFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileShouldThrowExceptionForOnInvalidXML()
+    public function testFromFileShouldThrowExceptionForOnInvalidXML(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Unable to read xml from',
@@ -69,7 +69,7 @@ class BaselineSetFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileViolationMissingRuleShouldThrowException()
+    public function testFromFileViolationMissingRuleShouldThrowException(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Missing `rule` attribute in `violation`',
@@ -81,7 +81,7 @@ class BaselineSetFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileViolationMissingFileShouldThrowException()
+    public function testFromFileViolationMissingFileShouldThrowException(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Missing `file` attribute in `violation` in',

--- a/src/test/php/PHPMD/Baseline/BaselineSetTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetTest.php
@@ -13,7 +13,7 @@ class BaselineSetTest extends AbstractTestCase
      * @covers ::addEntry
      * @covers ::contains
      */
-    public function testSetContainsEntryWithoutMethodName()
+    public function testSetContainsEntryWithoutMethodName(): void
     {
         $set = new BaselineSet();
         $set->addEntry(new ViolationBaseline('rule', 'foobar', null));
@@ -25,7 +25,7 @@ class BaselineSetTest extends AbstractTestCase
      * @covers ::addEntry
      * @covers ::contains
      */
-    public function testSetContainsEntryWithMethodName()
+    public function testSetContainsEntryWithMethodName(): void
     {
         $set = new BaselineSet();
         $set->addEntry(new ViolationBaseline('rule', 'foobar', 'method'));
@@ -37,7 +37,7 @@ class BaselineSetTest extends AbstractTestCase
      * @covers ::addEntry
      * @covers ::contains
      */
-    public function testShouldFindEntryForIdenticalRules()
+    public function testShouldFindEntryForIdenticalRules(): void
     {
         $set = new BaselineSet();
         $set->addEntry(new ViolationBaseline('rule', 'foo', null));
@@ -54,7 +54,7 @@ class BaselineSetTest extends AbstractTestCase
      * @covers ::addEntry
      * @covers ::contains
      */
-    public function testShouldNotFindEntryForNonExistingRule()
+    public function testShouldNotFindEntryForNonExistingRule(): void
     {
         $set = new BaselineSet();
         $set->addEntry(new ViolationBaseline('rule', 'foo', null));
@@ -66,7 +66,7 @@ class BaselineSetTest extends AbstractTestCase
      * @covers ::addEntry
      * @covers ::contains
      */
-    public function testShouldNotFindEntryForNonExistingMethod()
+    public function testShouldNotFindEntryForNonExistingMethod(): void
     {
         $set = new BaselineSet();
         $set->addEntry(new ViolationBaseline('rule', 'foo', 'method'));

--- a/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -43,7 +43,7 @@ class BaselineValidatorTest extends AbstractTestCase
      * @dataProvider dataProvider
      * @covers ::isBaselined
      */
-    public function testIsBaselined($contains, $baselineMode, $isBaselined)
+    public function testIsBaselined($contains, $baselineMode, $isBaselined): void
     {
         $this->baselineSet->method('contains')->willReturn($contains);
         $validator = new BaselineValidator($this->baselineSet, $baselineMode);

--- a/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
+++ b/src/test/php/PHPMD/Baseline/ViolationBaselineTest.php
@@ -13,7 +13,7 @@ class ViolationBaselineTest extends TestCase
      * @covers ::__construct
      * @covers ::getRuleName
      */
-    public function testGetRuleName()
+    public function testGetRuleName(): void
     {
         $violation = new ViolationBaseline('rule', 'foobar', null);
         static::assertSame('rule', $violation->getRuleName());
@@ -22,11 +22,10 @@ class ViolationBaselineTest extends TestCase
     /**
      * Test the give file matches the baseline correctly
      *
-     * @return void
      * @covers ::__construct
      * @covers ::matches
      */
-    public function testMatchesWithMethod()
+    public function testMatchesWithMethod(): void
     {
         $violation = new ViolationBaseline('sniff', 'foobar.txt', 'method');
         static::assertTrue($violation->matches('foobar.txt', 'method'));
@@ -38,11 +37,10 @@ class ViolationBaselineTest extends TestCase
     /**
      * Test the give file matches the baseline correctly
      *
-     * @return void
      * @covers ::__construct
      * @covers ::matches
      */
-    public function testMatchesWithoutMethod()
+    public function testMatchesWithoutMethod(): void
     {
         $violation = new ViolationBaseline('sniff', 'foobar.txt', null);
         static::assertTrue($violation->matches('foobar.txt', null));

--- a/src/test/php/PHPMD/Cache/Model/ResultCacheKeyTest.php
+++ b/src/test/php/PHPMD/Cache/Model/ResultCacheKeyTest.php
@@ -13,7 +13,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::toArray
      */
-    public function testToArray()
+    public function testToArray(): void
     {
         $key = new ResultCacheKey(
             true,
@@ -36,7 +36,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::isEqualTo
      */
-    public function testIsEqualTo()
+    public function testIsEqualTo(): void
     {
         $keyA = new ResultCacheKey(
             true,
@@ -60,7 +60,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::isEqualTo
      */
-    public function testIsEqualToDiffStrict()
+    public function testIsEqualToDiffStrict(): void
     {
         $keyA = new ResultCacheKey(
             true,
@@ -84,7 +84,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::isEqualTo
      */
-    public function testIsEqualToDiffRules()
+    public function testIsEqualToDiffRules(): void
     {
         $keyA = new ResultCacheKey(
             true,
@@ -108,7 +108,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::isEqualTo
      */
-    public function testIsEqualToDiffComposer()
+    public function testIsEqualToDiffComposer(): void
     {
         $keyA = new ResultCacheKey(
             true,
@@ -132,7 +132,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::isEqualTo
      */
-    public function testIsEqualToDiffPhpVersion()
+    public function testIsEqualToDiffPhpVersion(): void
     {
         $keyA = new ResultCacheKey(
             true,
@@ -156,7 +156,7 @@ class ResultCacheKeyTest extends AbstractTestCase
     /**
      * @covers ::isEqualTo
      */
-    public function testIsEqualToDiffBaselineHash()
+    public function testIsEqualToDiffBaselineHash(): void
     {
         $keyA = new ResultCacheKey(
             true,

--- a/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
+++ b/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
@@ -208,7 +208,6 @@ class ResultCacheStateTest extends TestCase
                             ],
                         ],
                     ],
-
                 ],
             ],
         ];

--- a/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
+++ b/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
@@ -29,7 +29,7 @@ class ResultCacheStateTest extends TestCase
     /**
      * @covers ::getCacheKey
      */
-    public function testGetCacheKey()
+    public function testGetCacheKey(): void
     {
         static::assertSame($this->key, $this->state->getCacheKey());
     }
@@ -38,7 +38,7 @@ class ResultCacheStateTest extends TestCase
      * @covers ::getViolations
      * @covers ::setViolations
      */
-    public function testGetSetViolations()
+    public function testGetSetViolations(): void
     {
         $violations = ['violations'];
 
@@ -51,7 +51,7 @@ class ResultCacheStateTest extends TestCase
     /**
      * @covers ::addRuleViolation
      */
-    public function testAddRuleViolation()
+    public function testAddRuleViolation(): void
     {
         $rule = new BooleanArgumentFlag();
         $nodeInfo = new NodeInfo(
@@ -90,7 +90,7 @@ class ResultCacheStateTest extends TestCase
      * @covers ::findRuleIn
      * @covers ::getRuleViolations
      */
-    public function testGetRuleViolationsWithoutDescriptionArgs()
+    public function testGetRuleViolationsWithoutDescriptionArgs(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new BooleanArgumentFlag());
@@ -117,7 +117,7 @@ class ResultCacheStateTest extends TestCase
      * @covers ::findRuleIn
      * @covers ::getRuleViolations
      */
-    public function testGetRuleViolationsWithDescriptionArgs()
+    public function testGetRuleViolationsWithDescriptionArgs(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new BooleanArgumentFlag());
@@ -149,7 +149,7 @@ class ResultCacheStateTest extends TestCase
      * @covers ::isFileModified
      * @covers ::setFileState
      */
-    public function testIsFileModified()
+    public function testIsFileModified(): void
     {
         $this->state->setFileState('/file/path', 'hash');
 
@@ -161,7 +161,7 @@ class ResultCacheStateTest extends TestCase
     /**
      * @covers ::toArray
      */
-    public function testToArray()
+    public function testToArray(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new BooleanArgumentFlag());

--- a/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
+++ b/src/test/php/PHPMD/Cache/Model/ResultCacheStateTest.php
@@ -35,8 +35,8 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @covers ::setViolations
      * @covers ::getViolations
+     * @covers ::setViolations
      */
     public function testGetSetViolations()
     {
@@ -87,8 +87,8 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @covers ::getRuleViolations
      * @covers ::findRuleIn
+     * @covers ::getRuleViolations
      */
     public function testGetRuleViolationsWithoutDescriptionArgs()
     {
@@ -114,8 +114,8 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @covers ::getRuleViolations
      * @covers ::findRuleIn
+     * @covers ::getRuleViolations
      */
     public function testGetRuleViolationsWithDescriptionArgs()
     {
@@ -146,8 +146,8 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @covers ::setFileState
      * @covers ::isFileModified
+     * @covers ::setFileState
      */
     public function testIsFileModified()
     {

--- a/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
@@ -8,7 +8,7 @@ use PHPMD\Cache\Model\ResultCacheState;
 use PHPMD\Console\NullOutput;
 use PHPMD\RuleSet;
 use PHPMD\TextUI\CommandLineOptions;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionProperty;
 
 /**
@@ -47,10 +47,10 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
     /**
      * @covers ::create
      */
-    public function testCreateNotEnabledShouldReturnNull()
+    public function testCreateNotEnabledShouldReturnNull(): void
     {
-        $this->options->expects(self::once())->method('isCacheEnabled')->willReturn(false);
-        $this->keyFactory->expects(self::never())->method('create');
+        $this->options->expects(static::once())->method('isCacheEnabled')->willReturn(false);
+        $this->keyFactory->expects(static::never())->method('create');
 
         static::assertNull($this->engineFactory->create('/base/path/', $this->options, []));
     }
@@ -58,19 +58,19 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
     /**
      * @covers ::create
      */
-    public function testCreateCacheMissShouldHaveNoOriginalState()
+    public function testCreateCacheMissShouldHaveNoOriginalState(): void
     {
         $ruleSetList = [new RuleSet()];
         $cacheKeyA = new ResultCacheKey(true, 'baseline', [], [], 123);
         $cacheKeyB = new ResultCacheKey(false, 'baseline', [], [], 321);
         $state = new ResultCacheState($cacheKeyB, []);
 
-        $this->options->expects(self::once())->method('isCacheEnabled')->willReturn(true);
-        $this->options->expects(self::once())->method('hasStrict')->willReturn(true);
-        $this->options->expects(self::exactly(2))->method('cacheFile')->willReturn('/path/to/cache');
+        $this->options->expects(static::once())->method('isCacheEnabled')->willReturn(true);
+        $this->options->expects(static::once())->method('hasStrict')->willReturn(true);
+        $this->options->expects(static::exactly(2))->method('cacheFile')->willReturn('/path/to/cache');
 
-        $this->keyFactory->expects(self::once())->method('create')->with(true, $ruleSetList)->willReturn($cacheKeyA);
-        $this->stateFactory->expects(self::once())->method('fromFile')->with('/path/to/cache')->willReturn($state);
+        $this->keyFactory->expects(static::once())->method('create')->with(true, $ruleSetList)->willReturn($cacheKeyA);
+        $this->stateFactory->expects(static::once())->method('fromFile')->with('/path/to/cache')->willReturn($state);
 
         $engine = $this->engineFactory->create('/base/path/', $this->options, $ruleSetList);
         static::assertNotNull($engine);
@@ -80,18 +80,18 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
     /**
      * @covers ::create
      */
-    public function testCreateCacheHitShouldHaveOriginalState()
+    public function testCreateCacheHitShouldHaveOriginalState(): void
     {
         $ruleSetList = [new RuleSet()];
         $cacheKey = new ResultCacheKey(true, 'baseline', [], [], 123);
         $state = new ResultCacheState($cacheKey, []);
 
-        $this->options->expects(self::once())->method('isCacheEnabled')->willReturn(true);
-        $this->options->expects(self::once())->method('hasStrict')->willReturn(true);
-        $this->options->expects(self::exactly(3))->method('cacheFile')->willReturn('/path/to/cache');
+        $this->options->expects(static::once())->method('isCacheEnabled')->willReturn(true);
+        $this->options->expects(static::once())->method('hasStrict')->willReturn(true);
+        $this->options->expects(static::exactly(3))->method('cacheFile')->willReturn('/path/to/cache');
 
-        $this->keyFactory->expects(self::once())->method('create')->with(true, $ruleSetList)->willReturn($cacheKey);
-        $this->stateFactory->expects(self::once())->method('fromFile')->with('/path/to/cache')->willReturn($state);
+        $this->keyFactory->expects(static::once())->method('create')->with(true, $ruleSetList)->willReturn($cacheKey);
+        $this->stateFactory->expects(static::once())->method('fromFile')->with('/path/to/cache')->willReturn($state);
 
         $engine = $this->engineFactory->create('/base/path/', $this->options, $ruleSetList);
         static::assertNotNull($engine);

--- a/src/test/php/PHPMD/Cache/ResultCacheEngineTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheEngineTest.php
@@ -15,7 +15,7 @@ class ResultCacheEngineTest extends AbstractTestCase
      * @covers ::getUpdater
      * @covers ::getWriter
      */
-    public function testGetters()
+    public function testGetters(): void
     {
         $filter = $this->getMockFromBuilder(
             $this->getMockBuilder(ResultCacheFileFilter::class)->disableOriginalConstructor()

--- a/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheFileFilterTest.php
@@ -7,7 +7,7 @@ use PHPMD\Cache\Model\ResultCacheKey;
 use PHPMD\Cache\Model\ResultCacheState;
 use PHPMD\Cache\Model\ResultCacheStrategy as Strategy;
 use PHPMD\Console\NullOutput;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheFileFilter
@@ -17,8 +17,10 @@ class ResultCacheFileFilterTest extends AbstractTestCase
 {
     /** @var NullOutput */
     private $output;
+
     /** @var MockObject&ResultCacheKey */
     private $key;
+
     /** @var MockObject&ResultCacheState */
     private $state;
 
@@ -37,11 +39,11 @@ class ResultCacheFileFilterTest extends AbstractTestCase
      * @covers ::accept
      * @covers ::getState
      */
-    public function testAcceptStrategyContentModified()
+    public function testAcceptStrategyContentModified(): void
     {
         $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::CONTENT, $this->key, $this->state);
 
-        $this->state->expects(self::once())->method('isFileModified')->willReturn(true);
+        $this->state->expects(static::once())->method('isFileModified')->willReturn(true);
 
         static::assertTrue($filter->accept('ResultCacheFileFilterTest.php', __FILE__));
         $state = $filter->getState()->toArray();
@@ -52,12 +54,12 @@ class ResultCacheFileFilterTest extends AbstractTestCase
      * @covers ::accept
      * @covers ::getState
      */
-    public function testAcceptStrategyContentUnmodified()
+    public function testAcceptStrategyContentUnmodified(): void
     {
         $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::CONTENT, $this->key, $this->state);
 
-        $this->state->expects(self::once())->method('isFileModified')->willReturn(false);
-        $this->state->expects(self::once())->method('getViolations')->willReturn(['violations']);
+        $this->state->expects(static::once())->method('isFileModified')->willReturn(false);
+        $this->state->expects(static::once())->method('getViolations')->willReturn(['violations']);
 
         static::assertFalse($filter->accept('ResultCacheFileFilterTest.php', __FILE__));
         $state = $filter->getState()->toArray();
@@ -68,12 +70,12 @@ class ResultCacheFileFilterTest extends AbstractTestCase
      * @covers ::accept
      * @covers ::getState
      */
-    public function testAcceptStrategyTimestampModified()
+    public function testAcceptStrategyTimestampModified(): void
     {
         $timestamp = (string) filemtime(__FILE__);
         $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::TIMESTAMP, $this->key, $this->state);
 
-        $this->state->expects(self::once())->method('isFileModified')->willReturn(true);
+        $this->state->expects(static::once())->method('isFileModified')->willReturn(true);
 
         static::assertTrue($filter->accept('ResultCacheFileFilterTest.php', __FILE__));
         $state = $filter->getState()->toArray();
@@ -84,11 +86,11 @@ class ResultCacheFileFilterTest extends AbstractTestCase
      * @covers ::accept
      * @covers ::getState
      */
-    public function testAcceptWithoutState()
+    public function testAcceptWithoutState(): void
     {
         $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::CONTENT, $this->key, null);
 
-        $this->state->expects(self::never())->method('isFileModified')->willReturn(false);
+        $this->state->expects(static::never())->method('isFileModified')->willReturn(false);
 
         static::assertTrue($filter->accept('ResultCacheFileFilterTest.php', __FILE__));
         $state = $filter->getState()->toArray();
@@ -98,12 +100,12 @@ class ResultCacheFileFilterTest extends AbstractTestCase
     /**
      * @covers ::accept
      */
-    public function testAcceptShouldCacheResults()
+    public function testAcceptShouldCacheResults(): void
     {
         $filter = new ResultCacheFileFilter($this->output, __DIR__, Strategy::CONTENT, $this->key, $this->state);
 
         // expect one invocation
-        $this->state->expects(self::once())->method('isFileModified')->willReturn(true);
+        $this->state->expects(static::once())->method('isFileModified')->willReturn(true);
 
         // call twice
         static::assertTrue($filter->accept('ResultCacheFileFilterTest.php', __FILE__));

--- a/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
@@ -31,7 +31,7 @@ class ResultCacheKeyFactoryTest extends AbstractTestCase
      * @covers ::getBaselineHash
      * @covers ::getComposerHashes
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $rule = new DuplicatedArrayKey();
         $ruleSet = new RuleSet();

--- a/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
@@ -27,8 +27,8 @@ class ResultCacheKeyFactoryTest extends AbstractTestCase
 
     /**
      * @covers ::create
-     * @covers ::getBaselineHash
      * @covers ::createRuleHashes
+     * @covers ::getBaselineHash
      * @covers ::getComposerHashes
      */
     public function testCreate()

--- a/src/test/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
@@ -28,8 +28,8 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::fromFile
      * @covers ::createCacheKey
+     * @covers ::fromFile
      */
     public function testFromFileEmptyCache()
     {
@@ -38,8 +38,8 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::fromFile
      * @covers ::createCacheKey
+     * @covers ::fromFile
      */
     public function testFromFileIncompleteCacheKey()
     {
@@ -48,8 +48,8 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::fromFile
      * @covers ::createCacheKey
+     * @covers ::fromFile
      */
     public function testFromFileFullCache()
     {
@@ -73,8 +73,8 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @covers ::fromFile
      * @covers ::createCacheKey
+     * @covers ::fromFile
      */
     public function testFromFileWithCacheWithoutBaselineOrComposer()
     {

--- a/src/test/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
@@ -21,7 +21,7 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromFile
      */
-    public function testFromFileNonExisting()
+    public function testFromFileNonExisting(): void
     {
         $state = $this->factory->fromFile('foobar');
         static::assertNull($state);
@@ -31,7 +31,7 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
      * @covers ::createCacheKey
      * @covers ::fromFile
      */
-    public function testFromFileEmptyCache()
+    public function testFromFileEmptyCache(): void
     {
         $state = $this->factory->fromFile(static::createResourceUriForTest('.invalid-cache.php'));
         static::assertNull($state);
@@ -41,7 +41,7 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
      * @covers ::createCacheKey
      * @covers ::fromFile
      */
-    public function testFromFileIncompleteCacheKey()
+    public function testFromFileIncompleteCacheKey(): void
     {
         $state = $this->factory->fromFile(static::createResourceUriForTest('.incomplete-cache.php'));
         static::assertNull($state);
@@ -51,7 +51,7 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
      * @covers ::createCacheKey
      * @covers ::fromFile
      */
-    public function testFromFileFullCache()
+    public function testFromFileFullCache(): void
     {
         $state = $this->factory->fromFile(static::createResourceUriForTest('.result-cache.php'));
 
@@ -76,7 +76,7 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
      * @covers ::createCacheKey
      * @covers ::fromFile
      */
-    public function testFromFileWithCacheWithoutBaselineOrComposer()
+    public function testFromFileWithCacheWithoutBaselineOrComposer(): void
     {
         $state = $this->factory->fromFile(static::createResourceUriForTest('.minimal-cache.php'));
         static::assertNotNull($state);

--- a/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
@@ -6,7 +6,7 @@ use PHPMD\AbstractTestCase;
 use PHPMD\Cache\Model\ResultCacheState;
 use PHPMD\Console\NullOutput;
 use PHPMD\RuleSet;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheUpdater
@@ -32,24 +32,24 @@ class ResultCacheUpdaterTest extends AbstractTestCase
     /**
      * @covers ::update
      */
-    public function testUpdate()
+    public function testUpdate(): void
     {
         $ruleSet = new RuleSet();
         $report = $this->getReportMock();
         $violationA = $this->getRuleViolationMock('/base/path/violation/a');
         $violationB = $this->getRuleViolationMock('/base/path/violation/b');
 
-        $report->expects(self::once())->method('getRuleViolations')->willReturn([$violationA]);
-        $this->state->expects(self::once())
+        $report->expects(static::once())->method('getRuleViolations')->willReturn([$violationA]);
+        $this->state->expects(static::once())
             ->method('getRuleViolations')
             ->with('/base/path/', [$ruleSet])
             ->willReturn([$violationB]);
 
         // expect ViolationB be added to the report
-        $report->expects(self::once())->method('addRuleViolation')->with($violationB);
+        $report->expects(static::once())->method('addRuleViolation')->with($violationB);
 
         // expect ViolationA be added to the state
-        $this->state->expects(self::once())->method('addRuleViolation')->with('violation/a', $violationA);
+        $this->state->expects(static::once())->method('addRuleViolation')->with('violation/a', $violationA);
 
         $state = $this->updater->update([$ruleSet], $this->state, $report);
         static::assertSame($this->state, $state);

--- a/src/test/php/PHPMD/Cache/ResultCacheWriterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheWriterTest.php
@@ -28,7 +28,7 @@ class ResultCacheWriterTest extends AbstractTestCase
     /**
      * @covers ::write
      */
-    public function testWrite()
+    public function testWrite(): void
     {
         $cacheKey = new ResultCacheKey(true, 'baseline', [], [], 70000);
         $cacheState = new ResultCacheState($cacheKey, []);

--- a/src/test/php/PHPMD/Console/OutputTest.php
+++ b/src/test/php/PHPMD/Console/OutputTest.php
@@ -20,11 +20,10 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @covers ::getVerbosity
      * @covers ::setVerbosity
      */
-    public function testSetGetVerbosity()
+    public function testSetGetVerbosity(): void
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
         static::assertSame(OutputInterface::VERBOSITY_VERBOSE, $this->output->getVerbosity());
@@ -34,25 +33,23 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @covers ::write
      */
-    public function testWriteSingleMessage()
+    public function testWriteSingleMessage(): void
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
-        $this->output->write("message", false, OutputInterface::VERBOSITY_VERBOSE);
+        $this->output->write('message', false, OutputInterface::VERBOSITY_VERBOSE);
 
         static::assertSame('message', $this->output->getOutput());
     }
 
     /**
-     * @return void
      * @covers ::write
      */
-    public function testWriteMultiMessageWithNewline()
+    public function testWriteMultiMessageWithNewline(): void
     {
         $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
-        $this->output->write(["foo", "bar"], true, OutputInterface::VERBOSITY_VERBOSE);
+        $this->output->write(['foo', 'bar'], true, OutputInterface::VERBOSITY_VERBOSE);
 
         static::assertSame("foo\nbar\n", $this->output->getOutput());
     }
@@ -64,7 +61,7 @@ class OutputTest extends AbstractTestCase
      * @dataProvider verbosityProvider
      * @covers ::write
      */
-    public function testWriteWithVerbosityOption($verbosity, $expected, $msg)
+    public function testWriteWithVerbosityOption($verbosity, $expected, $msg): void
     {
         $this->output->setVerbosity($verbosity);
         $this->output->write('1', false);
@@ -108,12 +105,11 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @covers ::writeln
      */
-    public function testWritelnMessage()
+    public function testWritelnMessage(): void
     {
-        $this->output->writeln("message", OutputInterface::VERBOSITY_QUIET);
+        $this->output->writeln('message', OutputInterface::VERBOSITY_QUIET);
 
         static::assertSame("message\n", $this->output->getOutput());
     }

--- a/src/test/php/PHPMD/Console/StreamOutputTest.php
+++ b/src/test/php/PHPMD/Console/StreamOutputTest.php
@@ -13,7 +13,7 @@ class StreamOutputTest extends TestCase
      * @covers ::__construct
      * @covers ::doWrite
      */
-    public function testDoWrite()
+    public function testDoWrite(): void
     {
         $stream = fopen('php://memory', 'w+b');
         $output = new StreamOutput($stream);

--- a/src/test/php/PHPMD/Console/TestOutput.php
+++ b/src/test/php/PHPMD/Console/TestOutput.php
@@ -24,6 +24,7 @@ class TestOutput extends Output
     public function getOutput()
     {
         fseek($this->stream, 0);
+
         return fread($this->stream, 1024);
     }
 }

--- a/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
+++ b/src/test/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
@@ -30,12 +30,11 @@ class CommandLineInputFileOptionTest extends AbstractTestCase
     /**
      * testReportContainsExpectedRuleViolationWarning
      *
-     * @return void
      * @outputBuffering enabled
      */
-    public function testReportContainsExpectedRuleViolationWarning()
+    public function testReportContainsExpectedRuleViolationWarning(): void
     {
-        self::assertStringContainsString(
+        static::assertStringContainsString(
             "Avoid unused local variables such as '\$foo'.",
             self::runCommandLine()
         );
@@ -44,12 +43,11 @@ class CommandLineInputFileOptionTest extends AbstractTestCase
     /**
      * testReportNotContainsRuleViolationWarningForFileNotInList
      *
-     * @return void
      * @outputBuffering enabled
      */
-    public function testReportNotContainsRuleViolationWarningForFileNotInList()
+    public function testReportNotContainsRuleViolationWarningForFileNotInList(): void
     {
-        self::assertStringNotContainsString(
+        static::assertStringNotContainsString(
             "Avoid unused local variables such as '\$bar'.",
             self::runCommandLine()
         );

--- a/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
@@ -30,10 +30,9 @@ class CouplingBetweenObjectsIntegrationTest extends AbstractTestCase
     /**
      * testReportContainsCouplingBetweenObjectsWarning
      *
-     * @return void
      * @outputBuffering enabled
      */
-    public function testReportContainsCouplingBetweenObjectsWarning()
+    public function testReportContainsCouplingBetweenObjectsWarning(): void
     {
         $file = self::createTempFileUri();
 
@@ -48,7 +47,7 @@ class CouplingBetweenObjectsIntegrationTest extends AbstractTestCase
             ]
         );
 
-        self::assertStringContainsString(
+        static::assertStringContainsString(
             'has a coupling between objects value of 14. ' .
             'Consider to reduce the number of dependencies under 13.',
             file_get_contents($file)

--- a/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
+++ b/src/test/php/PHPMD/Integration/GotoStatementIntegrationTest.php
@@ -30,10 +30,9 @@ class GotoStatementIntegrationTest extends AbstractTestCase
     /**
      * testReportContainsGotoStatementWarning
      *
-     * @return void
      * @outputBuffering enabled
      */
-    public function testReportContainsGotoStatementWarning()
+    public function testReportContainsGotoStatementWarning(): void
     {
         $file = self::createTempFileUri();
 
@@ -48,6 +47,6 @@ class GotoStatementIntegrationTest extends AbstractTestCase
             ]
         );
 
-        self::assertStringContainsString('utilizes a goto statement.', file_get_contents($file));
+        static::assertStringContainsString('utilizes a goto statement.', file_get_contents($file));
     }
 }

--- a/src/test/php/PHPMD/Node/ASTNodeTest.php
+++ b/src/test/php/PHPMD/Node/ASTNodeTest.php
@@ -29,13 +29,11 @@ class ASTNodeTest extends AbstractTestCase
 {
     /**
      * testGetImageDelegatesToGetImageMethodOfWrappedNode
-     *
-     * @return void
      */
-    public function testGetImageDelegatesToGetImageMethodOfWrappedNode()
+    public function testGetImageDelegatesToGetImageMethodOfWrappedNode(): void
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
-        $mock->expects($this->once())
+        $mock->expects(static::once())
             ->method('getImage');
 
         $node = new ASTNode($mock, __FILE__);
@@ -44,13 +42,11 @@ class ASTNodeTest extends AbstractTestCase
 
     /**
      * testGetNameDelegatesToGetImageMethodOfWrappedNode
-     *
-     * @return void
      */
-    public function testGetNameDelegatesToGetImageMethodOfWrappedNode()
+    public function testGetNameDelegatesToGetImageMethodOfWrappedNode(): void
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
-        $mock->expects($this->once())
+        $mock->expects(static::once())
             ->method('getImage');
 
         $node = new ASTNode($mock, __FILE__);
@@ -59,55 +55,47 @@ class ASTNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsAnnotationForAlwaysReturnsFalse
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsAnnotationForAlwaysReturnsFalse()
+    public function testHasSuppressWarningsAnnotationForAlwaysReturnsFalse(): void
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
 
         $node = new ASTNode($mock, __FILE__);
         $rule = $this->getRuleMock();
 
-        $this->assertFalse($node->hasSuppressWarningsAnnotationFor($rule));
+        static::assertFalse($node->hasSuppressWarningsAnnotationFor($rule));
     }
 
     /**
      * testGetParentNameReturnsNull
-     *
-     * @return void
      */
-    public function testGetParentNameReturnsNull()
+    public function testGetParentNameReturnsNull(): void
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $node = new ASTNode($mock, __FILE__);
 
-        $this->assertNull($node->getParentName());
+        static::assertNull($node->getParentName());
     }
 
     /**
      * testGetNamespaceNameReturnsNull
-     *
-     * @return void
      */
-    public function testGetNamespaceNameReturnsNull()
+    public function testGetNamespaceNameReturnsNull(): void
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $node = new ASTNode($mock, __FILE__);
 
-        $this->assertNull($node->getNamespaceName());
+        static::assertNull($node->getNamespaceName());
     }
 
     /**
      * testGetFullQualifiedNameReturnsNull
-     *
-     * @return void
      */
-    public function testGetFullQualifiedNameReturnsNull()
+    public function testGetFullQualifiedNameReturnsNull(): void
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $node = new ASTNode($mock, __FILE__);
 
-        $this->assertNull($node->getFullQualifiedName());
+        static::assertNull($node->getFullQualifiedName());
     }
 }

--- a/src/test/php/PHPMD/Node/AnnotationTest.php
+++ b/src/test/php/PHPMD/Node/AnnotationTest.php
@@ -28,98 +28,82 @@ class AnnotationTest extends AbstractTestCase
 {
     /**
      * testAnnotationReturnsFalseWhenNoSuppressWarningAnnotationExists
-     *
-     * @return void
      */
-    public function testAnnotationReturnsFalseWhenNoSuppressWarningAnnotationExists()
+    public function testAnnotationReturnsFalseWhenNoSuppressWarningAnnotationExists(): void
     {
         $annotation = new Annotation('NoSuppressWarning', 'PMD');
-        $this->assertFalse($annotation->suppresses($this->getRuleMock()));
+        static::assertFalse($annotation->suppresses($this->getRuleMock()));
     }
 
     /**
      * testAnnotationReturnsFalseWhenSuppressWarningContainsInvalidValue
-     *
-     * @return void
      */
-    public function testAnnotationReturnsFalseWhenSuppressWarningContainsInvalidValue()
+    public function testAnnotationReturnsFalseWhenSuppressWarningContainsInvalidValue(): void
     {
         $annotation = new Annotation('SuppressWarnings', 'PHP');
-        $this->assertFalse($annotation->suppresses($this->getRuleMock()));
+        static::assertFalse($annotation->suppresses($this->getRuleMock()));
     }
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsWithPMD
-     *
-     * @return void
      */
-    public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPMD()
+    public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPMD(): void
     {
         $annotation = new Annotation('SuppressWarnings', 'PMD');
-        $this->assertTrue($annotation->suppresses($this->getRuleMock()));
+        static::assertTrue($annotation->suppresses($this->getRuleMock()));
     }
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMD
-     *
-     * @return void
      */
-    public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMD()
+    public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMD(): void
     {
         $annotation = new Annotation('SuppressWarnings', 'PHPMD');
-        $this->assertTrue($annotation->suppresses($this->getRuleMock()));
+        static::assertTrue($annotation->suppresses($this->getRuleMock()));
     }
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMDLCFirst
-     *
-     * @return void
      */
-    public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMDLCFirst()
+    public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMDLCFirst(): void
     {
         $annotation = new Annotation('suppressWarnings', 'PHPMD');
-        $this->assertTrue($annotation->suppresses($this->getRuleMock()));
+        static::assertTrue($annotation->suppresses($this->getRuleMock()));
     }
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsPMDPlusRuleName
-     *
-     * @return void
      */
-    public function testAnnotationReturnsTrueWhenSuppressWarningContainsPMDPlusRuleName()
+    public function testAnnotationReturnsTrueWhenSuppressWarningContainsPMDPlusRuleName(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('UnusedCodeRule');
 
         $annotation = new Annotation('SuppressWarnings', 'PMD.UnusedCodeRule');
-        $this->assertTrue($annotation->suppresses($rule));
+        static::assertTrue($annotation->suppresses($rule));
     }
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsPHPMDPlusRuleName
-     *
-     * @return void
      */
-    public function testAnnotationReturnsTrueWhenSuppressWarningContainsPHPMDPlusRuleName()
+    public function testAnnotationReturnsTrueWhenSuppressWarningContainsPHPMDPlusRuleName(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('UnusedCodeRule');
 
         $annotation = new Annotation('SuppressWarnings', 'PHPMD.UnusedCodeRule');
-        $this->assertTrue($annotation->suppresses($rule));
+        static::assertTrue($annotation->suppresses($rule));
     }
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsPartialRuleName
-     *
-     * @return void
      */
-    public function testAnnotationReturnsTrueWhenSuppressWarningContainsPartialRuleName()
+    public function testAnnotationReturnsTrueWhenSuppressWarningContainsPartialRuleName(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('UnusedCodeRule');
 
         $annotation = new Annotation('SuppressWarnings', 'unused');
-        $this->assertTrue($annotation->suppresses($rule));
+        static::assertTrue($annotation->suppresses($rule));
     }
 }

--- a/src/test/php/PHPMD/Node/AnnotationsTest.php
+++ b/src/test/php/PHPMD/Node/AnnotationsTest.php
@@ -28,28 +28,24 @@ class AnnotationsTest extends AbstractTestCase
 {
     /**
      * testCollectionReturnsFalseWhenNoAnnotationExists
-     *
-     * @return void
      */
-    public function testCollectionReturnsFalseWhenNoAnnotationExists()
+    public function testCollectionReturnsFalseWhenNoAnnotationExists(): void
     {
         $annotations = new Annotations($this->getClassMock());
-        $this->assertFalse($annotations->suppresses($this->getRuleMock()));
+        static::assertFalse($annotations->suppresses($this->getRuleMock()));
     }
 
     /**
      * testCollectionReturnsFalseWhenNoMatchingAnnotationExists
-     *
-     * @return void
      */
-    public function testCollectionReturnsFalseWhenNoMatchingAnnotationExists()
+    public function testCollectionReturnsFalseWhenNoMatchingAnnotationExists(): void
     {
         $class = $this->getClassMock();
-        $class->expects($this->once())
+        $class->expects(static::once())
             ->method('__call')
-            ->with($this->equalTo('getComment'))
+            ->with(static::equalTo('getComment'))
             ->will(
-                $this->returnValue(
+                static::returnValue(
                     '/**
                       * @SuppressWarnings("Foo")
                       * @SuppressWarnings("Bar")
@@ -59,39 +55,35 @@ class AnnotationsTest extends AbstractTestCase
             );
 
         $annotations = new Annotations($class);
-        $this->assertFalse($annotations->suppresses($this->getRuleMock()));
+        static::assertFalse($annotations->suppresses($this->getRuleMock()));
     }
 
     /**
      * testCollectionReturnsTrueWhenMatchingAnnotationExists
-     *
-     * @return void
      */
-    public function testCollectionReturnsTrueWhenMatchingAnnotationExists()
+    public function testCollectionReturnsTrueWhenMatchingAnnotationExists(): void
     {
         $class = $this->getClassMock();
-        $class->expects($this->once())
+        $class->expects(static::once())
             ->method('__call')
-            ->with($this->equalTo('getComment'))
-            ->will($this->returnValue('/** @SuppressWarnings("PMD") */'));
+            ->with(static::equalTo('getComment'))
+            ->will(static::returnValue('/** @SuppressWarnings("PMD") */'));
 
         $annotations = new Annotations($class);
-        $this->assertTrue($annotations->suppresses($this->getRuleMock()));
+        static::assertTrue($annotations->suppresses($this->getRuleMock()));
     }
 
     /**
      * testCollectionReturnsTrueWhenOneMatchingAnnotationExists
-     *
-     * @return void
      */
-    public function testCollectionReturnsTrueWhenOneMatchingAnnotationExists()
+    public function testCollectionReturnsTrueWhenOneMatchingAnnotationExists(): void
     {
         $class = $this->getClassMock();
-        $class->expects($this->once())
+        $class->expects(static::once())
             ->method('__call')
-            ->with($this->equalTo('getComment'))
+            ->with(static::equalTo('getComment'))
             ->will(
-                $this->returnValue(
+                static::returnValue(
                     '/**
                       * @SuppressWarnings("FooBar")
                       * @SuppressWarnings("PMD")
@@ -100,6 +92,6 @@ class AnnotationsTest extends AbstractTestCase
             );
 
         $annotations = new Annotations($class);
-        $this->assertTrue($annotations->suppresses($this->getRuleMock()));
+        static::assertTrue($annotations->suppresses($this->getRuleMock()));
     }
 }

--- a/src/test/php/PHPMD/Node/ClassNodeTest.php
+++ b/src/test/php/PHPMD/Node/ClassNodeTest.php
@@ -35,25 +35,21 @@ class ClassNodeTest extends AbstractTestCase
 {
     /**
      * testGetMethodNamesReturnsExpectedResult
-     *
-     * @return void
      */
-    public function testGetMethodNamesReturnsExpectedResult()
+    public function testGetMethodNamesReturnsExpectedResult(): void
     {
         $class = new ASTClass(null);
         $class->addMethod(new ASTMethod(__CLASS__));
         $class->addMethod(new ASTMethod(__FUNCTION__));
 
         $node = new ClassNode($class);
-        $this->assertEquals([__CLASS__, __FUNCTION__], $node->getMethodNames());
+        static::assertEquals([__CLASS__, __FUNCTION__], $node->getMethodNames());
     }
 
     /**
      * testHasSuppressWarningsAnnotationForReturnsTrue
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsAnnotationForReturnsTrue()
+    public function testHasSuppressWarningsAnnotationForReturnsTrue(): void
     {
         $class = new ASTClass(null);
         $class->setComment('/** @SuppressWarnings("PMD") */');
@@ -62,15 +58,13 @@ class ClassNodeTest extends AbstractTestCase
 
         $node = new ClassNode($class);
 
-        $this->assertTrue($node->hasSuppressWarningsAnnotationFor($rule));
+        static::assertTrue($node->hasSuppressWarningsAnnotationFor($rule));
     }
 
     /**
      * testHasSuppressWarningsWithRuleNameContainingSlashes
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsWithRuleNameContainingSlashes()
+    public function testHasSuppressWarningsWithRuleNameContainingSlashes(): void
     {
         $class = new ASTClass(null);
         $class->setComment('/** @SuppressWarnings(PMD.CouplingBetweenObjects) */');
@@ -80,7 +74,7 @@ class ClassNodeTest extends AbstractTestCase
 
         $node = new ClassNode($class);
 
-        $this->assertTrue($node->hasSuppressWarningsAnnotationFor($rule));
+        static::assertTrue($node->hasSuppressWarningsAnnotationFor($rule));
 
         $class = new ASTClass(null);
         $class->setComment('/** @SuppressWarnings(PMD.TooManyFields) */');
@@ -90,48 +84,37 @@ class ClassNodeTest extends AbstractTestCase
 
         $node = new ClassNode($class);
 
-        $this->assertFalse($node->hasSuppressWarningsAnnotationFor($rule));
+        static::assertFalse($node->hasSuppressWarningsAnnotationFor($rule));
     }
 
     /**
      * testGetFullQualifiedNameReturnsExpectedValue
-     *
-     * @return void
      */
-    public function testGetFullQualifiedNameReturnsExpectedValue()
+    public function testGetFullQualifiedNameReturnsExpectedValue(): void
     {
         $class = new ASTClass('MyClass');
         $class->setNamespace(new ASTNamespace('Sindelfingen'));
 
         $node = new ClassNode($class);
 
-        $this->assertSame(MyClass::class, $node->getFullQualifiedName());
+        static::assertSame(MyClass::class, $node->getFullQualifiedName());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConstantCountReturnsZeroByDefault()
+    public function testGetConstantCountReturnsZeroByDefault(): void
     {
         $class = new ClassNode(new ASTClass('MyClass'));
-        $this->assertSame(0, $class->getConstantCount());
+        static::assertSame(0, $class->getConstantCount());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConstantCount()
+    public function testGetConstantCount(): void
     {
         $class = $this->getClass();
-        $this->assertSame(3, $class->getConstantCount());
+        static::assertSame(3, $class->getConstantCount());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetParentNameReturnsNull()
+    public function testGetParentNameReturnsNull(): void
     {
         $class = new ClassNode(new ASTClass('MyClass'));
-        $this->assertNull($class->getParentName());
+        static::assertNull($class->getParentName());
     }
 }

--- a/src/test/php/PHPMD/Node/ClassNodeTest.php
+++ b/src/test/php/PHPMD/Node/ClassNodeTest.php
@@ -28,8 +28,8 @@ use Sindelfingen\MyClass;
 /**
  * Test case for the class node implementation.
  *
- * @covers \PHPMD\Node\ClassNode
  * @covers \PHPMD\Node\AbstractTypeNode
+ * @covers \PHPMD\Node\ClassNode
  */
 class ClassNodeTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Node/FunctionTest.php
+++ b/src/test/php/PHPMD/Node/FunctionTest.php
@@ -31,16 +31,14 @@ class FunctionTest extends AbstractTestCase
 {
     /**
      * testMagicCallDelegatesToWrappedPHPDependFunction
-     *
-     * @return void
      */
-    public function testMagicCallDelegatesToWrappedPHPDependFunction()
+    public function testMagicCallDelegatesToWrappedPHPDependFunction(): void
     {
         $function = $this->getMockFromBuilder(
             $this->getMockBuilder(ASTFunction::class)
                 ->setConstructorArgs([null])
         );
-        $function->expects($this->once())
+        $function->expects(static::once())
             ->method('getStartLine');
 
         $node = new FunctionNode($function);
@@ -49,10 +47,8 @@ class FunctionTest extends AbstractTestCase
 
     /**
      * testMagicCallThrowsExceptionWhenNoMatchingMethodExists
-     *
-     * @return void
      */
-    public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists()
+    public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists(): void
     {
         self::expectException(BadMethodCallException::class);
 

--- a/src/test/php/PHPMD/Node/FunctionTest.php
+++ b/src/test/php/PHPMD/Node/FunctionTest.php
@@ -24,8 +24,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the function node implementation.
  *
- * @covers \PHPMD\Node\FunctionNode
  * @covers \PHPMD\Node\AbstractCallableNode
+ * @covers \PHPMD\Node\FunctionNode
  */
 class FunctionTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Node/InterfaceNodeTest.php
+++ b/src/test/php/PHPMD/Node/InterfaceNodeTest.php
@@ -25,8 +25,8 @@ use Sindelfingen\MyInterface;
 /**
  * Test case for the interface node implementation.
  *
- * @covers \PHPMD\Node\InterfaceNode
  * @covers \PHPMD\Node\AbstractTypeNode
+ * @covers \PHPMD\Node\InterfaceNode
  */
 class InterfaceNodeTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Node/InterfaceNodeTest.php
+++ b/src/test/php/PHPMD/Node/InterfaceNodeTest.php
@@ -32,43 +32,32 @@ class InterfaceNodeTest extends AbstractTestCase
 {
     /**
      * testGetFullQualifiedNameReturnsExpectedValue
-     *
-     * @return void
      */
-    public function testGetFullQualifiedNameReturnsExpectedValue()
+    public function testGetFullQualifiedNameReturnsExpectedValue(): void
     {
         $interface = new ASTInterface('MyInterface');
         $interface->setNamespace(new ASTNamespace('Sindelfingen'));
 
         $node = new InterfaceNode($interface);
 
-        $this->assertSame(MyInterface::class, $node->getFullQualifiedName());
+        static::assertSame(MyInterface::class, $node->getFullQualifiedName());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConstantCountReturnsZeroByDefault()
+    public function testGetConstantCountReturnsZeroByDefault(): void
     {
         $interface = new InterfaceNode(new ASTInterface('MyInterface'));
-        $this->assertSame(0, $interface->getConstantCount());
+        static::assertSame(0, $interface->getConstantCount());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConstantCount()
+    public function testGetConstantCount(): void
     {
         $class = $this->getInterface();
-        $this->assertSame(3, $class->getConstantCount());
+        static::assertSame(3, $class->getConstantCount());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetParentNameReturnsNull()
+    public function testGetParentNameReturnsNull(): void
     {
         $interface = new InterfaceNode(new ASTInterface('MyInterface'));
-        $this->assertNull($interface->getParentName());
+        static::assertNull($interface->getParentName());
     }
 }

--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -33,16 +33,14 @@ class MethodNodeTest extends AbstractTestCase
 {
     /**
      * testMagicCallDelegatesToWrappedPHPDependMethod
-     *
-     * @return void
      */
-    public function testMagicCallDelegatesToWrappedPHPDependMethod()
+    public function testMagicCallDelegatesToWrappedPHPDependMethod(): void
     {
         $method = $this->getMockFromBuilder(
             $this->getMockBuilder(ASTMethod::class)
                 ->setConstructorArgs([null])
         );
-        $method->expects($this->once())
+        $method->expects(static::once())
             ->method('getStartLine');
 
         $node = new MethodNode($method);
@@ -51,10 +49,8 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testMagicCallThrowsExceptionWhenNoMatchingMethodExists
-     *
-     * @return void
      */
-    public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists()
+    public function testMagicCallThrowsExceptionWhenNoMatchingMethodExists(): void
     {
         self::expectException(BadMethodCallException::class);
 
@@ -64,12 +60,10 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testGetParentTypeReturnsInterfaceForInterfaceMethod
-     *
-     * @return void
      */
-    public function testGetParentTypeReturnsInterfaceForInterfaceMethod()
+    public function testGetParentTypeReturnsInterfaceForInterfaceMethod(): void
     {
-        $this->assertInstanceOf(
+        static::assertInstanceOf(
             InterfaceNode::class,
             $this->getMethod()->getParentType()
         );
@@ -77,23 +71,18 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testGetParentTypeReturnsClassForClassMethod
-     *
-     * @return void
      */
-    public function testGetParentTypeReturnsClassForClassMethod()
+    public function testGetParentTypeReturnsClassForClassMethod(): void
     {
-        $this->assertInstanceOf(
+        static::assertInstanceOf(
             ClassNode::class,
             $this->getMethod()->getParentType()
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testGetParentTypeReturnsTrait()
+    public function testGetParentTypeReturnsTrait(): void
     {
-        $this->assertInstanceOf(
+        static::assertInstanceOf(
             TraitNode::class,
             $this->getMethod()->getParentType()
         );
@@ -101,135 +90,117 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsExecutesDefaultImplementation
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsExecutesDefaultImplementation()
+    public function testHasSuppressWarningsExecutesDefaultImplementation(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('FooBar');
 
         $method = $this->getMethod();
-        $this->assertTrue($method->hasSuppressWarningsAnnotationFor($rule));
+        static::assertTrue($method->hasSuppressWarningsAnnotationFor($rule));
     }
 
     /**
      * testHasSuppressWarningsDelegatesToParentClassMethod
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsDelegatesToParentClassMethod()
+    public function testHasSuppressWarningsDelegatesToParentClassMethod(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('FooBar');
 
         $method = $this->getMethod();
-        $this->assertTrue($method->hasSuppressWarningsAnnotationFor($rule));
+        static::assertTrue($method->hasSuppressWarningsAnnotationFor($rule));
     }
 
     /**
      * testHasSuppressWarningsDelegatesToParentInterfaceMethod
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsDelegatesToParentInterfaceMethod()
+    public function testHasSuppressWarningsDelegatesToParentInterfaceMethod(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('FooBar');
 
         $method = $this->getMethod();
-        $this->assertTrue($method->hasSuppressWarningsAnnotationFor($rule));
+        static::assertTrue($method->hasSuppressWarningsAnnotationFor($rule));
     }
 
     /**
      * testHasSuppressWarningsIgnoresCaseFirstLetter
-     *
-     * @return void
      */
-    public function testHasSuppressWarningsIgnoresCaseFirstLetter()
+    public function testHasSuppressWarningsIgnoresCaseFirstLetter(): void
     {
         $rule = $this->getRuleMock();
         $rule->setName('FooBar');
 
         $method = $this->getMethod();
-        $this->assertTrue($method->hasSuppressWarningsAnnotationFor($rule));
+        static::assertTrue($method->hasSuppressWarningsAnnotationFor($rule));
     }
 
     /**
      * testIsDeclarationReturnsTrueForMethodDeclaration
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testIsDeclarationReturnsTrueForMethodDeclaration()
+    public function testIsDeclarationReturnsTrueForMethodDeclaration(): void
     {
         $method = $this->getMethod();
-        $this->assertTrue($method->isDeclaration());
+        static::assertTrue($method->isDeclaration());
     }
 
     /**
      * testIsDeclarationReturnsTrueForMethodDeclarationWithParent
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testIsDeclarationReturnsTrueForMethodDeclarationWithParent()
+    public function testIsDeclarationReturnsTrueForMethodDeclarationWithParent(): void
     {
         $method = $this->getMethod();
-        $this->assertTrue($method->isDeclaration());
+        static::assertTrue($method->isDeclaration());
     }
 
     /**
      * testIsDeclarationReturnsFalseForInheritMethodDeclaration
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testIsDeclarationReturnsFalseForInheritMethodDeclaration()
+    public function testIsDeclarationReturnsFalseForInheritMethodDeclaration(): void
     {
         $method = $this->getMethod();
-        $this->assertFalse($method->isDeclaration());
+        static::assertFalse($method->isDeclaration());
     }
 
     /**
      * testIsDeclarationReturnsFalseForImplementedAbstractMethod
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testIsDeclarationReturnsFalseForImplementedAbstractMethod()
+    public function testIsDeclarationReturnsFalseForImplementedAbstractMethod(): void
     {
         $method = $this->getMethod();
-        $this->assertFalse($method->isDeclaration());
+        static::assertFalse($method->isDeclaration());
     }
 
     /**
      * testIsDeclarationReturnsFalseForImplementedInterfaceMethod
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testIsDeclarationReturnsFalseForImplementedInterfaceMethod()
+    public function testIsDeclarationReturnsFalseForImplementedInterfaceMethod(): void
     {
         $method = $this->getMethod();
-        $this->assertFalse($method->isDeclaration());
+        static::assertFalse($method->isDeclaration());
     }
 
-    /**
-     * @return void
-     */
-    public function testIsDeclarationReturnsTrueForPrivateMethod()
+    public function testIsDeclarationReturnsTrueForPrivateMethod(): void
     {
         $method = $this->getMethod();
-        $this->assertTrue($method->isDeclaration());
+        static::assertTrue($method->isDeclaration());
     }
 
     /**
      * testGetFullQualifiedNameReturnsExpectedValue
-     *
-     * @return void
      */
-    public function testGetFullQualifiedNameReturnsExpectedValue()
+    public function testGetFullQualifiedNameReturnsExpectedValue(): void
     {
         $class = new ASTClass('MyClass');
         $class->setNamespace(new ASTNamespace('Sindelfingen'));
@@ -239,6 +210,6 @@ class MethodNodeTest extends AbstractTestCase
 
         $node = new MethodNode($method);
 
-        $this->assertSame('Sindelfingen\\MyClass::beer()', $node->getFullQualifiedName());
+        static::assertSame('Sindelfingen\\MyClass::beer()', $node->getFullQualifiedName());
     }
 }

--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -26,8 +26,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the method node implementation.
  *
- * @covers \PHPMD\Node\MethodNode
  * @covers \PHPMD\Node\AbstractCallableNode
+ * @covers \PHPMD\Node\MethodNode
  */
 class MethodNodeTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Node/NodeInfoFactoryTest.php
+++ b/src/test/php/PHPMD/Node/NodeInfoFactoryTest.php
@@ -3,7 +3,7 @@
 namespace PHPMD\Node;
 
 use PHPMD\AbstractTestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @coversDefaultClass \PHPMD\Node\NodeInfoFactory
@@ -13,7 +13,7 @@ class NodeInfoFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromNode
      */
-    public function testFromNodeForAbstractTypeNode()
+    public function testFromNodeForAbstractTypeNode(): void
     {
         /** @var AbstractTypeNode&MockObject $node */
         $node = $this->getMockFromBuilder(
@@ -38,7 +38,7 @@ class NodeInfoFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromNode
      */
-    public function testFromNodeForMethodNode()
+    public function testFromNodeForMethodNode(): void
     {
         /** @var MethodNode&MockObject $node */
         $node = $this->getMockFromBuilder(
@@ -64,7 +64,7 @@ class NodeInfoFactoryTest extends AbstractTestCase
     /**
      * @covers ::fromNode
      */
-    public function testFromNodeForFunctionNode()
+    public function testFromNodeForFunctionNode(): void
     {
         /** @var MethodNode&MockObject $node */
         $node = $this->getMockFromBuilder(

--- a/src/test/php/PHPMD/Node/NodeInfoTest.php
+++ b/src/test/php/PHPMD/Node/NodeInfoTest.php
@@ -12,7 +12,7 @@ class NodeInfoTest extends AbstractTestCase
     /**
      * @covers ::__construct
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $nodeInfo = new NodeInfo(
             '/file/path',

--- a/src/test/php/PHPMD/Node/TraitNodeTest.php
+++ b/src/test/php/PHPMD/Node/TraitNodeTest.php
@@ -25,8 +25,8 @@ use Sindelfingen\MyTrait;
 /**
  * Test case for the trait node implementation.
  *
- * @covers \PHPMD\Node\TraitNode
  * @covers \PHPMD\Node\AbstractTypeNode
+ * @covers \PHPMD\Node\TraitNode
  */
 class TraitNodeTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Node/TraitNodeTest.php
+++ b/src/test/php/PHPMD/Node/TraitNodeTest.php
@@ -32,34 +32,26 @@ class TraitNodeTest extends AbstractTestCase
 {
     /**
      * testGetFullQualifiedNameReturnsExpectedValue
-     *
-     * @return void
      */
-    public function testGetFullQualifiedNameReturnsExpectedValue()
+    public function testGetFullQualifiedNameReturnsExpectedValue(): void
     {
         $trait = new ASTTrait('MyTrait');
         $trait->setNamespace(new ASTNamespace('Sindelfingen'));
 
         $node = new TraitNode($trait);
 
-        $this->assertSame(MyTrait::class, $node->getFullQualifiedName());
+        static::assertSame(MyTrait::class, $node->getFullQualifiedName());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConstantCountReturnsZeroByDefault()
+    public function testGetConstantCountReturnsZeroByDefault(): void
     {
         $trait = new TraitNode(new ASTTrait('MyTrait'));
-        $this->assertSame(0, $trait->getConstantCount());
+        static::assertSame(0, $trait->getConstantCount());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetParentNameReturnsNull()
+    public function testGetParentNameReturnsNull(): void
     {
         $trait = new TraitNode(new ASTTrait('MyTrait'));
-        $this->assertNull($trait->getParentName());
+        static::assertNull($trait->getParentName());
     }
 }

--- a/src/test/php/PHPMD/PHPMDTest.php
+++ b/src/test/php/PHPMD/PHPMDTest.php
@@ -22,7 +22,7 @@ use PHPMD\Baseline\BaselineSet;
 use PHPMD\Baseline\BaselineValidator;
 use PHPMD\Renderer\XMLRenderer;
 use PHPMD\Stubs\WriterStub;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Test case for the main PHPMD class.
@@ -41,10 +41,8 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * Tests the main PHPMD interface with default settings an a xml-renderer.
-     *
-     * @return void
      */
-    public function testRunWithDefaultSettingsAndXmlRenderer()
+    public function testRunWithDefaultSettingsAndXmlRenderer(): void
     {
         self::changeWorkingDirectory();
 
@@ -68,10 +66,8 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testRunWithDefaultSettingsAndXmlRendererAgainstSingleFile
-     *
-     * @return void
      */
-    public function testRunWithDefaultSettingsAndXmlRendererAgainstDirectory()
+    public function testRunWithDefaultSettingsAndXmlRendererAgainstDirectory(): void
     {
         self::changeWorkingDirectory();
 
@@ -94,10 +90,8 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testRunWithDefaultSettingsAndXmlRendererAgainstSingleFile
-     *
-     * @return void
      */
-    public function testRunWithDefaultSettingsAndXmlRendererAgainstSingleFile()
+    public function testRunWithDefaultSettingsAndXmlRendererAgainstSingleFile(): void
     {
         self::changeWorkingDirectory();
 
@@ -120,32 +114,26 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testHasErrorsReturnsFalseByDefault
-     *
-     * @return void
      */
-    public function testHasErrorsReturnsFalseByDefault()
+    public function testHasErrorsReturnsFalseByDefault(): void
     {
         $phpmd = new PHPMD();
-        $this->assertFalse($phpmd->hasErrors());
+        static::assertFalse($phpmd->hasErrors());
     }
 
     /**
      * testHasViolationsReturnsFalseByDefault
-     *
-     * @return void
      */
-    public function testHasViolationsReturnsFalseByDefault()
+    public function testHasViolationsReturnsFalseByDefault(): void
     {
         $phpmd = new PHPMD();
-        $this->assertFalse($phpmd->hasViolations());
+        static::assertFalse($phpmd->hasViolations());
     }
 
     /**
      * testHasViolationsReturnsFalseForSourceWithoutViolations
-     *
-     * @return void
      */
-    public function testHasViolationsReturnsFalseForSourceWithoutViolations()
+    public function testHasViolationsReturnsFalseForSourceWithoutViolations(): void
     {
         self::changeWorkingDirectory();
 
@@ -161,16 +149,14 @@ class PHPMDTest extends AbstractTestCase
             new Report()
         );
 
-        $this->assertFalse($phpmd->hasErrors());
-        $this->assertFalse($phpmd->hasViolations());
+        static::assertFalse($phpmd->hasErrors());
+        static::assertFalse($phpmd->hasViolations());
     }
 
     /**
      * testHasViolationsReturnsTrueForSourceWithViolation
-     *
-     * @return void
      */
-    public function testHasViolationsReturnsTrueForSourceWithViolation()
+    public function testHasViolationsReturnsTrueForSourceWithViolation(): void
     {
         self::changeWorkingDirectory();
 
@@ -186,14 +172,11 @@ class PHPMDTest extends AbstractTestCase
             new Report()
         );
 
-        $this->assertFalse($phpmd->hasErrors());
-        $this->assertTrue($phpmd->hasViolations());
+        static::assertFalse($phpmd->hasErrors());
+        static::assertTrue($phpmd->hasViolations());
     }
 
-    /**
-     * @return void
-     */
-    public function testHasViolationsReturnsFalseWhenViolationIsBaselined()
+    public function testHasViolationsReturnsFalseWhenViolationIsBaselined(): void
     {
         self::changeWorkingDirectory();
 
@@ -220,10 +203,8 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testHasErrorsReturnsTrueForSourceWithError
-     *
-     * @return void
      */
-    public function testHasErrorsReturnsTrueForSourceWithError()
+    public function testHasErrorsReturnsTrueForSourceWithError(): void
     {
         self::changeWorkingDirectory();
 
@@ -239,16 +220,14 @@ class PHPMDTest extends AbstractTestCase
             new Report()
         );
 
-        $this->assertTrue($phpmd->hasErrors());
-        $this->assertFalse($phpmd->hasViolations());
+        static::assertTrue($phpmd->hasErrors());
+        static::assertFalse($phpmd->hasViolations());
     }
 
     /**
      * testIgnorePattern
-     *
-     * @return void
      */
-    public function testIgnorePattern()
+    public function testIgnorePattern(): void
     {
         self::changeWorkingDirectory();
 
@@ -263,8 +242,8 @@ class PHPMDTest extends AbstractTestCase
             new Report()
         );
 
-        $this->assertFalse($phpmd->hasErrors());
-        $this->assertTrue($phpmd->hasViolations());
+        static::assertFalse($phpmd->hasErrors());
+        static::assertTrue($phpmd->hasViolations());
 
         // Process with exclusions, should result in no violations.
         $phpmd->processFiles(
@@ -275,7 +254,7 @@ class PHPMDTest extends AbstractTestCase
             new Report()
         );
 
-        $this->assertFalse($phpmd->hasErrors());
-        $this->assertFalse($phpmd->hasViolations());
+        static::assertFalse($phpmd->hasErrors());
+        static::assertFalse($phpmd->hasViolations());
     }
 }

--- a/src/test/php/PHPMD/ParserFactoryTest.php
+++ b/src/test/php/PHPMD/ParserFactoryTest.php
@@ -28,10 +28,8 @@ class ParserFactoryTest extends AbstractTestCase
 {
     /**
      * testFactoryConfiguresInputDirectory
-     *
-     * @return void
      */
-    public function testFactoryConfiguresInputDirectory()
+    public function testFactoryConfiguresInputDirectory(): void
     {
         $factory = new ParserFactory();
 
@@ -41,7 +39,7 @@ class ParserFactoryTest extends AbstractTestCase
             $this->getMockBuilder(PHPMD::class)
                 ->onlyMethods(['getInput'])
         );
-        $phpmd->expects($this->once())
+        $phpmd->expects(static::once())
             ->method('getInput')
             ->willReturn($uri);
 
@@ -54,10 +52,8 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresInputFile
-     *
-     * @return void
      */
-    public function testFactoryConfiguresInputFile()
+    public function testFactoryConfiguresInputFile(): void
     {
         $factory = new ParserFactory();
 
@@ -67,9 +63,9 @@ class ParserFactoryTest extends AbstractTestCase
             $this->getMockBuilder(PHPMD::class)
                 ->onlyMethods(['getInput'])
         );
-        $phpmd->expects($this->once())
+        $phpmd->expects(static::once())
             ->method('getInput')
-            ->will($this->returnValue($uri));
+            ->will(static::returnValue($uri));
 
         $ruleSet = $this->getRuleSetMock(ClassNode::class);
 
@@ -80,10 +76,8 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresMultipleInputDirectories
-     *
-     * @return void
      */
-    public function testFactoryConfiguresMultipleInputDirectories()
+    public function testFactoryConfiguresMultipleInputDirectories(): void
     {
         $factory = new ParserFactory();
 
@@ -94,9 +88,9 @@ class ParserFactoryTest extends AbstractTestCase
             $this->getMockBuilder(PHPMD::class)
                 ->onlyMethods(['getInput'])
         );
-        $phpmd->expects($this->once())
+        $phpmd->expects(static::once())
             ->method('getInput')
-            ->will($this->returnValue($uri1 . ',' . $uri2));
+            ->will(static::returnValue($uri1 . ',' . $uri2));
 
         $ruleSet = $this->getRuleSetMock(ClassNode::class, 2);
 
@@ -107,10 +101,8 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresMultipleInputFilesAndDirectories
-     *
-     * @return void
      */
-    public function testFactoryConfiguresMultipleInputFilesAndDirectories()
+    public function testFactoryConfiguresMultipleInputFilesAndDirectories(): void
     {
         $factory = new ParserFactory();
 
@@ -118,9 +110,9 @@ class ParserFactoryTest extends AbstractTestCase
         $uri2 = $this->createFileUri('ParserFactory/Directory');
 
         $phpmd = $this->getMockFromBuilder($this->getMockBuilder(PHPMD::class)->onlyMethods(['getInput']));
-        $phpmd->expects($this->once())
+        $phpmd->expects(static::once())
             ->method('getInput')
-            ->will($this->returnValue($uri1 . ',' . $uri2));
+            ->will(static::returnValue($uri1 . ',' . $uri2));
 
         $ruleSet = $this->getRuleSetMock(ClassNode::class, 2);
 
@@ -131,10 +123,8 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresIgnorePattern
-     *
-     * @return void
      */
-    public function testFactoryConfiguresIgnorePattern()
+    public function testFactoryConfiguresIgnorePattern(): void
     {
         $factory = new ParserFactory();
 
@@ -144,10 +134,10 @@ class ParserFactoryTest extends AbstractTestCase
             $this->getMockBuilder(PHPMD::class)
                 ->onlyMethods(['getIgnorePatterns', 'getInput'])
         );
-        $phpmd->expects($this->exactly(2))
+        $phpmd->expects(static::exactly(2))
             ->method('getIgnorePatterns')
             ->willReturn(['Test']);
-        $phpmd->expects($this->once())
+        $phpmd->expects(static::once())
             ->method('getInput')
             ->willReturn($uri);
 
@@ -156,10 +146,8 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresFileExtensions
-     *
-     * @return void
      */
-    public function testFactoryConfiguresFileExtensions()
+    public function testFactoryConfiguresFileExtensions(): void
     {
         $factory = new ParserFactory();
 
@@ -169,10 +157,10 @@ class ParserFactoryTest extends AbstractTestCase
             $this->getMockBuilder(PHPMD::class)
                 ->onlyMethods(['getFileExtensions', 'getInput'])
         );
-        $phpmd->expects($this->exactly(2))
+        $phpmd->expects(static::exactly(2))
             ->method('getFileExtensions')
             ->willReturn(['.php']);
-        $phpmd->expects($this->once())
+        $phpmd->expects(static::once())
             ->method('getInput')
             ->willReturn($uri);
 

--- a/src/test/php/PHPMD/ParserTest.php
+++ b/src/test/php/PHPMD/ParserTest.php
@@ -41,15 +41,13 @@ class ParserTest extends AbstractTestCase
 {
     /**
      * Tests that the metrics adapter delegates a node to a registered rule-set.
-     *
-     * @return void
      */
-    public function testAdapterDelegatesClassNodeToRuleSet()
+    public function testAdapterDelegatesClassNodeToRuleSet(): void
     {
         $mock = $this->getPHPDependClassMock();
-        $mock->expects($this->once())
+        $mock->expects(static::once())
             ->method('isUserDefined')
-            ->will($this->returnValue(true));
+            ->will(static::returnValue(true));
 
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock(ClassNode::class));
@@ -60,15 +58,13 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the metrics adapter does not delegate a node without source
      * code file to a registered rule-set.
-     *
-     * @return void
      */
-    public function testAdapterDoesNotDelegateNonSourceClassNodeToRuleSet()
+    public function testAdapterDoesNotDelegateNonSourceClassNodeToRuleSet(): void
     {
         $mock = $this->getPHPDependClassMock();
-        $mock->expects($this->once())
+        $mock->expects(static::once())
             ->method('isUserDefined')
-            ->will($this->returnValue(false));
+            ->will(static::returnValue(false));
 
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock());
@@ -78,10 +74,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the metrics adapter delegates a node to a registered rule-set.
-     *
-     * @return void
      */
-    public function testAdapterDelegatesMethodNodeToRuleSet()
+    public function testAdapterDelegatesMethodNodeToRuleSet(): void
     {
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock(MethodNode::class));
@@ -92,10 +86,8 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the metrics adapter does not delegate a node without source
      * code file to a registered rule-set.
-     *
-     * @return void
      */
-    public function testAdapterDoesNotDelegateNonSourceMethodNodeToRuleSet()
+    public function testAdapterDoesNotDelegateNonSourceMethodNodeToRuleSet(): void
     {
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock());
@@ -105,10 +97,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the metrics adapter delegates a node to a registered rule-set.
-     *
-     * @return void
      */
-    public function testAdapterDelegatesFunctionNodeToRuleSet()
+    public function testAdapterDelegatesFunctionNodeToRuleSet(): void
     {
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock(FunctionNode::class));
@@ -119,10 +109,8 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the metrics adapter does not delegate a node without source
      * code file to a registered rule-set.
-     *
-     * @return void
      */
-    public function testAdapterDoesNotDelegateNonSourceFunctionNodeToRuleSet()
+    public function testAdapterDoesNotDelegateNonSourceFunctionNodeToRuleSet(): void
     {
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock());
@@ -133,19 +121,18 @@ class ParserTest extends AbstractTestCase
     /**
      * testParserStoreParsingExceptionsInReport
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testParserStoreParsingExceptionsInReport()
+    public function testParserStoreParsingExceptionsInReport(): void
     {
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('addError');
 
         $pdepend = $this->getPHPDependMock();
-        $pdepend->expects($this->once())
+        $pdepend->expects(static::once())
             ->method('getExceptions')
-            ->will($this->returnValue([
+            ->will(static::returnValue([
                 new InvalidStateException(42, __FILE__, 'foo'),
             ]));
 
@@ -184,18 +171,18 @@ class ParserTest extends AbstractTestCase
             $this->getMockBuilder(ASTClass::class)
                 ->setConstructorArgs([null])
         );
-        $class->expects($this->any())
+        $class->expects(static::any())
             ->method('getCompilationUnit')
-            ->will($this->returnValue($this->getPHPDependFileMock('foo.php')));
-        $class->expects($this->any())
+            ->will(static::returnValue($this->getPHPDependFileMock('foo.php')));
+        $class->expects(static::any())
             ->method('getConstants')
-            ->will($this->returnValue(new ArrayIterator([])));
-        $class->expects($this->any())
+            ->will(static::returnValue(new ArrayIterator([])));
+        $class->expects(static::any())
             ->method('getProperties')
-            ->will($this->returnValue(new ArrayIterator([])));
-        $class->expects($this->any())
+            ->will(static::returnValue(new ArrayIterator([])));
+        $class->expects(static::any())
             ->method('getMethods')
-            ->will($this->returnValue(new ArrayIterator([])));
+            ->will(static::returnValue(new ArrayIterator([])));
 
         return $class;
     }
@@ -212,9 +199,9 @@ class ParserTest extends AbstractTestCase
             $this->getMockBuilder(ASTFunction::class)
                 ->setConstructorArgs([null])
         );
-        $function->expects($this->atLeastOnce())
+        $function->expects(static::atLeastOnce())
             ->method('getCompilationUnit')
-            ->will($this->returnValue($this->getPHPDependFileMock($fileName)));
+            ->will(static::returnValue($this->getPHPDependFileMock($fileName)));
 
         return $function;
     }
@@ -231,9 +218,9 @@ class ParserTest extends AbstractTestCase
             $this->getMockBuilder(ASTMethod::class)
                 ->setConstructorArgs([null])
         );
-        $method->expects($this->atLeastOnce())
+        $method->expects(static::atLeastOnce())
             ->method('getCompilationUnit')
-            ->will($this->returnValue($this->getPHPDependFileMock($fileName)));
+            ->will(static::returnValue($this->getPHPDependFileMock($fileName)));
 
         return $method;
     }
@@ -250,9 +237,9 @@ class ParserTest extends AbstractTestCase
             $this->getMockBuilder(ASTCompilationUnit::class)
                 ->setConstructorArgs([null])
         );
-        $file->expects($this->any())
+        $file->expects(static::any())
             ->method('getFileName')
-            ->will($this->returnValue($fileName));
+            ->will(static::returnValue($fileName));
 
         return $file;
     }

--- a/src/test/php/PHPMD/ProcessingErrorTest.php
+++ b/src/test/php/PHPMD/ProcessingErrorTest.php
@@ -27,13 +27,11 @@ class ProcessingErrorTest extends AbstractTestCase
 {
     /**
      * testGetMessageReturnsTheExpectedValue
-     *
-     * @return void
      */
-    public function testGetMessageReturnsTheExpectedValue()
+    public function testGetMessageReturnsTheExpectedValue(): void
     {
         $processingError = new ProcessingError('Hello World.');
-        $this->assertEquals('Hello World.', $processingError->getMessage());
+        static::assertEquals('Hello World.', $processingError->getMessage());
     }
 
     /**
@@ -41,13 +39,12 @@ class ProcessingErrorTest extends AbstractTestCase
      * a given exception message,
      *
      * @param string $message The original exception message
-     * @return void
      * @dataProvider getParserExceptionMessages
      */
-    public function testGetFileReturnsExpectedFileName($message)
+    public function testGetFileReturnsExpectedFileName($message): void
     {
         $processingError = new ProcessingError($message);
-        $this->assertEquals('/tmp/foo.php', $processingError->getFile());
+        static::assertEquals('/tmp/foo.php', $processingError->getFile());
     }
 
     /**

--- a/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
@@ -30,10 +30,8 @@ class AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest extends AbstractR
 {
     /**
      * testCliAcceptsDirectoryAsInput
-     *
-     * @return void
      */
-    public function testCliAcceptsDirectoryAsInput()
+    public function testCliAcceptsDirectoryAsInput(): void
     {
         self::changeWorkingDirectory();
 
@@ -54,10 +52,8 @@ class AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest extends AbstractR
 
     /**
      * testCliAcceptsSingleFileAsInput
-     *
-     * @return void
      */
-    public function testCliAcceptsSingleFileAsInput()
+    public function testCliAcceptsSingleFileAsInput(): void
     {
         self::changeWorkingDirectory();
 

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest.php
@@ -27,10 +27,8 @@ class ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest extends Abstr
 {
     /**
      * testRuleSetInvokesRuleForClassInstance
-     *
-     * @return void
      */
-    public function testRuleSetInvokesRuleForClassInstance()
+    public function testRuleSetInvokesRuleForClassInstance(): void
     {
         $rule = new ExcessivePublicCount();
         $rule->addProperty('minimum', 3);

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
@@ -21,7 +21,7 @@ use PHPMD\PHPMD;
 use PHPMD\Renderer\TextRenderer;
 use PHPMD\Report;
 use PHPMD\RuleSetFactory;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Regression test for issue 409.
@@ -30,14 +30,10 @@ use PHPUnit_Framework_MockObject_MockObject;
  */
 class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends AbstractRegressionTestCase
 {
-    /**
-     * @var string Beginning of the violation message
-     */
+    /** @var string Beginning of the violation message */
     private const VIOLATION_MESSAGE = 'The class ExcessivePublicCountWorksForPublicStaticMethods has 71 public methods';
 
-    /**
-     * @var PHPUnit_Framework_MockObject_MockObject|TextRenderer
-     */
+    /** @var PHPUnit_Framework_MockObject_MockObject|TextRenderer */
     private $renderer;
 
     /**
@@ -60,21 +56,19 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
      * - TooManyMethods
      * - TooManyPublicMethods
      * - ExcessiveClassComplexity
-     *
-     * @return void
      */
-    public function testReportIsGeneratedIWithNoSuppression()
+    public function testReportIsGeneratedIWithNoSuppression(): void
     {
         self::changeWorkingDirectory();
         $phpmd = new PHPMD();
         $self = $this;
         $ruleSetFactory = new RuleSetFactory();
 
-        $this->renderer->expects($this->once())
+        $this->renderer->expects(static::once())
             ->method('renderReport')
             ->will(
-                $this->returnCallback(
-                    function (Report $report) use ($self) {
+                static::returnCallback(
+                    function (Report $report) use ($self): void {
                         $isViolating = false;
                         foreach ($report->getRuleViolations() as $ruleViolation) {
                             if (str_starts_with($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE)) {
@@ -105,21 +99,19 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
      * - TooManyMethods
      * - TooManyPublicMethods
      * - ExcessiveClassComplexity
-     *
-     * @return void
      */
-    public function testReportIsNotGeneratedIWithSuppression()
+    public function testReportIsNotGeneratedIWithSuppression(): void
     {
         self::changeWorkingDirectory();
         $phpmd = new PHPMD();
         $self = $this;
         $ruleSetFactory = new RuleSetFactory();
 
-        $this->renderer->expects($this->once())
+        $this->renderer->expects(static::once())
             ->method('renderReport')
             ->will(
-                $this->returnCallback(
-                    function (Report $report) use ($self) {
+                static::returnCallback(
+                    function (Report $report) use ($self): void {
                         $isViolating = false;
                         foreach ($report->getRuleViolations() as $ruleViolation) {
                             if (str_starts_with($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE)) {

--- a/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
+++ b/src/test/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
@@ -79,6 +79,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
                         foreach ($report->getRuleViolations() as $ruleViolation) {
                             if (str_starts_with($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE)) {
                                 $isViolating = true;
+
                                 break;
                             }
                         }
@@ -123,6 +124,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
                         foreach ($report->getRuleViolations() as $ruleViolation) {
                             if (str_starts_with($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE)) {
                                 $isViolating = true;
+
                                 break;
                             }
                         }

--- a/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest.php
@@ -27,10 +27,8 @@ class InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest extend
 {
     /**
      * testLocalVariableUsedInDoubleQuoteStringGetsNotReported
-     *
-     * @return void
      */
-    public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported()
+    public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported(): void
     {
         $rule = new UnusedLocalVariable();
         $rule->setReport($this->getReportWithNoViolation());
@@ -39,10 +37,8 @@ class InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest extend
 
     /**
      * testFormalParameterUsedInDoubleQuoteStringGetsNotReported
-     *
-     * @return void
      */
-    public function testFormalParameterUsedInDoubleQuoteStringGetsNotReported()
+    public function testFormalParameterUsedInDoubleQuoteStringGetsNotReported(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
@@ -47,7 +47,6 @@ class MaximumNestingLevelTicket24975295RegressionTest extends AbstractRegression
         $renderers = [$renderer];
         $factory = new RuleSetFactory();
 
-
         $phpmd = new PHPMD();
         $phpmd->processFiles(
             $inputs,

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
@@ -34,10 +34,9 @@ class MaximumNestingLevelTicket24975295RegressionTest extends AbstractRegression
     /**
      * testLocalVariableUsedInDoubleQuoteStringGetsNotReported
      *
-     * @return void
      * @outputBuffering enabled
      */
-    public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported()
+    public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported(): void
     {
         $renderer = new TextRenderer();
         $renderer->setWriter(new StreamWriter(self::createTempFileUri()));

--- a/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
+++ b/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
@@ -22,287 +22,287 @@ namespace PHPMD\Regression\Sources;
  */
 class ExcessivePublicCountSuppressionWorksForPublicStaticMethods
 {
-    public static function aMethod()
+    public static function aMethod(): void
     {
     }
 
-    public static function bMethod()
+    public static function bMethod(): void
     {
     }
 
-    public static function cMethod()
+    public static function cMethod(): void
     {
     }
 
-    public static function dMethod()
+    public static function dMethod(): void
     {
     }
 
-    public static function eMethod()
+    public static function eMethod(): void
     {
     }
 
-    public static function fMethod()
+    public static function fMethod(): void
     {
     }
 
-    public static function gMethod()
+    public static function gMethod(): void
     {
     }
 
-    public static function hMethod()
+    public static function hMethod(): void
     {
     }
 
-    public static function iMethod()
+    public static function iMethod(): void
     {
     }
 
-    public static function jMethod()
+    public static function jMethod(): void
     {
     }
 
-    public static function kMethod()
+    public static function kMethod(): void
     {
     }
 
-    public static function lMethod()
+    public static function lMethod(): void
     {
     }
 
-    public static function mMethod()
+    public static function mMethod(): void
     {
     }
 
-    public static function nMethod()
+    public static function nMethod(): void
     {
     }
 
-    public static function oMethod()
+    public static function oMethod(): void
     {
     }
 
-    public static function pMethod()
+    public static function pMethod(): void
     {
     }
 
-    public static function rMethod()
+    public static function rMethod(): void
     {
     }
 
-    public static function sMethod()
+    public static function sMethod(): void
     {
     }
 
-    public static function tMethod()
+    public static function tMethod(): void
     {
     }
 
-    public static function uMethod()
+    public static function uMethod(): void
     {
     }
 
-    public static function wMethod()
+    public static function wMethod(): void
     {
     }
 
-    public static function xMethod()
+    public static function xMethod(): void
     {
     }
 
-    public static function yMethod()
+    public static function yMethod(): void
     {
     }
 
-    public static function zMethod()
+    public static function zMethod(): void
     {
     }
 
-    public static function aaMethod()
+    public static function aaMethod(): void
     {
     }
 
-    public static function abMethod()
+    public static function abMethod(): void
     {
     }
 
-    public static function acMethod()
+    public static function acMethod(): void
     {
     }
 
-    public static function adMethod()
+    public static function adMethod(): void
     {
     }
 
-    public static function aeMethod()
+    public static function aeMethod(): void
     {
     }
 
-    public static function afMethod()
+    public static function afMethod(): void
     {
     }
 
-    public static function agMethod()
+    public static function agMethod(): void
     {
     }
 
-    public static function ahMethod()
+    public static function ahMethod(): void
     {
     }
 
-    public static function ajMethod()
+    public static function ajMethod(): void
     {
     }
 
-    public static function akMethod()
+    public static function akMethod(): void
     {
     }
 
-    public static function alMethod()
+    public static function alMethod(): void
     {
     }
 
-    public static function amMethod()
+    public static function amMethod(): void
     {
     }
 
-    public static function anMethod()
+    public static function anMethod(): void
     {
     }
 
-    public static function aoMethod()
+    public static function aoMethod(): void
     {
     }
 
-    public static function apMethod()
+    public static function apMethod(): void
     {
     }
 
-    public static function arMethod()
+    public static function arMethod(): void
     {
     }
 
-    public static function asMethod()
+    public static function asMethod(): void
     {
     }
 
-    public static function atMethod()
+    public static function atMethod(): void
     {
     }
 
-    public static function auMethod()
+    public static function auMethod(): void
     {
     }
 
-    public static function awMethod()
+    public static function awMethod(): void
     {
     }
 
-    public static function axMethod()
+    public static function axMethod(): void
     {
     }
 
-    public static function ayMethod()
+    public static function ayMethod(): void
     {
     }
 
-    public static function azMethod()
+    public static function azMethod(): void
     {
     }
 
-    public static function baMethod()
+    public static function baMethod(): void
     {
     }
 
-    public static function bbMethod()
+    public static function bbMethod(): void
     {
     }
 
-    public static function bcMethod()
+    public static function bcMethod(): void
     {
     }
 
-    public static function bdMethod()
+    public static function bdMethod(): void
     {
     }
 
-    public static function beMethod()
+    public static function beMethod(): void
     {
     }
 
-    public static function bfMethod()
+    public static function bfMethod(): void
     {
     }
 
-    public static function bgMethod()
+    public static function bgMethod(): void
     {
     }
 
-    public static function bhMethod()
+    public static function bhMethod(): void
     {
     }
 
-    public static function biMethod()
+    public static function biMethod(): void
     {
     }
 
-    public static function bjMethod()
+    public static function bjMethod(): void
     {
     }
 
-    public static function bkMethod()
+    public static function bkMethod(): void
     {
     }
 
-    public static function blmethod()
+    public static function blmethod(): void
     {
     }
 
-    public static function bmmethod()
+    public static function bmmethod(): void
     {
     }
 
-    public static function bnMethod()
+    public static function bnMethod(): void
     {
     }
 
-    public static function boMethod()
+    public static function boMethod(): void
     {
     }
 
-    public static function bpMethod()
+    public static function bpMethod(): void
     {
     }
 
-    public static function brMethod()
+    public static function brMethod(): void
     {
     }
 
-    public static function bsMethod()
+    public static function bsMethod(): void
     {
     }
 
-    public static function btMethod()
+    public static function btMethod(): void
     {
     }
 
-    public static function buMethod()
+    public static function buMethod(): void
     {
     }
 
-    public static function bwMethod()
+    public static function bwMethod(): void
     {
     }
 
-    public static function bxMethod()
+    public static function bxMethod(): void
     {
     }
 
-    public static function byMethod()
+    public static function byMethod(): void
     {
     }
 
-    public static function bzMethod()
+    public static function bzMethod(): void
     {
     }
 }

--- a/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php
+++ b/src/test/php/PHPMD/Regression/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php
@@ -19,287 +19,287 @@ namespace PHPMD\Regression\Sources;
 
 class ExcessivePublicCountWorksForPublicStaticMethods
 {
-    public static function aMethod()
+    public static function aMethod(): void
     {
     }
 
-    public static function bMethod()
+    public static function bMethod(): void
     {
     }
 
-    public static function cMethod()
+    public static function cMethod(): void
     {
     }
 
-    public static function dMethod()
+    public static function dMethod(): void
     {
     }
 
-    public static function eMethod()
+    public static function eMethod(): void
     {
     }
 
-    public static function fMethod()
+    public static function fMethod(): void
     {
     }
 
-    public static function gMethod()
+    public static function gMethod(): void
     {
     }
 
-    public static function hMethod()
+    public static function hMethod(): void
     {
     }
 
-    public static function iMethod()
+    public static function iMethod(): void
     {
     }
 
-    public static function jMethod()
+    public static function jMethod(): void
     {
     }
 
-    public static function kMethod()
+    public static function kMethod(): void
     {
     }
 
-    public static function lMethod()
+    public static function lMethod(): void
     {
     }
 
-    public static function mMethod()
+    public static function mMethod(): void
     {
     }
 
-    public static function nMethod()
+    public static function nMethod(): void
     {
     }
 
-    public static function oMethod()
+    public static function oMethod(): void
     {
     }
 
-    public static function pMethod()
+    public static function pMethod(): void
     {
     }
 
-    public static function rMethod()
+    public static function rMethod(): void
     {
     }
 
-    public static function sMethod()
+    public static function sMethod(): void
     {
     }
 
-    public static function tMethod()
+    public static function tMethod(): void
     {
     }
 
-    public static function uMethod()
+    public static function uMethod(): void
     {
     }
 
-    public static function wMethod()
+    public static function wMethod(): void
     {
     }
 
-    public static function xMethod()
+    public static function xMethod(): void
     {
     }
 
-    public static function yMethod()
+    public static function yMethod(): void
     {
     }
 
-    public static function zMethod()
+    public static function zMethod(): void
     {
     }
 
-    public static function aaMethod()
+    public static function aaMethod(): void
     {
     }
 
-    public static function abMethod()
+    public static function abMethod(): void
     {
     }
 
-    public static function acMethod()
+    public static function acMethod(): void
     {
     }
 
-    public static function adMethod()
+    public static function adMethod(): void
     {
     }
 
-    public static function aeMethod()
+    public static function aeMethod(): void
     {
     }
 
-    public static function afMethod()
+    public static function afMethod(): void
     {
     }
 
-    public static function agMethod()
+    public static function agMethod(): void
     {
     }
 
-    public static function ahMethod()
+    public static function ahMethod(): void
     {
     }
 
-    public static function ajMethod()
+    public static function ajMethod(): void
     {
     }
 
-    public static function akMethod()
+    public static function akMethod(): void
     {
     }
 
-    public static function alMethod()
+    public static function alMethod(): void
     {
     }
 
-    public static function amMethod()
+    public static function amMethod(): void
     {
     }
 
-    public static function anMethod()
+    public static function anMethod(): void
     {
     }
 
-    public static function aoMethod()
+    public static function aoMethod(): void
     {
     }
 
-    public static function apMethod()
+    public static function apMethod(): void
     {
     }
 
-    public static function arMethod()
+    public static function arMethod(): void
     {
     }
 
-    public static function asMethod()
+    public static function asMethod(): void
     {
     }
 
-    public static function atMethod()
+    public static function atMethod(): void
     {
     }
 
-    public static function auMethod()
+    public static function auMethod(): void
     {
     }
 
-    public static function awMethod()
+    public static function awMethod(): void
     {
     }
 
-    public static function axMethod()
+    public static function axMethod(): void
     {
     }
 
-    public static function ayMethod()
+    public static function ayMethod(): void
     {
     }
 
-    public static function azMethod()
+    public static function azMethod(): void
     {
     }
 
-    public static function baMethod()
+    public static function baMethod(): void
     {
     }
 
-    public static function bbMethod()
+    public static function bbMethod(): void
     {
     }
 
-    public static function bcMethod()
+    public static function bcMethod(): void
     {
     }
 
-    public static function bdMethod()
+    public static function bdMethod(): void
     {
     }
 
-    public static function beMethod()
+    public static function beMethod(): void
     {
     }
 
-    public static function bfMethod()
+    public static function bfMethod(): void
     {
     }
 
-    public static function bgMethod()
+    public static function bgMethod(): void
     {
     }
 
-    public static function bhMethod()
+    public static function bhMethod(): void
     {
     }
 
-    public static function biMethod()
+    public static function biMethod(): void
     {
     }
 
-    public static function bjMethod()
+    public static function bjMethod(): void
     {
     }
 
-    public static function bkMethod()
+    public static function bkMethod(): void
     {
     }
 
-    public static function blmethod()
+    public static function blmethod(): void
     {
     }
 
-    public static function bmmethod()
+    public static function bmmethod(): void
     {
     }
 
-    public static function bnMethod()
+    public static function bnMethod(): void
     {
     }
 
-    public static function boMethod()
+    public static function boMethod(): void
     {
     }
 
-    public static function bpMethod()
+    public static function bpMethod(): void
     {
     }
 
-    public static function brMethod()
+    public static function brMethod(): void
     {
     }
 
-    public static function bsMethod()
+    public static function bsMethod(): void
     {
     }
 
-    public static function btMethod()
+    public static function btMethod(): void
     {
     }
 
-    public static function buMethod()
+    public static function buMethod(): void
     {
     }
 
-    public static function bwMethod()
+    public static function bwMethod(): void
     {
     }
 
-    public static function bxMethod()
+    public static function bxMethod(): void
     {
     }
 
-    public static function byMethod()
+    public static function byMethod(): void
     {
     }
 
-    public static function bzMethod()
+    public static function bzMethod(): void
     {
     }
 }

--- a/src/test/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020RegressionTest.php
@@ -26,10 +26,8 @@ class StaticVariablesFlaggedAsUnusedTicket020RegressionTest extends AbstractRegr
 {
     /**
      * testRuleDoesNotApplyToAnySuperGlobalVariable
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToAnyStaticLocalVariable()
+    public function testRuleDoesNotApplyToAnyStaticLocalVariable(): void
     {
         $rule = new UnusedLocalVariable();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019RegressionTest.php
@@ -26,10 +26,8 @@ class SuperGlobalsFlaggedAsUnusedTicket019RegressionTest extends AbstractRegress
 {
     /**
      * testRuleDoesNotApplyToAnySuperGlobalVariable
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToAnySuperGlobalVariable()
+    public function testRuleDoesNotApplyToAnySuperGlobalVariable(): void
     {
         $rule = new UnusedLocalVariable();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036RegressionTest.php
@@ -27,10 +27,8 @@ class SuppressWarningsNotAppliesToUnusedPrivateMethod036RegressionTest extends A
 {
     /**
      * testRuleDoesNotApplyToPrivateMethodWithSuppressWarningsAnnotation
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateMethodWithSuppressWarningsAnnotation()
+    public function testRuleDoesNotApplyToPrivateMethodWithSuppressWarningsAnnotation(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new UnusedPrivateMethod());

--- a/src/test/php/PHPMD/Regression/UnusedParameterArgvTicket14990109RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/UnusedParameterArgvTicket14990109RegressionTest.php
@@ -30,10 +30,8 @@ class UnusedParameterArgvTicket14990109RegressionTest extends AbstractRegression
 {
     /**
      * testRuleDoesNotApplyToFunctionParameterNamedArgv
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToFunctionParameterNamedArgv()
+    public function testRuleDoesNotApplyToFunctionParameterNamedArgv(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new UnusedFormalParameter());
@@ -44,10 +42,8 @@ class UnusedParameterArgvTicket14990109RegressionTest extends AbstractRegression
 
     /**
      * testRuleDoesNotApplyToMethodParameterNamedArgv
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToMethodParameterNamedArgv()
+    public function testRuleDoesNotApplyToMethodParameterNamedArgv(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->addRule(new UnusedFormalParameter());

--- a/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/AnsiRendererTest.php
@@ -30,10 +30,8 @@ class AnsiRendererTest extends AbstractTestCase
 {
     /**
      * testRendererOutputsForReportWithContents
-     *
-     * @return void
      */
-    public function testRendererOutputsForReportWithContents()
+    public function testRendererOutputsForReportWithContents(): void
     {
         $writer = new WriterStub();
 
@@ -48,21 +46,21 @@ class AnsiRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->atLeastOnce())
+        $report->expects(static::atLeastOnce())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator($violations)));
-        $report->expects($this->atLeastOnce())
+            ->will(static::returnValue(new ArrayIterator($violations)));
+        $report->expects(static::atLeastOnce())
             ->method('isEmpty')
-            ->will($this->returnValue(false));
-        $report->expects($this->atLeastOnce())
+            ->will(static::returnValue(false));
+        $report->expects(static::atLeastOnce())
             ->method('hasErrors')
-            ->will($this->returnValue(true));
-        $report->expects($this->atLeastOnce())
+            ->will(static::returnValue(true));
+        $report->expects(static::atLeastOnce())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator($errors)));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator($errors)));
+        $report->expects(static::once())
             ->method('getElapsedTimeInMillis')
-            ->will($this->returnValue(200));
+            ->will(static::returnValue(200));
 
         $renderer = new AnsiRenderer();
         $renderer->setWriter($writer);
@@ -72,20 +70,20 @@ class AnsiRendererTest extends AbstractTestCase
         $renderer->end();
 
         $expectedChunks = [
-            PHP_EOL . "FILE: /bar.php" . PHP_EOL . "--------------" . PHP_EOL,
+            PHP_EOL . 'FILE: /bar.php' . PHP_EOL . '--------------' . PHP_EOL,
             " 1 | \e[31mVIOLATION\e[0m | Test description" . PHP_EOL,
             PHP_EOL,
-            PHP_EOL . "FILE: /foo.php" . PHP_EOL . "--------------" . PHP_EOL,
+            PHP_EOL . 'FILE: /foo.php' . PHP_EOL . '--------------' . PHP_EOL,
             " 2 | \e[31mVIOLATION\e[0m | Test description" . PHP_EOL,
             " 3 | \e[31mVIOLATION\e[0m | Test description" . PHP_EOL,
-            PHP_EOL . "\e[33mERROR\e[0m while parsing /foo/baz.php" . PHP_EOL . "--------------------------------" .
+            PHP_EOL . "\e[33mERROR\e[0m while parsing /foo/baz.php" . PHP_EOL . '--------------------------------' .
             (version_compare(PHP_VERSION, '5.4.0-dev', '<') ? '--' : '') . PHP_EOL,
-            "Error in file \"/foo/baz.php\"" . PHP_EOL,
-            PHP_EOL . "Found 3 violations and 1 error in 200ms" . PHP_EOL,
+            'Error in file "/foo/baz.php"' . PHP_EOL,
+            PHP_EOL . 'Found 3 violations and 1 error in 200ms' . PHP_EOL,
         ];
 
         foreach ($writer->getChunks() as $i => $chunk) {
-            $this->assertEquals(
+            static::assertEquals(
                 $expectedChunks[$i],
                 $chunk,
                 sprintf('Chunk %s did not match expected string', $i)
@@ -95,29 +93,27 @@ class AnsiRendererTest extends AbstractTestCase
 
     /**
      * testRendererOutputsForReportWithoutContents
-     *
-     * @return void
      */
-    public function testRendererOutputsForReportWithoutContents()
+    public function testRendererOutputsForReportWithoutContents(): void
     {
         $writer = new WriterStub();
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->atLeastOnce())
+        $report->expects(static::atLeastOnce())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator([])));
-        $report->expects($this->atLeastOnce())
+            ->will(static::returnValue(new ArrayIterator([])));
+        $report->expects(static::atLeastOnce())
             ->method('isEmpty')
-            ->will($this->returnValue(true));
-        $report->expects($this->atLeastOnce())
+            ->will(static::returnValue(true));
+        $report->expects(static::atLeastOnce())
             ->method('hasErrors')
-            ->will($this->returnValue(false));
-        $report->expects($this->atLeastOnce())
+            ->will(static::returnValue(false));
+        $report->expects(static::atLeastOnce())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator([])));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator([])));
+        $report->expects(static::once())
             ->method('getElapsedTimeInMillis')
-            ->will($this->returnValue(200));
+            ->will(static::returnValue(200));
 
         $renderer = new AnsiRenderer();
         $renderer->setWriter($writer);
@@ -127,12 +123,12 @@ class AnsiRendererTest extends AbstractTestCase
         $renderer->end();
 
         $expectedChunks = [
-            PHP_EOL . "Found 0 violations and 0 errors in 200ms" . PHP_EOL,
+            PHP_EOL . 'Found 0 violations and 0 errors in 200ms' . PHP_EOL,
             PHP_EOL . "\e[32mNo mess detected\e[0m" . PHP_EOL,
         ];
 
         foreach ($writer->getChunks() as $i => $chunk) {
-            $this->assertEquals(
+            static::assertEquals(
                 $expectedChunks[$i],
                 $chunk,
                 sprintf('Chunk %s did not match expected string', $i)

--- a/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/BaselineRendererTest.php
@@ -6,7 +6,7 @@ use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\Report;
 use PHPMD\Stubs\WriterStub;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @coversDefaultClass \PHPMD\Renderer\BaselineRenderer
@@ -17,7 +17,7 @@ class BaselineRendererTest extends AbstractTestCase
     /**
      * @covers ::renderReport
      */
-    public function testRenderReport()
+    public function testRenderReport(): void
     {
         $writer = new WriterStub();
         $violations = [
@@ -46,7 +46,7 @@ class BaselineRendererTest extends AbstractTestCase
     /**
      * @covers ::renderReport
      */
-    public function testRenderReportShouldWriteMethodName()
+    public function testRenderReportShouldWriteMethodName(): void
     {
         $writer = new WriterStub();
         $violationMock = $this->getRuleViolationMock('/src/php/bar.php');
@@ -73,7 +73,7 @@ class BaselineRendererTest extends AbstractTestCase
     /**
      * @covers ::renderReport
      */
-    public function testRenderReportShouldDeduplicateSimilarViolations()
+    public function testRenderReportShouldDeduplicateSimilarViolations(): void
     {
         $writer = new WriterStub();
         $violationMock = $this->getRuleViolationMock('/src/php/bar.php');
@@ -101,7 +101,7 @@ class BaselineRendererTest extends AbstractTestCase
     /**
      * @covers ::renderReport
      */
-    public function testRenderEmptyReport()
+    public function testRenderEmptyReport(): void
     {
         $writer = new WriterStub();
         $report = $this->getReportWithNoViolation();

--- a/src/test/php/PHPMD/Renderer/CheckStyleRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/CheckStyleRendererTest.php
@@ -31,10 +31,8 @@ class CheckStyleRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfXmlElements
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfXmlElements()
+    public function testRendererCreatesExpectedNumberOfXmlElements(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -46,12 +44,12 @@ class CheckStyleRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator($violations)));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator($violations)));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator([])));
+            ->will(static::returnValue(new ArrayIterator([])));
 
         $renderer = new XMLRenderer();
         $renderer->setWriter($writer);
@@ -69,10 +67,9 @@ class CheckStyleRendererTest extends AbstractTestCase
     /**
      * testRendererAddsProcessingErrorsToXmlReport
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testRendererAddsProcessingErrorsToXmlReport()
+    public function testRendererAddsProcessingErrorsToXmlReport(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -84,12 +81,12 @@ class CheckStyleRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator([])));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator([])));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator($processingErrors)));
+            ->will(static::returnValue(new ArrayIterator($processingErrors)));
 
         $renderer = new XMLRenderer();
         $renderer->setWriter($writer);

--- a/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/GitHubRendererTest.php
@@ -31,10 +31,8 @@ class GitHubRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfTextEntries
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfTextEntries()
+    public function testRendererCreatesExpectedNumberOfTextEntries(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -46,12 +44,12 @@ class GitHubRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator($violations)));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator($violations)));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator([])));
+            ->will(static::returnValue(new ArrayIterator([])));
 
         $renderer = new GitHubRenderer();
         $renderer->setWriter($writer);
@@ -60,20 +58,18 @@ class GitHubRendererTest extends AbstractTestCase
         $renderer->renderReport($report);
         $renderer->end();
 
-        $this->assertEquals(
-            "::warning file=/bar.php,line=1::Test description" . PHP_EOL .
-            "::warning file=/foo.php,line=2::Test description" . PHP_EOL .
-            "::warning file=/foo.php,line=3::Test description" . PHP_EOL,
+        static::assertEquals(
+            '::warning file=/bar.php,line=1::Test description' . PHP_EOL .
+            '::warning file=/foo.php,line=2::Test description' . PHP_EOL .
+            '::warning file=/foo.php,line=3::Test description' . PHP_EOL,
             $writer->getData()
         );
     }
 
     /**
      * testRendererAddsProcessingErrorsToTextReport
-     *
-     * @return void
      */
-    public function testRendererAddsProcessingErrorsToTextReport()
+    public function testRendererAddsProcessingErrorsToTextReport(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -85,12 +81,12 @@ class GitHubRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator([])));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator([])));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator($errors)));
+            ->will(static::returnValue(new ArrayIterator($errors)));
 
         $renderer = new GitHubRenderer();
         $renderer->setWriter($writer);
@@ -99,10 +95,10 @@ class GitHubRendererTest extends AbstractTestCase
         $renderer->renderReport($report);
         $renderer->end();
 
-        $this->assertEquals(
-            "::error file=/tmp/foo.php::Failed for file \"/tmp/foo.php\"." . PHP_EOL .
-            "::error file=/tmp/bar.php::Failed for file \"/tmp/bar.php\"." . PHP_EOL .
-            "::error file=/tmp/baz.php::Failed for file \"/tmp/baz.php\"." . PHP_EOL,
+        static::assertEquals(
+            '::error file=/tmp/foo.php::Failed for file "/tmp/foo.php".' . PHP_EOL .
+            '::error file=/tmp/bar.php::Failed for file "/tmp/bar.php".' . PHP_EOL .
+            '::error file=/tmp/baz.php::Failed for file "/tmp/baz.php".' . PHP_EOL,
             $writer->getData()
         );
     }

--- a/src/test/php/PHPMD/Renderer/GitLabRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/GitLabRendererTest.php
@@ -31,10 +31,8 @@ class GitLabRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfGitLabElements
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfGitLabElements()
+    public function testRendererCreatesExpectedNumberOfGitLabElements(): void
     {
         $writer = new WriterStub();
 
@@ -45,12 +43,12 @@ class GitLabRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator($violations)));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator($violations)));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator([])));
+            ->will(static::returnValue(new ArrayIterator([])));
 
         $renderer = new GitLabRenderer();
         $renderer->setWriter($writer);
@@ -67,10 +65,8 @@ class GitLabRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToGitLabReport
-     *
-     * @return void
      */
-    public function testRendererAddsProcessingErrorsToGitLabReport()
+    public function testRendererAddsProcessingErrorsToGitLabReport(): void
     {
         $writer = new WriterStub();
 
@@ -82,12 +78,12 @@ class GitLabRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator([])));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator([])));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator($processingErrors)));
+            ->will(static::returnValue(new ArrayIterator($processingErrors)));
 
         $renderer = new GitLabRenderer();
         $renderer->setWriter($writer);

--- a/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -30,10 +30,8 @@ class HTMLRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfTextEntries
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedHtmlTableRow()
+    public function testRendererCreatesExpectedHtmlTableRow(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -45,9 +43,9 @@ class HTMLRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator($violations)));
+            ->will(static::returnValue(new ArrayIterator($violations)));
 
         $extraLineInExcerpt = 2;
         $renderer = new HTMLRenderer($extraLineInExcerpt);
@@ -57,7 +55,7 @@ class HTMLRendererTest extends AbstractTestCase
         $renderer->renderReport($report);
         $renderer->end();
 
-        $this->assertMatchesRegularExpression(
+        static::assertMatchesRegularExpression(
             "~.*<section class='prb' id='p-(\d+)'> <header> <h3> <a href='#p-\d+' class='indx'>.*~",
             $writer->getData()
         );

--- a/src/test/php/PHPMD/Renderer/JSONRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/JSONRendererTest.php
@@ -31,10 +31,8 @@ class JSONRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfJsonElements
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfJsonElements()
+    public function testRendererCreatesExpectedNumberOfJsonElements(): void
     {
         $writer = new WriterStub();
 
@@ -45,12 +43,12 @@ class JSONRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator($violations)));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator($violations)));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator([])));
+            ->will(static::returnValue(new ArrayIterator([])));
 
         $renderer = new JSONRenderer();
         $renderer->setWriter($writer);
@@ -67,10 +65,8 @@ class JSONRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToJsonReport
-     *
-     * @return void
      */
-    public function testRendererAddsProcessingErrorsToJsonReport()
+    public function testRendererAddsProcessingErrorsToJsonReport(): void
     {
         $writer = new WriterStub();
 
@@ -82,12 +78,12 @@ class JSONRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator([])));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator([])));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator($processingErrors)));
+            ->will(static::returnValue(new ArrayIterator($processingErrors)));
 
         $renderer = new JSONRenderer();
         $renderer->setWriter($writer);

--- a/src/test/php/PHPMD/Renderer/RendererFactoryTest.php
+++ b/src/test/php/PHPMD/Renderer/RendererFactoryTest.php
@@ -13,7 +13,7 @@ class RendererFactoryTest extends AbstractTestCase
     /**
      * @covers ::createBaselineRenderer
      */
-    public function testCreateBaselineRendererSuccessfully()
+    public function testCreateBaselineRendererSuccessfully(): void
     {
         $writer = new StreamWriter(tmpfile());
         $renderer = RendererFactory::createBaselineRenderer($writer);

--- a/src/test/php/PHPMD/Renderer/SARIFRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/SARIFRendererTest.php
@@ -32,10 +32,8 @@ class SARIFRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfJsonElements
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfJsonElements()
+    public function testRendererCreatesExpectedNumberOfJsonElements(): void
     {
         $writer = new WriterStub();
 
@@ -56,12 +54,12 @@ class SARIFRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator($violations)));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator($violations)));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator([])));
+            ->will(static::returnValue(new ArrayIterator([])));
 
         $renderer = new SARIFRenderer();
         $renderer->setWriter($writer);
@@ -74,7 +72,7 @@ class SARIFRendererTest extends AbstractTestCase
         $actual['runs'][0]['originalUriBaseIds']['WORKINGDIR']['uri'] = 'file://#{workingDirectory}/';
         $flags = defined('JSON_PRETTY_PRINT') ? constant('JSON_PRETTY_PRINT') : 0;
 
-        $this->assertSame(
+        static::assertSame(
             json_encode($actual, $flags),
             json_encode(json_decode(file_get_contents(
                 __DIR__ . '/../../../resources/files/renderer/sarif_renderer_expected.sarif'
@@ -84,10 +82,8 @@ class SARIFRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToJsonReport
-     *
-     * @return void
      */
-    public function testRendererAddsProcessingErrorsToJsonReport()
+    public function testRendererAddsProcessingErrorsToJsonReport(): void
     {
         $writer = new WriterStub();
 
@@ -99,12 +95,12 @@ class SARIFRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator([])));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator([])));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator($processingErrors)));
+            ->will(static::returnValue(new ArrayIterator($processingErrors)));
 
         $renderer = new SARIFRenderer();
         $renderer->setWriter($writer);
@@ -121,7 +117,7 @@ class SARIFRendererTest extends AbstractTestCase
         $actual['runs'][0]['originalUriBaseIds']['WORKINGDIR']['uri'] = 'file://#{workingDirectory}/';
         $flags = defined('JSON_PRETTY_PRINT') ? constant('JSON_PRETTY_PRINT') : 0;
 
-        $this->assertSame(
+        static::assertSame(
             json_encode(json_decode(file_get_contents(
                 __DIR__ . '/../../../resources/files/renderer/sarif_renderer_processing_errors.sarif'
             )), $flags),

--- a/src/test/php/PHPMD/Renderer/TextRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/TextRendererTest.php
@@ -33,10 +33,8 @@ class TextRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfTextEntries
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfTextEntries()
+    public function testRendererCreatesExpectedNumberOfTextEntries(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -51,12 +49,12 @@ class TextRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator($violations)));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator($violations)));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator([])));
+            ->will(static::returnValue(new ArrayIterator([])));
 
         $renderer = new TextRenderer();
         $renderer->setWriter($writer);
@@ -65,18 +63,15 @@ class TextRendererTest extends AbstractTestCase
         $renderer->renderReport($report);
         $renderer->end();
 
-        $this->assertEquals(
-            "/bar.php:1      LongerNamedRule  An other description for this rule" . PHP_EOL .
-            "/foo-biz.php:2  RuleStub         Test description" . PHP_EOL .
-            "/foo.php:34     RuleStub         Test description" . PHP_EOL,
+        static::assertEquals(
+            '/bar.php:1      LongerNamedRule  An other description for this rule' . PHP_EOL .
+            '/foo-biz.php:2  RuleStub         Test description' . PHP_EOL .
+            '/foo.php:34     RuleStub         Test description' . PHP_EOL,
             $writer->getData()
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testRendererSupportVerbose()
+    public function testRendererSupportVerbose(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -93,18 +88,18 @@ class TextRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator($violations)));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator($violations)));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator([])));
+            ->will(static::returnValue(new ArrayIterator([])));
 
         $renderer->start();
         $renderer->renderReport($report);
         $renderer->end();
 
-        $this->assertEquals(
+        static::assertEquals(
             'LongerNamedRule  An other description for this rule' . PHP_EOL .
             '📁 in /bar.php on line 1' . PHP_EOL .
             '🔗 testruleset.xml https://phpmd.org/rules/testruleset.html#longernamedrule' . PHP_EOL . PHP_EOL,
@@ -112,10 +107,7 @@ class TextRendererTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testRendererSupportColor()
+    public function testRendererSupportColor(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -132,18 +124,18 @@ class TextRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator($violations)));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator($violations)));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator([])));
+            ->will(static::returnValue(new ArrayIterator([])));
 
         $renderer->start();
         $renderer->renderReport($report);
         $renderer->end();
 
-        $this->assertEquals(
+        static::assertEquals(
             "/bar.php:1  \033[33mLongerNamedRule\033[0m  \033[31mAn other description for this rule\033[0m" . PHP_EOL,
             $writer->getData()
         );
@@ -151,10 +143,8 @@ class TextRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToTextReport
-     *
-     * @return void
      */
-    public function testRendererAddsProcessingErrorsToTextReport()
+    public function testRendererAddsProcessingErrorsToTextReport(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -166,12 +156,12 @@ class TextRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator([])));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator([])));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator($errors)));
+            ->will(static::returnValue(new ArrayIterator($errors)));
 
         $renderer = new TextRenderer();
         $renderer->setWriter($writer);
@@ -180,7 +170,7 @@ class TextRendererTest extends AbstractTestCase
         $renderer->renderReport($report);
         $renderer->end();
 
-        $this->assertEquals(
+        static::assertEquals(
             "/tmp/foo.php\t-\tFailed for file \"/tmp/foo.php\"." . PHP_EOL .
             "/tmp/bar.php\t-\tFailed for file \"/tmp/bar.php\"." . PHP_EOL .
             "/tmp/baz.php\t-\tFailed for file \"/tmp/baz.php\"." . PHP_EOL,

--- a/src/test/php/PHPMD/Renderer/XMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/XMLRendererTest.php
@@ -31,10 +31,8 @@ class XMLRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfXmlElements
-     *
-     * @return void
      */
-    public function testRendererCreatesExpectedNumberOfXmlElements()
+    public function testRendererCreatesExpectedNumberOfXmlElements(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -46,12 +44,12 @@ class XMLRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator($violations)));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator($violations)));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator([])));
+            ->will(static::returnValue(new ArrayIterator([])));
 
         $renderer = new XMLRenderer();
         $renderer->setWriter($writer);
@@ -69,10 +67,9 @@ class XMLRendererTest extends AbstractTestCase
     /**
      * testRendererAddsProcessingErrorsToXmlReport
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testRendererAddsProcessingErrorsToXmlReport()
+    public function testRendererAddsProcessingErrorsToXmlReport(): void
     {
         // Create a writer instance.
         $writer = new WriterStub();
@@ -84,12 +81,12 @@ class XMLRendererTest extends AbstractTestCase
         ];
 
         $report = $this->getReportWithNoViolation();
-        $report->expects($this->once())
+        $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will($this->returnValue(new ArrayIterator([])));
-        $report->expects($this->once())
+            ->will(static::returnValue(new ArrayIterator([])));
+        $report->expects(static::once())
             ->method('getErrors')
-            ->will($this->returnValue(new ArrayIterator($processingErrors)));
+            ->will(static::returnValue(new ArrayIterator($processingErrors)));
 
         $renderer = new XMLRenderer();
         $renderer->setWriter($writer);

--- a/src/test/php/PHPMD/ReportTest.php
+++ b/src/test/php/PHPMD/ReportTest.php
@@ -32,10 +32,8 @@ class ReportTest extends AbstractTestCase
     /**
      * Tests that the report returns a linear/sorted list of all rule violation
      * files.
-     *
-     * @return void
      */
-    public function testReportReturnsAListWithAllRuleViolations()
+    public function testReportReturnsAListWithAllRuleViolations(): void
     {
         $report = new Report();
 
@@ -52,15 +50,13 @@ class ReportTest extends AbstractTestCase
 
         $expected = ['bar.txt', 'bar.txt', 'foo.txt', 'foo.txt', 'foo.txt'];
 
-        $this->assertSame($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 
     /**
      * Tests that the report returns the result by the violation line number.
-     *
-     * @return void
      */
-    public function testReportSortsResultByLineNumber()
+    public function testReportSortsResultByLineNumber(): void
     {
         $report = new Report();
 
@@ -89,15 +85,13 @@ class ReportTest extends AbstractTestCase
             ['foo.txt', 4, 5],
         ];
 
-        $this->assertSame($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 
     /**
      * Tests that the timer method returns the expected result.
-     *
-     * @return void
      */
-    public function testReportTimerReturnsMilliSeconds()
+    public function testReportTimerReturnsMilliSeconds(): void
     {
         $start = microtime(true);
 
@@ -110,94 +104,84 @@ class ReportTest extends AbstractTestCase
 
         // Windows does not compute the time correctly, simply skipping
         if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
-            $this->assertGreaterThanOrEqual(50, $report->getElapsedTimeInMillis());
+            static::assertGreaterThanOrEqual(50, $report->getElapsedTimeInMillis());
         }
-        $this->assertLessThanOrEqual($time, $report->getElapsedTimeInMillis());
+        static::assertLessThanOrEqual($time, $report->getElapsedTimeInMillis());
     }
 
     /**
      * testIsEmptyReturnsTrueByDefault
-     *
-     * @return void
      */
-    public function testIsEmptyReturnsTrueByDefault()
+    public function testIsEmptyReturnsTrueByDefault(): void
     {
         $report = new Report();
-        $this->assertTrue($report->isEmpty());
+        static::assertTrue($report->isEmpty());
     }
 
     /**
      * testIsEmptyReturnsFalseWhenAtLeastOneViolationExists
-     *
-     * @return void
      */
-    public function testIsEmptyReturnsFalseWhenAtLeastOneViolationExists()
+    public function testIsEmptyReturnsFalseWhenAtLeastOneViolationExists(): void
     {
         $report = new Report();
         $report->addRuleViolation($this->getRuleViolationMock('foo.txt', 4, 5));
 
-        $this->assertFalse($report->isEmpty());
+        static::assertFalse($report->isEmpty());
     }
 
     /**
      * testHasErrorsReturnsFalseByDefault
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testHasErrorsReturnsFalseByDefault()
+    public function testHasErrorsReturnsFalseByDefault(): void
     {
         $report = new Report();
-        $this->assertFalse($report->hasErrors());
+        static::assertFalse($report->hasErrors());
     }
 
     /**
      * testHasErrorsReturnsTrueWhenReportContainsAtLeastOneError
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testHasErrorsReturnsTrueWhenReportContainsAtLeastOneError()
+    public function testHasErrorsReturnsTrueWhenReportContainsAtLeastOneError(): void
     {
         $report = new Report();
         $report->addError(new ProcessingError('Failing file "/foo.php".'));
 
-        $this->assertTrue($report->hasErrors());
+        static::assertTrue($report->hasErrors());
     }
 
     /**
      * testGetErrorsReturnsEmptyIteratorByDefault
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testGetErrorsReturnsEmptyIteratorByDefault()
+    public function testGetErrorsReturnsEmptyIteratorByDefault(): void
     {
         $report = new Report();
-        $this->assertSame(0, iterator_count($report->getErrors()));
+        static::assertSame(0, iterator_count($report->getErrors()));
     }
 
     /**
      * testGetErrorsReturnsPreviousAddedProcessingError
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testGetErrorsReturnsPreviousAddedProcessingError()
+    public function testGetErrorsReturnsPreviousAddedProcessingError(): void
     {
         $report = new Report();
         $report->addError(new ProcessingError('Failing file "/foo.php".'));
 
-        $this->assertSame(1, iterator_count($report->getErrors()));
+        static::assertSame(1, iterator_count($report->getErrors()));
     }
 
-    /**
-     * @return void
-     */
-    public function testReportShouldIgnoreBaselineViolation()
+    public function testReportShouldIgnoreBaselineViolation(): void
     {
         /** @var RuleViolation $ruleA */
         $ruleA = $this->getRuleViolationMock('foo.txt');
+
         /** @var RuleViolation $ruleB */
         $ruleB = $this->getRuleViolationMock('bar.txt', 1, 2);
 
@@ -217,13 +201,11 @@ class ReportTest extends AbstractTestCase
         static::assertSame($ruleB, $violations[0]);
     }
 
-    /**
-     * @return void
-     */
-    public function testReportShouldIgnoreNewViolationsOnBaselineUpdate()
+    public function testReportShouldIgnoreNewViolationsOnBaselineUpdate(): void
     {
         /** @var RuleViolation $ruleA */
         $ruleA = $this->getRuleViolationMock('foo.txt');
+
         /** @var RuleViolation $ruleB */
         $ruleB = $this->getRuleViolationMock('bar.txt', 1, 2);
 

--- a/src/test/php/PHPMD/Rule/CleanCode/BooleanArgumentFlagTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/BooleanArgumentFlagTest.php
@@ -43,10 +43,9 @@ class BooleanArgumentFlagTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getApplyingCases
      */
-    public function testRuleAppliesTo($file)
+    public function testRuleAppliesTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::ONE_VIOLATION, $file);
     }
@@ -55,10 +54,9 @@ class BooleanArgumentFlagTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getNotApplyingCases
      */
-    public function testRuleDoesNotApplyTo($file)
+    public function testRuleDoesNotApplyTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::NO_VIOLATION, $file);
     }

--- a/src/test/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
@@ -29,10 +29,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutArrayDefinition
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithoutArrayDefinition()
+    public function testRuleNotAppliesToMethodWithoutArrayDefinition(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithNonAssotiativeArrayDefinition
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithNonAssotiativeArrayDefinition()
+    public function testRuleNotAppliesToMethodWithNonAssotiativeArrayDefinition(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithNoViolation());
@@ -53,10 +49,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithAssotiativeArrayDefinitionWithoutDuplicatedKeys
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithAssotiativeArrayDefinitionWithoutDuplicatedKeys()
+    public function testRuleNotAppliesToMethodWithAssotiativeArrayDefinitionWithoutDuplicatedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithNoViolation());
@@ -65,10 +59,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys()
+    public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithOneViolation());
@@ -77,10 +69,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys()
+    public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithOneViolation());
@@ -89,10 +79,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys()
+    public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithOneViolation());
@@ -101,10 +89,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesMultipleTimesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys()
+    public function testRuleAppliesMultipleTimesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportMock(3));
@@ -113,10 +99,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutArrayDefinition
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithoutArrayDefinition()
+    public function testRuleNotAppliesToFunctionWithoutArrayDefinition(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithNoViolation());
@@ -125,10 +109,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithNonAssotiativeArrayDefinition
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithNonAssotiativeArrayDefinition()
+    public function testRuleNotAppliesToFunctionWithNonAssotiativeArrayDefinition(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithNoViolation());
@@ -137,10 +119,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithAssotiativeArrayDefinitionWithoutDuplicatedKeys
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithAssotiativeArrayDefinitionWithoutDuplicatedKeys()
+    public function testRuleNotAppliesToFunctionWithAssotiativeArrayDefinitionWithoutDuplicatedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithNoViolation());
@@ -149,10 +129,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys()
+    public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithOneViolation());
@@ -161,10 +139,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys()
+    public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithOneViolation());
@@ -173,10 +149,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys()
+    public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportWithOneViolation());
@@ -185,10 +159,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys
-     *
-     * @return void
      */
-    public function testRuleAppliesMultipleTimesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys()
+    public function testRuleAppliesMultipleTimesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportMock(3));
@@ -197,10 +169,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenKeyIsDeclaredInNonStandardWay
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenKeyIsDeclaredInNonStandardWay()
+    public function testRuleAppliesWhenKeyIsDeclaredInNonStandardWay(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportMock(4));
@@ -209,10 +179,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesCorrectlyWithNestedArrays
-     *
-     * @return void
      */
-    public function testRuleAppliesCorrectlyWithNestedArrays()
+    public function testRuleAppliesCorrectlyWithNestedArrays(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportMock(4));
@@ -221,10 +189,8 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesCorrectlyToMultipleArrays
-     *
-     * @return void
      */
-    public function testRuleAppliesCorrectlyToMultipleArrays()
+    public function testRuleAppliesCorrectlyToMultipleArrays(): void
     {
         $rule = new DuplicatedArrayKey();
         $rule->setReport($this->getReportMock(4));

--- a/src/test/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
@@ -21,21 +21,21 @@ use PHPMD\AbstractTestCase;
 
 class ElseExpressionTest extends AbstractTestCase
 {
-    public function testRuleNotAppliesToMethodWithoutElseExpression()
+    public function testRuleNotAppliesToMethodWithoutElseExpression(): void
     {
         $rule = new ElseExpression();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleAppliesToMethodWithElseExpression()
+    public function testRuleAppliesToMethodWithElseExpression(): void
     {
         $rule = new ElseExpression();
         $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleAppliesMultipleTimesToMethodWithMultipleElseExpressions()
+    public function testRuleAppliesMultipleTimesToMethodWithMultipleElseExpressions(): void
     {
         $rule = new ElseExpression();
         $rule->setReport($this->getReportMock(3));

--- a/src/test/php/PHPMD/Rule/CleanCode/ErrorControlOperatorTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/ErrorControlOperatorTest.php
@@ -29,10 +29,9 @@ class ErrorControlOperatorTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply to unary operators in functions
      *
-     * @return void
      * @covers ::apply
      */
-    public function testDoesNotApplyToOtherUnaryOperatorsInFunction()
+    public function testDoesNotApplyToOtherUnaryOperatorsInFunction(): void
     {
         $rule = new ErrorControlOperator();
         $rule->setReport($this->getReportWithOneViolation());
@@ -42,10 +41,9 @@ class ErrorControlOperatorTest extends AbstractTestCase
     /**
      * Tests that the rule applies error control operators to functions
      *
-     * @return void
      * @covers ::apply
      */
-    public function testAppliesToErrorControlOperatorInFunction()
+    public function testAppliesToErrorControlOperatorInFunction(): void
     {
         $rule = new ErrorControlOperator();
         $rule->setReport($this->getReportMock(3));
@@ -55,10 +53,9 @@ class ErrorControlOperatorTest extends AbstractTestCase
     /**
      * Tests that the rule applies error control operators to classes and methods
      *
-     * @return void
      * @covers ::apply
      */
-    public function testAppliedToClassesAndMethods()
+    public function testAppliedToClassesAndMethods(): void
     {
         $rule = new ErrorControlOperator();
         $rule->setReport($this->getReportMock(6));

--- a/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
@@ -21,70 +21,70 @@ use PHPMD\AbstractTestCase;
 
 class IfStatementAssignmentTest extends AbstractTestCase
 {
-    public function testRuleNotAppliesInsideClosure()
+    public function testRuleNotAppliesInsideClosure(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesInsideClosureCallbacks()
+    public function testRuleNotAppliesInsideClosureCallbacks(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToIfsWithoutAssignment()
+    public function testRuleNotAppliesToIfsWithoutAssignment(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToIfsWithConditionsOnly()
+    public function testRuleNotAppliesToIfsWithConditionsOnly(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToLogicalOperators()
+    public function testRuleNotAppliesToLogicalOperators(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleWorksCorrectlyWhenExpressionContainsMath()
+    public function testRuleWorksCorrectlyWhenExpressionContainsMath(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportMock(3));
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleAppliesToFunctions()
+    public function testRuleAppliesToFunctions(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
-    public function testRuleAppliesMultipleIfConditions()
+    public function testRuleAppliesMultipleIfConditions(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getFunction());
     }
 
-    public function testRuleAppliesToMultilevelIfConditions()
+    public function testRuleAppliesToMultilevelIfConditions(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportMock(6));
         $rule->apply($this->getFunction());
     }
 
-    public function testRuleAppliesMultipleTimesInOneIfCondition()
+    public function testRuleAppliesMultipleTimesInOneIfCondition(): void
     {
         $rule = new IfStatementAssignment();
         $rule->setReport($this->getReportMock(3));

--- a/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/MissingImportTest.php
@@ -35,6 +35,7 @@ class MissingImportTest extends AbstractTestCase
     {
         $rule = new MissingImport();
         $rule->addProperty('ignore-global', 'false');
+
         return $rule;
     }
 
@@ -42,10 +43,9 @@ class MissingImportTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getApplyingCases
      */
-    public function testRuleAppliesTo($file)
+    public function testRuleAppliesTo($file): void
     {
         $expectedInvokes = str_contains($file, 'testRuleAppliesTwice')
             ? 2
@@ -57,10 +57,9 @@ class MissingImportTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getNotApplyingCases
      */
-    public function testRuleDoesNotApplyTo($file)
+    public function testRuleDoesNotApplyTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::NO_VIOLATION, $file);
     }
@@ -68,11 +67,10 @@ class MissingImportTest extends AbstractTestCase
     /**
      * Tests that it applies to a class that has fully qualified class names
      *
-     * @return void
      * @covers ::apply
      * @covers ::isSelfReference
      */
-    public function testRuleAppliesTwiceToClassWithNotImportedDependencies()
+    public function testRuleAppliesTwiceToClassWithNotImportedDependencies(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportMock(2));
@@ -82,11 +80,10 @@ class MissingImportTest extends AbstractTestCase
     /**
      * Tests that it does not apply to a class in root namespace when configured.
      *
-     * @return void
      * @covers ::apply
      * @covers ::isGlobalNamespace
      */
-    public function testRuleDoesNotApplyWhenSuppressed()
+    public function testRuleDoesNotApplyWhenSuppressed(): void
     {
         $rule = new MissingImport();
         $rule->addProperty('ignore-global', 'true');
@@ -95,6 +92,7 @@ class MissingImportTest extends AbstractTestCase
             // Covers case when the new property is set and the rule *should* apply.
             if (strpos($file, 'WithNotImportedDeepDependencies')) {
                 $this->expectRuleHasViolationsForFile($rule, static::ONE_VIOLATION, $file);
+
                 continue;
             }
             // Covers case when the new property is set and the rule *should not* apply.

--- a/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
@@ -24,28 +24,28 @@ use PHPMD\AbstractTestCase;
  */
 class StaticAccessTest extends AbstractTestCase
 {
-    public function testRuleNotAppliesToParentStaticCall()
+    public function testRuleNotAppliesToParentStaticCall(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToSelfStaticCall()
+    public function testRuleNotAppliesToSelfStaticCall(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToDynamicMethodCall()
+    public function testRuleNotAppliesToDynamicMethodCall(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToStaticMethodAccessWhenExcluded()
+    public function testRuleNotAppliesToStaticMethodAccessWhenExcluded(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithNoViolation());
@@ -53,14 +53,14 @@ class StaticAccessTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleAppliesToStaticMethodAccess()
+    public function testRuleAppliesToStaticMethodAccess(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleAppliesToStaticMethodAccessWhenNotAllExcluded()
+    public function testRuleAppliesToStaticMethodAccessWhenNotAllExcluded(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithOneViolation());
@@ -68,7 +68,7 @@ class StaticAccessTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToConstantAccess()
+    public function testRuleNotAppliesToConstantAccess(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithNoViolation());
@@ -79,7 +79,7 @@ class StaticAccessTest extends AbstractTestCase
      * @covers ::apply
      * @covers ::isMethodIgnored
      */
-    public function testRuleNotAppliesToStaticMethodAccessWhenIgnored()
+    public function testRuleNotAppliesToStaticMethodAccessWhenIgnored(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithNoViolation());
@@ -91,7 +91,7 @@ class StaticAccessTest extends AbstractTestCase
      * @covers ::apply
      * @covers ::isMethodIgnored
      */
-    public function testRuleAppliesToStaticMethodAccessWhenNotIgnored()
+    public function testRuleAppliesToStaticMethodAccessWhenNotIgnored(): void
     {
         $rule = new StaticAccess();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/CleanCode/UndefinedVariableTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/UndefinedVariableTest.php
@@ -40,10 +40,9 @@ class UndefinedVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getApplyingCases
      */
-    public function testRuleAppliesTo($file)
+    public function testRuleAppliesTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::ONE_VIOLATION, $file);
     }
@@ -52,10 +51,9 @@ class UndefinedVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getNotApplyingCases
      */
-    public function testRuleDoesNotApplyTo($file)
+    public function testRuleDoesNotApplyTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::NO_VIOLATION, $file);
     }

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
@@ -25,10 +25,7 @@ use PHPMD\Node\ClassNode;
  */
 class CamelCaseClassNameTest extends AbstractTestCase
 {
-    /**
-     * @return void
-     */
-    public function testRuleDoesNotApplyForValidClassName()
+    public function testRuleDoesNotApplyForValidClassName(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -38,10 +35,7 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('ValidClass'));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleDoesNotApplyForValidClassNameWithUppercaseAbbreviation()
+    public function testRuleDoesNotApplyForValidClassNameWithUppercaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -51,10 +45,7 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('ValidURLClass'));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleDoesApplyForClassNameWithUppercaseAbbreviation()
+    public function testRuleDoesApplyForClassNameWithUppercaseAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -64,10 +55,7 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('ValidURLClass'));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleDoesNotApplyForClassNameWithCamelcaseAbbreviation()
+    public function testRuleDoesNotApplyForClassNameWithCamelcaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -77,10 +65,7 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('ValidUrlClass'));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleAppliesForClassNameWithLowerCase()
+    public function testRuleAppliesForClassNameWithLowerCase(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -90,10 +75,7 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('invalidClass'));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleAppliesForClassNameWithLowerCaseAndCamelcaseAbbreviation()
+    public function testRuleAppliesForClassNameWithLowerCaseAndCamelcaseAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();
 

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -29,10 +29,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does not apply for a valid method name.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidMethodName()
+    public function testRuleDoesNotApplyForValidMethodName(): void
     {
         // $method = $this->getMethod();
         $report = $this->getReportWithNoViolation();
@@ -47,10 +45,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for method name
      * with all caps abbreviation.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForMethodNameWithAllCapsAbbreviation()
+    public function testRuleDoesApplyForMethodNameWithAllCapsAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -65,10 +61,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for method name
      * with camelcase abbreviation.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForMethodNameWithCamelcaseAbbreviation()
+    public function testRuleDoesNotApplyForMethodNameWithCamelcaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -83,10 +77,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for an method name
      * starting with a capital.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForMethodNameWithCapital()
+    public function testRuleDoesApplyForMethodNameWithCapital(): void
     {
         // Test method name with capital at the beginning
         $method = $this->getMethod();
@@ -102,10 +94,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a method name
      * with underscores.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForMethodNameWithUnderscores()
+    public function testRuleDoesApplyForMethodNameWithUnderscores(): void
     {
         // Test method name with underscores
         $method = $this->getMethod();
@@ -121,10 +111,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid method name
      * with an underscore at the beginning when it is allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForValidMethodNameWithUnderscoreWhenNotAllowed()
+    public function testRuleDoesApplyForValidMethodNameWithUnderscoreWhenNotAllowed(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithOneViolation();
@@ -139,10 +127,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid method name
      * with an underscore at the beginning when it is not allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidMethodNameWithUnderscoreWhenAllowed()
+    public function testRuleDoesNotApplyForValidMethodNameWithUnderscoreWhenAllowed(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithNoViolation();
@@ -157,10 +143,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid method name
      * with an underscore at the beginning when it is not allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForMagicMethods()
+    public function testRuleDoesNotApplyForMagicMethods(): void
     {
         $methods = $this->getClass()->getMethods();
 
@@ -178,10 +162,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid test method name
      * with an underscore.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForTestMethodWithUnderscoreWhenNotAllowed()
+    public function testRuleDoesApplyForTestMethodWithUnderscoreWhenNotAllowed(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithOneViolation();
@@ -196,10 +178,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid test method name
      * with an underscore when underscores are allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForTestMethodWithUnderscoreWhenAllowed()
+    public function testRuleDoesNotApplyForTestMethodWithUnderscoreWhenAllowed(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithNoViolation();
@@ -214,10 +194,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid test method name
      * with multiple underscores in different positions when underscores are allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForTestMethodWithMultipleUnderscoresWhenAllowed()
+    public function testRuleDoesNotApplyForTestMethodWithMultipleUnderscoresWhenAllowed(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithNoViolation();
@@ -232,10 +210,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a test method name
      * with consecutive underscores even when underscores are allowed.
-     *
-     * @return void
      */
-    public function testRuleAppliesToTestMethodWithTwoConsecutiveUnderscoresWhenAllowed()
+    public function testRuleAppliesToTestMethodWithTwoConsecutiveUnderscoresWhenAllowed(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithOneViolation();
@@ -250,10 +226,8 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply to for test method names that
      * have a capital after their single allowed underscore.
-     *
-     * @return void
      */
-    public function testRuleAppliesToTestMethodWithUnderscoreFollowedByCapital()
+    public function testRuleAppliesToTestMethodWithUnderscoreFollowedByCapital(): void
     {
         $method = $this->getMethod();
         $report = $this->getReportWithOneViolation();

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -34,7 +34,7 @@ class CamelCaseMethodNameTest extends AbstractTestCase
      */
     public function testRuleDoesNotApplyForValidMethodName()
     {
-        //$method = $this->getMethod();
+        // $method = $this->getMethod();
         $report = $this->getReportWithNoViolation();
 
         $rule = new CamelCaseMethodName();

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
@@ -28,7 +28,7 @@ class CamelCaseNamespaceTest extends AbstractTestCase
     /**
      * Rule does not apply for valid namespace.
      */
-    public function testRuleDoesNotApplyForValidNamespace()
+    public function testRuleDoesNotApplyForValidNamespace(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -40,7 +40,7 @@ class CamelCaseNamespaceTest extends AbstractTestCase
     /**
      * Rule does apply for incorrect namespace.
      */
-    public function testRuleDoesApplyForIncorrectNamespace()
+    public function testRuleDoesApplyForIncorrectNamespace(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -52,7 +52,7 @@ class CamelCaseNamespaceTest extends AbstractTestCase
     /**
      * Rule does not apply for namespace with uppercase abbreviation.
      */
-    public function testRuleDoesNotApplyForNamespaceWithUppercaseAbbreviation()
+    public function testRuleDoesNotApplyForNamespaceWithUppercaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -64,7 +64,7 @@ class CamelCaseNamespaceTest extends AbstractTestCase
     /**
      * Rule does apply for namespace with uppercase abbreviation.
      */
-    public function testRuleDoesApplyForNamespaceWithUppercaseAbbreviation()
+    public function testRuleDoesApplyForNamespaceWithUppercaseAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -77,7 +77,7 @@ class CamelCaseNamespaceTest extends AbstractTestCase
     /**
      * Rule does not apply for invalid namespace in exception list.
      */
-    public function testRuleDoesNotApplyForNamespaceInException()
+    public function testRuleDoesNotApplyForNamespaceInException(): void
     {
         $report = $this->getReportWithNoViolation();
 

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
@@ -28,10 +28,8 @@ class CamelCaseParameterNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does apply for an invalid parameter name
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForInParameterNameWithUnderscore()
+    public function testRuleDoesApplyForInParameterNameWithUnderscore(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -45,10 +43,8 @@ class CamelCaseParameterNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does apply for all caps abbreviation when not allowed
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForAllCapsAbbreviation()
+    public function testRuleDoesApplyForAllCapsAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -63,10 +59,8 @@ class CamelCaseParameterNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does not apply for camelcase abbreviation
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForCamelcaseAbbreviation()
+    public function testRuleDoesNotApplyForCamelcaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -82,10 +76,8 @@ class CamelCaseParameterNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for an invalid parameter name
      * starting with a capital.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForParameterNameWithCapital()
+    public function testRuleDoesApplyForParameterNameWithCapital(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -99,10 +91,8 @@ class CamelCaseParameterNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does NOT apply for a valid parameter name
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidParameterName()
+    public function testRuleDoesNotApplyForValidParameterName(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -117,10 +107,8 @@ class CamelCaseParameterNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid parameter name
      * with an underscore at the beginning when it is allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidParameterNameWithUnderscoreWhenAllowed()
+    public function testRuleDoesNotApplyForValidParameterNameWithUnderscoreWhenAllowed(): void
     {
         $report = $this->getReportWithNoViolation();
 

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
@@ -28,10 +28,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does not apply for a valid property name.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidPropertyName()
+    public function testRuleDoesNotApplyForValidPropertyName(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -43,10 +41,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does apply for all caps abbreviation in property name.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForAllCapsAbbreviationInProperty()
+    public function testRuleDoesApplyForAllCapsAbbreviationInProperty(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -59,10 +55,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does not apply for a camelcase abbreviation in property name.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForCamelcaseAbbreviationInProperty()
+    public function testRuleDoesNotApplyForCamelcaseAbbreviationInProperty(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -76,10 +70,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a property name
      * starting with a capital.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForPropertyNameWithCapital()
+    public function testRuleDoesApplyForPropertyNameWithCapital(): void
     {
         // Test property name with capital at the beginning
         $report = $this->getReportWithOneViolation();
@@ -93,10 +85,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a property name
      * with underscores.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForPropertyNameWithUnderscores()
+    public function testRuleDoesApplyForPropertyNameWithUnderscores(): void
     {
         // Test property name with underscores
         $report = $this->getReportWithOneViolation();
@@ -110,10 +100,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid property name
      * with an underscore at the beginning when it is allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForValidPropertyNameWithUnderscoreWhenNotAllowed()
+    public function testRuleDoesApplyForValidPropertyNameWithUnderscoreWhenNotAllowed(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -126,10 +114,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid property name
      * with no underscore at the beginning when it is allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidPropertyNameWithNoUnderscoreWhenAllowed()
+    public function testRuleDoesNotApplyForValidPropertyNameWithNoUnderscoreWhenAllowed(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -142,10 +128,8 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid property name
      * with an underscore at the beginning when it is allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidPropertyNameWithUnderscoreWhenAllowed()
+    public function testRuleDoesNotApplyForValidPropertyNameWithUnderscoreWhenAllowed(): void
     {
         $report = $this->getReportWithNoViolation();
 

--- a/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
+++ b/src/test/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
@@ -28,10 +28,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does apply for an invalid variable name
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForInvariableNameWithUnderscore()
+    public function testRuleDoesApplyForInvariableNameWithUnderscore(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -44,10 +42,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for variable name
      * with all caps abbreviation.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForAllCapsAbbreviation()
+    public function testRuleDoesApplyForAllCapsAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -61,10 +57,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for variable name
      * with camelcase abbreviation.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForCamelcaseAbbreviation()
+    public function testRuleDoesNotApplyForCamelcaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -78,10 +72,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for an invalid variable name
      * starting with a capital.
-     *
-     * @return void
      */
-    public function testRuleDoesApplyForVariableNameWithCapital()
+    public function testRuleDoesApplyForVariableNameWithCapital(): void
     {
         $report = $this->getReportWithOneViolation();
 
@@ -93,10 +85,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does NOT apply for a valid variable name
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidVariableName()
+    public function testRuleDoesNotApplyForValidVariableName(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -108,10 +98,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does NOT apply for a statically accessed variable
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForStaticVariableAccess()
+    public function testRuleDoesNotApplyForStaticVariableAccess(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -123,10 +111,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does NOT apply if name allowed by config
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyIfExcluded()
+    public function testRuleDoesNotApplyIfExcluded(): void
     {
         $report = $this->getReportWithNoViolation();
 
@@ -139,10 +125,8 @@ class CamelCaseVariableNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid variable name
      * with an underscore at the beginning when it is allowed.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValidVariableNameWithUnderscoreWhenAllowed()
+    public function testRuleDoesNotApplyForValidVariableNameWithUnderscoreWhenAllowed(): void
     {
         $report = $this->getReportWithNoViolation();
 

--- a/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/CyclomaticComplexityTest.php
@@ -29,10 +29,8 @@ class CyclomaticComplexityTest extends AbstractTestCase
     /**
      * Tests that the rule applies for a value greater than the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueGreaterThanThreshold()
+    public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
         $method = $this->getMethodMock('ccn2', 42);
         $report = $this->getReportWithOneViolation();
@@ -46,10 +44,8 @@ class CyclomaticComplexityTest extends AbstractTestCase
     /**
      * Test that the rule applies for a value that is equal with the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueEqualToThreshold()
+    public function testRuleAppliesForValueEqualToThreshold(): void
     {
         $method = $this->getMethodMock('ccn2', 42);
         $report = $this->getReportWithOneViolation();
@@ -63,10 +59,8 @@ class CyclomaticComplexityTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply when the value is at least one lower
      * than the threshold.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValueLowerThanThreshold()
+    public function testRuleDoesNotApplyForValueLowerThanThreshold(): void
     {
         $method = $this->getMethodMock('ccn2', 22);
         $report = $this->getReportWithNoViolation();

--- a/src/test/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
@@ -28,10 +28,8 @@ class CountInLoopExpressionTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToAllTypesOfLoops
-     *
-     * @return void
      */
-    public function testRuleAppliesToAllTypesOfLoops()
+    public function testRuleAppliesToAllTypesOfLoops(): void
     {
         $rule = new CountInLoopExpression();
         $rule->setReport($this->getReportMock(3));
@@ -40,10 +38,8 @@ class CountInLoopExpressionTest extends AbstractTestCase
 
     /**
      * testRuleNotApplyToExpressionElsewhere
-     *
-     * @return void
      */
-    public function testRuleNotApplyToExpressionElsewhere()
+    public function testRuleNotApplyToExpressionElsewhere(): void
     {
         $rule = new CountInLoopExpression();
         $rule->setReport($this->getReportWithNoViolation());
@@ -52,10 +48,8 @@ class CountInLoopExpressionTest extends AbstractTestCase
 
     /**
      * testRuleApplyToNestedLoops
-     *
-     * @return void
      */
-    public function testRuleApplyToNestedLoops()
+    public function testRuleApplyToNestedLoops(): void
     {
         $rule = new CountInLoopExpression();
         $rule->setReport($this->getReportMock(8));
@@ -64,10 +58,8 @@ class CountInLoopExpressionTest extends AbstractTestCase
 
     /**
      * testMutedRuleAtClassLevel
-     *
-     * @return void
      */
-    public function testMutedRuleAtClassLevel()
+    public function testMutedRuleAtClassLevel(): void
     {
         $rule = new CountInLoopExpression();
         $rule->setReport($this->getReportWithNoViolation());
@@ -76,10 +68,8 @@ class CountInLoopExpressionTest extends AbstractTestCase
 
     /**
      * testMutedRuleAtMethodLevel
-     *
-     * @return void
      */
-    public function testMutedRuleAtMethodLevel()
+    public function testMutedRuleAtMethodLevel(): void
     {
         $rule = new CountInLoopExpression();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
@@ -29,10 +29,8 @@ class CouplingBetweenObjectsTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToClassWithCboLessThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassWithCboLessThanThreshold()
+    public function testRuleNotAppliesToClassWithCboLessThanThreshold(): void
     {
         $rule = new CouplingBetweenObjects();
         $rule->setReport($this->getReportWithNoViolation());
@@ -42,10 +40,8 @@ class CouplingBetweenObjectsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithCboEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassWithCboEqualToThreshold()
+    public function testRuleAppliesToClassWithCboEqualToThreshold(): void
     {
         $rule = new CouplingBetweenObjects();
         $rule->setReport($this->getReportWithOneViolation());
@@ -55,10 +51,8 @@ class CouplingBetweenObjectsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithCboGreaterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassWithCboGreaterThanThreshold()
+    public function testRuleAppliesToClassWithCboGreaterThanThreshold(): void
     {
         $rule = new CouplingBetweenObjects();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
@@ -28,10 +28,8 @@ class DepthOfInheritanceTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToClassWithNumberOfParentLessThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassWithNumberOfParentLessThanThreshold()
+    public function testRuleNotAppliesToClassWithNumberOfParentLessThanThreshold(): void
     {
         $rule = new DepthOfInheritance();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class DepthOfInheritanceTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithNumberOfParentIdenticalToThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassWithNumberOfParentIdenticalToThreshold()
+    public function testRuleAppliesToClassWithNumberOfParentIdenticalToThreshold(): void
     {
         $rule = new DepthOfInheritance();
         $rule->setReport($this->getReportWithOneViolation());
@@ -54,10 +50,8 @@ class DepthOfInheritanceTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithNumberOfParentGreaterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassWithNumberOfParentGreaterThanThreshold()
+    public function testRuleAppliesToClassWithNumberOfParentGreaterThanThreshold(): void
     {
         $rule = new DepthOfInheritance();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/src/test/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -30,10 +30,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutSuspectFunctionCall
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithoutSuspectFunctionCall()
+    public function testRuleNotAppliesToMethodWithoutSuspectFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithNoViolation());
@@ -42,10 +40,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithSuspectFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithSuspectFunctionCall()
+    public function testRuleAppliesToMethodWithSuspectFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithOneViolation());
@@ -54,10 +50,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithMultipleSuspectFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithMultipleSuspectFunctionCall()
+    public function testRuleAppliesToMethodWithMultipleSuspectFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportMock(3));
@@ -66,10 +60,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall()
+    public function testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithOneViolation());
@@ -78,10 +70,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall()
+    public function testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportMock(3));
@@ -90,10 +80,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutSuspectFunctionCall
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithoutSuspectFunctionCall()
+    public function testRuleNotAppliesToFunctionWithoutSuspectFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithNoViolation());
@@ -102,10 +90,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithSuspectFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithSuspectFunctionCall()
+    public function testRuleAppliesToFunctionWithSuspectFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithOneViolation());
@@ -114,10 +100,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithMultipleSuspectFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithMultipleSuspectFunctionCall()
+    public function testRuleAppliesToFunctionWithMultipleSuspectFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportMock(3));
@@ -126,10 +110,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithSuspectFullyQualifiedFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithSuspectFullyQualifiedFunctionCall()
+    public function testRuleAppliesToFunctionWithSuspectFullyQualifiedFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithOneViolation());
@@ -138,10 +120,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithMultipleSuspectFullyQualifiedFunctionCall
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithMultipleSuspectFullyQualifiedFunctionCall()
+    public function testRuleAppliesToFunctionWithMultipleSuspectFullyQualifiedFunctionCall(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportMock(3));
@@ -150,10 +130,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithinNamespace
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithinNamespace()
+    public function testRuleAppliesToMethodWithinNamespace(): void
     {
         $rule = $this->getRule();
         $rule->addProperty('ignore-namespaces', 'true');
@@ -163,10 +141,8 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithinNamespaceByDefault
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithinNamespaceByDefault()
+    public function testRuleNotAppliesToMethodWithinNamespaceByDefault(): void
     {
         $rule = $this->getRule();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
+++ b/src/test/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
@@ -29,10 +29,8 @@ class EmptyCatchBlockTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutTryCatchBlock
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithoutTryCatchBlock()
+    public function testRuleNotAppliesToMethodWithoutTryCatchBlock(): void
     {
         $rule = new EmptyCatchBlock();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class EmptyCatchBlockTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithEmptyCatchBlock
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithEmptyCatchBlock()
+    public function testRuleAppliesToFunctionWithEmptyCatchBlock(): void
     {
         $rule = new EmptyCatchBlock();
         $rule->setReport($this->getReportMock(3));
@@ -53,10 +49,8 @@ class EmptyCatchBlockTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithNonEmptyCatchBlock
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithNonEmptyCatchBlock()
+    public function testRuleNotAppliesToFunctionWithNonEmptyCatchBlock(): void
     {
         $rule = new EmptyCatchBlock();
         $rule->setReport($this->getReportWithNoViolation());
@@ -65,10 +59,8 @@ class EmptyCatchBlockTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToCatchBlockWithComments
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToCatchBlockWithComments()
+    public function testRuleNotAppliesToCatchBlockWithComments(): void
     {
         $rule = new EmptyCatchBlock();
         $rule->setReport($this->getReportWithNoViolation());
@@ -77,10 +69,8 @@ class EmptyCatchBlockTest extends AbstractTestCase
 
     /**
      * testRuleWorksWithNestedTryCatchBlocksAndNonSPLExceptions
-     *
-     * @return void
      */
-    public function testRuleWorksWithNestedTryCatchBlocksAndNonSPLExceptions()
+    public function testRuleWorksWithNestedTryCatchBlocksAndNonSPLExceptions(): void
     {
         $rule = new EmptyCatchBlock();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/EvalExpressionTest.php
@@ -28,10 +28,8 @@ class EvalExpressionTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutEvalExpression
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithoutEvalExpression()
+    public function testRuleNotAppliesToMethodWithoutEvalExpression(): void
     {
         $rule = new EvalExpression();
         $rule->setReport($this->getReportWithNoViolation());
@@ -40,10 +38,8 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithEvalExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithEvalExpression()
+    public function testRuleAppliesToMethodWithEvalExpression(): void
     {
         $rule = new EvalExpression();
         $rule->setReport($this->getReportWithOneViolation());
@@ -52,10 +48,8 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToMethodWithEvalExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesMultipleTimesToMethodWithEvalExpression()
+    public function testRuleAppliesMultipleTimesToMethodWithEvalExpression(): void
     {
         $rule = new EvalExpression();
         $rule->setReport($this->getReportMock(3));
@@ -64,10 +58,8 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutEvalExpression
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithoutEvalExpression()
+    public function testRuleNotAppliesToFunctionWithoutEvalExpression(): void
     {
         $rule = new EvalExpression();
         $rule->setReport($this->getReportWithNoViolation());
@@ -76,10 +68,8 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithEvalExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithEvalExpression()
+    public function testRuleAppliesToFunctionWithEvalExpression(): void
     {
         $rule = new EvalExpression();
         $rule->setReport($this->getReportWithOneViolation());
@@ -88,10 +78,8 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToFunctionWithEvalExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesMultipleTimesToFunctionWithEvalExpression()
+    public function testRuleAppliesMultipleTimesToFunctionWithEvalExpression(): void
     {
         $rule = new EvalExpression();
         $rule->setReport($this->getReportMock(3));

--- a/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
+++ b/src/test/php/PHPMD/Rule/Design/ExitExpressionTest.php
@@ -28,10 +28,8 @@ class ExitExpressionTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutExitExpression
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithoutExitExpression()
+    public function testRuleNotAppliesToMethodWithoutExitExpression(): void
     {
         $rule = new ExitExpression();
         $rule->setReport($this->getReportWithNoViolation());
@@ -40,10 +38,8 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithExitExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithExitExpression()
+    public function testRuleAppliesToMethodWithExitExpression(): void
     {
         $rule = new ExitExpression();
         $rule->setReport($this->getReportWithOneViolation());
@@ -52,10 +48,8 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToMethodWithExitExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesMultipleTimesToMethodWithExitExpression()
+    public function testRuleAppliesMultipleTimesToMethodWithExitExpression(): void
     {
         $rule = new ExitExpression();
         $rule->setReport($this->getReportMock(3));
@@ -64,10 +58,8 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutExitExpression
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithoutExitExpression()
+    public function testRuleNotAppliesToFunctionWithoutExitExpression(): void
     {
         $rule = new ExitExpression();
         $rule->setReport($this->getReportWithNoViolation());
@@ -76,10 +68,8 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithExitExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithExitExpression()
+    public function testRuleAppliesToFunctionWithExitExpression(): void
     {
         $rule = new ExitExpression();
         $rule->setReport($this->getReportWithOneViolation());
@@ -88,10 +78,8 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToFunctionWithExitExpression
-     *
-     * @return void
      */
-    public function testRuleAppliesMultipleTimesToFunctionWithExitExpression()
+    public function testRuleAppliesMultipleTimesToFunctionWithExitExpression(): void
     {
         $rule = new ExitExpression();
         $rule->setReport($this->getReportMock(3));

--- a/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
+++ b/src/test/php/PHPMD/Rule/Design/GotoStatementTest.php
@@ -29,10 +29,8 @@ class GotoStatementTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutGotoStatement
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithoutGotoStatement()
+    public function testRuleNotAppliesToMethodWithoutGotoStatement(): void
     {
         $rule = new GotoStatement();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class GotoStatementTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithGotoStatement
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithGotoStatement()
+    public function testRuleAppliesToMethodWithGotoStatement(): void
     {
         $rule = new GotoStatement();
         $rule->setReport($this->getReportWithOneViolation());
@@ -53,10 +49,8 @@ class GotoStatementTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutGotoStatement
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithoutGotoStatement()
+    public function testRuleNotAppliesToFunctionWithoutGotoStatement(): void
     {
         $rule = new GotoStatement();
         $rule->setReport($this->getReportWithNoViolation());
@@ -65,10 +59,8 @@ class GotoStatementTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithGotoStatement
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithGotoStatement()
+    public function testRuleAppliesToFunctionWithGotoStatement(): void
     {
         $rule = new GotoStatement();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Design/LongClassTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongClassTest.php
@@ -29,10 +29,8 @@ class LongClassTest extends AbstractTestCase
     /**
      * Tests that the rule applies for a value greater than the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueGreaterThanThreshold()
+    public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
         $class = $this->getClassMock('loc', 42);
         $report = $this->getReportWithOneViolation();
@@ -47,10 +45,8 @@ class LongClassTest extends AbstractTestCase
     /**
      * Test that the rule applies for a value that is equal with the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueEqualToThreshold()
+    public function testRuleAppliesForValueEqualToThreshold(): void
     {
         $class = $this->getClassMock('loc', 42);
         $report = $this->getReportWithOneViolation();
@@ -65,10 +61,8 @@ class LongClassTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply when the value is at least one lower
      * than the threshold.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValueLowerThanThreshold()
+    public function testRuleDoesNotApplyForValueLowerThanThreshold(): void
     {
         $class = $this->getClassMock('loc', 22);
         $report = $this->getReportWithNoViolation();
@@ -82,10 +76,8 @@ class LongClassTest extends AbstractTestCase
 
     /**
      * Tests that the rule uses eloc when ignore whitespace is set
-     *
-     * @return void
      */
-    public function testRuleUsesElocWhenIgnoreWhitespaceSet()
+    public function testRuleUsesElocWhenIgnoreWhitespaceSet(): void
     {
         $class = $this->getClassMock('eloc', 22);
         $report = $this->getReportWithNoViolation();

--- a/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongMethodTest.php
@@ -29,10 +29,8 @@ class LongMethodTest extends AbstractTestCase
     /**
      * Tests that the rule applies for a value greater than the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueGreaterThanThreshold()
+    public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
         $method = $this->getMethodMock('loc', 42);
         $report = $this->getReportWithOneViolation();
@@ -47,10 +45,8 @@ class LongMethodTest extends AbstractTestCase
     /**
      * Test that the rule applies for a value that is equal with the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueEqualToThreshold()
+    public function testRuleAppliesForValueEqualToThreshold(): void
     {
         $method = $this->getMethodMock('loc', 42);
         $report = $this->getReportWithOneViolation();
@@ -65,10 +61,8 @@ class LongMethodTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply when the value is at least one lower
      * than the threshold.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValueLowerThanThreshold()
+    public function testRuleDoesNotApplyForValueLowerThanThreshold(): void
     {
         $method = $this->getMethodMock('loc', 22);
         $report = $this->getReportWithNoViolation();
@@ -82,10 +76,8 @@ class LongMethodTest extends AbstractTestCase
 
     /**
      * Tests that the rule uses eloc when ignore whitespace is set
-     *
-     * @return void
      */
-    public function testRuleUsesElocWhenIgnoreWhitespaceSet()
+    public function testRuleUsesElocWhenIgnoreWhitespaceSet(): void
     {
         $class = $this->getClassMock('eloc', 22);
         $report = $this->getReportWithNoViolation();

--- a/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
+++ b/src/test/php/PHPMD/Rule/Design/LongParameterListTest.php
@@ -30,10 +30,8 @@ class LongParameterListTest extends AbstractTestCase
 {
     /**
      * testApplyIgnoresMethodsWithLessParametersThanMinimum
-     *
-     * @return void
      */
-    public function testApplyIgnoresMethodsWithLessParametersThanMinimum()
+    public function testApplyIgnoresMethodsWithLessParametersThanMinimum(): void
     {
         $rule = new LongParameterList();
         $rule->setReport($this->getReportWithNoViolation());
@@ -43,10 +41,8 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyReportsMethodsWithIdenticalParametersAndMinimum
-     *
-     * @return void
      */
-    public function testApplyReportsMethodsWithIdenticalParametersAndMinimum()
+    public function testApplyReportsMethodsWithIdenticalParametersAndMinimum(): void
     {
         $rule = new LongParameterList();
         $rule->setReport($this->getReportWithOneViolation());
@@ -56,10 +52,8 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyReportsMethodsWithMoreParametersThanMinimum
-     *
-     * @return void
      */
-    public function testApplyReportsMethodsWithMoreParametersThanMinimum()
+    public function testApplyReportsMethodsWithMoreParametersThanMinimum(): void
     {
         $rule = new LongParameterList();
         $rule->setReport($this->getReportWithOneViolation());
@@ -69,10 +63,8 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyIgnoresFunctionsWithLessParametersThanMinimum
-     *
-     * @return void
      */
-    public function testApplyIgnoresFunctionsWithLessParametersThanMinimum()
+    public function testApplyIgnoresFunctionsWithLessParametersThanMinimum(): void
     {
         $rule = new LongParameterList();
         $rule->setReport($this->getReportWithNoViolation());
@@ -82,10 +74,8 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyReportsFunctionsWithIdenticalParametersAndMinimum
-     *
-     * @return void
      */
-    public function testApplyReportsFunctionsWithIdenticalParametersAndMinimum()
+    public function testApplyReportsFunctionsWithIdenticalParametersAndMinimum(): void
     {
         $rule = new LongParameterList();
         $rule->setReport($this->getReportWithOneViolation());
@@ -95,10 +85,8 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyReportsFunctionsWithMoreParametersThanMinimum
-     *
-     * @return void
      */
-    public function testApplyReportsFunctionsWithMoreParametersThanMinimum()
+    public function testApplyReportsFunctionsWithMoreParametersThanMinimum(): void
     {
         $rule = new LongParameterList();
         $rule->setReport($this->getReportWithOneViolation());
@@ -138,9 +126,9 @@ class LongParameterListTest extends AbstractTestCase
      */
     private function initFunctionOrMethodMock($mock, $parameterCount)
     {
-        $mock->expects($this->once())
+        $mock->expects(static::once())
             ->method('getParameterCount')
-            ->will($this->returnValue($parameterCount));
+            ->will(static::returnValue($parameterCount));
 
         return $mock;
     }

--- a/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NpathComplexityTest.php
@@ -29,10 +29,8 @@ class NpathComplexityTest extends AbstractTestCase
     /**
      * Tests that the rule applies for a value greater than the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueGreaterThanThreshold()
+    public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
         $method = $this->getMethodMock('npath', 42);
         $report = $this->getReportWithOneViolation();
@@ -46,10 +44,8 @@ class NpathComplexityTest extends AbstractTestCase
     /**
      * Test that the rule applies for a value that is equal with the configured
      * threshold.
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueEqualToThreshold()
+    public function testRuleAppliesForValueEqualToThreshold(): void
     {
         $method = $this->getMethodMock('npath', 42);
         $report = $this->getReportWithOneViolation();
@@ -63,10 +59,8 @@ class NpathComplexityTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply when the value is at least one lower
      * than the threshold.
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyForValueLowerThanThreshold()
+    public function testRuleDoesNotApplyForValueLowerThanThreshold(): void
     {
         $method = $this->getMethodMock('npath', 22);
         $report = $this->getReportWithNoViolation();

--- a/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
+++ b/src/test/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
@@ -28,10 +28,8 @@ class NumberOfChildrenTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToClassWithChildrenLessThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassWithChildrenLessThanThreshold()
+    public function testRuleNotAppliesToClassWithChildrenLessThanThreshold(): void
     {
         $rule = new NumberOfChildren();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class NumberOfChildrenTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithChildrenIdenticalToThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassWithChildrenIdenticalToThreshold()
+    public function testRuleAppliesToClassWithChildrenIdenticalToThreshold(): void
     {
         $rule = new NumberOfChildren();
         $rule->setReport($this->getReportWithOneViolation());
@@ -54,10 +50,8 @@ class NumberOfChildrenTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithChildrenGreaterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassWithChildrenGreaterThanThreshold()
+    public function testRuleAppliesToClassWithChildrenGreaterThanThreshold(): void
     {
         $rule = new NumberOfChildren();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyFieldsTest.php
@@ -28,10 +28,8 @@ class TooManyFieldsTest extends AbstractTestCase
 {
     /**
      * testRuleDoesNotApplyToClassesWithLessFieldsThanThreshold
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassesWithLessFieldsThanThreshold()
+    public function testRuleDoesNotApplyToClassesWithLessFieldsThanThreshold(): void
     {
         $rule = new TooManyFields();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class TooManyFieldsTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToClassesWithSameNumberOfFieldsAsThreshold
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassesWithSameNumberOfFieldsAsThreshold()
+    public function testRuleDoesNotApplyToClassesWithSameNumberOfFieldsAsThreshold(): void
     {
         $rule = new TooManyFields();
         $rule->setReport($this->getReportWithNoViolation());
@@ -54,10 +50,8 @@ class TooManyFieldsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassesWithMoreFieldsThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassesWithMoreFieldsThanThreshold()
+    public function testRuleAppliesToClassesWithMoreFieldsThanThreshold(): void
     {
         $rule = new TooManyFields();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -29,10 +29,8 @@ class TooManyMethodsTest extends AbstractTestCase
 {
     /**
      * testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold()
+    public function testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -43,10 +41,8 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold()
+    public function testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -57,10 +53,8 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassesWithMoreMethodsThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassesWithMoreMethodsThanThreshold()
+    public function testRuleAppliesToClassesWithMoreMethodsThanThreshold(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithOneViolation());
@@ -71,10 +65,8 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresGetterMethodsInTest
-     *
-     * @return void
      */
-    public function testRuleIgnoresGetterMethodsInTest()
+    public function testRuleIgnoresGetterMethodsInTest(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -85,10 +77,8 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresSetterMethodsInTest
-     *
-     * @return void
      */
-    public function testRuleIgnoresSetterMethodsInTest()
+    public function testRuleIgnoresSetterMethodsInTest(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -99,10 +89,8 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven
-     *
-     * @return void
      */
-    public function testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven()
+    public function testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -113,10 +101,8 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresGetterAndSetterMethodsInTest
-     *
-     * @return void
      */
-    public function testRuleIgnoresGetterAndSetterMethodsInTest()
+    public function testRuleIgnoresGetterAndSetterMethodsInTest(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -125,10 +111,7 @@ class TooManyMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(3, ['invoke', 'getClass', 'setClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresHassers()
+    public function testRuleIgnoresHassers(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -137,10 +120,7 @@ class TooManyMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'hasClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresIssers()
+    public function testRuleIgnoresIssers(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -149,10 +129,7 @@ class TooManyMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'isClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresWithers()
+    public function testRuleIgnoresWithers(): void
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -168,14 +145,14 @@ class TooManyMethodsTest extends AbstractTestCase
      * @param string[] $methodNames
      * @return ClassNode
      */
-    private function createClassMock($numberOfMethods, array $methodNames = null)
+    private function createClassMock($numberOfMethods, ?array $methodNames = null)
     {
         $class = $this->getClassMock('nom', $numberOfMethods);
 
         if (is_array($methodNames)) {
-            $class->expects($this->once())
+            $class->expects(static::once())
                 ->method('getMethodNames')
-                ->will($this->returnValue($methodNames));
+                ->will(static::returnValue($methodNames));
         }
 
         return $class;

--- a/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -31,10 +31,7 @@ use PHPMD\Report;
  */
 class TooManyPublicMethodsTest extends AbstractTestCase
 {
-    /**
-     * @return void
-     */
-    public function testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold()
+    public function testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -43,10 +40,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(23));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold()
+    public function testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -55,10 +49,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(42));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleAppliesToClassesWithMoreMethodsThanThreshold()
+    public function testRuleAppliesToClassesWithMoreMethodsThanThreshold(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithOneViolation());
@@ -67,10 +58,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresGetterMethodsInTest()
+    public function testRuleIgnoresGetterMethodsInTest(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -79,10 +67,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'getClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresSetterMethodsInTest()
+    public function testRuleIgnoresSetterMethodsInTest(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -91,10 +76,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'setClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven()
+    public function testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -103,10 +85,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'injectClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresGetterAndSetterMethodsInTest()
+    public function testRuleIgnoresGetterAndSetterMethodsInTest(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -115,10 +94,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(3, ['foo', 'bar'], ['baz', 'bah']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresPrivateMethods()
+    public function testRuleIgnoresPrivateMethods(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -127,10 +103,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'getClass', 'setClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresHassers()
+    public function testRuleIgnoresHassers(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -139,10 +112,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'hasClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresIssers()
+    public function testRuleIgnoresIssers(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -151,10 +121,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'isClass']));
     }
 
-    /**
-     * @return void
-     */
-    public function testRuleIgnoresWithers()
+    public function testRuleIgnoresWithers(): void
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
@@ -163,7 +130,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'withClass']));
     }
 
-    public function testRuleApplyToBasicClass()
+    public function testRuleApplyToBasicClass(): void
     {
         $class = $this->getClass();
         $rule = new TooManyPublicMethods();
@@ -174,9 +141,9 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($class);
         $violations = $report->getRuleViolations();
 
-        $this->assertCount(1, $violations);
+        static::assertCount(1, $violations);
 
-        $this->assertSame(6, $violations[0]->getBeginLine());
+        static::assertSame(6, $violations[0]->getBeginLine());
     }
 
     /**
@@ -191,9 +158,9 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     {
         $class = $this->getClassMock('npm', $numberOfMethods);
 
-        $class->expects($this->any())
+        $class->expects(static::any())
             ->method('getMethods')
-            ->will($this->returnValue(array_merge(
+            ->will(static::returnValue(array_merge(
                 array_map([$this, 'createPublicMethod'], $publicMethods),
                 array_map([$this, 'createPrivateMethod'], $privateMethods)
             )));

--- a/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
+++ b/src/test/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
@@ -29,10 +29,8 @@ class WeightedMethodCountTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesForValueGreaterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueGreaterThanThreshold()
+    public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
         $class = $this->getClassMock('wmc', 42);
         $report = $this->getReportWithOneViolation();
@@ -45,10 +43,8 @@ class WeightedMethodCountTest extends AbstractTestCase
 
     /**
      * testRuleAppliesForValueEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesForValueEqualToThreshold()
+    public function testRuleAppliesForValueEqualToThreshold(): void
     {
         $class = $this->getClassMock('wmc', 42);
         $report = $this->getReportWithOneViolation();
@@ -61,10 +57,8 @@ class WeightedMethodCountTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesForValueLowerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesForValueLowerThanThreshold()
+    public function testRuleNotAppliesForValueLowerThanThreshold(): void
     {
         $class = $this->getClassMock('wmc', 42);
         $report = $this->getReportWithNoViolation();

--- a/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
+++ b/src/test/php/PHPMD/Rule/ExcessivePublicCountTest.php
@@ -28,10 +28,8 @@ class ExcessivePublicCountTest extends AbstractTestCase
 {
     /**
      * testRuleDoesNotApplyToClassesWithLessPublicMembersThanThreshold
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassesWithLessPublicMembersThanThreshold()
+    public function testRuleDoesNotApplyToClassesWithLessPublicMembersThanThreshold(): void
     {
         $rule = new ExcessivePublicCount();
         $rule->setReport($this->getReportWithNoViolation());
@@ -41,10 +39,8 @@ class ExcessivePublicCountTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassesWithSameNumberOfPublicMembersAsThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassesWithSameNumberOfPublicMembersAsThreshold()
+    public function testRuleAppliesToClassesWithSameNumberOfPublicMembersAsThreshold(): void
     {
         $rule = new ExcessivePublicCount();
         $rule->setReport($this->getReportWithOneViolation());
@@ -54,10 +50,8 @@ class ExcessivePublicCountTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassesWithMorePublicMembersThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassesWithMorePublicMembersThanThreshold()
+    public function testRuleAppliesToClassesWithMorePublicMembersThanThreshold(): void
     {
         $rule = new ExcessivePublicCount();
         $rule->setReport($this->getReportWithOneViolation());

--- a/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
@@ -29,10 +29,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToMethodStartingWithGetAndReturningBoolean
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodStartingWithGetAndReturningBoolean()
+    public function testRuleAppliesToMethodStartingWithGetAndReturningBoolean(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
@@ -42,10 +40,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodStartingWithGetAndReturningBool
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodStartingWithGetAndReturningBool()
+    public function testRuleAppliesToMethodStartingWithGetAndReturningBool(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
@@ -55,10 +51,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToPearPrivateMethodStartingWithGetAndReturningBoolean
-     *
-     * @return void
      */
-    public function testRuleAppliesToPearPrivateMethodStartingWithGetAndReturningBoolean()
+    public function testRuleAppliesToPearPrivateMethodStartingWithGetAndReturningBoolean(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
@@ -68,10 +62,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresParametersWhenNotExplicitConfigured
-     *
-     * @return void
      */
-    public function testRuleIgnoresParametersWhenNotExplicitConfigured()
+    public function testRuleIgnoresParametersWhenNotExplicitConfigured(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
@@ -81,10 +73,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesWhenParametersAreExplicitEnabled
-     *
-     * @return void
      */
-    public function testRuleNotAppliesWhenParametersAreExplicitEnabled()
+    public function testRuleNotAppliesWhenParametersAreExplicitEnabled(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'true');
@@ -95,10 +85,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodStartingWithIs
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodStartingWithIs()
+    public function testRuleNotAppliesToMethodStartingWithIs(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
@@ -109,10 +97,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodStartingWithHas
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodStartingWithHas()
+    public function testRuleNotAppliesToMethodStartingWithHas(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');
@@ -123,10 +109,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithReturnTypeNotBoolean
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithReturnTypeNotBoolean()
+    public function testRuleNotAppliesToMethodWithReturnTypeNotBoolean(): void
     {
         $rule = new BooleanGetMethodName();
         $rule->addProperty('checkParameterizedMethods', 'false');

--- a/src/test/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
@@ -28,10 +28,8 @@ class ConstantNamingConventionsTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToClassConstantWithLowerCaseCharacters
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassConstantWithLowerCaseCharacters()
+    public function testRuleAppliesToClassConstantWithLowerCaseCharacters(): void
     {
         $rule = new ConstantNamingConventions();
         $rule->setReport($this->getReportMock(2));
@@ -40,10 +38,8 @@ class ConstantNamingConventionsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToInterfaceConstantWithLowerCaseCharacters
-     *
-     * @return void
      */
-    public function testRuleAppliesToInterfaceConstantWithLowerCaseCharacters()
+    public function testRuleAppliesToInterfaceConstantWithLowerCaseCharacters(): void
     {
         $rule = new ConstantNamingConventions();
         $rule->setReport($this->getReportMock(3));
@@ -52,10 +48,8 @@ class ConstantNamingConventionsTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToClassConstantWithUpperCaseCharacters
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassConstantWithUpperCaseCharacters()
+    public function testRuleNotAppliesToClassConstantWithUpperCaseCharacters(): void
     {
         $rule = new ConstantNamingConventions();
         $rule->setReport($this->getReportWithNoViolation());
@@ -64,10 +58,8 @@ class ConstantNamingConventionsTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToInterfaceConstantWithUpperCaseCharacters
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToInterfaceConstantWithUpperCaseCharacters()
+    public function testRuleNotAppliesToInterfaceConstantWithUpperCaseCharacters(): void
     {
         $rule = new ConstantNamingConventions();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
@@ -28,10 +28,8 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToConstructorMethodNamedAsEnclosingClass
-     *
-     * @return void
      */
-    public function testRuleAppliesToConstructorMethodNamedAsEnclosingClass()
+    public function testRuleAppliesToConstructorMethodNamedAsEnclosingClass(): void
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
         $rule->setReport($this->getReportWithOneViolation());
@@ -40,10 +38,8 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToConstructorMethodNamedAsEnclosingClassCaseInsensitive
-     *
-     * @return void
      */
-    public function testRuleAppliesToConstructorMethodNamedAsEnclosingClassCaseInsensitive()
+    public function testRuleAppliesToConstructorMethodNamedAsEnclosingClassCaseInsensitive(): void
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
         $rule->setReport($this->getReportWithOneViolation());
@@ -52,24 +48,22 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodNamedSimilarToEnclosingClass
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodNamedSimilarToEnclosingClass()
+    public function testRuleNotAppliesToMethodNamedSimilarToEnclosingClass(): void
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToMethodNamedAsEnclosingInterface()
+    public function testRuleNotAppliesToMethodNamedAsEnclosingInterface(): void
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getMethod());
     }
 
-    public function testRuleNotAppliesToMethodInNamespaces()
+    public function testRuleNotAppliesToMethodInNamespaces(): void
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Rule/Naming/LongClassNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/LongClassNameTest.php
@@ -28,10 +28,8 @@ class LongClassNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does not apply to class name length (43) below threshold (44)
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassNameBelowThreshold()
+    public function testRuleNotAppliesToClassNameBelowThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 44);
@@ -41,10 +39,8 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to class name length (40) below threshold (39)
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassNameAboveThreshold()
+    public function testRuleAppliesToClassNameAboveThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 39);
@@ -54,10 +50,8 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does not apply to interface name length (47) below threshold (47)
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToInterfaceNameBelowThreshold()
+    public function testRuleNotAppliesToInterfaceNameBelowThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 47);
@@ -67,10 +61,8 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to class name length (44) above threshold (43)
-     *
-     * @return void
      */
-    public function testRuleAppliesToInterfaceNameAboveThreshold()
+    public function testRuleAppliesToInterfaceNameAboveThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 43);
@@ -80,10 +72,8 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to trait name length (40) above threshold (39)
-     *
-     * @return void
      */
-    public function testRuleAppliesToTraitNameAboveThreshold()
+    public function testRuleAppliesToTraitNameAboveThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 39);
@@ -93,10 +83,8 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to enum name length (39) above threshold (38)
-     *
-     * @return void
      */
-    public function testRuleAppliesToEnumNameAboveThreshold()
+    public function testRuleAppliesToEnumNameAboveThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 38);
@@ -107,10 +95,8 @@ class LongClassNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply to class name length (69) below threshold (60)
      * with configured suffix length (9)
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassNameLengthWithSuffixSubtractedBelowThreshold()
+    public function testRuleNotAppliesToClassNameLengthWithSuffixSubtractedBelowThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 60);
@@ -121,10 +107,8 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to class name length (66) above threshold (56) with configured suffix length (9)
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassNameLengthWithSuffixSubtractedAboveThreshold()
+    public function testRuleAppliesToClassNameLengthWithSuffixSubtractedAboveThreshold(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 56);
@@ -136,10 +120,8 @@ class LongClassNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply to class name length (55) below threshold (54)
      * not matching configured suffix length (9)
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassNameLengthWithoutSuffixSubtracted()
+    public function testRuleAppliesToClassNameLengthWithoutSuffixSubtracted(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 54);
@@ -151,10 +133,8 @@ class LongClassNameTest extends AbstractTestCase
     /**
      * Tests that the rule applies to class name length (43) below threshold (40)
      * not matching configured prefix length (15)
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassNameWithPrefixMatched()
+    public function testRuleAppliesToClassNameWithPrefixMatched(): void
     {
         $rule = new LongClassName();
         $rule->addProperty('maximum', 45);

--- a/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/LongVariableTest.php
@@ -28,10 +28,8 @@ class LongVariableTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToLocalVariableInFunctionWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToLocalVariableInFunctionWithNameLongerThanThreshold()
+    public function testRuleAppliesToLocalVariableInFunctionWithNameLongerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 21);
@@ -41,10 +39,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInFunctionWithNameSmallerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInFunctionWithNameSmallerThanThreshold()
+    public function testRuleNotAppliesToLocalVariableInFunctionWithNameSmallerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 6);
@@ -54,10 +50,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold()
+    public function testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 6);
@@ -67,10 +61,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionParameterWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionParameterWithNameLongerThanThreshold()
+    public function testRuleAppliesToFunctionParameterWithNameLongerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -80,10 +72,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionParameterWithNameSmallerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionParameterWithNameSmallerThanThreshold()
+    public function testRuleNotAppliesToFunctionParameterWithNameSmallerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -93,10 +83,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToLocalVariableInMethodWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToLocalVariableInMethodWithNameLongerThanThreshold()
+    public function testRuleAppliesToLocalVariableInMethodWithNameLongerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -112,10 +100,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold()
+    public function testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 6);
@@ -125,10 +111,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInMethodWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInMethodWithNameShorterThanThreshold()
+    public function testRuleNotAppliesToLocalVariableInMethodWithNameShorterThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -138,10 +122,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodParameterWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodParameterWithNameLongerThanThreshold()
+    public function testRuleAppliesToMethodParameterWithNameLongerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 3);
@@ -157,10 +139,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodParameterWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodParameterWithNameShorterThanThreshold()
+    public function testRuleNotAppliesToMethodParameterWithNameShorterThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -170,10 +150,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFieldWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFieldWithNameLongerThanThreshold()
+    public function testRuleAppliesToFieldWithNameLongerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -183,10 +161,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFieldWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFieldWithNameEqualToThreshold()
+    public function testRuleNotAppliesToFieldWithNameEqualToThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 6);
@@ -196,10 +172,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFieldWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFieldWithNameShorterThanThreshold()
+    public function testRuleNotAppliesToFieldWithNameShorterThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 8);
@@ -209,10 +183,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFieldAndParameterWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFieldAndParameterWithNameLongerThanThreshold()
+    public function testRuleAppliesToFieldAndParameterWithNameLongerThanThreshold(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 3);
@@ -228,10 +200,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToStaticMembersAccessedInMethod
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToStaticMembersAccessedInMethod()
+    public function testRuleNotAppliesToStaticMembersAccessedInMethod(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 3);
@@ -241,10 +211,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToIdenticalVariableOnlyOneTime
-     *
-     * @return void
      */
-    public function testRuleAppliesToIdenticalVariableOnlyOneTime()
+    public function testRuleAppliesToIdenticalVariableOnlyOneTime(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -254,10 +222,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes
-     *
-     * @return void
      */
-    public function testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes()
+    public function testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -274,10 +240,9 @@ class LongVariableTest extends AbstractTestCase
     /**
      * testRuleAppliesForLongPrivateProperty
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testRuleAppliesForLongPrivateProperty()
+    public function testRuleAppliesForLongPrivateProperty(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -288,10 +253,9 @@ class LongVariableTest extends AbstractTestCase
     /**
      * testRuleAppliesForLongPrivateStaticProperty
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testRuleAppliesForLongPrivateStaticProperty()
+    public function testRuleAppliesForLongPrivateStaticProperty(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 17);
@@ -301,10 +265,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToVariableNameSmallerThanThresholdWithSuffixSubtracted
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToVariableNameSmallerThanThresholdWithSuffixSubtracted()
+    public function testRuleNotAppliesToVariableNameSmallerThanThresholdWithSuffixSubtracted(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 10);
@@ -315,10 +277,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameLongerThanThresholdWithSuffixSubtracted
-     *
-     * @return void
      */
-    public function testRuleAppliesToVariableNameLongerThanThresholdWithSuffixSubtracted()
+    public function testRuleAppliesToVariableNameLongerThanThresholdWithSuffixSubtracted(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 9);
@@ -329,10 +289,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameLongerThanThresholdWithMultipleSuffixesDefined
-     *
-     * @return void
      */
-    public function testRuleAppliesToVariableNameLongerThanThresholdWithMultipleSuffixesDefined()
+    public function testRuleAppliesToVariableNameLongerThanThresholdWithMultipleSuffixesDefined(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 19);
@@ -343,10 +301,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameSuffixIsNotSubtractedWhenNotASuffix
-     *
-     * @return void
      */
-    public function testRuleAppliesToVariableNameSuffixIsNotSubtractedWhenNotASuffix()
+    public function testRuleAppliesToVariableNameSuffixIsNotSubtractedWhenNotASuffix(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 24);
@@ -357,10 +313,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameWithEmptySubtractSuffixes
-     *
-     * @return void
      */
-    public function testRuleAppliesToVariableNameWithEmptySubtractSuffixes()
+    public function testRuleAppliesToVariableNameWithEmptySubtractSuffixes(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 20);
@@ -371,10 +325,8 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameFollowingHungarianNotation
-     *
-     * @return void
      */
-    public function testRuleAppliesToVariableNameFollowingHungarianNotation()
+    public function testRuleAppliesToVariableNameFollowingHungarianNotation(): void
     {
         $rule = new LongVariable();
         $rule->addProperty('maximum', 12);

--- a/src/test/php/PHPMD/Rule/Naming/ShortClassNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortClassNameTest.php
@@ -28,10 +28,8 @@ class ShortClassNameTest extends AbstractTestCase
 {
     /**
      * Tests that rule does not apply to class name length (43) above threshold (43)
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassNameAboveThreshold()
+    public function testRuleNotAppliesToClassNameAboveThreshold(): void
     {
         $rule = new ShortClassName();
         $rule->addProperty('minimum', 43);
@@ -41,10 +39,8 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule applies to class name length (40) below threshold (41)
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassNameBelowThreshold()
+    public function testRuleAppliesToClassNameBelowThreshold(): void
     {
         $rule = new ShortClassName();
         $rule->addProperty('minimum', 41);
@@ -54,10 +50,8 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule does not apply to interface name length (47) above threshold (47)
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToInterfaceNameAboveThreshold()
+    public function testRuleNotAppliesToInterfaceNameAboveThreshold(): void
     {
         $rule = new ShortClassName();
         $rule->addProperty('minimum', 47);
@@ -67,10 +61,8 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule applies for interface name length (44) below threshold (45)
-     *
-     * @return void
      */
-    public function testRuleAppliesToInterfaceNameBelowThreshold()
+    public function testRuleAppliesToInterfaceNameBelowThreshold(): void
     {
         $rule = new ShortClassName();
         $rule->addProperty('minimum', 45);
@@ -80,10 +72,8 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule does not apply for class name length (55) below threshold (61) when set in exceptions
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToClassNameBelowThresholdInExceptions()
+    public function testRuleNotAppliesToClassNameBelowThresholdInExceptions(): void
     {
         $rule = new ShortClassName();
         $rule->addProperty('minimum', 61);
@@ -94,10 +84,8 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule applies to class name length (55) below threshold (56) when not set in exceptions
-     *
-     * @return void
      */
-    public function testRuleAppliesToClassNameBelowThresholdNotInExceptions()
+    public function testRuleAppliesToClassNameBelowThresholdNotInExceptions(): void
     {
         $rule = new ShortClassName();
         $rule->addProperty('minimum', 56);

--- a/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
@@ -28,10 +28,8 @@ class ShortMethodNameTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToFunctionWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionWithNameShorterThanThreshold()
+    public function testRuleAppliesToFunctionWithNameShorterThanThreshold(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 54);
@@ -42,10 +40,8 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithNameEqualToThreshold()
+    public function testRuleNotAppliesToFunctionWithNameEqualToThreshold(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 52);
@@ -56,10 +52,8 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionWithNameLongerThanThreshold()
+    public function testRuleNotAppliesToFunctionWithNameLongerThanThreshold(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 54);
@@ -70,10 +64,8 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodWithNameShorterThanThreshold()
+    public function testRuleAppliesToMethodWithNameShorterThanThreshold(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 52);
@@ -84,10 +76,8 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithNameEqualToThreshold()
+    public function testRuleNotAppliesToMethodWithNameEqualToThreshold(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 50);
@@ -98,10 +88,8 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithNameLongerThanThreshold()
+    public function testRuleNotAppliesToMethodWithNameLongerThanThreshold(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 52);
@@ -112,10 +100,8 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodWithShortNameWhenException()
+    public function testRuleNotAppliesToMethodWithShortNameWhenException(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 100);
@@ -127,12 +113,11 @@ class ShortMethodNameTest extends AbstractTestCase
     /**
      * testRuleAlsoWorksWithoutExceptionListConfigured
      *
-     * @return void
      * @link https://github.com/phpmd/phpmd/issues/80
      * @link https://github.com/phpmd/phpmd/issues/270
      * @since 2.2.2
      */
-    public function testRuleAppliesAlsoWithoutExceptionListConfiguredOnMock()
+    public function testRuleAppliesAlsoWithoutExceptionListConfiguredOnMock(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 100);
@@ -140,7 +125,7 @@ class ShortMethodNameTest extends AbstractTestCase
         $rule->apply($this->getMethodMock());
     }
 
-    public function testRuleAppliesAlsoWithoutExceptionListConfigured()
+    public function testRuleAppliesAlsoWithoutExceptionListConfigured(): void
     {
         $rule = new ShortMethodName();
         $rule->addProperty('minimum', 100);

--- a/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -28,10 +28,8 @@ class ShortVariableTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToLocalVariableInFunctionWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToLocalVariableInFunctionWithNameShorterThanThreshold()
+    public function testRuleAppliesToLocalVariableInFunctionWithNameShorterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -42,10 +40,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToTryCatchBlocks
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToTryCatchBlocksInsideForeach()
+    public function testRuleNotAppliesToTryCatchBlocksInsideForeach(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -56,10 +52,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInFunctionWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInFunctionWithNameLongerThanThreshold()
+    public function testRuleNotAppliesToLocalVariableInFunctionWithNameLongerThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 2);
@@ -70,10 +64,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold()
+    public function testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -84,10 +76,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionParameterWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionParameterWithNameShorterThanThreshold()
+    public function testRuleAppliesToFunctionParameterWithNameShorterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -98,10 +88,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionParameterWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFunctionParameterWithNameLongerThanThreshold()
+    public function testRuleNotAppliesToFunctionParameterWithNameLongerThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -112,10 +100,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToLocalVariableInMethodWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToLocalVariableInMethodWithNameShorterThanThreshold()
+    public function testRuleAppliesToLocalVariableInMethodWithNameShorterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -132,10 +118,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold()
+    public function testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -146,10 +130,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInMethodWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToLocalVariableInMethodWithNameLongerThanThreshold()
+    public function testRuleNotAppliesToLocalVariableInMethodWithNameLongerThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 2);
@@ -160,10 +142,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodParameterWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodParameterWithNameShorterThanThreshold()
+    public function testRuleAppliesToMethodParameterWithNameShorterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -180,10 +160,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodParameterWithNameLongerThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToMethodParameterWithNameLongerThanThreshold()
+    public function testRuleNotAppliesToMethodParameterWithNameLongerThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 2);
@@ -194,10 +172,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFieldWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFieldWithNameShorterThanThreshold()
+    public function testRuleAppliesToFieldWithNameShorterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -208,10 +184,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFieldWithNameEqualToThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFieldWithNameEqualToThreshold()
+    public function testRuleNotAppliesToFieldWithNameEqualToThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -222,10 +196,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFieldWithNameGreaterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFieldWithNameGreaterThanThreshold()
+    public function testRuleNotAppliesToFieldWithNameGreaterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 2);
@@ -236,10 +208,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFieldAndParameterWithNameShorterThanThreshold
-     *
-     * @return void
      */
-    public function testRuleAppliesToFieldAndParameterWithNameShorterThanThreshold()
+    public function testRuleAppliesToFieldAndParameterWithNameShorterThanThreshold(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -256,10 +226,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToShortVariableNameAsForLoopIndex
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToShortVariableNameAsForLoopIndex()
+    public function testRuleNotAppliesToShortVariableNameAsForLoopIndex(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -270,10 +238,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToShortVariableNameAsForeachLoopIndex
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToShortVariableNameAsForeachLoopIndex()
+    public function testRuleNotAppliesToShortVariableNameAsForeachLoopIndex(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -284,10 +250,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToShortVariableNameInCatchStatement
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToShortVariableNameInCatchStatement()
+    public function testRuleNotAppliesToShortVariableNameInCatchStatement(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -298,10 +262,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToStaticMembersAccessedInMethod
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToStaticMembersAccessedInMethod()
+    public function testRuleNotAppliesToStaticMembersAccessedInMethod(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -312,10 +274,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToIdenticalVariableOnlyOneTime
-     *
-     * @return void
      */
-    public function testRuleAppliesToIdenticalVariableOnlyOneTime()
+    public function testRuleAppliesToIdenticalVariableOnlyOneTime(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -326,10 +286,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes
-     *
-     * @return void
      */
-    public function testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes()
+    public function testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -346,10 +304,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToVariablesFromExceptionsList
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToVariablesFromExceptionsList()
+    public function testRuleNotAppliesToVariablesFromExceptionsList(): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);
@@ -362,10 +318,9 @@ class ShortVariableTest extends AbstractTestCase
     /**
      * testRuleAppliesToVariablesWithinForeach
      *
-     * @return void
      * @dataProvider provideClassWithShortForeachVariables
      */
-    public function testRuleAppliesToVariablesWithinForeach($allowShortVarInLoop, $expectedErrorsCount)
+    public function testRuleAppliesToVariablesWithinForeach($allowShortVarInLoop, $expectedErrorsCount): void
     {
         $rule = new ShortVariable();
         $rule->addProperty('minimum', 3);

--- a/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -29,10 +29,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToFunctionUnusedFormalParameter
-     *
-     * @return void
      */
-    public function testRuleAppliesToFunctionUnusedFormalParameter()
+    public function testRuleAppliesToFunctionUnusedFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithOneViolation());
@@ -41,10 +39,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMultipleFunctionUnusedFormalParameter
-     *
-     * @return void
      */
-    public function testRuleAppliesToMultipleFunctionUnusedFormalParameter()
+    public function testRuleAppliesToMultipleFunctionUnusedFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportMock(3));
@@ -53,10 +49,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodUnusedFormalParameter
-     *
-     * @return void
      */
-    public function testRuleAppliesToMethodUnusedFormalParameter()
+    public function testRuleAppliesToMethodUnusedFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithOneViolation());
@@ -65,10 +59,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToEnumMethodUnusedFormalParameter
-     *
-     * @return void
      */
-    public function testRuleAppliesToEnumMethodUnusedFormalParameter()
+    public function testRuleAppliesToEnumMethodUnusedFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithOneViolation());
@@ -77,10 +69,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClosureUnusedFormalParameter
-     *
-     * @return void
      */
-    public function testRuleAppliesToClosureUnusedFormalParameter()
+    public function testRuleAppliesToClosureUnusedFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithOneViolation());
@@ -89,10 +79,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMultipleMethodUnusedFormalParameter
-     *
-     * @return void
      */
-    public function testRuleAppliesToMultipleMethodUnusedFormalParameter()
+    public function testRuleAppliesToMultipleMethodUnusedFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportMock(2));
@@ -110,10 +98,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleAppliesToFormalParameterWhenSimilarStaticMemberIsAccessed()
+    public function testRuleAppliesToFormalParameterWhenSimilarStaticMemberIsAccessed(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithOneViolation());
@@ -130,10 +116,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFormalParameterUsedInPropertyCompoundVariable()
+    public function testRuleNotAppliesToFormalParameterUsedInPropertyCompoundVariable(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -150,10 +134,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleNotAppliesToFormalParameterUsedInMethodCompoundVariable()
+    public function testRuleNotAppliesToFormalParameterUsedInMethodCompoundVariable(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -162,10 +144,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToAbstractMethodFormalParameter
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToAbstractMethodFormalParameter()
+    public function testRuleDoesNotApplyToAbstractMethodFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -174,10 +154,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToInterfaceMethodFormalParameter
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToInterfaceMethodFormalParameter()
+    public function testRuleDoesNotApplyToInterfaceMethodFormalParameter(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -186,10 +164,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToInnerFunctionDeclaration
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToInnerFunctionDeclaration()
+    public function testRuleDoesNotApplyToInnerFunctionDeclaration(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -207,10 +183,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToFormalParameterUsedInCompoundExpression()
+    public function testRuleDoesNotApplyToFormalParameterUsedInCompoundExpression(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -227,10 +201,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToMethodArgument()
+    public function testRuleDoesNotApplyToMethodArgument(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -239,10 +211,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToMethodArgumentUsedAsArrayIndex
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToMethodArgumentUsedAsArrayIndex()
+    public function testRuleDoesNotApplyToMethodArgumentUsedAsArrayIndex(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -259,10 +229,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToParameterUsedAsArrayIndex()
+    public function testRuleDoesNotApplyToParameterUsedAsArrayIndex(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -279,10 +247,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToParameterUsedAsStringIndex()
+    public function testRuleDoesNotApplyToParameterUsedAsStringIndex(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -303,10 +269,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToMethodWithFuncGetArgs()
+    public function testRuleDoesNotApplyToMethodWithFuncGetArgs(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -314,10 +278,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @since 2.0.0
      */
-    public function testFuncGetArgsRuleWorksCaseInsensitive()
+    public function testFuncGetArgsRuleWorksCaseInsensitive(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -327,10 +290,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
     /**
      * testRuleDoesNotApplyToInheritMethod
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testRuleDoesNotApplyToInheritMethod()
+    public function testRuleDoesNotApplyToInheritMethod(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -340,10 +302,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
     /**
      * testRuleDoesNotApplyToImplementedAbstractMethod
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testRuleDoesNotApplyToImplementedAbstractMethod()
+    public function testRuleDoesNotApplyToImplementedAbstractMethod(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -353,10 +314,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
     /**
      * testRuleDoesNotApplyToImplementedInterfaceMethod
      *
-     * @return void
      * @since 1.2.1
      */
-    public function testRuleDoesNotApplyToImplementedInterfaceMethod()
+    public function testRuleDoesNotApplyToImplementedInterfaceMethod(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -365,10 +325,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToMagicMethod
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToMagicMethod()
+    public function testRuleDoesNotApplyToMagicMethod(): void
     {
         $methods = array_filter(
             $this->getClass()->getMethods(),
@@ -383,7 +341,7 @@ class UnusedFormalParameterTest extends AbstractTestCase
     /**
      * testRuleDoesNotApplyToMethodWithInheritdocAnnotation
      */
-    public function testRuleDoesNotApplyToMethodWithInheritdocAnnotation()
+    public function testRuleDoesNotApplyToMethodWithInheritdocAnnotation(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -393,7 +351,7 @@ class UnusedFormalParameterTest extends AbstractTestCase
     /**
      * testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase
      */
-    public function testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase()
+    public function testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -401,10 +359,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @since 2.0.0
      */
-    public function testCompactFunctionRuleDoesNotApply()
+    public function testCompactFunctionRuleDoesNotApply(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -412,10 +369,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @since 2.0.0
      */
-    public function testCompactFunctionRuleOnlyAppliesToUsedParameters()
+    public function testCompactFunctionRuleOnlyAppliesToUsedParameters(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportMock(2));
@@ -423,10 +379,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @since 2.0.0
      */
-    public function testCompactFunctionRuleWorksCaseInsensitive()
+    public function testCompactFunctionRuleWorksCaseInsensitive(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -434,10 +389,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @since 2.0.1
      */
-    public function testNamespacedCompactFunctionRuleDoesNotApply()
+    public function testNamespacedCompactFunctionRuleDoesNotApply(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -445,10 +399,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @since 2.0.1
      */
-    public function testNamespacedCompactFunctionRuleOnlyAppliesToUsedParameters()
+    public function testNamespacedCompactFunctionRuleOnlyAppliesToUsedParameters(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportMock(2));
@@ -456,10 +409,9 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @since 2.0.1
      */
-    public function testNamespacedCompactFunctionRuleWorksCaseInsensitive()
+    public function testNamespacedCompactFunctionRuleWorksCaseInsensitive(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -476,10 +428,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToFormalParameterUsedInStringCompoundVariable()
+    public function testRuleDoesNotApplyToFormalParameterUsedInStringCompoundVariable(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -500,10 +450,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToFormalParameterUsedAsParameterInStringCompoundVariable()
+    public function testRuleDoesNotApplyToFormalParameterUsedAsParameterInStringCompoundVariable(): void
     {
         $rule = new UnusedFormalParameter();
         $rule->setReport($this->getReportWithNoViolation());
@@ -518,10 +466,8 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     public function __construct(private string $foo) {}
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPropertyPromotionParameters()
+    public function testRuleDoesNotApplyToPropertyPromotionParameters(): void
     {
         $methods = array_filter(
             $this->getClass()->getMethods(),

--- a/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -22,8 +22,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the unused formal parameter rule.
  *
- * @covers \PHPMD\Rule\UnusedFormalParameter
  * @covers \PHPMD\Rule\AbstractLocalVariable
+ * @covers \PHPMD\Rule\UnusedFormalParameter
  */
 class UnusedFormalParameterTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -314,7 +314,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @test
      * @return void
      * @since 2.0.0
      */
@@ -402,7 +401,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @test
      * @return void
      * @since 2.0.0
      */
@@ -414,7 +412,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @test
      * @return void
      * @since 2.0.0
      */
@@ -426,7 +423,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @test
      * @return void
      * @since 2.0.0
      */
@@ -438,7 +434,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @test
      * @return void
      * @since 2.0.1
      */
@@ -450,7 +445,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @test
      * @return void
      * @since 2.0.1
      */
@@ -462,7 +456,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @test
      * @return void
      * @since 2.0.1
      */

--- a/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
@@ -57,10 +57,9 @@ class UnusedLocalVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getApplyingCases
      */
-    public function testRuleAppliesTo($file)
+    public function testRuleAppliesTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule($file), static::ONE_VIOLATION, $file);
     }
@@ -69,10 +68,9 @@ class UnusedLocalVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     * @return void
      * @dataProvider getNotApplyingCases
      */
-    public function testRuleDoesNotApplyTo($file)
+    public function testRuleDoesNotApplyTo($file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule($file), static::NO_VIOLATION, $file);
     }

--- a/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedLocalVariableTest.php
@@ -22,8 +22,8 @@ use PHPMD\AbstractTestCase;
 /**
  * Test case for the unused local variable rule.
  *
- * @covers \PHPMD\Rule\UnusedLocalVariable
  * @covers \PHPMD\Rule\AbstractLocalVariable
+ * @covers \PHPMD\Rule\UnusedLocalVariable
  */
 class UnusedLocalVariableTest extends AbstractTestCase
 {

--- a/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
@@ -28,10 +28,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToUnusedPrivateField
-     *
-     * @return void
      */
-    public function testRuleAppliesToUnusedPrivateField()
+    public function testRuleAppliesToUnusedPrivateField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -40,10 +38,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToUnusedPrivateStaticField
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenFieldWithSameNameIsAccessedOnDifferentObject()
+    public function testRuleAppliesWhenFieldWithSameNameIsAccessedOnDifferentObject(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -52,10 +48,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToUnusedPrivateStaticField
-     *
-     * @return void
      */
-    public function testRuleAppliesToUnusedPrivateStaticField()
+    public function testRuleAppliesToUnusedPrivateStaticField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -64,10 +58,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnDifferentClass
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnDifferentClass()
+    public function testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnDifferentClass(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -76,10 +68,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnParent
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnParent()
+    public function testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnParent(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -98,10 +88,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenLocalVariableIsUsedInStaticMemberPrefix()
+    public function testRuleAppliesWhenLocalVariableIsUsedInStaticMemberPrefix(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -120,10 +108,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotResultInFatalErrorByCallingNonObject()
+    public function testRuleDoesNotResultInFatalErrorByCallingNonObject(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithOneViolation());
@@ -132,10 +118,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToUnusedPublicField
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToUnusedPublicField()
+    public function testRuleDoesNotApplyToUnusedPublicField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -144,10 +128,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToUnusedProtectedField
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToUnusedProtectedField()
+    public function testRuleDoesNotApplyToUnusedProtectedField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -156,10 +138,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToThisAccessedPrivateField
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToThisAccessedPrivateField()
+    public function testRuleDoesNotApplyToThisAccessedPrivateField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -168,10 +148,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToSelfAccessedPrivateField
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToSelfAccessedPrivateField()
+    public function testRuleDoesNotApplyToSelfAccessedPrivateField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -180,10 +158,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToStaticAccessedPrivateField
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToStaticAccessedPrivateField()
+    public function testRuleDoesNotApplyToStaticAccessedPrivateField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -192,10 +168,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToClassNameAccessedPrivateField
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassNameAccessedPrivateField()
+    public function testRuleDoesNotApplyToClassNameAccessedPrivateField(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -214,10 +188,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateFieldInChainedMethodCall()
+    public function testRuleDoesNotApplyToPrivateFieldInChainedMethodCall(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -236,10 +208,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateArrayFieldAccess()
+    public function testRuleDoesNotApplyToPrivateArrayFieldAccess(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -258,10 +228,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateStringIndexFieldAccess()
+    public function testRuleDoesNotApplyToPrivateStringIndexFieldAccess(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());
@@ -270,10 +238,8 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToFieldWithMethodsThatReturnArray
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToFieldWithMethodsThatReturnArray()
+    public function testRuleDoesNotApplyToFieldWithMethodsThatReturnArray(): void
     {
         $rule = new UnusedPrivateField();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateMethodTest.php
@@ -28,10 +28,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToUnusedPrivateMethod
-     *
-     * @return void
      */
-    public function testRuleAppliesToUnusedPrivateMethod()
+    public function testRuleAppliesToUnusedPrivateMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -40,10 +38,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToUnusedStaticPrivateMethod
-     *
-     * @return void
      */
-    public function testRuleAppliesToUnusedStaticPrivateMethod()
+    public function testRuleAppliesToUnusedStaticPrivateMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -52,10 +48,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToParentReferencedUnusedPrivateMethod
-     *
-     * @return void
      */
-    public function testRuleAppliesToParentReferencedUnusedPrivateMethod()
+    public function testRuleAppliesToParentReferencedUnusedPrivateMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -64,10 +58,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenMethodIsReferencedOnDifferentObject
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenMethodIsReferencedOnDifferentObject()
+    public function testRuleAppliesWhenMethodIsReferencedOnDifferentObject(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -76,10 +68,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenMethodIsReferencedOnDifferentClass
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenMethodIsReferencedOnDifferentClass()
+    public function testRuleAppliesWhenMethodIsReferencedOnDifferentClass(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -88,10 +78,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenPropertyWithSimilarNameIsReferenced
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenPropertyWithSimilarNameIsReferenced()
+    public function testRuleAppliesWhenPropertyWithSimilarNameIsReferenced(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -110,10 +98,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleAppliesWhenMethodWithSimilarNameIsInInvocationChain()
+    public function testRuleAppliesWhenMethodWithSimilarNameIsInInvocationChain(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithOneViolation());
@@ -122,10 +108,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToMethodUsedViaCallable
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToMethodUsedViaCallable()
+    public function testRuleDoesNotApplyToMethodUsedViaCallable(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -134,10 +118,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToPrivateConstructor
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateConstructor()
+    public function testRuleDoesNotApplyToPrivateConstructor(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -146,10 +128,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToPrivatePhp4Constructor
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivatePhp4Constructor()
+    public function testRuleDoesNotApplyToPrivatePhp4Constructor(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -158,10 +138,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToPrivateCloneMethod
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateCloneMethod()
+    public function testRuleDoesNotApplyToPrivateCloneMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -170,10 +148,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToThisReferencedMethod
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToThisReferencedMethod()
+    public function testRuleDoesNotApplyToThisReferencedMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -182,10 +158,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToSelfReferencedMethod
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToSelfReferencedMethod()
+    public function testRuleDoesNotApplyToSelfReferencedMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -194,10 +168,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToStaticReferencedMethod
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToStaticReferencedMethod()
+    public function testRuleDoesNotApplyToStaticReferencedMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -206,10 +178,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToClassNameReferencedMethod
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToClassNameReferencedMethod()
+    public function testRuleDoesNotApplyToClassNameReferencedMethod(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -229,10 +199,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateMethodInChainedMethodCall()
+    public function testRuleDoesNotApplyToPrivateMethodInChainedMethodCall(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());
@@ -241,10 +209,8 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo
-     *
-     * @return void
      */
-    public function testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo()
+    public function testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo(): void
     {
         $rule = new UnusedPrivateMethod();
         $rule->setReport($this->getReportWithNoViolation());

--- a/src/test/php/PHPMD/RuleSetFactoryTest.php
+++ b/src/test/php/PHPMD/RuleSetFactoryTest.php
@@ -42,230 +42,194 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetFileNameFindsXmlFileInBundledRuleSets
-     *
-     * @return void
      */
-    public function testCreateRuleSetFileNameFindsXmlFileInBundledRuleSets()
+    public function testCreateRuleSetFileNameFindsXmlFileInBundledRuleSets(): void
     {
         $factory = new RuleSetFactory();
         $ruleSet = $factory->createSingleRuleSet('codesize');
 
-        $this->assertStringContainsString('The Code Size Ruleset', $ruleSet->getDescription());
+        static::assertStringContainsString('The Code Size Ruleset', $ruleSet->getDescription());
     }
 
     /**
      * testCreateRuleSetFileNameFindsXmlFileInCurrentWorkingDirectory
-     *
-     * @return void
      */
-    public function testCreateRuleSetFileNameFindsXmlFileInCurrentWorkingDirectory()
+    public function testCreateRuleSetFileNameFindsXmlFileInCurrentWorkingDirectory(): void
     {
         self::changeWorkingDirectory('rulesets');
 
         $factory = new RuleSetFactory();
         $ruleSet = $factory->createSingleRuleSet('set1.xml');
 
-        $this->assertEquals('First description...', $ruleSet->getDescription());
+        static::assertEquals('First description...', $ruleSet->getDescription());
     }
 
     /**
      * testCreateRuleSetsReturnsArray
-     *
-     * @return void
      */
-    public function testCreateRuleSetsReturnsArray()
+    public function testCreateRuleSetsReturnsArray(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
-        $this->assertIsArray($ruleSets);
+        static::assertIsArray($ruleSets);
     }
 
     /**
      * testCreateRuleSetsForSingleFileReturnsArrayWithOneElement
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForSingleFileReturnsArrayWithOneElement()
+    public function testCreateRuleSetsForSingleFileReturnsArrayWithOneElement(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
-        $this->assertEquals(1, count($ruleSets));
+        static::assertCount(1, $ruleSets);
     }
 
     /**
      * testCreateRuleSetsForSingleFileReturnsOneRuleSetInstance
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForSingleFileReturnsOneRuleSetInstance()
+    public function testCreateRuleSetsForSingleFileReturnsOneRuleSetInstance(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
-        $this->assertInstanceOf(RuleSet::class, $ruleSets[0]);
+        static::assertInstanceOf(RuleSet::class, $ruleSets[0]);
     }
 
     /**
      * testCreateRuleSetsConfiguresExpectedRuleSetName
-     *
-     * @return void
      */
-    public function testCreateRuleSetsConfiguresExpectedRuleSetName()
+    public function testCreateRuleSetsConfiguresExpectedRuleSetName(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
-        $this->assertEquals('First Test RuleSet', $ruleSets[0]->getName());
+        static::assertEquals('First Test RuleSet', $ruleSets[0]->getName());
     }
 
     /**
      * testCreateRuleSetsConfiguresExpectedRuleSetName
-     *
-     * @return void
      */
-    public function testCreateRuleSetsConfiguresExpectedRuleSetDescription()
+    public function testCreateRuleSetsConfiguresExpectedRuleSetDescription(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
-        $this->assertEquals('First description...', $ruleSets[0]->getDescription());
+        static::assertEquals('First description...', $ruleSets[0]->getDescription());
     }
 
     /**
      * testCreateRuleSetsForTwoFilesReturnsArrayWithTwoElements
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForTwoFilesReturnsArrayWithTwoElements()
+    public function testCreateRuleSetsForTwoFilesReturnsArrayWithTwoElements(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles(
             'rulesets/set1.xml',
             'rulesets/set2.xml'
         );
-        $this->assertEquals(2, count($ruleSets));
+        static::assertCount(2, $ruleSets);
     }
 
     /**
      * testCreateRuleSetsForTwoFilesReturnsExpectedRuleSetInstances
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForTwoFilesReturnsExpectedRuleSetInstances()
+    public function testCreateRuleSetsForTwoFilesReturnsExpectedRuleSetInstances(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles(
             'rulesets/set1.xml',
             'rulesets/set2.xml'
         );
-        $this->assertInstanceOf(RuleSet::class, $ruleSets[0]);
-        $this->assertInstanceOf(RuleSet::class, $ruleSets[1]);
+        static::assertInstanceOf(RuleSet::class, $ruleSets[0]);
+        static::assertInstanceOf(RuleSet::class, $ruleSets[1]);
     }
 
     /**
      * testCreateRuleSetsForTwoConfiguresExpectedRuleSetNames
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForTwoConfiguresExpectedRuleSetNames()
+    public function testCreateRuleSetsForTwoConfiguresExpectedRuleSetNames(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles(
             'rulesets/set1.xml',
             'rulesets/set2.xml'
         );
-        $this->assertEquals('First Test RuleSet', $ruleSets[0]->getName());
-        $this->assertEquals('Second Test RuleSet', $ruleSets[1]->getName());
+        static::assertEquals('First Test RuleSet', $ruleSets[0]->getName());
+        static::assertEquals('Second Test RuleSet', $ruleSets[1]->getName());
     }
 
     /**
      * testCreateRuleSetsForTwoConfiguresExpectedRuleSetDescriptions
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForTwoConfiguresExpectedRuleSetDescriptions()
+    public function testCreateRuleSetsForTwoConfiguresExpectedRuleSetDescriptions(): void
     {
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles(
             'rulesets/set1.xml',
             'rulesets/set2.xml'
         );
-        $this->assertSame('First description...', $ruleSets[0]->getDescription());
-        $this->assertSame('Second description...', $ruleSets[1]->getDescription());
+        static::assertSame('First description...', $ruleSets[0]->getDescription());
+        static::assertSame('Second description...', $ruleSets[1]->getDescription());
     }
 
     /**
      * testCreateRuleSetsForSingleLocalFileNameReturnsArray
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForLocalFileNameReturnsArray()
+    public function testCreateRuleSetsForLocalFileNameReturnsArray(): void
     {
         self::changeWorkingDirectory();
 
         $ruleSets = $this->createRuleSetsFromFiles('rulesets/set1.xml');
-        $this->assertIsArray($ruleSets);
+        static::assertIsArray($ruleSets);
     }
 
     /**
      * testCreateRuleSetsForSingleLocalFileNameReturnsArrayWithOneElement
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForLocalFileNameReturnsArrayWithOneElement()
+    public function testCreateRuleSetsForLocalFileNameReturnsArrayWithOneElement(): void
     {
         self::changeWorkingDirectory();
 
         $ruleSets = $this->createRuleSetsFromFiles('rulesets/set1.xml');
-        $this->assertEquals(1, count($ruleSets));
+        static::assertCount(1, $ruleSets);
     }
 
     /**
      * testCreateRuleSetsForSingleLocalFileNameConfiguresExpectedRuleSetName
-     *
-     * @return void
      */
-    public function testCreateRuleSetsForLocalFileNameConfiguresExpectedRuleSetName()
+    public function testCreateRuleSetsForLocalFileNameConfiguresExpectedRuleSetName(): void
     {
         self::changeWorkingDirectory();
 
         $ruleSets = $this->createRuleSetsFromFiles('rulesets/set1.xml');
-        $this->assertEquals('First Test RuleSet', $ruleSets[0]->getName());
+        static::assertEquals('First Test RuleSet', $ruleSets[0]->getName());
     }
 
     /**
      * testCreateRuleSetsWithReferenceContainsExpectedRuleSet
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithReferenceContainsExpectedRuleSet()
+    public function testCreateRuleSetsWithReferenceContainsExpectedRuleSet(): void
     {
         self::changeWorkingDirectory();
 
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/refset1.xml');
-        $this->assertEquals('First Test RuleSet', $ruleSets[0]->getName());
+        static::assertEquals('First Test RuleSet', $ruleSets[0]->getName());
     }
 
     /**
      * testCreateRuleSetsWithReferenceContainsExpectedNumberOfRules
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithReferenceContainsExpectedNumberOfRules()
+    public function testCreateRuleSetsWithReferenceContainsExpectedNumberOfRules(): void
     {
         self::changeWorkingDirectory();
 
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/refset1.xml');
-        $this->assertEquals(4, iterator_count($ruleSets[0]));
+        static::assertEquals(4, iterator_count($ruleSets[0]));
     }
 
     /**
      * testCreateRuleSetsForLocalFileWithRuleSetReferenceNodes
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithReferenceContainsRuleInstances()
+    public function testCreateRuleSetsWithReferenceContainsRuleInstances(): void
     {
         self::changeWorkingDirectory();
 
         $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/refset1.xml');
-        $this->assertInstanceOf(AbstractRule::class, $ruleSets[0]->getRules()->current());
+        static::assertInstanceOf(AbstractRule::class, $ruleSets[0]->getRules()->current());
     }
 
     /**
      * testCreateRuleSetsWithReferenceContainsExpectedRules
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithReferenceContainsExpectedRules()
+    public function testCreateRuleSetsWithReferenceContainsExpectedRules(): void
     {
         self::changeWorkingDirectory();
 
@@ -278,30 +242,26 @@ class RuleSetFactoryTest extends AbstractTestCase
             $actual[] = $rule->getName();
         }
 
-        $this->assertEquals($expected, $actual);
+        static::assertEquals($expected, $actual);
     }
 
     /**
      * testCreateSingleRuleSetReturnsRuleSetInstance
-     *
-     * @return void
      */
-    public function testCreateSingleRuleSetReturnsRuleSetInstance()
+    public function testCreateSingleRuleSetReturnsRuleSetInstance(): void
     {
         self::changeWorkingDirectory();
 
         $factory = new RuleSetFactory();
         $ruleSet = $factory->createSingleRuleSet('set1');
 
-        $this->assertInstanceOf(RuleSet::class, $ruleSet);
+        static::assertInstanceOf(RuleSet::class, $ruleSet);
     }
 
     /**
      * Tests that the rule-set factory applies a set minimum priority filter correct.
-     *
-     * @return void
      */
-    public function testCreateRuleSetWithSpecifiedMinimumPriorityOnlyContainsMatchingRules()
+    public function testCreateRuleSetWithSpecifiedMinimumPriorityOnlyContainsMatchingRules(): void
     {
         self::changeWorkingDirectory();
 
@@ -309,15 +269,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $factory->setMinimumPriority(2);
 
         $ruleSet = $factory->createSingleRuleSet('set1');
-        $this->assertSame(1, iterator_count($ruleSet->getRules()));
+        static::assertSame(1, iterator_count($ruleSet->getRules()));
     }
 
     /**
      * Tests that the rule-set factory applies a set maximum priority filter correct.
-     *
-     * @return void
      */
-    public function testCreateRuleSetWithSpecifiedMaximumPriorityOnlyContainsMatchingRules()
+    public function testCreateRuleSetWithSpecifiedMaximumPriorityOnlyContainsMatchingRules(): void
     {
         self::changeWorkingDirectory();
 
@@ -325,15 +283,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $factory->setMaximumPriority(2);
 
         $ruleSet = $factory->createSingleRuleSet('set1');
-        $this->assertSame(1, iterator_count($ruleSet->getRules()));
+        static::assertSame(1, iterator_count($ruleSet->getRules()));
     }
 
     /**
      * Tests that the rule-set factory applies a set maximum priority filter correct.
-     *
-     * @return void
      */
-    public function testCreateRuleSetWithSpecifiedPrioritiesOnlyContainsMatchingRules()
+    public function testCreateRuleSetWithSpecifiedPrioritiesOnlyContainsMatchingRules(): void
     {
         self::changeWorkingDirectory();
 
@@ -342,15 +298,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $factory->setMaximumPriority(2);
 
         $ruleSet = $factory->createSingleRuleSet('set1');
-        $this->assertCount(0, $ruleSet->getRules());
+        static::assertCount(0, $ruleSet->getRules());
     }
 
     /**
      * testCreateRuleWithExcludePattern
-     *
-     * @return void
      */
-    public function testCreateRuleWithExcludePattern()
+    public function testCreateRuleWithExcludePattern(): void
     {
         self::changeWorkingDirectory();
 
@@ -362,15 +316,13 @@ class RuleSetFactoryTest extends AbstractTestCase
             '*sourceExcluded\*.php',
         ];
 
-        $this->assertEquals($expected, $excludes);
+        static::assertEquals($expected, $excludes);
     }
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesPrioritySetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesPrioritySetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesPrioritySetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -378,15 +330,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $ruleSets = $factory->createRuleSets('refset3');
 
         $rule = $ruleSets[0]->getRules()->current();
-        $this->assertSame(4, $rule->getPriority());
+        static::assertSame(4, $rule->getPriority());
     }
 
     /**
      * testCreateRuleWithExpectedExample
-     *
-     * @return void
      */
-    public function testCreateRuleWithExpectedExample()
+    public function testCreateRuleWithExpectedExample(): void
     {
         self::changeWorkingDirectory();
 
@@ -394,15 +344,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $ruleSets = $factory->createRuleSets('set1');
 
         $rule = $ruleSets[0]->getRules()->current();
-        $this->assertEquals([__FUNCTION__], $rule->getExamples());
+        static::assertEquals([__FUNCTION__], $rule->getExamples());
     }
 
     /**
      * testCreateRuleWithExpectedMultipleExamples
-     *
-     * @return void
      */
-    public function testCreateRuleWithExpectedMultipleExamples()
+    public function testCreateRuleWithExpectedMultipleExamples(): void
     {
         self::changeWorkingDirectory();
 
@@ -410,15 +358,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $ruleSets = $factory->createRuleSets('set2');
 
         $rule = $ruleSets[0]->getRules()->current();
-        $this->assertEquals([__FUNCTION__ . 'One', __FUNCTION__ . 'Two'], $rule->getExamples());
+        static::assertEquals([__FUNCTION__ . 'One', __FUNCTION__ . 'Two'], $rule->getExamples());
     }
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesDescriptionSetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesDescriptionSetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesDescriptionSetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -426,15 +372,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $ruleSets = $factory->createRuleSets('refset3');
 
         $rule = $ruleSets[0]->getRules()->current();
-        $this->assertSame('description 42', $rule->getDescription());
+        static::assertSame('description 42', $rule->getDescription());
     }
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesPropertySetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesPropertySetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesPropertySetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -442,15 +386,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $ruleSets = $factory->createRuleSets('refset3');
 
         $rule = $ruleSets[0]->getRules()->current();
-        $this->assertSame(42, $rule->getIntProperty('foo'));
+        static::assertSame(42, $rule->getIntProperty('foo'));
     }
 
     /**
      * testFactorySupportsAlternativeSyntaxForPropertyValue
-     *
-     * @return void
      */
-    public function testFactorySupportsAlternativeSyntaxForPropertyValue()
+    public function testFactorySupportsAlternativeSyntaxForPropertyValue(): void
     {
         self::changeWorkingDirectory();
 
@@ -458,15 +400,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $ruleSets = $factory->createRuleSets('alternative-property-value-syntax');
 
         $rule = $ruleSets[0]->getRules()->current();
-        $this->assertSame(42, $rule->getIntProperty('foo'));
+        static::assertSame(42, $rule->getIntProperty('foo'));
     }
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesExamplesSetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesExamplesSetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesExamplesSetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -476,15 +416,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $rule = $ruleSets[0]->getRules()->current();
 
         $examples = $rule->getExamples();
-        $this->assertEquals('foreach ($foo as $bar) { echo $bar; }', $examples[0]);
+        static::assertEquals('foreach ($foo as $bar) { echo $bar; }', $examples[0]);
     }
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesExamplesSetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesNameSetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesNameSetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -492,15 +430,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $ruleSets = $factory->createRuleSets('refset4');
 
         $rule = $ruleSets[0]->getRules()->current();
-        $this->assertEquals('Name overwritten', $rule->getName());
+        static::assertEquals('Name overwritten', $rule->getName());
     }
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesMessageSetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesMessageSetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesMessageSetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -508,15 +444,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $ruleSets = $factory->createRuleSets('refset4');
 
         $rule = $ruleSets[0]->getRules()->current();
-        $this->assertEquals('Message overwritten', $rule->getMessage());
+        static::assertEquals('Message overwritten', $rule->getMessage());
     }
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesExtInfoUrlSetting
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceThatOverwritesExtInfoUrlSetting()
+    public function testCreateRuleSetsWithRuleReferenceThatOverwritesExtInfoUrlSetting(): void
     {
         self::changeWorkingDirectory();
 
@@ -524,15 +458,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $ruleSets = $factory->createRuleSets('refset4');
 
         $rule = $ruleSets[0]->getRules()->current();
-        $this->assertEquals('http://example.com/overwritten', $rule->getExternalInfoUrl());
+        static::assertEquals('http://example.com/overwritten', $rule->getExternalInfoUrl());
     }
 
     /**
      * testCreateRuleSetsWithRuleReferenceNotContainsExcludedRule
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceNotContainsExcludedRule()
+    public function testCreateRuleSetsWithRuleReferenceNotContainsExcludedRule(): void
     {
         self::changeWorkingDirectory();
 
@@ -540,15 +472,13 @@ class RuleSetFactoryTest extends AbstractTestCase
         $ruleSets = $factory->createRuleSets('refset-exclude-one');
 
         $rules = $ruleSets[0]->getRules();
-        $this->assertEquals(1, iterator_count($rules));
+        static::assertEquals(1, iterator_count($rules));
     }
 
     /**
      * testCreateRuleSetsWithRuleReferenceNotContainsExcludedRules
-     *
-     * @return void
      */
-    public function testCreateRuleSetsWithRuleReferenceNotContainsExcludedRules()
+    public function testCreateRuleSetsWithRuleReferenceNotContainsExcludedRules(): void
     {
         self::changeWorkingDirectory();
 
@@ -556,17 +486,16 @@ class RuleSetFactoryTest extends AbstractTestCase
         $ruleSets = $factory->createRuleSets('refset-exclude-all');
 
         $rules = $ruleSets[0]->getRules();
-        $this->assertEquals(0, iterator_count($rules));
+        static::assertEquals(0, iterator_count($rules));
     }
 
     /**
      * Tests that the factory throws the expected exception for an invalid ruleset
      * identifier.
      *
-     * @return void
      * @covers \PHPMD\Exception\RuleSetNotFoundException
      */
-    public function testCreateRuleSetsThrowsExceptionForInvalidIdentifier()
+    public function testCreateRuleSetsThrowsExceptionForInvalidIdentifier(): void
     {
         self::expectExceptionObject(new RuleSetNotFoundException('foo-bar-ruleset-23'));
 
@@ -579,10 +508,9 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Tests that the factory throws an exception when the source code filename
      * for the configured rule does not exist.
      *
-     * @return void
      * @covers \PHPMD\Exception\RuleClassFileNotFoundException
      */
-    public function testCreateRuleSetsThrowsExceptionWhenClassFileNotInIncludePath()
+    public function testCreateRuleSetsThrowsExceptionWhenClassFileNotInIncludePath(): void
     {
         self::expectExceptionObject(new RuleClassFileNotFoundException(
             ClassFileNotFoundRule::class,
@@ -598,10 +526,9 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Tests that the factory throws the expected exception when a rule class
      * cannot be found.
      *
-     * @return void
      * @covers \PHPMD\Exception\RuleClassNotFoundException
      */
-    public function testCreateRuleSetThrowsExceptionWhenFileNotContainsClass()
+    public function testCreateRuleSetThrowsExceptionWhenFileNotContainsClass(): void
     {
         self::expectExceptionObject(new RuleClassNotFoundException(
             ClassNotFoundRule::class,
@@ -616,10 +543,9 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Tests that the factory throws the expected exception when a rule class
      * cannot be found.
      *
-     * @return void
      * @covers \PHPMD\Exception\RuleClassNotFoundException
      */
-    public function testCreateRuleSetsThrowsExpectedExceptionForInvalidXmlFile()
+    public function testCreateRuleSetsThrowsExpectedExceptionForInvalidXmlFile(): void
     {
         self::expectException(RuntimeException::class);
 
@@ -631,10 +557,8 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsActivatesStrictModeOnRuleSet
-     *
-     * @return void
      */
-    public function testCreateRuleSetsActivatesStrictModeOnRuleSet()
+    public function testCreateRuleSetsActivatesStrictModeOnRuleSet(): void
     {
         $fileName = self::createFileUri('rulesets/set1.xml');
 
@@ -643,7 +567,7 @@ class RuleSetFactoryTest extends AbstractTestCase
 
         $ruleSets = $factory->createRuleSets($fileName);
 
-        $this->assertTrue($ruleSets[0]->isStrict());
+        static::assertTrue($ruleSets[0]->isStrict());
     }
 
     /**
@@ -651,10 +575,9 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Also implicitly tests (by parsing the ruleset) that
      * reference-by-includepath and explicit-classfile-declaration works.
      *
-     * @return void
      * @throws Exception
      */
-    public function testAddPHPIncludePath()
+    public function testAddPHPIncludePath(): void
     {
         $includePathBefore = get_include_path();
 
@@ -665,17 +588,18 @@ class RuleSetFactoryTest extends AbstractTestCase
             $factory = new RuleSetFactory();
             $factory->createRuleSets($fileName);
 
-            $expectedIncludePath = "/foo/bar/baz";
+            $expectedIncludePath = '/foo/bar/baz';
             $actualIncludePaths = explode(PATH_SEPARATOR, get_include_path());
-            $isIncludePathPresent = in_array($expectedIncludePath, $actualIncludePaths);
+            $isIncludePathPresent = in_array($expectedIncludePath, $actualIncludePaths, true);
         } catch (Exception $exception) {
             set_include_path($includePathBefore);
+
             throw $exception;
         }
 
         set_include_path($includePathBefore);
 
-        $this->assertTrue(
+        static::assertTrue(
             $isIncludePathPresent,
             "The include-path from '{$rulesetFilepath}' was not set!"
         );
@@ -684,10 +608,9 @@ class RuleSetFactoryTest extends AbstractTestCase
     /**
      * Checks if PHPMD doesn't treat directories named as code rule as files
      *
-     * @return void
      * @link https://github.com/phpmd/phpmd/issues/47
      */
-    public function testIfGettingRuleFilePathExcludeUnreadablePaths()
+    public function testIfGettingRuleFilePathExcludeUnreadablePaths(): void
     {
         self::changeWorkingDirectory(__DIR__);
         $factory = new RuleSetFactory();
@@ -696,7 +619,7 @@ class RuleSetFactoryTest extends AbstractTestCase
 
         foreach ($this->getPathsForFileAccessTest() as $path) {
             try {
-                $this->assertEquals(
+                static::assertEquals(
                     [
                         '*sourceExcluded/*.php',
                         '*sourceExcluded\*.php',
@@ -709,21 +632,21 @@ class RuleSetFactoryTest extends AbstractTestCase
                 $runtimeExceptionCount++;
             }
         }
-        $this->assertEquals(0, $runtimeExceptionCount);
-        $this->assertEquals(5, $ruleSetNotFoundExceptionCount);
+        static::assertEquals(0, $runtimeExceptionCount);
+        static::assertEquals(5, $ruleSetNotFoundExceptionCount);
     }
 
     /**
      * Checks the ruleset XML files provided with PHPMD all provide externalInfoUrls
      *
      * @param string $file The path to the ruleset xml to test
-     * @return void
      * @dataProvider getDefaultRuleSets
      */
-    public function testDefaultRuleSetsProvideExternalInfoUrls($file)
+    public function testDefaultRuleSetsProvideExternalInfoUrls($file): void
     {
         $ruleSets = $this->createRuleSetsFromFiles($file);
         $ruleSet = $ruleSets[0];
+
         /** @var Rule $rule */
         foreach ($ruleSet->getRules() as $rule) {
             $message = sprintf(
@@ -732,7 +655,7 @@ class RuleSetFactoryTest extends AbstractTestCase
                 $ruleSet->getName()
             );
 
-            $this->assertNotEmpty($rule->getExternalInfoUrl(), $message);
+            static::assertNotEmpty($rule->getExternalInfoUrl(), $message);
         }
     }
 

--- a/src/test/php/PHPMD/RuleSetTest.php
+++ b/src/test/php/PHPMD/RuleSetTest.php
@@ -36,50 +36,42 @@ class RuleSetTest extends AbstractTestCase
 {
     /**
      * testGetRuleByNameReturnsNullWhenNoMatchingRuleExists
-     *
-     * @return void
      */
-    public function testGetRuleByNameThrowsExceptionWhenNoMatchingRuleExists()
+    public function testGetRuleByNameThrowsExceptionWhenNoMatchingRuleExists(): void
     {
         self::expectException(RuleByNameNotFoundException::class);
 
         $ruleSet = $this->createRuleSetFixture();
-        $this->assertNull($ruleSet->getRuleByName(__FUNCTION__));
+        static::assertNull($ruleSet->getRuleByName(__FUNCTION__));
     }
 
     /**
      * testGetRuleByNameReturnsMatchingRuleInstance
-     *
-     * @return void
      */
-    public function testGetRuleByNameReturnsMatchingRuleInstance()
+    public function testGetRuleByNameReturnsMatchingRuleInstance(): void
     {
         $ruleSet = $this->createRuleSetFixture(__FUNCTION__, __CLASS__, __METHOD__);
         $rule = $ruleSet->getRuleByName(__CLASS__);
 
-        $this->assertEquals(__CLASS__, $rule->getName());
+        static::assertEquals(__CLASS__, $rule->getName());
     }
 
     /**
      * testApplyNotInvokesRuleWhenSuppressAnnotationExists
-     *
-     * @return void
      */
-    public function testApplyNotInvokesRuleWhenSuppressAnnotationExists()
+    public function testApplyNotInvokesRuleWhenSuppressAnnotationExists(): void
     {
         $ruleSet = $this->createRuleSetFixture(__FUNCTION__);
         $ruleSet->setReport($this->getReportWithNoViolation());
         $ruleSet->apply($this->getClass());
 
-        $this->assertNull($ruleSet->getRuleByName(__FUNCTION__)->node);
+        static::assertNull($ruleSet->getRuleByName(__FUNCTION__)->node);
     }
 
     /**
      * testApplyInvokesRuleWhenStrictModeIsSet
-     *
-     * @return void
      */
-    public function testApplyInvokesRuleWhenStrictModeIsSet()
+    public function testApplyInvokesRuleWhenStrictModeIsSet(): void
     {
         $ruleSet = $this->createRuleSetFixture(__FUNCTION__);
         $ruleSet->setReport($this->getReportWithNoViolation());
@@ -88,32 +80,32 @@ class RuleSetTest extends AbstractTestCase
         $class = $this->getClass();
         $ruleSet->apply($class);
 
-        $this->assertSame($class, $ruleSet->getRuleByName(__FUNCTION__)->node);
+        static::assertSame($class, $ruleSet->getRuleByName(__FUNCTION__)->node);
     }
 
-    public function testDescriptionCanBeChanged()
+    public function testDescriptionCanBeChanged(): void
     {
         $ruleSet = new RuleSet();
 
-        $this->assertSame('', $ruleSet->getDescription());
+        static::assertSame('', $ruleSet->getDescription());
 
         $ruleSet->setDescription('foobar');
 
-        $this->assertSame('foobar', $ruleSet->getDescription());
+        static::assertSame('foobar', $ruleSet->getDescription());
     }
 
-    public function testStrictnessCanBeEnabled()
+    public function testStrictnessCanBeEnabled(): void
     {
         $ruleSet = new RuleSet();
 
-        $this->assertFalse($ruleSet->isStrict());
+        static::assertFalse($ruleSet->isStrict());
 
         $ruleSet->setStrict();
 
-        $this->assertTrue($ruleSet->isStrict());
+        static::assertTrue($ruleSet->isStrict());
     }
 
-    public function testReport()
+    public function testReport(): void
     {
         $ruleSet = new RuleSet();
         $ruleSet->setReport(new Report());
@@ -125,10 +117,10 @@ class RuleSetTest extends AbstractTestCase
             $iteration[] = $rule;
         }
 
-        $this->assertSame([$else], $iteration);
+        static::assertSame([$else], $iteration);
         $ruleSet->apply(new ClassNode(new ASTClass('FooBar')));
 
-        $this->assertCount(0, $ruleSet->getReport()->getRuleViolations());
+        static::assertCount(0, $ruleSet->getReport()->getRuleViolations());
 
         $function = new ASTFunction('fooBar');
         $statement = new ASTIfStatement('if');
@@ -138,7 +130,7 @@ class RuleSetTest extends AbstractTestCase
         $function->addChild($statement);
         $ruleSet->apply(new FunctionNode($function));
 
-        $this->assertCount(1, $ruleSet->getReport()->getRuleViolations());
+        static::assertCount(1, $ruleSet->getReport()->getRuleViolations());
     }
 
     /**

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -172,8 +172,8 @@ class RuleTest extends AbstractTestCase
      * testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
      * @return void
-     * @covers ::getStringProperty
      * @covers ::getProperty
+     * @covers ::getStringProperty
      */
     public function testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists()
     {
@@ -188,8 +188,8 @@ class RuleTest extends AbstractTestCase
      * testGetStringPropertyReturnsStringValue
      *
      * @return void
-     * @covers ::getStringProperty
      * @covers ::getProperty
+     * @covers ::getStringProperty
      */
     public function testGetStringPropertyReturnsString()
     {
@@ -204,8 +204,8 @@ class RuleTest extends AbstractTestCase
      * Tests the getStringProperty method with a fallback value
      *
      * @return void
-     * @covers ::getStringProperty
      * @covers ::getProperty
+     * @covers ::getStringProperty
      */
     public function testGetStringPropertyReturnsFallbackString()
     {

--- a/src/test/php/PHPMD/RuleTest.php
+++ b/src/test/php/PHPMD/RuleTest.php
@@ -29,106 +29,99 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetBooleanPropertyReturnsTrueForStringValue1
      *
-     * @return void
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
-    public function testGetBooleanPropertyReturnsTrueForStringValue1()
+    public function testGetBooleanPropertyReturnsTrueForStringValue1(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->addProperty(__FUNCTION__, '1');
 
-        $this->assertTrue($rule->getBooleanProperty(__FUNCTION__));
+        static::assertTrue($rule->getBooleanProperty(__FUNCTION__));
     }
 
     /**
      * testGetBooleanPropertyReturnsTrueForStringValueOn
      *
-     * @return void
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
-    public function testGetBooleanPropertyReturnsTrueForStringValueOn()
+    public function testGetBooleanPropertyReturnsTrueForStringValueOn(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->addProperty(__FUNCTION__, 'on');
 
-        $this->assertTrue($rule->getBooleanProperty(__FUNCTION__));
+        static::assertTrue($rule->getBooleanProperty(__FUNCTION__));
     }
 
     /**
      * testGetBooleanPropertyReturnsTrueForStringValueTrue
      *
-     * @return void
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
-    public function testGetBooleanPropertyReturnsTrueForStringValueTrue()
+    public function testGetBooleanPropertyReturnsTrueForStringValueTrue(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->addProperty(__FUNCTION__, 'true');
 
-        $this->assertTrue($rule->getBooleanProperty(__FUNCTION__));
+        static::assertTrue($rule->getBooleanProperty(__FUNCTION__));
     }
 
     /**
      * testGetBooleanPropertyReturnsTrueForDifferentStringValue
      *
-     * @return void
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
-    public function testGetBooleanPropertyReturnsTrueForDifferentStringValue()
+    public function testGetBooleanPropertyReturnsTrueForDifferentStringValue(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->addProperty(__FUNCTION__, 'True');
 
-        $this->assertFalse($rule->getBooleanProperty(__FUNCTION__));
+        static::assertFalse($rule->getBooleanProperty(__FUNCTION__));
     }
 
     /**
      * Tests the getBooleanProperty method with a fallback value
      *
-     * @return void
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
-    public function testGetBooleanPropertyReturnsFallbackString()
+    public function testGetBooleanPropertyReturnsFallbackString(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
 
-        $this->assertTrue($rule->getBooleanProperty(__FUNCTION__, true));
+        static::assertTrue($rule->getBooleanProperty(__FUNCTION__, true));
     }
 
     /**
      * testGetIntPropertyReturnsValueOfTypeInteger
      *
-     * @return void
      * @covers ::getIntProperty
      * @covers ::getProperty
      */
-    public function testGetIntPropertyReturnsValueOfTypeInteger()
+    public function testGetIntPropertyReturnsValueOfTypeInteger(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->addProperty(__FUNCTION__, '42.3');
 
-        $this->assertSame(42, $rule->getIntProperty(__FUNCTION__));
+        static::assertSame(42, $rule->getIntProperty(__FUNCTION__));
     }
 
     /**
      * testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
-     * @return void
      * @covers ::getIntProperty
      * @covers ::getProperty
      */
-    public function testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists()
+    public function testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists(): void
     {
         self::expectException(OutOfBoundsException::class);
 
@@ -140,26 +133,24 @@ class RuleTest extends AbstractTestCase
     /**
      * Tests the getIntProperty method with a fallback value
      *
-     * @return void
      * @covers ::getIntProperty
      * @covers ::getProperty
      */
-    public function testGetIntPropertyReturnsFallbackString()
+    public function testGetIntPropertyReturnsFallbackString(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
 
-        $this->assertSame(123, $rule->getIntProperty(__FUNCTION__, '123'));
+        static::assertSame(123, $rule->getIntProperty(__FUNCTION__, '123'));
     }
 
     /**
      * testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
-     * @return void
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
-    public function testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists()
+    public function testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists(): void
     {
         self::expectException(OutOfBoundsException::class);
 
@@ -171,11 +162,10 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
-     * @return void
      * @covers ::getProperty
      * @covers ::getStringProperty
      */
-    public function testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists()
+    public function testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists(): void
     {
         self::expectException(OutOfBoundsException::class);
 
@@ -187,31 +177,29 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetStringPropertyReturnsStringValue
      *
-     * @return void
      * @covers ::getProperty
      * @covers ::getStringProperty
      */
-    public function testGetStringPropertyReturnsString()
+    public function testGetStringPropertyReturnsString(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
         $rule->addProperty(__FUNCTION__, 'Forty Two');
 
-        $this->assertSame('Forty Two', $rule->getStringProperty(__FUNCTION__));
+        static::assertSame('Forty Two', $rule->getStringProperty(__FUNCTION__));
     }
 
     /**
      * Tests the getStringProperty method with a fallback value
      *
-     * @return void
      * @covers ::getProperty
      * @covers ::getStringProperty
      */
-    public function testGetStringPropertyReturnsFallbackString()
+    public function testGetStringPropertyReturnsFallbackString(): void
     {
         /** @var AbstractRule $rule */
         $rule = $this->getMockForAbstractClass(AbstractRule::class);
 
-        $this->assertSame('fallback', $rule->getStringProperty(__FUNCTION__, 'fallback'));
+        static::assertSame('fallback', $rule->getStringProperty(__FUNCTION__, 'fallback'));
     }
 }

--- a/src/test/php/PHPMD/RuleViolationTest.php
+++ b/src/test/php/PHPMD/RuleViolationTest.php
@@ -27,10 +27,7 @@ use PHPMD\Node\NodeInfo;
  */
 class RuleViolationTest extends AbstractTestCase
 {
-    /**
-     * @return void
-     */
-    public function testNodeInfoGetters()
+    public function testNodeInfoGetters(): void
     {
         $rule = $this->getRuleMock();
 

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -731,7 +731,7 @@ class CommandLineOptionsTest extends AbstractTestCase
             ['sarif', SARIFRenderer::class],
             ['PHPMD_Test_Renderer_PEARRenderer', 'PHPMD_Test_Renderer_PEARRenderer'],
             [NamespaceRenderer::class, NamespaceRenderer::class],
-            /* Test what happens when class already exists. */
+            // Test what happens when class already exists.
             [NamespaceRenderer::class, NamespaceRenderer::class],
         ];
     }

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -47,22 +47,20 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testAssignsInputArgumentToInputProperty
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testAssignsInputArgumentToInputProperty()
+    public function testAssignsInputArgumentToInputProperty(): void
     {
         $args = ['foo.php', __FILE__, 'text', 'design'];
         $opts = new CommandLineOptions($args);
 
-        self::assertEquals(__FILE__, $opts->getInputPath());
+        static::assertEquals(__FILE__, $opts->getInputPath());
     }
 
     /**
-     * @return void
      * @since 2.14.0
      */
-    public function testVerbose()
+    public function testVerbose(): void
     {
         $args = ['foo.php', __FILE__, 'text', 'design', '-vvv'];
         $opts = new CommandLineOptions($args);
@@ -73,14 +71,13 @@ class CommandLineOptionsTest extends AbstractTestCase
 
         $verbosityLevel = $verbosityExtractor->getValue($renbderer);
 
-        self::assertSame(OutputInterface::VERBOSITY_DEBUG, $verbosityLevel);
+        static::assertSame(OutputInterface::VERBOSITY_DEBUG, $verbosityLevel);
     }
 
     /**
-     * @return void
      * @since 2.14.0
      */
-    public function testColored()
+    public function testColored(): void
     {
         $args = ['foo.php', __FILE__, 'text', 'design', '--color'];
         $opts = new CommandLineOptions($args);
@@ -91,71 +88,66 @@ class CommandLineOptionsTest extends AbstractTestCase
 
         $colored = $coloredExtractor->getValue($renderer);
 
-        self::assertTrue($colored);
+        static::assertTrue($colored);
     }
 
     /**
-     * @return void
      * @since 2.14.0
      */
-    public function testStdInDashShortCut()
+    public function testStdInDashShortCut(): void
     {
         $args = ['foo.php', '-', 'text', 'design'];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame('php://stdin', $opts->getInputPath());
+        static::assertSame('php://stdin', $opts->getInputPath());
     }
 
     /**
-     * @return void
      * @since 2.14.0
      */
-    public function testMultipleFiles()
+    public function testMultipleFiles(): void
     {
         // What happen when calling: phpmd src/*Service.php text design
         $args = ['foo.php', 'src/FooService.php', 'src/BarService.php', 'text', 'design'];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame('src/FooService.php,src/BarService.php', $opts->getInputPath());
-        self::assertSame('text', $opts->getReportFormat());
-        self::assertSame('design', $opts->getRuleSets());
+        static::assertSame('src/FooService.php,src/BarService.php', $opts->getInputPath());
+        static::assertSame('text', $opts->getReportFormat());
+        static::assertSame('design', $opts->getRuleSets());
     }
 
     /**
      * testAssignsFormatArgumentToReportFormatProperty
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testAssignsFormatArgumentToReportFormatProperty()
+    public function testAssignsFormatArgumentToReportFormatProperty(): void
     {
         $args = ['foo.php', __FILE__, 'text', 'design'];
         $opts = new CommandLineOptions($args);
 
-        self::assertEquals('text', $opts->getReportFormat());
+        static::assertEquals('text', $opts->getReportFormat());
     }
 
     /**
      * testAssignsRuleSetsArgumentToRuleSetProperty
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testAssignsRuleSetsArgumentToRuleSetProperty()
+    public function testAssignsRuleSetsArgumentToRuleSetProperty(): void
     {
         $args = ['foo.php', __FILE__, 'text', 'design'];
         $opts = new CommandLineOptions($args);
 
-        self::assertEquals('design', $opts->getRuleSets());
+        static::assertEquals('design', $opts->getRuleSets());
     }
 
     /**
      * testThrowsExpectedExceptionWhenRequiredArgumentsNotSet
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testThrowsExpectedExceptionWhenRequiredArgumentsNotSet()
+    public function testThrowsExpectedExceptionWhenRequiredArgumentsNotSet(): void
     {
         self::expectException(InvalidArgumentException::class);
 
@@ -166,7 +158,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
-    public function testThrowsExpectedExceptionWhenOptionNotFound()
+    public function testThrowsExpectedExceptionWhenOptionNotFound(): void
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage(
@@ -183,7 +175,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
-    public function testThrowsExpectedExceptionWhenOptionNotFoundInFront()
+    public function testThrowsExpectedExceptionWhenOptionNotFoundInFront(): void
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage(
@@ -200,7 +192,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
-    public function testThrowsExpectedExceptionWhenOptionNotFoundUsingArgumentSeparator()
+    public function testThrowsExpectedExceptionWhenOptionNotFoundUsingArgumentSeparator(): void
     {
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage(
@@ -217,7 +209,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
-    public function testThrowsExpectedExceptionWhenBooleanOptionReceiveValue()
+    public function testThrowsExpectedExceptionWhenBooleanOptionReceiveValue(): void
     {
         self::expectExceptionObject(new InvalidArgumentException(
             '--color option does not accept a value',
@@ -230,80 +222,76 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
-    public function testOptionEqualSyntax()
+    public function testOptionEqualSyntax(): void
     {
         $args = [__FILE__, '--exclude=*/vendor/*', '-', 'text', 'design'];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame('*/vendor/*', $opts->getIgnore());
+        static::assertSame('*/vendor/*', $opts->getIgnore());
     }
 
     /**
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
-    public function testArgumentSeparatorEnforced()
+    public function testArgumentSeparatorEnforced(): void
     {
         $args = [__FILE__, '--', '--help', 'text', 'design'];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame('--help', $opts->getInputPath());
+        static::assertSame('--help', $opts->getInputPath());
     }
 
     /**
      * testAssignsInputFileOptionToInputPathProperty
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testAssignsInputFileOptionToInputPathProperty()
+    public function testAssignsInputFileOptionToInputPathProperty(): void
     {
         $uri = self::createResourceUriForTest('inputfile.txt');
 
         $args = ['foo.php', 'text', 'design', '--inputfile', $uri];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame('Dir1/Class1.php,Dir2/Class2.php', $opts->getInputPath());
+        static::assertSame('Dir1/Class1.php,Dir2/Class2.php', $opts->getInputPath());
     }
 
     /**
      * testAssignsFormatArgumentCorrectWhenCalledWithInputFile
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testAssignsFormatArgumentCorrectWhenCalledWithInputFile()
+    public function testAssignsFormatArgumentCorrectWhenCalledWithInputFile(): void
     {
         $uri = self::createResourceUriForTest('inputfile.txt');
 
         $args = ['foo.php', 'text', 'design', '--inputfile', $uri];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame('text', $opts->getReportFormat());
+        static::assertSame('text', $opts->getReportFormat());
     }
 
     /**
      * testAssignsRuleSetsArgumentCorrectWhenCalledWithInputFile
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testAssignsRuleSetsArgumentCorrectWhenCalledWithInputFile()
+    public function testAssignsRuleSetsArgumentCorrectWhenCalledWithInputFile(): void
     {
         $uri = self::createResourceUriForTest('inputfile.txt');
 
         $args = ['foo.php', 'text', 'design', '--inputfile', $uri];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame('design', $opts->getRuleSets());
+        static::assertSame('design', $opts->getRuleSets());
     }
 
     /**
      * testThrowsExpectedExceptionWhenInputFileNotExists
      *
-     * @return void
      * @since 1.1.0
      */
-    public function testThrowsExpectedExceptionWhenInputFileNotExists()
+    public function testThrowsExpectedExceptionWhenInputFileNotExists(): void
     {
         self::expectExceptionObject(new InvalidArgumentException(
             "Unable to load 'inputfail.txt'.",
@@ -315,119 +303,101 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * testHasVersionReturnsFalseByDefault
-     *
-     * @return void
      */
-    public function testHasVersionReturnsFalseByDefault()
+    public function testHasVersionReturnsFalseByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'unusedcode'];
         $opts = new CommandLineOptions($args);
 
-        self::assertFalse($opts->hasVersion());
+        static::assertFalse($opts->hasVersion());
     }
 
     /**
      * testCliOptionsAcceptsVersionArgument
-     *
-     * @return void
      */
-    public function testCliOptionsAcceptsVersionArgument()
+    public function testCliOptionsAcceptsVersionArgument(): void
     {
         $args = [__FILE__, '--version'];
         $opts = new CommandLineOptions($args);
 
-        self::assertTrue($opts->hasVersion());
+        static::assertTrue($opts->hasVersion());
     }
 
     /**
      * Tests if ignoreErrorsOnExit returns false by default
-     *
-     * @return void
      */
-    public function testIgnoreErrorsOnExitReturnsFalseByDefault()
+    public function testIgnoreErrorsOnExitReturnsFalseByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'unusedcode'];
         $opts = new CommandLineOptions($args);
 
-        self::assertFalse($opts->ignoreErrorsOnExit());
+        static::assertFalse($opts->ignoreErrorsOnExit());
     }
 
     /**
      * Tests if CLI options accepts ignoreErrorsOnExit argument
-     *
-     * @return void
      */
-    public function testCliOptionsAcceptsIgnoreErrorsOnExitArgument()
+    public function testCliOptionsAcceptsIgnoreErrorsOnExitArgument(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'unusedcode', '--ignore-errors-on-exit'];
         $opts = new CommandLineOptions($args);
 
-        self::assertTrue($opts->ignoreErrorsOnExit());
+        static::assertTrue($opts->ignoreErrorsOnExit());
     }
 
     /**
      * Tests if CLI usage contains ignoreErrorsOnExit option
-     *
-     * @return void
      */
-    public function testCliUsageContainsIgnoreErrorsOnExitOption()
+    public function testCliUsageContainsIgnoreErrorsOnExitOption(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
 
-        self::assertStringContainsString('--ignore-errors-on-exit:', $opts->usage());
+        static::assertStringContainsString('--ignore-errors-on-exit:', $opts->usage());
     }
 
     /**
      * Tests if ignoreViolationsOnExit returns false by default
-     *
-     * @return void
      */
-    public function testIgnoreViolationsOnExitReturnsFalseByDefault()
+    public function testIgnoreViolationsOnExitReturnsFalseByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'unusedcode'];
         $opts = new CommandLineOptions($args);
 
-        self::assertFalse($opts->ignoreViolationsOnExit());
+        static::assertFalse($opts->ignoreViolationsOnExit());
     }
 
     /**
      * Tests if CLI options accepts ignoreViolationsOnExit argument
-     *
-     * @return void
      */
-    public function testCliOptionsAcceptsIgnoreViolationsOnExitArgument()
+    public function testCliOptionsAcceptsIgnoreViolationsOnExitArgument(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'unusedcode', '--ignore-violations-on-exit'];
         $opts = new CommandLineOptions($args);
 
-        self::assertTrue($opts->ignoreViolationsOnExit());
+        static::assertTrue($opts->ignoreViolationsOnExit());
     }
 
     /**
      * Tests if CLI usage contains ignoreViolationsOnExit option
-     *
-     * @return void
      */
-    public function testCliUsageContainsIgnoreViolationsOnExitOption()
+    public function testCliUsageContainsIgnoreViolationsOnExitOption(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
 
-        self::assertStringContainsString('--ignore-violations-on-exit:', $opts->usage());
+        static::assertStringContainsString('--ignore-violations-on-exit:', $opts->usage());
     }
 
     /**
      * Tests if CLI usage contains the auto-discovered renderers
-     *
-     * @return void
      */
-    public function testCliUsageContainsAutoDiscoveredRenderers()
+    public function testCliUsageContainsAutoDiscoveredRenderers(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
 
-        self::assertStringContainsString(
+        static::assertStringContainsString(
             'Available formats: ansi, baseline, checkstyle, github, gitlab, html, json, sarif, text, xml.',
             $opts->usage()
         );
@@ -435,188 +405,142 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * testCliUsageContainsStrictOption
-     *
-     * @return void
      */
-    public function testCliUsageContainsStrictOption()
+    public function testCliUsageContainsStrictOption(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
 
-        self::assertStringContainsString('--strict:', $opts->usage());
+        static::assertStringContainsString('--strict:', $opts->usage());
     }
 
     /**
      * testCliOptionsIsStrictReturnsFalseByDefault
      *
-     * @return void
      * @since 1.2.0
      */
-    public function testCliOptionsIsStrictReturnsFalseByDefault()
+    public function testCliOptionsIsStrictReturnsFalseByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
 
-        self::assertFalse($opts->hasStrict());
+        static::assertFalse($opts->hasStrict());
     }
 
     /**
      * testCliOptionsAcceptsStrictArgument
      *
-     * @return void
      * @since 1.2.0
      */
-    public function testCliOptionsAcceptsStrictArgument()
+    public function testCliOptionsAcceptsStrictArgument(): void
     {
         $args = [__FILE__, '--strict', __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
 
-        self::assertTrue($opts->hasStrict());
+        static::assertTrue($opts->hasStrict());
 
         $args = [__FILE__, '--not-strict', __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
 
-        self::assertFalse($opts->hasStrict());
+        static::assertFalse($opts->hasStrict());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionsAcceptsMinimumpriorityArgument()
+    public function testCliOptionsAcceptsMinimumpriorityArgument(): void
     {
         $args = [__FILE__, '--minimumpriority', 42, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame(42, $opts->getMinimumPriority());
+        static::assertSame(42, $opts->getMinimumPriority());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionsAcceptsMaximumpriorityArgument()
+    public function testCliOptionsAcceptsMaximumpriorityArgument(): void
     {
         $args = [__FILE__, '--maximumpriority', 42, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame(42, $opts->getMaximumPriority());
+        static::assertSame(42, $opts->getMaximumPriority());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionGenerateBaselineFalseByDefault()
+    public function testCliOptionGenerateBaselineFalseByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
         static::assertSame(BaselineMode::NONE, $opts->generateBaseline());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionVerbosityNormal()
+    public function testCliOptionVerbosityNormal(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
         static::assertSame(OutputInterface::VERBOSITY_NORMAL, $opts->getVerbosity());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionVerbosityVerbose()
+    public function testCliOptionVerbosityVerbose(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '-v'];
         $opts = new CommandLineOptions($args);
         static::assertSame(OutputInterface::VERBOSITY_VERBOSE, $opts->getVerbosity());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionVerbosityVeryVerbose()
+    public function testCliOptionVerbosityVeryVerbose(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '-vv'];
         $opts = new CommandLineOptions($args);
         static::assertSame(OutputInterface::VERBOSITY_VERY_VERBOSE, $opts->getVerbosity());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionVerbosityDebug()
+    public function testCliOptionVerbosityDebug(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '-vvv'];
         $opts = new CommandLineOptions($args);
         static::assertSame(OutputInterface::VERBOSITY_DEBUG, $opts->getVerbosity());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionGenerateBaselineShouldBeSet()
+    public function testCliOptionGenerateBaselineShouldBeSet(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--generate-baseline'];
         $opts = new CommandLineOptions($args);
         static::assertSame(BaselineMode::GENERATE, $opts->generateBaseline());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionUpdateBaselineShouldBeSet()
+    public function testCliOptionUpdateBaselineShouldBeSet(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--update-baseline'];
         $opts = new CommandLineOptions($args);
         static::assertSame(BaselineMode::UPDATE, $opts->generateBaseline());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionBaselineFileShouldBeNullByDefault()
+    public function testCliOptionBaselineFileShouldBeNullByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
         static::assertNull($opts->baselineFile());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionBaselineFileShouldBeWithFilename()
+    public function testCliOptionBaselineFileShouldBeWithFilename(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--baseline-file', 'foobar.txt'];
         $opts = new CommandLineOptions($args);
         static::assertSame('foobar.txt', $opts->baselineFile());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetMinimumPriorityReturnsLowestValueByDefault()
+    public function testGetMinimumPriorityReturnsLowestValueByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame(Rule::LOWEST_PRIORITY, $opts->getMinimumPriority());
+        static::assertSame(Rule::LOWEST_PRIORITY, $opts->getMinimumPriority());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetCoverageReportReturnsNullByDefault()
+    public function testGetCoverageReportReturnsNullByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
         $opts = new CommandLineOptions($args);
 
-        self::assertNull($opts->getCoverageReport());
+        static::assertNull($opts->getCoverageReport());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetCoverageReportWithCliOption()
+    public function testGetCoverageReportWithCliOption(): void
     {
         $opts = new CommandLineOptions(
             [
@@ -629,13 +553,10 @@ class CommandLineOptionsTest extends AbstractTestCase
             ]
         );
 
-        self::assertSame(__METHOD__, $opts->getCoverageReport());
+        static::assertSame(__METHOD__, $opts->getCoverageReport());
     }
 
-    /**
-     * @return void
-     */
-    public function testGetCacheWithCliOption()
+    public function testGetCacheWithCliOption(): void
     {
         $opts = new CommandLineOptions(
             [
@@ -646,8 +567,8 @@ class CommandLineOptionsTest extends AbstractTestCase
             ]
         );
 
-        self::assertSame(ResultCacheStrategy::CONTENT, $opts->cacheStrategy());
-        self::assertFalse($opts->isCacheEnabled());
+        static::assertSame(ResultCacheStrategy::CONTENT, $opts->cacheStrategy());
+        static::assertFalse($opts->isCacheEnabled());
 
         $opts = new CommandLineOptions(
             [
@@ -661,8 +582,8 @@ class CommandLineOptionsTest extends AbstractTestCase
             ]
         );
 
-        self::assertSame(ResultCacheStrategy::TIMESTAMP, $opts->cacheStrategy());
-        self::assertTrue($opts->isCacheEnabled());
+        static::assertSame(ResultCacheStrategy::TIMESTAMP, $opts->cacheStrategy());
+        static::assertTrue($opts->isCacheEnabled());
 
         $opts = new CommandLineOptions(
             [
@@ -678,43 +599,39 @@ class CommandLineOptionsTest extends AbstractTestCase
             ]
         );
 
-        self::assertSame(ResultCacheStrategy::CONTENT, $opts->cacheStrategy());
-        self::assertSame('abc', $opts->cacheFile());
-        self::assertTrue($opts->isCacheEnabled());
+        static::assertSame(ResultCacheStrategy::CONTENT, $opts->cacheStrategy());
+        static::assertSame('abc', $opts->cacheFile());
+        static::assertTrue($opts->isCacheEnabled());
     }
 
-    /**
-     * @return void
-     */
-    public function testExcludeOption()
+    public function testExcludeOption(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--ignore', 'foo/bar', '--error-file', 'abc'];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame('abc', $opts->getErrorFile());
-        self::assertSame('foo/bar', $opts->getIgnore());
-        self::assertSame([
+        static::assertSame('abc', $opts->getErrorFile());
+        static::assertSame('foo/bar', $opts->getIgnore());
+        static::assertSame([
             'The --ignore option is deprecated, please use --exclude instead.',
         ], $opts->getDeprecations());
 
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--exclude', 'bar/biz'];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame('bar/biz', $opts->getIgnore());
+        static::assertSame('bar/biz', $opts->getIgnore());
     }
 
     /**
      * @param string $reportFormat
      * @param string $expectedClass
-     * @return void
      * @dataProvider dataProviderCreateRenderer
      */
-    public function testCreateRenderer($reportFormat, $expectedClass)
+    public function testCreateRenderer($reportFormat, $expectedClass): void
     {
         $args = [__FILE__, __FILE__, $reportFormat, 'codesize'];
         $opts = new CommandLineOptions($args);
 
-        self::assertInstanceOf($expectedClass, $opts->createRenderer($reportFormat));
+        static::assertInstanceOf($expectedClass, $opts->createRenderer($reportFormat));
     }
 
     public static function dataProviderCreateRenderer(): array
@@ -764,12 +681,12 @@ class CommandLineOptionsTest extends AbstractTestCase
      * @param string $newName
      * @dataProvider dataProviderDeprecatedCliOptions
      */
-    public function testDeprecatedCliOptions($deprecatedName, $newName, Closure $result)
+    public function testDeprecatedCliOptions($deprecatedName, $newName, Closure $result): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', sprintf('--%s', $deprecatedName), '42'];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame(
+        static::assertSame(
             [
                 sprintf(
                     'The --%s option is deprecated, please use --%s instead.',
@@ -784,7 +701,7 @@ class CommandLineOptionsTest extends AbstractTestCase
         $args = [__FILE__, __FILE__, 'text', 'codesize', sprintf('--%s', $newName), '42'];
         $opts = new CommandLineOptions($args);
 
-        self::assertSame(
+        static::assertSame(
             [],
             $opts->getDeprecations()
         );
@@ -794,31 +711,27 @@ class CommandLineOptionsTest extends AbstractTestCase
     public static function dataProviderDeprecatedCliOptions(): array
     {
         return [
-            ['extensions', 'suffixes', static function (CommandLineOptions $opts) {
+            ['extensions', 'suffixes', static function (CommandLineOptions $opts): void {
                 self::assertSame('42', $opts->getExtensions());
             }],
-            ['ignore', 'exclude', static function (CommandLineOptions $opts) {
+            ['ignore', 'exclude', static function (CommandLineOptions $opts): void {
                 self::assertSame('42', $opts->getIgnore());
             }],
         ];
     }
 
     /**
-     * @return void
      * @dataProvider dataProviderGetReportFiles
      */
-    public function testGetReportFiles(array $options, array $expected)
+    public function testGetReportFiles(array $options, array $expected): void
     {
         $args = array_merge([__FILE__, __FILE__, 'text', 'codesize'], $options);
         $opts = new CommandLineOptions($args);
 
-        self::assertEquals($expected, $opts->getReportFiles());
+        static::assertEquals($expected, $opts->getReportFiles());
     }
 
-    /**
-     * @return void
-     */
-    public function testCliOptionExtraLineInExcerptShouldBeWithNumber()
+    public function testCliOptionExtraLineInExcerptShouldBeWithNumber(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--extra-line-in-excerpt', '5'];
         $opts = new CommandLineOptions($args);

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -27,9 +27,7 @@ use PHPMD\Utility\Paths;
  */
 class CommandTest extends AbstractTestCase
 {
-    /**
-     * @var resource
-     */
+    /** @var resource */
     private $stderrStreamFilter;
 
     protected function tearDown(): void
@@ -43,10 +41,9 @@ class CommandTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @dataProvider dataProviderTestMainWithOption
      */
-    public function testMainStrictOptionIsOfByDefault($sourceFile, $expectedExitCode, array $options = null)
+    public function testMainStrictOptionIsOfByDefault($sourceFile, $expectedExitCode, ?array $options = null): void
     {
         $args = array_filter(
             array_merge(
@@ -63,7 +60,7 @@ class CommandTest extends AbstractTestCase
         );
 
         $exitCode = Command::main($args);
-        $this->assertEquals($expectedExitCode, $exitCode);
+        static::assertEquals($expectedExitCode, $exitCode);
     }
 
     public static function dataProviderTestMainWithOption(): array
@@ -132,10 +129,7 @@ class CommandTest extends AbstractTestCase
         ];
     }
 
-    /**
-     * @return void
-     */
-    public function testWithMultipleReportFiles()
+    public function testWithMultipleReportFiles(): void
     {
         $args = [
             __FILE__,
@@ -160,15 +154,15 @@ class CommandTest extends AbstractTestCase
 
         Command::main($args);
 
-        $this->assertFileExists($xml);
-        $this->assertFileExists($html);
-        $this->assertFileExists($text);
-        $this->assertFileExists($json);
-        $this->assertFileExists($checkstyle);
-        $this->assertFileExists($sarif);
+        static::assertFileExists($xml);
+        static::assertFileExists($html);
+        static::assertFileExists($text);
+        static::assertFileExists($json);
+        static::assertFileExists($checkstyle);
+        static::assertFileExists($sarif);
     }
 
-    public function testOutput()
+    public function testOutput(): void
     {
         $uri = realpath(self::createFileUri('source/source_with_anonymous_class.php'));
         $temp = self::createTempFileUri();
@@ -181,8 +175,8 @@ class CommandTest extends AbstractTestCase
             $temp,
         ]);
 
-        $this->assertSame(Command::EXIT_VIOLATION, $exitCode);
-        $this->assertSame(
+        static::assertSame(Command::EXIT_VIOLATION, $exitCode);
+        static::assertSame(
             "$uri:8  ShortVariable  Avoid variables with short names like \$a. " .
             'Configured minimum length is 3.' . PHP_EOL,
             file_get_contents($temp)
@@ -192,10 +186,9 @@ class CommandTest extends AbstractTestCase
     /**
      * @param string $option
      * @param string $value
-     * @return void
      * @dataProvider dataProviderWithFilter
      */
-    public function testWithFilter($option, $value)
+    public function testWithFilter($option, $value): void
     {
         $args = [
             __FILE__,
@@ -209,7 +202,7 @@ class CommandTest extends AbstractTestCase
         ];
 
         $exitCode = Command::main($args);
-        $this->assertEquals(Command::EXIT_SUCCESS, $exitCode);
+        static::assertEquals(Command::EXIT_SUCCESS, $exitCode);
     }
 
     public static function dataProviderWithFilter(): array
@@ -220,9 +213,9 @@ class CommandTest extends AbstractTestCase
         ];
     }
 
-    public function testMainGenerateBaseline()
+    public function testMainGenerateBaseline(): void
     {
-        $uri = str_replace("\\", "/", realpath(self::createFileUri('source/source_with_anonymous_class.php')));
+        $uri = str_replace('\\', '/', realpath(self::createFileUri('source/source_with_anonymous_class.php')));
         $temp = self::createTempFileUri();
         $exitCode = Command::main([
             __FILE__,
@@ -248,7 +241,7 @@ class CommandTest extends AbstractTestCase
      * - ShortVariable violation should still exist
      * - BooleanGetMethodName shouldn't be added
      */
-    public function testMainUpdateBaseline()
+    public function testMainUpdateBaseline(): void
     {
         $sourceTemp = self::createTempFileUri('ClassWithMultipleViolations.php');
         $baselineTemp = self::createTempFileUri();
@@ -275,7 +268,7 @@ class CommandTest extends AbstractTestCase
         );
     }
 
-    public function testMainBaselineViolationShouldBeIgnored()
+    public function testMainBaselineViolationShouldBeIgnored(): void
     {
         $sourceFile = realpath(static::createResourceUriForTest('Baseline/ClassWithShortVariable.php'));
         $baselineFile = realpath(static::createResourceUriForTest('Baseline/phpmd.baseline.xml'));
@@ -291,7 +284,7 @@ class CommandTest extends AbstractTestCase
         static::assertSame(Command::EXIT_SUCCESS, $exitCode);
     }
 
-    public function testMainWritesExceptionMessageToStderr()
+    public function testMainWritesExceptionMessageToStderr(): void
     {
         stream_filter_register('stderr_stream', StreamFilter::class);
 
@@ -306,13 +299,13 @@ class CommandTest extends AbstractTestCase
             ]
         );
 
-        $this->assertStringContainsString(
+        static::assertStringContainsString(
             'Can\'t find the custom report class: ',
             StreamFilter::$streamHandle
         );
     }
 
-    public function testMainWritesExceptionMessageToErrorFileIfSpecified()
+    public function testMainWritesExceptionMessageToErrorFileIfSpecified(): void
     {
         $file = tempnam(sys_get_temp_dir(), 'err');
 
@@ -330,7 +323,7 @@ class CommandTest extends AbstractTestCase
         $errors = (string) file_get_contents($file);
         unlink($file);
 
-        $this->assertSame("Can't find the custom report class: ''" . PHP_EOL, $errors);
+        static::assertSame("Can't find the custom report class: ''" . PHP_EOL, $errors);
 
         $file = tempnam(sys_get_temp_dir(), 'err');
 
@@ -349,8 +342,8 @@ class CommandTest extends AbstractTestCase
         $errors = (string) file_get_contents($file);
         unlink($file);
 
-        $this->assertStringStartsWith("Can't find the custom report class: ''" . PHP_EOL, $errors);
-        $this->assertMatchesRegularExpression(
+        static::assertStringStartsWith("Can't find the custom report class: ''" . PHP_EOL, $errors);
+        static::assertMatchesRegularExpression(
             '`' . preg_quote(str_replace(
                 '/',
                 DIRECTORY_SEPARATOR,
@@ -358,7 +351,7 @@ class CommandTest extends AbstractTestCase
             ), '`') . '\d+' . PHP_EOL . '`',
             $errors
         );
-        $this->assertMatchesRegularExpression(
+        static::assertMatchesRegularExpression(
             '`' . preg_quote(str_replace(
                 '/',
                 DIRECTORY_SEPARATOR,
@@ -368,7 +361,7 @@ class CommandTest extends AbstractTestCase
         );
     }
 
-    public function testOutputDeprecation()
+    public function testOutputDeprecation(): void
     {
         $file = tempnam(sys_get_temp_dir(), 'err');
 
@@ -388,13 +381,13 @@ class CommandTest extends AbstractTestCase
         $errors = (string) file_get_contents($file);
         unlink($file);
 
-        $this->assertSame(
+        static::assertSame(
             'The --ignore option is deprecated, please use --exclude instead.' . PHP_EOL . PHP_EOL,
             $errors
         );
     }
 
-    public function testMainPrintsVersionToStdout()
+    public function testMainPrintsVersionToStdout(): void
     {
         stream_filter_register('stderr_stream', StreamFilter::class);
 
@@ -410,6 +403,6 @@ class CommandTest extends AbstractTestCase
         $data = @parse_ini_file(__DIR__ . '/../../../../../build.properties');
         $version = $data['project.version'];
 
-        $this->assertEquals('PHPMD ' . $version, trim(StreamFilter::$streamHandle));
+        static::assertEquals('PHPMD ' . $version, trim(StreamFilter::$streamHandle));
     }
 }

--- a/src/test/php/PHPMD/Utility/PathsTest.php
+++ b/src/test/php/PHPMD/Utility/PathsTest.php
@@ -13,7 +13,7 @@ class PathsTest extends AbstractTestCase
     /**
      * @covers ::getRelativePath
      */
-    public function testGetRelativePathShouldSubtractBasePath()
+    public function testGetRelativePathShouldSubtractBasePath(): void
     {
         static::assertSame('bar/', Paths::getRelativePath('/foo', '/foo/bar/'));
     }
@@ -21,7 +21,7 @@ class PathsTest extends AbstractTestCase
     /**
      * @covers ::getRelativePath
      */
-    public function testGetRelativePathShouldTreatForwardAndBackwardSlashes()
+    public function testGetRelativePathShouldTreatForwardAndBackwardSlashes(): void
     {
         static::assertSame('text.txt', Paths::getRelativePath('\\foo/bar\\', '/foo\\bar/text.txt'));
     }
@@ -29,7 +29,7 @@ class PathsTest extends AbstractTestCase
     /**
      * @covers ::getRelativePath
      */
-    public function testGetRelativePathShouldNotSubtractOnInfixPath()
+    public function testGetRelativePathShouldNotSubtractOnInfixPath(): void
     {
         static::assertSame('/foo/bar/text.txt', Paths::getRelativePath('/bar', '/foo/bar/text.txt'));
     }
@@ -37,7 +37,7 @@ class PathsTest extends AbstractTestCase
     /**
      * @covers ::concat
      */
-    public function testConcat()
+    public function testConcat(): void
     {
         static::assertSame('pathA/pathB', Paths::concat('pathA', 'pathB'));
         static::assertSame('pathA/pathB', Paths::concat('pathA', '/pathB'));
@@ -48,7 +48,7 @@ class PathsTest extends AbstractTestCase
     /**
      * @covers ::getRealPath
      */
-    public function testGetRealPathShouldReturnTheRealPath()
+    public function testGetRealPathShouldReturnTheRealPath(): void
     {
         $path = static::createResourceUriForTest('resource.txt');
         static::assertSame(realpath($path), Paths::getRealPath($path));
@@ -57,7 +57,7 @@ class PathsTest extends AbstractTestCase
     /**
      * @covers ::getRealPath
      */
-    public function testGetRealPathShouldThrowExceptionOnFailure()
+    public function testGetRealPathShouldThrowExceptionOnFailure(): void
     {
         self::expectExceptionObject(new RuntimeException(
             'Unable to determine the realpath for: unknown/path',

--- a/src/test/php/PHPMD/Utility/StringsTest.php
+++ b/src/test/php/PHPMD/Utility/StringsTest.php
@@ -29,70 +29,56 @@ class StringsTest extends AbstractTestCase
 {
     /**
      * Tests the lengthWithoutSuffixes() method with an empty string
-     *
-     * @return void
      */
-    public function testLengthWithoutSuffixesEmptyString()
+    public function testLengthWithoutSuffixesEmptyString(): void
     {
         static::assertSame(0, Strings::lengthWithoutSuffixes('', []));
     }
 
     /**
      * Tests the lengthWithoutSuffixes() method with an empty string with list of suffixes
-     *
-     * @return void
      */
-    public function testLengthWithoutSuffixesEmptyStringWithConfiguredSubtractSuffix()
+    public function testLengthWithoutSuffixesEmptyStringWithConfiguredSubtractSuffix(): void
     {
         static::assertSame(0, Strings::lengthWithoutSuffixes('', ['Foo', 'Bar']));
     }
 
     /**
      * Tests the lengthWithoutSuffixes() method with a string not in the list of suffixes
-     *
-     * @return void
      */
-    public function testLengthWithoutSuffixesStringWithoutSubtractSuffixMatch()
+    public function testLengthWithoutSuffixesStringWithoutSubtractSuffixMatch(): void
     {
         static::assertSame(8, Strings::lengthWithoutSuffixes('UnitTest', ['Foo', 'Bar']));
     }
 
     /**
      * Tests the lengthWithoutSuffixes() method with a string in the list of suffixes
-     *
-     * @return void
      */
-    public function testLengthWithoutSuffixesStringWithSubtractSuffixMatch()
+    public function testLengthWithoutSuffixesStringWithSubtractSuffixMatch(): void
     {
         static::assertSame(4, Strings::lengthWithoutSuffixes('UnitBar', ['Foo', 'Bar']));
     }
 
     /**
      * Tests the lengthWithoutSuffixes() method with a string that should match only once for two potential matches
-     *
-     * @return void
      */
-    public function testLengthWithoutSuffixesStringWithDoubleSuffixMatchSubtractOnce()
+    public function testLengthWithoutSuffixesStringWithDoubleSuffixMatchSubtractOnce(): void
     {
         static::assertSame(7, Strings::lengthWithoutSuffixes('UnitFooBar', ['Foo', 'Bar']));
     }
 
     /**
      * Tests the lengthWithoutSuffixes() method that a Prefix should not be matched
-     *
-     * @return void
      */
-    public function testLengthWithoutSuffixesStringWithPrefixMatchShouldNotSubtract()
+    public function testLengthWithoutSuffixesStringWithPrefixMatchShouldNotSubtract(): void
     {
         static::assertSame(11, Strings::lengthWithoutSuffixes('FooUnitTest', ['Foo', 'Bar']));
     }
 
     /**
      * Tests the lengthWithoutSuffixes() method that a Prefix should be matched
-     *
-     * @return void
      */
-    public function testlengthWithPrefixesAndSuffixesStringWithPrefixMatchShouldSubtract()
+    public function testlengthWithPrefixesAndSuffixesStringWithPrefixMatchShouldSubtract(): void
     {
         static::assertSame(11, Strings::lengthWithoutSuffixes('FooUnitTest', ['Foo', 'Bar']));
         static::assertSame(8, Strings::lengthWithoutSuffixes('UnitTestFoo', ['Foo', 'Bar']));
@@ -100,10 +86,8 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the lengthWithoutPrefixesAndSuffixes() method that a Prefix should not be matched in order
-     *
-     * @return void
      */
-    public function testlengthWithPrefixesAndSuffixesStringWithPrefixesMatchShouldSubtractInOrder()
+    public function testlengthWithPrefixesAndSuffixesStringWithPrefixesMatchShouldSubtractInOrder(): void
     {
         $prefixes = ['Foo', 'Bar'];
         $suffixes = ['Foo', 'FooUnit'];
@@ -113,10 +97,8 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the splitToList() method with an empty separator
-     *
-     * @return void
      */
-    public function testSplitToListEmptySeparatorThrowsException()
+    public function testSplitToListEmptySeparatorThrowsException(): void
     {
         self::expectExceptionObject(new InvalidArgumentException(
             "Separator can't be empty string",
@@ -127,60 +109,48 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the splitToList() method with an empty string
-     *
-     * @return void
      */
-    public function testSplitToListEmptyString()
+    public function testSplitToListEmptyString(): void
     {
         static::assertSame([], Strings::splitToList('', ','));
     }
 
     /**
      * Tests the splitToList() method with a non-matching separator
-     *
-     * @return void
      */
-    public function testSplitToListStringWithoutMatchingSeparator()
+    public function testSplitToListStringWithoutMatchingSeparator(): void
     {
         static::assertSame(['UnitTest'], Strings::splitToList('UnitTest', ','));
     }
 
     /**
      * Tests the splitToList() method with a matching separator
-     *
-     * @return void
      */
-    public function testSplitToListStringWithMatchingSeparator()
+    public function testSplitToListStringWithMatchingSeparator(): void
     {
         static::assertSame(['Unit', 'Test'], Strings::splitToList('Unit,Test', ','));
     }
 
     /**
      * Tests the splitToList() method with trailing whitespace
-     *
-     * @return void
      */
-    public function testSplitToListStringTrimsLeadingAndTrailingWhitespace()
+    public function testSplitToListStringTrimsLeadingAndTrailingWhitespace(): void
     {
         static::assertSame(['Unit', 'Test'], Strings::splitToList('Unit , Test', ','));
     }
 
     /**
      * Tests the splitToList() method that it removes empty strings from list
-     *
-     * @return void
      */
-    public function testSplitToListStringRemoveEmptyStringValues()
+    public function testSplitToListStringRemoveEmptyStringValues(): void
     {
         static::assertSame(['Foo'], Strings::splitToList('Foo,,,', ','));
     }
 
     /**
      * Tests the splitToList() method that it does not remove zero values from list
-     *
-     * @return void
      */
-    public function testSplitToListStringShouldNotRemoveAZeroValue()
+    public function testSplitToListStringShouldNotRemoveAZeroValue(): void
     {
         static::assertSame(['0', '1', '2'], Strings::splitToList('0,1,2', ','));
     }

--- a/src/test/php/PHPMD/Writer/StreamWriterTest.php
+++ b/src/test/php/PHPMD/Writer/StreamWriterTest.php
@@ -13,7 +13,7 @@ class StreamWriterTest extends TestCase
     /**
      * @covers ::getStream
      */
-    public function testGetStream()
+    public function testGetStream(): void
     {
         $writer = new StreamWriter(STDOUT);
         static::assertSame(STDOUT, $writer->getStream());

--- a/src/test/php/bootstrap.php
+++ b/src/test/php/bootstrap.php
@@ -18,7 +18,7 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
 spl_autoload_register(
-    function ($class) {
+    function ($class): void {
         $file = __DIR__ . '/' . strtr($class, '\\', '/') . '.php';
         if (file_exists($file)) {
             include $file;

--- a/src/test/php/load-coverage-tokens.php
+++ b/src/test/php/load-coverage-tokens.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * When running old PHPUnit version such as <= 5 with PHP >= 8.0,
  * new PHP tokens will be missing and generate errors.
  *


### PR DESCRIPTION
Type: refactoring
Issue: Resolves None
Breaking change: No

Merged the PHP CS Fixer rules  provided by @AJenbo in with some amendmends.

Many of them are marked "risky", though.

The following rules from him are either disabled or have a different config:

``` php
        'binary_operator_spaces' => ['operators' => ['=' => 'single_space','=>' => 'align_single_space_minimal']],
        'cast_spaces' => ['space' => 'none'],
        'blank_line_before_statement' => ['statements' => ['continue','declare','return','throw','try']],
        'explicit_string_variable' => true,
        'increment_style' => ['style' => 'post'],
        'is_null' => true,
        'no_blank_lines_after_phpdoc' => true,
        'no_unneeded_control_parentheses' => true,
        'operator_linebreak' => true,
        'php_unit_strict' => true,
        'phpdoc_align' => true,
        'phpdoc_annotation_without_dot' => true,
        'phpdoc_no_alias_tag' => true,
        'phpdoc_order' => true,
        'phpdoc_separation' => true,
        'phpdoc_summary' => true,
        'phpdoc_tag_type' => true,
        'phpdoc_to_comment' => true,
        'phpdoc_types_order' => true,
        'return_assignment' => true,
        'simplified_if_return' => true,
        'string_implicit_backslashes' => true,
```