### PR TITLE
Adjust to changes in latest PDepend

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "php": "^8.1",
     "ext-xml": "*",
     "composer/xdebug-handler": "^3.0",
-    "pdepend/pdepend": "3.x-dev"
+    "pdepend/pdepend": "3.x-dev#bd4de6b346154c3b8e96dc41e5a84fe33b973970"
   },
   "require-dev": {
     "ext-json": "*",

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -20,7 +20,6 @@ namespace PHPMD;
 use BadMethodCallException;
 use OutOfBoundsException;
 use PDepend\Source\AST\AbstractASTArtifact;
-use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTVariable;
@@ -95,6 +94,28 @@ abstract class AbstractNode
     }
 
     /**
+     * Returns the first parent node of the specified type
+     *
+     * @template T of PDependNode
+     *
+     * @param class-string<T> $type The searched parent type.
+     * @return ASTNode<T>|null
+     */
+    public function getParentOfType($type)
+    {
+        $parent = $this->node->getParent();
+
+        while ($parent) {
+            if ($parent instanceof $type) {
+                return new ASTNode($parent, $this->getFileName());
+            }
+            $parent = $parent->getParent();
+        }
+
+        return null;
+    }
+
+    /**
      * Returns a child node at the given index.
      *
      * @param int $index The child offset.
@@ -157,7 +178,7 @@ abstract class AbstractNode
      * the current node.
      *
      * @param class-string<PDependNode> $type The searched child type.
-     * @return array<int, AbstractASTNode|ASTArtifact>
+     * @return list<PDependNode>
      */
     public function findChildrenWithParentType($type)
     {
@@ -206,7 +227,7 @@ abstract class AbstractNode
      */
     public function getImage()
     {
-        return $this->node->getName();
+        return $this->node->getImage();
     }
 
     /**
@@ -217,7 +238,7 @@ abstract class AbstractNode
      */
     public function getName()
     {
-        return $this->node->getName();
+        return $this->node->getImage();
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -57,7 +57,7 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
         }
 
         $currNode = $node->getNode();
-        $parent = is_callable([$currNode, 'getParent']) ? $currNode->getParent() : null;
+        $parent = $currNode->getParent();
 
         if ($parent &&
             ($parent instanceof AbstractASTClassOrInterface) &&

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -140,27 +140,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      */
     protected function isNameAllowedInContext(AbstractNode $node)
     {
-        return $this->isChildOf($node, ASTMemberPrimaryPrefix::class);
-    }
-
-    /**
-     * Checks if the given node is a direct or indirect child of a node with
-     * the given type.
-     *
-     * @param string $type
-     * @return bool
-     */
-    protected function isChildOf(AbstractNode $node, $type)
-    {
-        $parent = $node->getParent();
-        while (is_object($parent)) {
-            if ($parent->isInstanceOf($type)) {
-                return true;
-            }
-            $parent = $parent->getParent();
-        }
-
-        return false;
+        return $node->getParentOfType(ASTMemberPrimaryPrefix::class) !== null;
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -250,15 +250,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      */
     protected function isChildOf(AbstractNode $node, $type)
     {
-        $parent = $node->getParent();
-        while (is_object($parent)) {
-            if ($parent->isInstanceOf($type)) {
-                return true;
-            }
-            $parent = $parent->getParent();
-        }
-
-        return false;
+        return $node->getParentOfType($type) !== null;
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Rule;
 
 use OutOfBoundsException;
+use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PDepend\Source\AST\ASTCompoundVariable;
 use PDepend\Source\AST\ASTExpression;
@@ -33,6 +34,8 @@ use PHPMD\Node\MethodNode;
 /**
  * This rule collects all formal parameters of a given function or method that
  * are not used in a statement of the artifact's body.
+ *
+ * @SuppressWarnings("PMD.CouplingBetweenObjects")
  */
 class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAware, MethodAware
 {
@@ -160,6 +163,11 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
     {
         // First collect the formal parameters containers
         foreach ($node->findChildrenOfType(ASTFormalParameters::class) as $parameters) {
+            $parent = $parameters->getParentOfType(AbstractASTCallable::class);
+            if ($parent->getNode() !== $node->getNode()) {
+                continue;
+            }
+
             // Now get all declarators in the formal parameters container
             $declarators = $parameters->findChildrenOfType(ASTVariableDeclarator::class);
 

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -19,6 +19,7 @@ namespace PHPMD\Rule;
 
 use InvalidArgumentException;
 use OutOfBoundsException;
+use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\ASTAssignmentExpression;
 use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTCompoundVariable;
@@ -142,7 +143,10 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
         }
 
         foreach ($node->findChildrenOfType(ASTVariableDeclarator::class) as $variable) {
-            $this->collectVariable($variable);
+            $parent = $variable->getParentOfType(AbstractASTCallable::class);
+            if ($parent->getNode() === $node->getNode()) {
+                $this->collectVariable($variable);
+            }
         }
 
         foreach ($node->findChildrenOfType(ASTFunctionPostfix::class) as $func) {


### PR DESCRIPTION
Type: bugfix
Breaking change: no

Fixes #1141

Peg PDepend to a specific commit. Both to trigger and update in CI, but also so we don't have breakage sneak up on us at unexpected times and halt progress.

Since the AST tree is now less fragmented more elements were picked up during the walk and need to be explicitly handled. In `UnusedFormalParameter` & `UnusedLocalVariable` we are looking for variables by name and finding similar ones in nested function. We then do a look back though the parents to check if they are in the scope we expected, and exclude them if not.