### PR TITLE
[3.x] Use Value as Data Provider Key

### DIFF
--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -119,7 +119,11 @@ abstract class AbstractStaticTestCase extends TestCase
      */
     protected static function getValuesAsArrays($values)
     {
-        return array_map(static fn($value) => [$value], $values);
+        array_walk($values, static function ($value, $key) use (&$valuesAsArray): void {
+            $valuesAsArray[$value] = [$value];
+        });
+
+        return $valuesAsArray;
     }
 
     /**


### PR DESCRIPTION
Type: Feature
Issue: Resolves None
Breaking change: No

Set value as data provider key to locate test file easier.

Before: The test file was only mentioned truncated

````
PHPMD\Rule\UnusedLocalVariableTest::testRuleAppliesTo with data set #0 ('C:\{snip}...rs.php')
testRuleAppliesToInnerFunctionParameters.php failed:
Expected 1 violation
But 0 violations raised.

C:\{snip}\phpmd\src\test\php\PHPMD\AbstractTestCase.php:268
C:\{snip}\phpmd\src\test\php\PHPMD\Rule\UnusedLocalVariableTest.php:65
````

Now: The test file gets mentioned in full

````
PHPMD\Rule\UnusedLocalVariableTest::testRuleAppliesTo with data set "C:\{snip}\phpmd\src\test\php\PHPMD/../../resources/files/Rule/UnusedLocalVariable/testRuleAppliesToInnerFunctionParameters.php" ('C:\{snip}...rs.php')
testRuleAppliesToInnerFunctionParameters.php failed:
Expected 1 violation
But 0 violations raised.

C:\{snip}\phpmd\src\test\php\PHPMD\AbstractTestCase.php:268
C:\{snip}\phpmd\src\test\php\PHPMD\Rule\UnusedLocalVariableTest.php:65
````

Additionally, they also show up when executing the test suite, e.g. in PhpStorm:

![grafik](https://github.com/phpmd/phpmd/assets/625761/25ae00a4-e74d-40c4-9f89-81052151ef2e)