### PR TITLE
[3.x] Assert something to prevent risky tests

### DIFF
--- a/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
@@ -41,13 +41,16 @@ class AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest extends AbstractR
         $ruleSetFactory = new RuleSetFactory();
 
         $phpmd = new PHPMD();
+        $inputPath = self::createFileUri('001/source');
         $phpmd->processFiles(
-            self::createFileUri('001/source'),
+            $inputPath,
             $ruleSetFactory->getIgnorePattern('pmd-refset1'),
             [$renderer],
             $ruleSetFactory->createRuleSets('pmd-refset1'),
             new Report()
         );
+
+        static::assertSame($inputPath, $phpmd->getInput());
     }
 
     /**
@@ -63,12 +66,15 @@ class AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest extends AbstractR
         $ruleSetFactory = new RuleSetFactory();
 
         $phpmd = new PHPMD();
+        $inputPath = self::createFileUri('001/source/FooBar.php');
         $phpmd->processFiles(
-            self::createFileUri('001/source/FooBar.php'),
+            $inputPath,
             $ruleSetFactory->getIgnorePattern('pmd-refset1'),
             [$renderer],
             $ruleSetFactory->createRuleSets('pmd-refset1'),
             new Report()
         );
+
+        static::assertSame($inputPath, $phpmd->getInput());
     }
 }

--- a/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
+++ b/src/test/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
@@ -54,5 +54,7 @@ class MaximumNestingLevelTicket24975295RegressionTest extends AbstractRegression
             $factory->createRuleSets($rules),
             new Report()
         );
+
+        static::assertFalse($phpmd->hasErrors());
     }
 }


### PR DESCRIPTION
Type: bugfix
Issue: Resolves None
Breaking change: No

Assert something to prevent risky tests.
These were probably not detected in older PHPUnit versions.

Haven't put much effort into asserting relevant, though.