### PR TITLE
Seal up protected

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "php": "^8.1",
     "ext-xml": "*",
     "composer/xdebug-handler": "^3.0",
-    "pdepend/pdepend": "3.x-dev"
+    "pdepend/pdepend": "3.x-dev#bd4de6b346154c3b8e96dc41e5a84fe33b973970"
   },
   "require-dev": {
     "ext-json": "*",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ parameters:
     paths:
         - src/main
     rememberPossiblyImpureFunctionValues: false
-    level: 4
+    level: 5
     exceptions:
         reportUncheckedExceptionDeadCatch: true
         implicitThrows: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ parameters:
     paths:
         - src/main
     rememberPossiblyImpureFunctionValues: false
-    level: 5
+    level: 6
     exceptions:
         reportUncheckedExceptionDeadCatch: true
         implicitThrows: false

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -20,7 +20,6 @@ namespace PHPMD;
 use BadMethodCallException;
 use OutOfBoundsException;
 use PDepend\Source\AST\AbstractASTArtifact;
-use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTVariable;
@@ -95,6 +94,28 @@ abstract class AbstractNode
     }
 
     /**
+     * Returns the first parent node of the specified type
+     *
+     * @template T of PDependNode
+     *
+     * @param class-string<T> $type The searched parent type.
+     * @return ASTNode<T>|null
+     */
+    public function getParentOfType($type)
+    {
+        $parent = $this->node->getParent();
+
+        while ($parent) {
+            if ($parent instanceof $type) {
+                return new ASTNode($parent, $this->getFileName());
+            }
+            $parent = $parent->getParent();
+        }
+
+        return null;
+    }
+
+    /**
      * Returns a child node at the given index.
      *
      * @param int $index The child offset.
@@ -157,7 +178,7 @@ abstract class AbstractNode
      * the current node.
      *
      * @param class-string<PDependNode> $type The searched child type.
-     * @return array<int, AbstractASTNode|ASTArtifact>
+     * @return list<PDependNode>
      */
     public function findChildrenWithParentType($type)
     {
@@ -206,7 +227,7 @@ abstract class AbstractNode
      */
     public function getImage()
     {
-        return $this->node->getName();
+        return $this->node->getImage();
     }
 
     /**
@@ -217,7 +238,7 @@ abstract class AbstractNode
      */
     public function getName()
     {
-        return $this->node->getName();
+        return $this->node->getImage();
     }
 
     /**

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -20,7 +20,6 @@ namespace PHPMD;
 use BadMethodCallException;
 use OutOfBoundsException;
 use PDepend\Source\AST\AbstractASTArtifact;
-use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTVariable;
 use PHPMD\Node\ASTNode;
@@ -29,7 +28,7 @@ use PHPMD\Node\ASTNode;
  * This is an abstract base class for PHPMD code nodes, it is just a wrapper
  * around PDepend's object model.
  *
- * @template TNode of ASTArtifact|PDependNode
+ * @template-covariant TNode of PDependNode
  *
  * @mixin TNode
  */
@@ -81,7 +80,7 @@ abstract class AbstractNode
      * Returns the parent of this node or <b>null</b> when no parent node
      * exists.
      *
-     * @return AbstractNode|null
+     * @return ASTNode|null
      */
     public function getParent()
     {
@@ -119,7 +118,7 @@ abstract class AbstractNode
      * Returns a child node at the given index.
      *
      * @param int $index The child offset.
-     * @return AbstractNode
+     * @return ASTNode
      * @throws OutOfBoundsException
      */
     public function getChild($index)
@@ -155,9 +154,7 @@ abstract class AbstractNode
      * type.
      *
      * @template T of PDependNode
-     *
      * @param class-string<T> $type The searched child type.
-     *
      * @return array<int, ASTNode<T>>
      */
     public function findChildrenOfType($type)

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -61,6 +61,7 @@ abstract class AbstractNode
      * to the underlying PDepend AST node.
      *
      * @param string $name
+     * @param array<mixed> $args
      * @throws BadMethodCallException When the underlying PDepend node
      *         does not contain a method named <b>$name</b>.
      */
@@ -80,7 +81,7 @@ abstract class AbstractNode
      * Returns the parent of this node or <b>null</b> when no parent node
      * exists.
      *
-     * @return ASTNode|null
+     * @return ASTNode<PDependNode>|null
      */
     public function getParent()
     {
@@ -118,7 +119,7 @@ abstract class AbstractNode
      * Returns a child node at the given index.
      *
      * @param int $index The child offset.
-     * @return ASTNode
+     * @return ASTNode<PDependNode>
      * @throws OutOfBoundsException
      */
     public function getChild($index)
@@ -155,7 +156,7 @@ abstract class AbstractNode
      *
      * @template T of PDependNode
      * @param class-string<T> $type The searched child type.
-     * @return array<int, ASTNode<T>>
+     * @return list<ASTNode<T>>
      */
     public function findChildrenOfType($type)
     {

--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -17,8 +17,7 @@
 
 namespace PHPMD;
 
-use LogicException;
-use RuntimeException;
+use Exception;
 
 /**
  * Abstract base class for PHPMD rendering engines.
@@ -63,8 +62,7 @@ abstract class AbstractRenderer
      * This method will be called when the engine has finished the source analysis
      * phase.
      *
-     * @throws RuntimeException
-     * @throws LogicException
+     * @throws Exception
      */
     abstract public function renderReport(Report $report): void;
 

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -20,6 +20,7 @@ namespace PHPMD;
 use InvalidArgumentException;
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
+use PDepend\Source\AST\ASTNode;
 use PHPMD\Node\AbstractTypeNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\EnumNode;
@@ -63,7 +64,7 @@ abstract class AbstractRule implements Rule
     /**
      * A list of code examples for this rule.
      *
-     * @var array<string>
+     * @var list<string>
      */
     private array $examples = [];
 
@@ -185,7 +186,7 @@ abstract class AbstractRule implements Rule
     /**
      * Returns a list of examples for this rule.
      *
-     * @return string[]
+     * @return list<string>
      */
     public function getExamples(): array
     {
@@ -346,6 +347,9 @@ abstract class AbstractRule implements Rule
     /**
      * This method adds a violation to all reports for this violation type and
      * for the given <b>$node</b> instance.
+     *
+     * @param AbstractNode<ASTNode> $node
+     * @param array<int, string> $args
      */
     protected function addViolation(
         AbstractNode $node,
@@ -380,14 +384,4 @@ abstract class AbstractRule implements Rule
             $this->apply($method);
         }
     }
-
-    /**
-     * This method should implement the violation analysis algorithm of concrete
-     * rule implementations. All extending classes must implement this method.
-     *
-     * @throws OutOfBoundsException
-     * @throws InvalidArgumentException
-     * @throws ASTClassOrInterfaceRecursiveInheritanceException
-     */
-    abstract public function apply(AbstractNode $node): void;
 }

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -26,6 +26,7 @@ use PHPMD\Node\EnumNode;
 use PHPMD\Node\InterfaceNode;
 use PHPMD\Node\NodeInfoFactory;
 use PHPMD\Node\TraitNode;
+use RuntimeException;
 
 /**
  * This is the abstract base class for PHPMD rules.
@@ -367,6 +368,7 @@ abstract class AbstractRule implements Rule
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException
+     * @throws RuntimeException
      */
     protected function applyOnClassMethods(AbstractTypeNode $node): void
     {

--- a/src/main/php/PHPMD/Baseline/BaselineSet.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSet.php
@@ -4,7 +4,7 @@ namespace PHPMD\Baseline;
 
 class BaselineSet
 {
-    /** @var array<string, ViolationBaseline[]> */
+    /** @var array<string, list<ViolationBaseline>> */
     private $violations = [];
 
     public function addEntry(ViolationBaseline $entry): void

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -16,11 +16,11 @@ class BaselineSetFactory
      */
     public static function fromFile($fileName)
     {
-        if (!file_exists($fileName)) {
-            throw new RuntimeException('Unable to locate the baseline file at: ' . $fileName);
+        $content = file_get_contents($fileName);
+        if ($content === false) {
+            throw new RuntimeException('Unable to load the baseline file at: ' . $fileName);
         }
-
-        $xml = @simplexml_load_string(file_get_contents($fileName));
+        $xml = @simplexml_load_string($content);
         if (!$xml) {
             throw new RuntimeException('Unable to read xml from: ' . $fileName);
         }

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheKey.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheKey.php
@@ -32,7 +32,7 @@ class ResultCacheKey
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     public function toArray()
     {

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
@@ -13,11 +13,11 @@ class ResultCacheState
     /** @var ResultCacheKey */
     private $cacheKey;
 
-    /** @var array{files?: array<string, array{hash: string, violations?: array}>} */
+    /** @var array{files?: array<string, array{hash: string, violations?: list<array<string, mixed>>}>} */
     private $state;
 
     /**
-     * @param array{files?: array<string, array{hash: string, violations?: array}>} $state
+     * @param array{files?: array<string, array{hash: string, violations?: list<array<string, mixed>>}>} $state
      */
     public function __construct(ResultCacheKey $cacheKey, $state = [])
     {
@@ -35,7 +35,7 @@ class ResultCacheState
 
     /**
      * @param string $filePath
-     * @return array
+     * @return list<array<string, mixed>>
      */
     public function getViolations($filePath)
     {
@@ -48,6 +48,7 @@ class ResultCacheState
 
     /**
      * @param string $filePath
+     * @param list<array<string, mixed>> $violations
      */
     public function setViolations($filePath, array $violations): void
     {
@@ -74,8 +75,9 @@ class ResultCacheState
     }
 
     /**
-     * @param string    $basePath
-     * @param RuleSet[] $ruleSetList
+     * @param string $basePath
+     * @param list<RuleSet> $ruleSetList
+     * @return list<RuleViolation>
      */
     public function getRuleViolations($basePath, array $ruleSetList)
     {
@@ -130,14 +132,15 @@ class ResultCacheState
     /**
      * @param string $filePath
      * @param string $hash
+     * @return void
      */
     public function setFileState($filePath, $hash)
     {
-        return $this->state['files'][$filePath]['hash'] = $hash;
+        $this->state['files'][$filePath]['hash'] = $hash;
     }
 
     /**
-     * @return array
+     * @return array<string, array<string, mixed>>
      */
     public function toArray()
     {

--- a/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
@@ -65,13 +65,15 @@ class ResultCacheFileFilter implements Filter
         }
 
         // Determine if file was modified since last analyse
-        if ($this->state === null) {
+        if ($this->state === null || $hash === false) {
             $isModified = true;
         } else {
             $isModified = $this->state->isFileModified($filePath, $hash);
         }
 
-        $this->newState->setFileState($filePath, $hash);
+        if ($hash !== false) {
+            $this->newState->setFileState($filePath, $hash);
+        }
         if (!$isModified) {
             // File was not modified, transfer previous violations
             $this->newState->setViolations($filePath, $this->state->getViolations($filePath));

--- a/src/main/php/PHPMD/Cache/ResultCacheKeyFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheKeyFactory.php
@@ -70,7 +70,7 @@ class ResultCacheKeyFactory
             return null;
         }
 
-        return sha1_file($this->baselineFile);
+        return sha1_file($this->baselineFile) ?: null;
     }
 
     /**
@@ -83,7 +83,10 @@ class ResultCacheKeyFactory
         foreach (['composer.json', 'composer.lock'] as $file) {
             $filePath = Paths::concat($this->basePath, $file);
             if (file_exists($filePath)) {
-                $result[$file] = sha1_file($filePath);
+                $hash = sha1_file($filePath);
+                if ($hash) {
+                    $result[$file] = $hash;
+                }
             }
         }
 

--- a/src/main/php/PHPMD/Cache/ResultCacheKeyFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheKeyFactory.php
@@ -2,7 +2,6 @@
 
 namespace PHPMD\Cache;
 
-use PHPMD\AbstractRule;
 use PHPMD\Cache\Model\ResultCacheKey;
 use PHPMD\RuleSet;
 use PHPMD\Utility\Paths;
@@ -27,6 +26,7 @@ class ResultCacheKeyFactory
     /**
      * @param bool      $strict
      * @param RuleSet[] $ruleSetList
+     * @return ResultCacheKey
      */
     public function create($strict, array $ruleSetList)
     {
@@ -51,7 +51,6 @@ class ResultCacheKeyFactory
     {
         $result = [];
         foreach ($ruleSetList as $ruleSet) {
-            /** @var AbstractRule $rule */
             foreach ($ruleSet->getRules() as $rule) {
                 $result[$rule::class] = hash('sha1', serialize($rule));
             }

--- a/src/main/php/PHPMD/Cache/ResultCacheStateFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheStateFactory.php
@@ -31,6 +31,7 @@ class ResultCacheStateFactory
     }
 
     /**
+     * @param array<string, mixed> $data
      * @return ResultCacheKey|null
      */
     private function createCacheKey(array $data)

--- a/src/main/php/PHPMD/Node/ASTNode.php
+++ b/src/main/php/PHPMD/Node/ASTNode.php
@@ -24,7 +24,7 @@ use PHPMD\Rule;
 /**
  * Wrapper around a PHP_Depend ast node.
  *
- * @template TNode of PDependNode
+ * @template-covariant TNode of PDependNode
  *
  * @extends AbstractNode<TNode>
  */

--- a/src/main/php/PHPMD/Node/AbstractCallableNode.php
+++ b/src/main/php/PHPMD/Node/AbstractCallableNode.php
@@ -22,7 +22,7 @@ use PDepend\Source\AST\AbstractASTCallable;
 /**
  * Abstract base class for PHP_Depend function and method wrappers.
  *
- * @template TNode of AbstractASTCallable
+ * @template-covariant TNode of AbstractASTCallable
  *
  * @extends AbstractNode<TNode>
  */

--- a/src/main/php/PHPMD/Node/AbstractNode.php
+++ b/src/main/php/PHPMD/Node/AbstractNode.php
@@ -24,7 +24,7 @@ use PHPMD\Rule;
 /**
  * Abstract base class for all code nodes.
  *
- * @template TNode of ASTArtifact
+ * @template-covariant TNode of ASTArtifact
  *
  * @extends BaseNode<TNode>
  */

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -18,24 +18,25 @@
 namespace PHPMD\Node;
 
 use PDepend\Source\AST\AbstractASTClassOrInterface;
-use PDepend\Source\AST\ASTArtifact;
 
 /**
  * Abstract base class for classes and interfaces.
  *
- * @template-covariant TNode of ASTArtifact
+ * @template-covariant TNode of AbstractASTClassOrInterface
  *
  * @extends AbstractNode<TNode>
  */
 abstract class AbstractTypeNode extends AbstractNode
 {
     /**
-     * @var AbstractASTClassOrInterface
+     * @var TNode
      */
     private $node;
 
     /**
      * Constructs a new generic class or interface node.
+     *
+     * @param TNode $node
      */
     public function __construct(AbstractASTClassOrInterface $node)
     {

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -23,7 +23,7 @@ use PDepend\Source\AST\ASTArtifact;
 /**
  * Abstract base class for classes and interfaces.
  *
- * @template TNode of ASTArtifact
+ * @template-covariant TNode of ASTArtifact
  *
  * @extends AbstractNode<TNode>
  */

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -48,7 +48,7 @@ abstract class AbstractTypeNode extends AbstractNode
      * Returns an <b>array</b> with all methods defined in the context class or
      * interface.
      *
-     * @return MethodNode[]
+     * @return list<MethodNode>
      */
     public function getMethods()
     {
@@ -64,7 +64,7 @@ abstract class AbstractTypeNode extends AbstractNode
      * Returns an array with the names of all methods within this class or
      * interface node.
      *
-     * @return string[]
+     * @return list<string>
      */
     public function getMethodNames()
     {

--- a/src/main/php/PHPMD/Node/Annotations.php
+++ b/src/main/php/PHPMD/Node/Annotations.php
@@ -29,7 +29,7 @@ class Annotations
     /**
      * Detected annotations.
      *
-     * @var Annotation[]
+     * @var list<Annotation>
      */
     private $annotations = [];
 

--- a/src/main/php/PHPMD/Node/EnumNode.php
+++ b/src/main/php/PHPMD/Node/EnumNode.php
@@ -21,6 +21,8 @@ use PDepend\Source\AST\ASTEnum;
 
 /**
  * Wrapper around PHP_Depend's enum objects.
+ *
+ * @extends AbstractTypeNode<ASTEnum>
  */
 class EnumNode extends AbstractTypeNode
 {

--- a/src/main/php/PHPMD/Node/InterfaceNode.php
+++ b/src/main/php/PHPMD/Node/InterfaceNode.php
@@ -21,6 +21,8 @@ use PDepend\Source\AST\ASTInterface;
 
 /**
  * Wrapper around PHP_Depend's interface objects.
+ *
+ * @extends AbstractTypeNode<ASTInterface>
  */
 class InterfaceNode extends AbstractTypeNode
 {

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -17,7 +17,7 @@
 
 namespace PHPMD\Node;
 
-use PDepend\Source\AST\ASTArtifact;
+use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PDepend\Source\AST\ASTEnum;
@@ -113,7 +113,7 @@ class MethodNode extends AbstractCallableNode
     /**
      * Returns the parent class or interface instance.
      *
-     * @return AbstractTypeNode<ASTArtifact>
+     * @return AbstractTypeNode<AbstractASTClassOrInterface>
      * @throws RuntimeException
      */
     public function getParentType()

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Node;
 
+use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PDepend\Source\AST\ASTEnum;
@@ -112,7 +113,7 @@ class MethodNode extends AbstractCallableNode
     /**
      * Returns the parent class or interface instance.
      *
-     * @return AbstractTypeNode
+     * @return AbstractTypeNode<ASTArtifact>
      * @throws RuntimeException
      */
     public function getParentType()

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -20,9 +20,11 @@ namespace PHPMD\Node;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PDepend\Source\AST\ASTEnum;
+use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTTrait;
 use PHPMD\Rule;
+use RuntimeException;
 
 /**
  * Wrapper around a PHP_Depend method node.
@@ -96,6 +98,7 @@ class MethodNode extends AbstractCallableNode
      * instance.
      *
      * @return bool
+     * @throws RuntimeException
      */
     public function hasSuppressWarningsAnnotationFor(Rule $rule)
     {
@@ -110,6 +113,7 @@ class MethodNode extends AbstractCallableNode
      * Returns the parent class or interface instance.
      *
      * @return AbstractTypeNode
+     * @throws RuntimeException
      */
     public function getParentType()
     {
@@ -127,7 +131,11 @@ class MethodNode extends AbstractCallableNode
             return new EnumNode($parentNode);
         }
 
-        return new InterfaceNode($parentNode);
+        if ($parentNode instanceof ASTInterface) {
+            return new InterfaceNode($parentNode);
+        }
+
+        throw new RuntimeException('Unexpected method parent type: ' . $parentNode::class);
     }
 
     /**

--- a/src/main/php/PHPMD/Node/NodeInfoFactory.php
+++ b/src/main/php/PHPMD/Node/NodeInfoFactory.php
@@ -2,10 +2,15 @@
 
 namespace PHPMD\Node;
 
+use PDepend\Source\AST\ASTNode;
 use PHPMD\AbstractNode as PHPMDAbstractNode;
 
 class NodeInfoFactory
 {
+    /**
+     * @param PHPMDAbstractNode<ASTNode> $node
+     * @return NodeInfo
+     */
     public static function fromNode(PHPMDAbstractNode $node)
     {
         $className = null;

--- a/src/main/php/PHPMD/Node/TraitNode.php
+++ b/src/main/php/PHPMD/Node/TraitNode.php
@@ -21,6 +21,8 @@ use PDepend\Source\AST\ASTTrait;
 
 /**
  * Wrapper around PHP_Depend's interface objects.
+ *
+ * @extends AbstractTypeNode<ASTTrait>
  */
 class TraitNode extends AbstractTypeNode
 {

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -42,14 +42,14 @@ class PHPMD
     /**
      * List of valid file extensions for analyzed files.
      *
-     * @var array(string)
+     * @var list<string>
      */
     private $fileExtensions = ['php', 'php3', 'php4', 'php5', 'inc'];
 
     /**
      * List of exclude directory patterns.
      *
-     * @var array(string)
+     * @var list<string>
      */
     private $ignorePatterns = ['.git', '.svn', 'CVS', '.bzr', '.hg', 'SCCS'];
 
@@ -75,7 +75,7 @@ class PHPMD
     /**
      * Additional options for PHPMD or one of it's parser backends.
      *
-     * @var array
+     * @var array<string, string>
      * @since 1.2.0
      */
     private $options = [];
@@ -186,7 +186,7 @@ class PHPMD
     /**
      * Returns additional options for PHPMD or one of it's parser backends.
      *
-     * @return array
+     * @return array<string, string>
      */
     public function getOptions()
     {
@@ -196,7 +196,7 @@ class PHPMD
     /**
      * Sets additional options for PHPMD or one of it's parser backends.
      *
-     * @param array $options Additional backend or PHPMD options.
+     * @param array<string, string> $options Additional backend or PHPMD options.
      */
     public function setOptions(array $options): void
     {
@@ -209,10 +209,9 @@ class PHPMD
      * argument. The result will be passed to all given renderer instances.
      *
      * @param string             $inputPath
-     * @param array|null         $ignorePattern
+     * @param string[]|null      $ignorePattern
      * @param AbstractRenderer[] $renderers
      * @param RuleSet[]          $ruleSetList
-     *
      * @throws Exception
      */
     public function processFiles(

--- a/src/main/php/PHPMD/Parser.php
+++ b/src/main/php/PHPMD/Parser.php
@@ -23,6 +23,7 @@ use PDepend\Engine;
 use PDepend\Metrics\Analyzer;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Report\CodeAwareGenerator;
+use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
@@ -31,6 +32,7 @@ use PDepend\Source\AST\ASTEnum;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\ASTVisitor\AbstractASTVisitor;
 use PHPMD\Node\AbstractNode;
@@ -49,21 +51,21 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
     /**
      * The analysing rule-set instance.
      *
-     * @var RuleSet[]
+     * @var list<RuleSet>
      */
     private $ruleSets = [];
 
     /**
      * The metric containing analyzer instances.
      *
-     * @var AnalyzerNodeAware[]
+     * @var list<AnalyzerNodeAware>
      */
     private $analyzers = [];
 
     /**
      * The raw PDepend code nodes.
      *
-     * @var ASTArtifactList
+     * @var ASTArtifactList<ASTNamespace>
      */
     private $artifacts = null;
 
@@ -280,6 +282,8 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
 
     /**
      * Sets the context code nodes.
+     *
+     * @param ASTArtifactList<ASTNamespace> $artifacts
      */
     public function setArtifacts(ASTArtifactList $artifacts): void
     {
@@ -289,6 +293,7 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
     /**
      * Applies all rule-sets to the given <b>$node</b> instance.
      *
+     * @param AbstractNode<ASTArtifact> $node
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException
@@ -305,6 +310,8 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
     /**
      * Collects the collected metrics for the given node and adds them to the
      * <b>$node</b>.
+     *
+     * @param AbstractNode<ASTArtifact> $node
      */
     private function collectMetrics(AbstractNode $node): void
     {

--- a/src/main/php/PHPMD/Parser.php
+++ b/src/main/php/PHPMD/Parser.php
@@ -33,6 +33,7 @@ use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\ASTVisitor\AbstractASTVisitor;
+use PHPMD\Node\AbstractNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\EnumNode;
 use PHPMD\Node\FunctionNode;

--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -38,7 +38,7 @@ class ParserFactory
     /**
      * Mapping between phpmd option names and those used by pdepend.
      *
-     * @var array
+     * @var array<string, string>
      */
     private $phpmd2pdepend = [
         'coverage' => 'coverage-report',

--- a/src/main/php/PHPMD/Renderer/AnsiRenderer.php
+++ b/src/main/php/PHPMD/Renderer/AnsiRenderer.php
@@ -49,8 +49,8 @@ class AnsiRenderer extends AbstractRenderer
     {
         $maxLength = null;
         foreach ($report->getRuleViolations() as $violation) {
-            if ($maxLength === null || strlen($violation->getBeginLine()) > $maxLength) {
-                $maxLength = strlen($violation->getBeginLine());
+            if ($maxLength === null || strlen((string) $violation->getBeginLine()) > $maxLength) {
+                $maxLength = strlen((string) $violation->getBeginLine());
             }
         }
 
@@ -76,7 +76,7 @@ class AnsiRenderer extends AbstractRenderer
     {
         $this->getWriter()->write(sprintf(
             " %s | \e[31mVIOLATION\e[0m | %s" . PHP_EOL,
-            str_pad($violation->getBeginLine(), $padding, ' '),
+            str_pad((string) $violation->getBeginLine(), $padding, ' '),
             $violation->getDescription()
         ));
     }

--- a/src/main/php/PHPMD/Renderer/AnsiRenderer.php
+++ b/src/main/php/PHPMD/Renderer/AnsiRenderer.php
@@ -3,7 +3,6 @@
 namespace PHPMD\Renderer;
 
 use PHPMD\AbstractRenderer;
-use PHPMD\ProcessingError;
 use PHPMD\Report;
 use PHPMD\RuleViolation;
 
@@ -87,7 +86,6 @@ class AnsiRenderer extends AbstractRenderer
             return;
         }
 
-        /** @var ProcessingError $error */
         foreach ($report->getErrors() as $error) {
             $errorHeader = sprintf(
                 "\e[33mERROR\e[0m while parsing %s",

--- a/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
+++ b/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
@@ -29,7 +29,7 @@ class CheckStyleRenderer extends XMLRenderer
      * - priority 2 maps to warning level severity
      * - priority > 2 maps to info level severity
      */
-    protected function mapPriorityToSeverity($priority)
+    private function mapPriorityToSeverity($priority)
     {
         if ($priority > 2) {
             return 'info';

--- a/src/main/php/PHPMD/Renderer/GitHubRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitHubRenderer.php
@@ -38,7 +38,7 @@ class GitHubRenderer extends AbstractRenderer
             $writer->write('::warning file=');
             $writer->write($violation->getFileName());
             $writer->write(',line=');
-            $writer->write($violation->getBeginLine());
+            $writer->write((string) $violation->getBeginLine());
             $writer->write('::');
             $writer->write($violation->getDescription());
             $writer->write(PHP_EOL);

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Renderer;
 
+use JsonException;
 use PHPMD\AbstractRenderer;
 use PHPMD\Report;
 
@@ -119,13 +120,13 @@ class GitLabRenderer extends AbstractRenderer
      * Encode report data to the JSON representation string
      *
      * @param array<mixed> $data The report data
-     *
      * @return string
+     * @throws JsonException
      */
     private function encodeReport($data)
     {
-        $encodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP |
-            (defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0);
+        $encodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+            | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR;
 
         return json_encode($data, $encodeOptions);
     }

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -47,7 +47,7 @@ class GitLabRenderer extends AbstractRenderer
      *
      * @return list<array<string, mixed>> The report output with violations, if any.
      */
-    protected function addViolationsToReport(Report $report)
+    private function addViolationsToReport(Report $report)
     {
         $data = [];
 
@@ -92,7 +92,7 @@ class GitLabRenderer extends AbstractRenderer
      * @param array<int, array<string, mixed>> $data The report output to add the errors to.
      * @return array<int, array<string, mixed>> The report output with errors, if any.
      */
-    protected function addErrorsToReport(Report $report, array $data)
+    private function addErrorsToReport(Report $report, array $data)
     {
         $errors = $report->getErrors();
         foreach ($errors as $error) {

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -19,7 +19,6 @@ namespace PHPMD\Renderer;
 
 use PHPMD\AbstractRenderer;
 use PHPMD\Report;
-use PHPMD\RuleViolation;
 
 /**
  * This class will render a GitLab compatible JSON report.
@@ -45,13 +44,12 @@ class GitLabRenderer extends AbstractRenderer
      *
      * @param Report $report The report with potential violations.
      *
-     * @return array The report output with violations, if any.
+     * @return list<array<string, mixed>> The report output with violations, if any.
      */
     protected function addViolationsToReport(Report $report)
     {
         $data = [];
 
-        /** @var RuleViolation $violation */
         foreach ($report->getRuleViolations() as $violation) {
             $violationResult = [
                 'type' => 'issue',
@@ -90,9 +88,8 @@ class GitLabRenderer extends AbstractRenderer
      * Add errors, if any, to GitLab Code Quality report format
      *
      * @param Report $report The report with potential errors.
-     * @param array  $data   The report output to add the errors to.
-     *
-     * @return array The report output with errors, if any.
+     * @param array<int, array<string, mixed>> $data The report output to add the errors to.
+     * @return array<int, array<string, mixed>> The report output with errors, if any.
      */
     protected function addErrorsToReport(Report $report, array $data)
     {
@@ -121,7 +118,7 @@ class GitLabRenderer extends AbstractRenderer
     /**
      * Encode report data to the JSON representation string
      *
-     * @param array $data The report data
+     * @param array<mixed> $data The report data
      *
      * @return string
      */

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -44,7 +44,7 @@ class HTMLRenderer extends AbstractRenderer
     /**
      * @var array<int, string>
      */
-    protected static array $priorityTitles = [
+    private static array $priorityTitles = [
         1 => 'Top (1)',
         2 => 'High (2)',
         3 => 'Moderate (3)',
@@ -57,7 +57,7 @@ class HTMLRenderer extends AbstractRenderer
      *
      * @var array<string, array<string, string>>
      */
-    protected static array $descHighlightRules = [
+    private static array $descHighlightRules = [
         'method' => [ // Method names.
             'regex' => 'method\s+(((["\']).*["\'])|(\S+))',
             'css-class' => 'hlt-method',
@@ -72,14 +72,14 @@ class HTMLRenderer extends AbstractRenderer
         ],
     ];
 
-    protected static ?string $compiledHighlightRegex = null;
+    private static ?string $compiledHighlightRegex = null;
 
     /**
      * Specify how many extra lines are added to a code snippet
      * By default 2
      * @var int
      */
-    protected $extraLineInExcerpt = 2;
+    private $extraLineInExcerpt = 2;
 
     /**
      * @param ?int $extraLineInExcerpt
@@ -450,7 +450,7 @@ class HTMLRenderer extends AbstractRenderer
      * @throws RuntimeException
      * @throws LogicException
      */
-    protected static function getLineExcerpt($file, $lineNumber, $extra = 0)
+    private static function getLineExcerpt($file, $lineNumber, $extra = 0)
     {
         if (!is_readable($file)) {
             return [];
@@ -484,7 +484,7 @@ class HTMLRenderer extends AbstractRenderer
      * @param string $message
      * @return string
      */
-    protected static function colorize($message)
+    private static function colorize($message)
     {
         // Compile final regex, if not done already.
         if (!self::$compiledHighlightRegex) {
@@ -514,7 +514,7 @@ class HTMLRenderer extends AbstractRenderer
      * @param string $path
      * @return string
      */
-    protected static function highlightFile($path)
+    private static function highlightFile($path)
     {
         $file = substr(strrchr($path, "/") ?: '', 1);
         $dir = str_replace($file, '', $path);
@@ -529,7 +529,7 @@ class HTMLRenderer extends AbstractRenderer
      * @param string $itemsTitle
      * @param array<int, int> $items
      */
-    protected function writeTable($title, $itemsTitle, $items): void
+    private function writeTable($title, $itemsTitle, $items): void
     {
         if (!$items) {
             return;
@@ -571,7 +571,7 @@ class HTMLRenderer extends AbstractRenderer
      * @param iterable<RuleViolation> $violations
      * @return array<string, array<int, int>>
      */
-    protected static function sumUpViolations($violations)
+    private static function sumUpViolations($violations)
     {
         $result = [
             self::CATEGORY_PRIORITY => [],
@@ -618,7 +618,7 @@ class HTMLRenderer extends AbstractRenderer
      * @param bool $eol
      * @return string
      */
-    protected static function reduceWhitespace($input, $eol = true)
+    private static function reduceWhitespace($input, $eol = true)
     {
         return preg_replace("#\s+#", " ", $input) . ($eol ? PHP_EOL : null);
     }

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -466,8 +466,11 @@ class HTMLRenderer extends AbstractRenderer
         if (!$file->eof()) {
             $file->seek($line);
             for ($i = 0; $i <= ($extra * 2); $i++) {
-                $result[++$line] = trim((string) $file->current(), "\n");
-                $file->next();
+                $lineContent = $file->current();
+                if (is_string($lineContent)) {
+                    $result[++$line] = trim($lineContent, "\n");
+                    $file->next();
+                }
             }
         }
 
@@ -513,7 +516,7 @@ class HTMLRenderer extends AbstractRenderer
      */
     protected static function highlightFile($path)
     {
-        $file = substr(strrchr($path, "/"), 1);
+        $file = substr(strrchr($path, "/") ?: '', 1);
         $dir = str_replace($file, '', $path);
 
         return $dir . "<span class='path-basename'>" . $file . '</span>';

--- a/src/main/php/PHPMD/Renderer/JSONRenderer.php
+++ b/src/main/php/PHPMD/Renderer/JSONRenderer.php
@@ -17,6 +17,7 @@
 
 namespace PHPMD\Renderer;
 
+use JsonException;
 use PHPMD\AbstractRenderer;
 use PHPMD\PHPMD;
 use PHPMD\Report;
@@ -113,13 +114,13 @@ class JSONRenderer extends AbstractRenderer
      * Encode report data to the JSON representation string
      *
      * @param array<mixed> $data The report data
-     *
      * @return string
+     * @throws JsonException
      */
     private function encodeReport($data)
     {
-        $encodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP |
-            (defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0);
+        $encodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+            | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR;
 
         return json_encode($data, $encodeOptions);
     }

--- a/src/main/php/PHPMD/Renderer/JSONRenderer.php
+++ b/src/main/php/PHPMD/Renderer/JSONRenderer.php
@@ -20,7 +20,6 @@ namespace PHPMD\Renderer;
 use PHPMD\AbstractRenderer;
 use PHPMD\PHPMD;
 use PHPMD\Report;
-use PHPMD\RuleViolation;
 
 /**
  * This class will render a JSON report.
@@ -44,7 +43,7 @@ class JSONRenderer extends AbstractRenderer
     /**
      * Create report data and add renderer meta properties
      *
-     * @return array
+     * @return array<string, string>
      */
     protected function initReportData()
     {
@@ -61,13 +60,12 @@ class JSONRenderer extends AbstractRenderer
      * Add violations, if any, to the report data
      *
      * @param Report $report The report with potential violations.
-     * @param array $data The report output to add the violations to.
-     * @return array The report output with violations, if any.
+     * @param array<string, mixed> $data The report output to add the violations to.
+     * @return array<string, mixed> The report output with violations, if any.
      */
     protected function addViolationsToReport(Report $report, array $data)
     {
         $filesList = [];
-        /** @var RuleViolation $violation */
         foreach ($report->getRuleViolations() as $violation) {
             $fileName = $violation->getFileName();
             $rule = $violation->getRule();
@@ -95,8 +93,8 @@ class JSONRenderer extends AbstractRenderer
      * Add errors, if any, to the report data
      *
      * @param Report $report The report with potential errors.
-     * @param array $data The report output to add the errors to.
-     * @return array The report output with errors, if any.
+     * @param array<string, mixed> $data The report output to add the errors to.
+     * @return array<string, mixed> The report output with errors, if any.
      */
     protected function addErrorsToReport(Report $report, array $data)
     {
@@ -114,7 +112,7 @@ class JSONRenderer extends AbstractRenderer
     /**
      * Encode report data to the JSON representation string
      *
-     * @param array $data The report data
+     * @param array<mixed> $data The report data
      *
      * @return string
      */

--- a/src/main/php/PHPMD/Renderer/RendererFactory.php
+++ b/src/main/php/PHPMD/Renderer/RendererFactory.php
@@ -12,7 +12,7 @@ class RendererFactory
     public static function createBaselineRenderer(StreamWriter $writer)
     {
         // set base path to current working directory
-        $renderer = new BaselineRenderer(getcwd());
+        $renderer = new BaselineRenderer(getcwd() ?: '');
         $renderer->setWriter($writer);
 
         return $renderer;

--- a/src/main/php/PHPMD/Renderer/SARIFRenderer.php
+++ b/src/main/php/PHPMD/Renderer/SARIFRenderer.php
@@ -50,7 +50,7 @@ class SARIFRenderer extends JSONRenderer
                     ],
                     'originalUriBaseIds' => [
                         'WORKINGDIR' => [
-                            'uri' => static::pathToUri(getcwd() ?: '') . '/',
+                            'uri' => self::pathToUri(getcwd() ?: '') . '/',
                         ],
                     ],
                     'results' => [],
@@ -135,7 +135,7 @@ class SARIFRenderer extends JSONRenderer
                 'locations' => [
                     [
                         'physicalLocation' => [
-                            'artifactLocation' => static::pathToArtifactLocation($violation->getFileName()),
+                            'artifactLocation' => self::pathToArtifactLocation($violation->getFileName()),
                             'region' => [
                                 'startLine' => $violation->getBeginLine(),
                                 'endLine' => $violation->getEndLine(),
@@ -173,7 +173,7 @@ class SARIFRenderer extends JSONRenderer
                 'locations' => [
                     [
                         'physicalLocation' => [
-                            'artifactLocation' => static::pathToArtifactLocation($error->getFile()),
+                            'artifactLocation' => self::pathToArtifactLocation($error->getFile()),
                         ],
                     ],
                 ],
@@ -191,7 +191,7 @@ class SARIFRenderer extends JSONRenderer
      * @param string $path
      * @return array<string, string>
      */
-    protected static function pathToArtifactLocation($path)
+    private static function pathToArtifactLocation($path)
     {
         $workingDir = getcwd() ?: '';
         if (substr($path, 0, strlen($workingDir)) === $workingDir) {
@@ -204,7 +204,7 @@ class SARIFRenderer extends JSONRenderer
 
         // absolute path with protocol
         return [
-            'uri' => static::pathToUri($path),
+            'uri' => self::pathToUri($path),
         ];
     }
 
@@ -214,7 +214,7 @@ class SARIFRenderer extends JSONRenderer
      * @param string $path
      * @return string
      */
-    protected static function pathToUri($path)
+    private static function pathToUri($path)
     {
         $path = str_replace(DIRECTORY_SEPARATOR, '/', $path);
 

--- a/src/main/php/PHPMD/Renderer/SARIFRenderer.php
+++ b/src/main/php/PHPMD/Renderer/SARIFRenderer.php
@@ -50,7 +50,7 @@ class SARIFRenderer extends JSONRenderer
                     ],
                     'originalUriBaseIds' => [
                         'WORKINGDIR' => [
-                            'uri' => static::pathToUri(getcwd()) . '/',
+                            'uri' => static::pathToUri(getcwd() ?: '') . '/',
                         ],
                     ],
                     'results' => [],
@@ -65,10 +65,9 @@ class SARIFRenderer extends JSONRenderer
      * Add violations, if any, to the report data
      *
      * @param Report $report The report with potential violations.
-     * @param array<string, array<int, array<string, array<string, array<mixed>>>>> $data The report output to add the
-     *                                                                                    violations to.
-     * @return array<string, array<int, array<string, array<string, array<mixed>>>>> The report output with violations,
-     *                                                                               if any.
+     * @param array<string, array<int, array<string, array<array<mixed>>>>> $data The report output to add the
+     *                                                                            violations to.
+     * @return array<string, array<int, array<string, array<array<mixed>>>>> The report output with violations, if any.
      */
     protected function addViolationsToReport(Report $report, array $data)
     {
@@ -194,7 +193,7 @@ class SARIFRenderer extends JSONRenderer
      */
     protected static function pathToArtifactLocation($path)
     {
-        $workingDir = getcwd();
+        $workingDir = getcwd() ?: '';
         if (substr($path, 0, strlen($workingDir)) === $workingDir) {
             // relative path
             return [

--- a/src/main/php/PHPMD/Renderer/SARIFRenderer.php
+++ b/src/main/php/PHPMD/Renderer/SARIFRenderer.php
@@ -19,7 +19,6 @@ namespace PHPMD\Renderer;
 
 use PHPMD\PHPMD;
 use PHPMD\Report;
-use PHPMD\RuleViolation;
 
 /**
  * This class will render a SARIF (Static Analysis
@@ -30,7 +29,7 @@ class SARIFRenderer extends JSONRenderer
     /**
      * Create report data and add renderer meta properties
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function initReportData()
     {
@@ -66,8 +65,10 @@ class SARIFRenderer extends JSONRenderer
      * Add violations, if any, to the report data
      *
      * @param Report $report The report with potential violations.
-     * @param array $data The report output to add the violations to.
-     * @return array The report output with violations, if any.
+     * @param array<string, array<int, array<string, array<string, array<mixed>>>>> $data The report output to add the
+     *                                                                                    violations to.
+     * @return array<string, array<int, array<string, array<string, array<mixed>>>>> The report output with violations,
+     *                                                                               if any.
      */
     protected function addViolationsToReport(Report $report, array $data)
     {
@@ -75,7 +76,6 @@ class SARIFRenderer extends JSONRenderer
         $results = [];
         $ruleIndices = [];
 
-        /** @var RuleViolation $violation */
         foreach ($report->getRuleViolations() as $violation) {
             $rule = $violation->getRule();
             $ruleRef = str_replace(' ', '', $rule->getRuleSetName()) . '/' . $rule->getName();
@@ -157,8 +157,10 @@ class SARIFRenderer extends JSONRenderer
      * Add errors, if any, to the report data
      *
      * @param Report $report The report with potential errors.
-     * @param array $data The report output to add the errors to.
-     * @return array The report output with errors, if any.
+     * @param array<string, array<int, array<string, list<array<string, mixed>>>>> $data The report output to add the
+     *                                                                                   errors to.
+     * @return array<string, array<int, array<string, list<array<string, mixed>>>>> The report output with errors, if
+     *                                                                              any.
      */
     protected function addErrorsToReport(Report $report, array $data)
     {
@@ -188,7 +190,7 @@ class SARIFRenderer extends JSONRenderer
      * and returns the result as a SARIF `artifactLocation`
      *
      * @param string $path
-     * @return array
+     * @return array<string, string>
      */
     protected static function pathToArtifactLocation($path)
     {

--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -29,11 +29,11 @@ use PHPMD\Report;
  */
 class TextRenderer extends AbstractRenderer implements Verbose, Color
 {
-    protected int $columnSpacing = 2;
+    private int $columnSpacing = 2;
 
-    protected int $verbosityLevel = OutputInterface::VERBOSITY_NORMAL;
+    private int $verbosityLevel = OutputInterface::VERBOSITY_NORMAL;
 
-    protected bool $colored = false;
+    private bool $colored = false;
 
     /**
      * This method will be called when the engine has finished the source analysis
@@ -99,7 +99,7 @@ class TextRenderer extends AbstractRenderer implements Verbose, Color
         $this->colored = $colored;
     }
 
-    protected function applyColor(string $text, string $color): string
+    private function applyColor(string $text, string $color): string
     {
         if (!$this->colored) {
             return $text;

--- a/src/main/php/PHPMD/Renderer/TextRenderer.php
+++ b/src/main/php/PHPMD/Renderer/TextRenderer.php
@@ -29,11 +29,11 @@ use PHPMD\Report;
  */
 class TextRenderer extends AbstractRenderer implements Verbose, Color
 {
-    protected $columnSpacing = 2;
+    protected int $columnSpacing = 2;
 
-    protected $verbosityLevel = OutputInterface::VERBOSITY_NORMAL;
+    protected int $verbosityLevel = OutputInterface::VERBOSITY_NORMAL;
 
-    protected $colored = false;
+    protected bool $colored = false;
 
     /**
      * This method will be called when the engine has finished the source analysis
@@ -99,7 +99,7 @@ class TextRenderer extends AbstractRenderer implements Verbose, Color
         $this->colored = $colored;
     }
 
-    protected function applyColor($text, $color)
+    protected function applyColor(string $text, string $color): string
     {
         if (!$this->colored) {
             return $text;
@@ -109,7 +109,7 @@ class TextRenderer extends AbstractRenderer implements Verbose, Color
             'yellow' => 33,
             'red' => 31,
         ];
-        $color = $colors[$color] ?? $color;
+        $color = $colors[$color] ?? 0;
 
         return "\033[{$color}m{$text}\033[0m";
     }

--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -30,7 +30,7 @@ class Report
     /**
      * List of rule violations detected in the analyzed source code.
      *
-     * @var array
+     * @var array<string, array<int, list<RuleViolation>>>
      */
     private $ruleViolations = [];
 
@@ -51,7 +51,7 @@ class Report
     /**
      * Errors that occurred while parsing the source.
      *
-     * @var array
+     * @var list<ProcessingError>
      * @since 1.2.1
      */
     private $errors = [];

--- a/src/main/php/PHPMD/Rule.php
+++ b/src/main/php/PHPMD/Rule.php
@@ -20,6 +20,7 @@ namespace PHPMD;
 use InvalidArgumentException;
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
+use PDepend\Source\AST\ASTNode;
 
 /**
  * Base interface for a PHPMD rule.
@@ -90,6 +91,8 @@ interface Rule
 
     /**
      * Returns a list of examples for this rule.
+     *
+     * @return list<string>
      */
     public function getExamples(): array;
 
@@ -167,6 +170,7 @@ interface Rule
      * This method should implement the violation analysis algorithm of concrete
      * rule implementations. All extending classes must implement this method.
      *
+     * @param AbstractNode<ASTNode> $node The node to check upon.
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -210,7 +210,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      */
     protected function getVariableImage($variable)
     {
-        if ($variable instanceof ASTNode) {
+        if ($variable instanceof AbstractNode) {
             $variable = $variable->getNode();
         }
         $image = $variable->getImage();

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -42,7 +42,7 @@ abstract class AbstractLocalVariable extends AbstractRule
     /**
      * @var list<string> Self reference class names.
      */
-    protected $selfReferences = ['self', 'static'];
+    private $selfReferences = ['self', 'static'];
 
     /**
      * PHP super globals that are available in all php scopes, so that they
@@ -51,7 +51,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * @var array<string, bool>
      * @link http://php.net/manual/en/reserved.variables.php
      */
-    protected static $superGlobals = [
+    private static $superGlobals = [
         '$argc' => true,
         '$argv' => true,
         '$_COOKIE' => true,
@@ -103,7 +103,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * @param AbstractNode<ASTVariable> $variable
      * @return bool
      */
-    protected function isNotSuperGlobal(AbstractNode $variable)
+    private function isNotSuperGlobal(AbstractNode $variable)
     {
         return !$this->isSuperGlobal($variable);
     }
@@ -144,7 +144,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * @return ASTNode<PDependNode>
      * @throws OutOfBoundsException
      */
-    protected function stripWrappedIndexExpression(ASTNode $node)
+    private function stripWrappedIndexExpression(ASTNode $node)
     {
         if (!$this->isWrappedByIndexExpression($node)) {
             return $node;
@@ -164,7 +164,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * @param ASTNode<PDependNode> $node
      * @return bool
      */
-    protected function isWrappedByIndexExpression(ASTNode $node)
+    private function isWrappedByIndexExpression(ASTNode $node)
     {
         return ($node->getParent()->isInstanceOf(ASTArrayIndexExpression::class)
             || $node->getParent()->isInstanceOf(ASTStringIndexExpression::class)
@@ -232,7 +232,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * @return ?string
      * @throws OutOfBoundsException
      */
-    protected function getParentMemberPrimaryPrefixImage($image, ASTPropertyPostfix $postfix)
+    private function getParentMemberPrimaryPrefixImage($image, ASTPropertyPostfix $postfix)
     {
         do {
             $postfix = $postfix->getParent();
@@ -257,7 +257,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * @param ASTNode<PDependNode>|PDependNode $node
      * @return PDependNode
      */
-    protected function getNode($node)
+    private function getNode($node)
     {
         if ($node instanceof ASTNode) {
             return $node->getNode();

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -149,7 +149,7 @@ abstract class AbstractLocalVariable extends AbstractRule
         }
 
         $parent = $node->getParent();
-        if ($parent->getChild(0)->getNode() === $node->getNode()) {
+        if ($parent?->getChild(0)->getNode() === $node->getNode()) {
             return $this->stripWrappedIndexExpression($parent);
         }
 
@@ -344,7 +344,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * same variable and won't overlap in a storage keyed by image as first one
      * image is "$foo", second one is "::$foo".
      *
-     * @param ASTPropertyPostfix|ASTVariable|ASTVariableDeclarator $variable
+     * @param PDependNode $variable
      * @return string
      * @throws OutOfBoundsException
      */
@@ -378,7 +378,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * }
      * ```
      *
-     * @param ASTPropertyPostfix|ASTVariable|ASTVariableDeclarator $variable
+     * @param PDependNode $variable
      * @param string $image
      * @return bool
      */

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -20,14 +20,12 @@ namespace PHPMD\Rule;
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTArrayIndexExpression;
-use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTPropertyPostfix;
 use PDepend\Source\AST\ASTStringIndexExpression;
 use PDepend\Source\AST\ASTVariable;
-use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
@@ -42,7 +40,7 @@ use ReflectionFunction;
 abstract class AbstractLocalVariable extends AbstractRule
 {
     /**
-     * @var array Self reference class names.
+     * @var list<string> Self reference class names.
      */
     protected $selfReferences = ['self', 'static'];
 
@@ -50,7 +48,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * PHP super globals that are available in all php scopes, so that they
      * can never be unused local variables.
      *
-     * @var array(string=>boolean)
+     * @var array<string, bool>
      * @link http://php.net/manual/en/reserved.variables.php
      */
     protected static $superGlobals = [
@@ -90,6 +88,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Tests if the given variable represents one of the PHP super globals
      * that are available in scopes.
      *
+     * @param AbstractNode<ASTVariable> $variable
      * @return bool
      */
     protected function isSuperGlobal(AbstractNode $variable)
@@ -101,6 +100,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Tests if the given variable does not represent one of the PHP super globals
      * that are available in scopes.
      *
+     * @param AbstractNode<ASTVariable> $variable
      * @return bool
      */
     protected function isNotSuperGlobal(AbstractNode $variable)
@@ -112,6 +112,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Tests if the given variable node is a regular variable an not property
      * or method postfix.
      *
+     * @param ASTNode<ASTVariable> $variable
      * @return bool
      * @throws OutOfBoundsException
      */
@@ -139,7 +140,8 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Removes all index expressions that are wrapped around the given node
      * instance.
      *
-     * @return ASTNode
+     * @param ASTNode<PDependNode> $node
+     * @return ASTNode<PDependNode>
      * @throws OutOfBoundsException
      */
     protected function stripWrappedIndexExpression(ASTNode $node)
@@ -159,6 +161,7 @@ abstract class AbstractLocalVariable extends AbstractRule
     /**
      * Tests if the given variable node os part of an index expression.
      *
+     * @param ASTNode<PDependNode> $node
      * @return bool
      */
     protected function isWrappedByIndexExpression(ASTNode $node)
@@ -172,6 +175,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * PHP is case insensitive so we should compare function names case
      * insensitive.
      *
+     * @param AbstractNode<PDependNode> $node
      * @param string $name
      * @return bool
      */
@@ -184,6 +188,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * AST puts namespace prefix to global functions called from a namespace.
      * This method checks if the last part of function fully qualified name is equal to $name
      *
+     * @param AbstractNode<PDependNode> $node
      * @param string $name
      * @return bool
      */
@@ -199,7 +204,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      *
      * Prefix self:: and static:: properties with "::".
      *
-     * @param AbstractNode|PDependNode $variable
+     * @param AbstractNode<PDependNode>|PDependNode $variable
      * @return string
      * @throws OutOfBoundsException
      */
@@ -223,6 +228,8 @@ abstract class AbstractLocalVariable extends AbstractRule
     }
 
     /**
+     * @param string $image
+     * @return ?string
      * @throws OutOfBoundsException
      */
     protected function getParentMemberPrimaryPrefixImage($image, ASTPropertyPostfix $postfix)
@@ -247,7 +254,8 @@ abstract class AbstractLocalVariable extends AbstractRule
      *
      * Or return the input as is if it's not an ASTNode PHPMD node.
      *
-     * @return ASTArtifact|PDependNode
+     * @param ASTNode<PDependNode>|PDependNode $node
+     * @return PDependNode
      */
     protected function getNode($node)
     {
@@ -288,18 +296,18 @@ abstract class AbstractLocalVariable extends AbstractRule
     /**
      * Return true if the given variable is passed by reference in a native PHP function.
      *
-     * @param ASTPropertyPostfix|ASTVariable|ASTVariableDeclarator $variable
+     * @param ASTVariable $variable
      * @return bool
      */
     protected function isPassedByReference($variable)
     {
-        $parent = $this->getNode($variable->getParent());
+        $parent = $variable->getParent();
 
         if (!($parent instanceof ASTArguments)) {
             return false;
         }
 
-        $argumentPosition = array_search($this->getNode($variable), $parent->getChildren());
+        $argumentPosition = array_search($variable, $parent->getChildren());
         $parentParent = $parent->getParent();
         if ($parentParent === null) {
             return false;
@@ -348,7 +356,7 @@ abstract class AbstractLocalVariable extends AbstractRule
      * @return string
      * @throws OutOfBoundsException
      */
-    private function prependMemberPrimaryPrefix($image, $variable)
+    private function prependMemberPrimaryPrefix(string $image, $variable)
     {
         $parent = $variable->getParent();
 

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -19,6 +19,7 @@ namespace PHPMD\Rule\CleanCode;
 
 use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTFormalParameter;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTValue;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
@@ -70,7 +71,7 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
         $this->scanFormalParameters($node);
     }
 
-    protected function isBooleanValue(ASTValue $value = null)
+    protected function isBooleanValue(ASTValue $value = null): bool
     {
         return $value?->isValueAvailable() && is_bool($value->getValue());
     }
@@ -89,6 +90,9 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
         return $this->exceptions;
     }
 
+    /**
+     * @param AbstractNode<ASTNode> $node
+     */
     private function scanFormalParameters(AbstractNode $node): void
     {
         foreach ($node->findChildrenOfType(ASTFormalParameter::class) as $param) {

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -57,7 +57,7 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
         }
 
         $currNode = $node->getNode();
-        $parent = is_callable([$currNode, 'getParent']) ? $currNode->getParent() : null;
+        $parent = $currNode->getParent();
 
         if ($parent &&
             ($parent instanceof AbstractASTClassOrInterface) &&

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -20,7 +20,6 @@ namespace PHPMD\Rule\CleanCode;
 use OutOfBoundsException;
 use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTArray;
-use PDepend\Source\AST\ASTArrayElement;
 use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTNode as PDependASTNode;
 use PHPMD\AbstractNode;
@@ -53,14 +52,16 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      * This method checks if a given function or method contains an array literal
      * with duplicated entries for any key and emits a rule violation if so.
      *
-     * @param ASTNode $node Array node.
+     * @param ASTNode<ASTArray> $node Array node.
      * @throws OutOfBoundsException
      */
     protected function checkForDuplicatedArrayKeys(ASTNode $node): void
     {
         $keys = [];
-        /** @var ASTArrayElement $arrayElement */
         foreach ($node->getChildren() as $index => $arrayElement) {
+            if (!$arrayElement instanceof AbstractASTNode) {
+                continue;
+            }
             $arrayElement = $this->normalizeKey($arrayElement, $index);
             if (null === $arrayElement) {
                 // skip everything that can't be resolved easily

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -70,7 +70,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
 
             $key = $arrayElement->getImage();
             if (isset($keys[$key])) {
-                $this->addViolation($node, [$key, $arrayElement->getStartLine()]);
+                $this->addViolation($node, [$key, (string) $arrayElement->getStartLine()]);
                 continue;
             }
             $keys[$key] = $arrayElement;

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -55,7 +55,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      * @param ASTNode<ASTArray> $node Array node.
      * @throws OutOfBoundsException
      */
-    protected function checkForDuplicatedArrayKeys(ASTNode $node): void
+    private function checkForDuplicatedArrayKeys(ASTNode $node): void
     {
         $keys = [];
         foreach ($node->getChildren() as $index => $arrayElement) {
@@ -91,7 +91,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      * @return ?AbstractASTNode Key name
      * @throws OutOfBoundsException
      */
-    protected function normalizeKey(AbstractASTNode $node, $index)
+    private function normalizeKey(AbstractASTNode $node, $index)
     {
         $childCount = count($node->getChildren());
         // Skip, if there is no array key, just an array value
@@ -120,7 +120,7 @@ class DuplicatedArrayKey extends AbstractRule implements MethodAware, FunctionAw
      *
      * @return string
      */
-    protected function castStringFromLiteral(PDependASTNode $key)
+    private function castStringFromLiteral(PDependASTNode $key)
     {
         $value = $key->getImage();
         switch ($value) {

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -42,6 +42,10 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
         foreach ($node->findChildrenOfType(ASTScopeStatement::class) as $scope) {
             $parent = $scope->getParent();
 
+            if (!$parent) {
+                continue;
+            }
+
             if (!$this->isIfOrElseIfStatement($parent)) {
                 continue;
             }

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Rule\CleanCode;
 
 use OutOfBoundsException;
+use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTScopeStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -61,6 +62,8 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
     /**
      * Whether the given scope is an else clause
      *
+     * @param AbstractNode<ASTScopeStatement> $scope
+     * @param ASTNode<PDependNode> $parent
      * @return bool
      * @throws OutOfBoundsException
      */
@@ -75,6 +78,7 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
     /**
      * Whether the parent node is an if or an elseif clause
      *
+     * @param ASTNode<PDependNode> $parent
      * @return bool
      */
     protected function isIfOrElseIfStatement(ASTNode $parent)

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -67,7 +67,7 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
      * @return bool
      * @throws OutOfBoundsException
      */
-    protected function isElseScope(AbstractNode $scope, ASTNode $parent)
+    private function isElseScope(AbstractNode $scope, ASTNode $parent)
     {
         return (
             count($parent->getChildren()) === 3 &&
@@ -81,7 +81,7 @@ class ElseExpression extends AbstractRule implements MethodAware, FunctionAware
      * @param ASTNode<PDependNode> $parent
      * @return bool
      */
-    protected function isIfOrElseIfStatement(ASTNode $parent)
+    private function isIfOrElseIfStatement(ASTNode $parent)
     {
         return ($parent->getName() === "if" || $parent->getName() === "elseif");
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
@@ -40,7 +40,7 @@ class ErrorControlOperator extends AbstractRule implements MethodAware, Function
     {
         foreach ($node->findChildrenOfType(ASTUnaryExpression::class) as $unaryExpression) {
             if ($unaryExpression->getImage() === '@') {
-                $this->addViolation($node, [$unaryExpression->getBeginLine()]);
+                $this->addViolation($node, [(string) $unaryExpression->getBeginLine()]);
             }
         }
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
@@ -69,7 +69,7 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @return array<int, ASTNode<ASTStatement>>
      */
-    protected function getStatements(AbstractCallableNode $node)
+    private function getStatements(AbstractCallableNode $node)
     {
         return [
             ...$node->findChildrenOfType(ASTIfStatement::class),
@@ -83,7 +83,7 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
      * @param array<ASTNode<ASTStatement>> $statements Array of if and elseif clauses
      * @return list<ASTNode<ASTExpression>>
      */
-    protected function getExpressions(array $statements)
+    private function getExpressions(array $statements)
     {
         $nodes = [];
 
@@ -104,7 +104,7 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
      * @param array<int, ASTNode<ASTExpression>> $expressions Array of expressions
      * @return array<int, ASTNode<ASTAssignmentExpression>>
      */
-    protected function getAssignments(array $expressions)
+    private function getAssignments(array $expressions)
     {
         $assignments = [];
         foreach ($expressions as $expression) {
@@ -123,7 +123,7 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
      * @param AbstractCallableNode<AbstractASTCallable> $node An instance of MethodNode or FunctionNode class
      * @param array<ASTNode<ASTAssignmentExpression>> $assignments Array of assignments
      */
-    protected function addViolations(AbstractCallableNode $node, array $assignments): void
+    private function addViolations(AbstractCallableNode $node, array $assignments): void
     {
         $processesViolations = [];
         foreach ($assignments as $assignment) {

--- a/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
@@ -24,6 +24,8 @@ use PDepend\Source\AST\ASTIfStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
+use PHPMD\Node\FunctionNode;
+use PHPMD\Node\MethodNode;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
 
@@ -94,8 +96,8 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
     /**
      * Extracts all assignments from expressions array
      *
-     * @param ASTExpression[] $expressions Array of expressions
-     * @return ASTAssignmentExpression[]
+     * @param array<int, ASTNode<ASTExpression>> $expressions Array of expressions
+     * @return array<int, ASTNode<ASTAssignmentExpression>>
      */
     protected function getAssignments(array $expressions)
     {
@@ -111,7 +113,7 @@ class IfStatementAssignment extends AbstractRule implements MethodAware, Functio
      * Signals if any violations have been found in given method or function
      *
      * @param AbstractNode $node An instance of MethodNode or FunctionNode class
-     * @param ASTAssignmentExpression[] $assignments Array of assignments
+     * @param array<int, ASTNode<ASTAssignmentExpression>> $assignments Array of assignments
      */
     protected function addViolations(AbstractNode $node, array $assignments): void
     {

--- a/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
@@ -35,7 +35,7 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
     /**
      * @var list<string> Self reference class names.
      */
-    protected $selfReferences = ['self', 'static'];
+    private $selfReferences = ['self', 'static'];
 
     /**
      * Checks for missing class imports and warns about it
@@ -77,7 +77,7 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
      * @param ASTNode<PDependNode> $classNode A class node to check.
      * @return bool Whether the given class node is a self reference.
      */
-    protected function isSelfReference(ASTNode $classNode)
+    private function isSelfReference(ASTNode $classNode)
     {
         return in_array($classNode->getImage(), $this->selfReferences, true);
     }
@@ -88,7 +88,7 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
      * @param ASTNode<PDependNode> $classNode A class node to check.
      * @return bool Whether the given class node is in the global namespace.
      */
-    protected function isGlobalNamespace(ASTNode $classNode)
+    private function isGlobalNamespace(ASTNode $classNode)
     {
         return $classNode->getImage() !== '' && !strpos($classNode->getImage(), '\\', 1);
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PDepend\Source\AST\ASTAllocationExpression;
+use PDepend\Source\AST\ASTNode as PDependNode;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
@@ -32,14 +33,12 @@ use PHPMD\Rule\MethodAware;
 class MissingImport extends AbstractRule implements MethodAware, FunctionAware
 {
     /**
-     * @var array Self reference class names.
+     * @var list<string> Self reference class names.
      */
     protected $selfReferences = ['self', 'static'];
 
     /**
      * Checks for missing class imports and warns about it
-     *
-     * @param AbstractNode $node The node to check upon.
      */
     public function apply(AbstractNode $node): void
     {
@@ -64,7 +63,10 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
             $fqcnLength = strlen($className);
 
             if ($classNameLength === $fqcnLength && substr($className, 0, 1) !== '$') {
-                $this->addViolation($classNode, [$classNode->getBeginLine(), $classNode->getStartColumn()]);
+                $this->addViolation(
+                    $classNode,
+                    [(string) $classNode->getBeginLine(), (string) $classNode->getStartColumn()]
+                );
             }
         }
     }
@@ -72,7 +74,7 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
     /**
      * Check whether a given class node is a self reference
      *
-     * @param ASTNode $classNode A class node to check.
+     * @param ASTNode<PDependNode> $classNode A class node to check.
      * @return bool Whether the given class node is a self reference.
      */
     protected function isSelfReference(ASTNode $classNode)
@@ -83,7 +85,7 @@ class MissingImport extends AbstractRule implements MethodAware, FunctionAware
     /**
      * Check whether a given class node is in the global namespace
      *
-     * @param ASTNode $classNode A class node to check.
+     * @param ASTNode<PDependNode> $classNode A class node to check.
      * @return bool Whether the given class node is in the global namespace.
      */
     protected function isGlobalNamespace(ASTNode $classNode)

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -42,7 +42,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
      *
      * @var ExceptionsList|null
      */
-    protected $exceptions;
+    private $exceptions;
 
     /**
      * Method checks for use of static access and warns about it.
@@ -75,7 +75,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
      * @param AbstractNode<ASTMemberPrimaryPrefix> $methodCall
      * @throws OutOfBoundsException
      */
-    protected function isStaticMethodCall(AbstractNode $methodCall): bool
+    private function isStaticMethodCall(AbstractNode $methodCall): bool
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTClassOrInterfaceReference &&
             $methodCall->getChild(1)->getNode() instanceof ASTMethodPostfix &&
@@ -87,7 +87,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
      * @param AbstractNode<ASTMemberPrimaryPrefix> $methodCall
      * @throws OutOfBoundsException
      */
-    protected function isCallingParent(AbstractNode $methodCall): bool
+    private function isCallingParent(AbstractNode $methodCall): bool
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTParentReference;
     }
@@ -96,7 +96,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
      * @param AbstractNode<ASTMemberPrimaryPrefix> $methodCall
      * @throws OutOfBoundsException
      */
-    protected function isCallingSelf(AbstractNode $methodCall): bool
+    private function isCallingSelf(AbstractNode $methodCall): bool
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTSelfReference;
     }
@@ -106,7 +106,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
      * @param string $ignorePattern
      * @return bool
      */
-    protected function isMethodIgnored(AbstractNode $methodCall, $ignorePattern)
+    private function isMethodIgnored(AbstractNode $methodCall, $ignorePattern)
     {
         if ($ignorePattern === '') {
             return false;
@@ -122,7 +122,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
      *
      * @return ExceptionsList
      */
-    protected function getExceptionsList()
+    private function getExceptionsList()
     {
         if ($this->exceptions === null) {
             $this->exceptions = new ExceptionsList($this, '\\');

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -72,9 +72,10 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
     }
 
     /**
+     * @param AbstractNode<ASTMemberPrimaryPrefix> $methodCall
      * @throws OutOfBoundsException
      */
-    protected function isStaticMethodCall(AbstractNode $methodCall)
+    protected function isStaticMethodCall(AbstractNode $methodCall): bool
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTClassOrInterfaceReference &&
             $methodCall->getChild(1)->getNode() instanceof ASTMethodPostfix &&
@@ -83,22 +84,25 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
     }
 
     /**
+     * @param AbstractNode<ASTMemberPrimaryPrefix> $methodCall
      * @throws OutOfBoundsException
      */
-    protected function isCallingParent(AbstractNode $methodCall)
+    protected function isCallingParent(AbstractNode $methodCall): bool
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTParentReference;
     }
 
     /**
+     * @param AbstractNode<ASTMemberPrimaryPrefix> $methodCall
      * @throws OutOfBoundsException
      */
-    protected function isCallingSelf(AbstractNode $methodCall)
+    protected function isCallingSelf(AbstractNode $methodCall): bool
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTSelfReference;
     }
 
     /**
+     * @param AbstractNode<ASTMemberPrimaryPrefix> $methodCall
      * @param string $ignorePattern
      * @return bool
      */

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -57,7 +57,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      *
      * @var array<string, PDependNode>
      */
-    protected $images = [];
+    private $images = [];
 
     /**
      * This method checks that all local variables within the given function or
@@ -100,7 +100,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
-    protected function collect(AbstractCallableNode $node): void
+    private function collect(AbstractCallableNode $node): void
     {
         $this->collectPropertyPostfix($node);
         $this->collectClosureParameters($node);
@@ -115,7 +115,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
     /**
      * @param AbstractASTClassOrInterface $node
      */
-    protected function collectProperties($node): void
+    private function collectProperties($node): void
     {
         if (!($node instanceof ASTClass)) {
             return;
@@ -134,7 +134,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
-    protected function collectGlobalStatements(AbstractCallableNode $node): void
+    private function collectGlobalStatements(AbstractCallableNode $node): void
     {
         foreach ($node->findChildrenWithParentType(ASTGlobalStatement::class) as $variable) {
             $this->addVariableDefinition($variable);
@@ -147,7 +147,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
-    protected function collectExceptionCatches(AbstractCallableNode $node): void
+    private function collectExceptionCatches(AbstractCallableNode $node): void
     {
         foreach ($node->findChildrenWithParentType(ASTCatchStatement::class) as $child) {
             if ($child instanceof ASTVariable) {
@@ -162,7 +162,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
-    protected function collectListExpressions(AbstractCallableNode $node): void
+    private function collectListExpressions(AbstractCallableNode $node): void
     {
         foreach ($node->findChildrenWithParentType(ASTListExpression::class) as $variable) {
             $this->addVariableDefinition($variable);
@@ -175,7 +175,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
-    protected function collectForeachStatements(AbstractCallableNode $node): void
+    private function collectForeachStatements(AbstractCallableNode $node): void
     {
         foreach ($node->findChildrenWithParentType(ASTForeachStatement::class) as $child) {
             if ($child instanceof ASTVariable) {
@@ -200,7 +200,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
-    protected function collectClosureParameters(AbstractCallableNode $node): void
+    private function collectClosureParameters(AbstractCallableNode $node): void
     {
         $closures = $node->findChildrenOfType(ASTClosure::class);
 
@@ -217,7 +217,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * @return bool
      * @throws OutOfBoundsException
      */
-    protected function checkVariableDefined(ASTNode $variable, AbstractCallableNode $parentNode)
+    private function checkVariableDefined(ASTNode $variable, AbstractCallableNode $parentNode)
     {
         $image = $this->getVariableImage($variable);
 
@@ -230,7 +230,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * @param AbstractNode<PDependNode> $node
      * @throws OutOfBoundsException
      */
-    protected function collectParameters(AbstractNode $node): void
+    private function collectParameters(AbstractNode $node): void
     {
         // Get formal parameter container
         $parameters = $node->getFirstChildOfType(ASTFormalParameters::class);
@@ -249,7 +249,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
-    protected function collectAssignments(AbstractCallableNode $node): void
+    private function collectAssignments(AbstractCallableNode $node): void
     {
         foreach ($node->findChildrenOfType(ASTAssignmentExpression::class) as $assignment) {
             $variable = $assignment->getChild(0);
@@ -277,7 +277,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
-    protected function collectPropertyPostfix(AbstractCallableNode $node): void
+    private function collectPropertyPostfix(AbstractCallableNode $node): void
     {
         foreach ($node->findChildrenWithParentType(ASTPropertyPostfix::class) as $child) {
             if ($child instanceof ASTVariable) {
@@ -292,7 +292,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * @param PDependNode $variable
      * @throws OutOfBoundsException
      */
-    protected function addVariableDefinition($variable): void
+    private function addVariableDefinition($variable): void
     {
         $image = $this->getVariableImage($variable);
 
@@ -308,7 +308,7 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * @param ASTNode<ASTVariable> $variable
      * @return bool
      */
-    protected function isNameAllowedInContext(AbstractCallableNode $node, ASTNode $variable)
+    private function isNameAllowedInContext(AbstractCallableNode $node, ASTNode $variable)
     {
         return (
             $node instanceof MethodNode &&

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -30,6 +30,9 @@ use PHPMD\Rule\MethodAware;
  */
 class CamelCaseMethodName extends AbstractRule implements MethodAware
 {
+    /**
+     * @var list<string>
+     */
     protected $ignoredMethods = [
         '__construct',
         '__destruct',
@@ -72,7 +75,7 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
     /**
      * @throws OutOfBoundsException
      */
-    protected function isValid($methodName)
+    protected function isValid(string $methodName): bool
     {
         // disallow any consecutive uppercase letters
         if ($this->getBooleanProperty('camelcase-abbreviations', false)

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -33,7 +33,7 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
     /**
      * @var list<string>
      */
-    protected $ignoredMethods = [
+    private $ignoredMethods = [
         '__construct',
         '__destruct',
         '__set',
@@ -75,7 +75,7 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
     /**
      * @throws OutOfBoundsException
      */
-    protected function isValid(string $methodName): bool
+    private function isValid(string $methodName): bool
     {
         // disallow any consecutive uppercase letters
         if ($this->getBooleanProperty('camelcase-abbreviations', false)

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -84,13 +84,13 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
         }
 
         if ($this->getBooleanProperty('allow-underscore-test') && str_starts_with($methodName, 'test')) {
-            return preg_match('/^test[a-zA-Z0-9]*(_[a-z][a-zA-Z0-9]*)*$/', $methodName);
+            return preg_match('/^test[a-zA-Z0-9]*(_[a-z][a-zA-Z0-9]*)*$/', $methodName) === 1;
         }
 
         if ($this->getBooleanProperty('allow-underscore')) {
-            return preg_match('/^_?[a-z][a-zA-Z0-9]*$/', $methodName);
+            return preg_match('/^_?[a-z][a-zA-Z0-9]*$/', $methodName) === 1;
         }
 
-        return preg_match('/^[a-z][a-zA-Z0-9]*$/', $methodName);
+        return preg_match('/^[a-z][a-zA-Z0-9]*$/', $methodName) === 1;
     }
 }

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
@@ -30,7 +30,7 @@ use PHPMD\Utility\Strings;
 class CamelCaseNamespace extends AbstractRule implements ClassAware, InterfaceAware, TraitAware, EnumAware
 {
     /** @var array<string, int>|null */
-    protected $exceptions;
+    private $exceptions;
 
     public function apply(AbstractNode $node): void
     {
@@ -61,7 +61,7 @@ class CamelCaseNamespace extends AbstractRule implements ClassAware, InterfaceAw
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
-    protected function getExceptionsList()
+    private function getExceptionsList()
     {
         if ($this->exceptions === null) {
             $this->exceptions = array_flip(

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -20,8 +20,7 @@ namespace PHPMD\Rule\Controversial;
 use OutOfBoundsException;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\FunctionNode;
-use PHPMD\Node\MethodNode;
+use PHPMD\Node\AbstractCallableNode;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
 
@@ -39,7 +38,7 @@ class CamelCaseParameterName extends AbstractRule implements MethodAware, Functi
      */
     public function apply(AbstractNode $node): void
     {
-        if (!$node instanceof FunctionNode && !$node instanceof MethodNode) {
+        if (!$node instanceof AbstractCallableNode) {
             return;
         }
 

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -66,9 +66,9 @@ class CamelCaseParameterName extends AbstractRule implements MethodAware, Functi
         }
 
         if ($this->getBooleanProperty('allow-underscore')) {
-            return preg_match('/^\$[_]?[a-z][a-zA-Z0-9]*$/', $parameterName);
+            return preg_match('/^\$[_]?[a-z][a-zA-Z0-9]*$/', $parameterName) === 1;
         }
 
-        return preg_match('/^\$[a-z][a-zA-Z0-9]*$/', $parameterName);
+        return preg_match('/^\$[a-z][a-zA-Z0-9]*$/', $parameterName) === 1;
     }
 }

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -57,7 +57,7 @@ class CamelCaseParameterName extends AbstractRule implements MethodAware, Functi
     /**
      * @throws OutOfBoundsException
      */
-    protected function isValid(string $parameterName): bool
+    private function isValid(string $parameterName): bool
     {
         // disallow any consecutive uppercase letters
         if ($this->getBooleanProperty('camelcase-abbreviations', false)

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -57,7 +57,7 @@ class CamelCaseParameterName extends AbstractRule implements MethodAware, Functi
     /**
      * @throws OutOfBoundsException
      */
-    protected function isValid($parameterName)
+    protected function isValid(string $parameterName): bool
     {
         // disallow any consecutive uppercase letters
         if ($this->getBooleanProperty('camelcase-abbreviations', false)

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
@@ -60,7 +60,7 @@ class CamelCasePropertyName extends AbstractRule implements ClassAware, TraitAwa
     /**
      * @throws OutOfBoundsException
      */
-    private function isValid($propertyName)
+    private function isValid(string $propertyName): bool
     {
         // disallow any consecutive uppercase letters
         if ($this->getBooleanProperty('camelcase-abbreviations', false)

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
@@ -69,9 +69,9 @@ class CamelCasePropertyName extends AbstractRule implements ClassAware, TraitAwa
         }
 
         if ($this->getBooleanProperty('allow-underscore')) {
-            return preg_match('/^\$[_]?[a-z][a-zA-Z0-9]*$/', $propertyName);
+            return preg_match('/^\$[_]?[a-z][a-zA-Z0-9]*$/', $propertyName) === 1;
         }
 
-        return preg_match('/^\$[a-z][a-zA-Z0-9]*$/', $propertyName);
+        return preg_match('/^\$[a-z][a-zA-Z0-9]*$/', $propertyName) === 1;
     }
 }

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
@@ -19,6 +19,7 @@ namespace PHPMD\Rule\Controversial;
 
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTPropertyPostfix;
+use PDepend\Source\AST\ASTVariable;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
@@ -33,7 +34,7 @@ use PHPMD\Rule\MethodAware;
 class CamelCaseVariableName extends AbstractRule implements MethodAware, FunctionAware
 {
     /**
-     * @var array
+     * @var list<string>
      */
     protected $exceptions = [
         '$php_errormsg',
@@ -70,9 +71,10 @@ class CamelCaseVariableName extends AbstractRule implements MethodAware, Functio
     }
 
     /**
+     * @param AbstractNode<ASTVariable> $variable
      * @throws OutOfBoundsException
      */
-    protected function isValid($variable)
+    protected function isValid(AbstractNode $variable): bool
     {
         $image = $variable->getImage();
 

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
@@ -36,7 +36,7 @@ class CamelCaseVariableName extends AbstractRule implements MethodAware, Functio
     /**
      * @var list<string>
      */
-    protected $exceptions = [
+    private $exceptions = [
         '$php_errormsg',
         '$http_response_header',
         '$GLOBALS',
@@ -74,7 +74,7 @@ class CamelCaseVariableName extends AbstractRule implements MethodAware, Functio
      * @param AbstractNode<ASTVariable> $variable
      * @throws OutOfBoundsException
      */
-    protected function isValid(AbstractNode $variable): bool
+    private function isValid(AbstractNode $variable): bool
     {
         $image = $variable->getImage();
 

--- a/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
+++ b/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
@@ -33,7 +33,7 @@ class Superglobals extends AbstractRule implements MethodAware, FunctionAware
     /**
      * @var list<string>
      */
-    protected $superglobals = [
+    private $superglobals = [
         '$GLOBALS',
         '$_SERVER',
         '$HTTP_SERVER_VARS',

--- a/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
+++ b/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
@@ -30,6 +30,9 @@ use PHPMD\Rule\MethodAware;
  */
 class Superglobals extends AbstractRule implements MethodAware, FunctionAware
 {
+    /**
+     * @var list<string>
+     */
     protected $superglobals = [
         '$GLOBALS',
         '$_SERVER',

--- a/src/main/php/PHPMD/Rule/CyclomaticComplexity.php
+++ b/src/main/php/PHPMD/Rule/CyclomaticComplexity.php
@@ -43,8 +43,8 @@ class CyclomaticComplexity extends AbstractRule implements FunctionAware, Method
             [
                 $node->getType(),
                 $node->getName(),
-                $ccn,
-                $threshold,
+                (string) $ccn,
+                (string) $threshold,
             ]
         );
     }

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -23,6 +23,7 @@ use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTForStatement;
 use PDepend\Source\AST\ASTFunctionPostfix;
 use PDepend\Source\AST\ASTNode as PDependNode;
+use PDepend\Source\AST\ASTStatement;
 use PDepend\Source\AST\ASTWhileStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -54,14 +55,14 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
     /**
      * List of functions to search against
      *
-     * @var array
+     * @var list<string>
      */
     protected $unwantedFunctions = ['count', 'sizeof'];
 
     /**
      * List of already processed functions
      *
-     * @var array
+     * @var array<string, bool>
      */
     protected $processedFunctions = [];
 
@@ -93,7 +94,6 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
             $node->findChildrenOfType(ASTDoWhileStatement::class)
         );
 
-        /** @var AbstractNode $loop */
         foreach ($loops as $loop) {
             $this->findViolations($loop);
         }
@@ -103,7 +103,7 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
      * Scans for expressions and count() or sizeof() functions inside,
      * if found, triggers a violation
      *
-     * @param AbstractNode $loop Loop statement to look against
+     * @param AbstractNode<ASTStatement> $loop Loop statement to look against
      */
     protected function findViolations(AbstractNode $loop): void
     {
@@ -131,6 +131,8 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
     /**
      * Checks whether node in a direct child of the loop
      *
+     * @param AbstractNode<ASTStatement> $loop
+     * @param ASTNode<ASTExpression> $expression
      * @return bool
      */
     protected function isDirectChild(AbstractNode $loop, ASTNode $expression)
@@ -166,6 +168,7 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
     /**
      * Checks the given function against the list of unwanted functions
      *
+     * @param ASTNode<ASTFunctionPostfix> $function
      * @return bool
      */
     protected function isUnwantedFunction(ASTNode $function)

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -17,11 +17,12 @@
 
 namespace PHPMD\Rule\Design;
 
-use PDepend\Source\AST\AbstractASTNode;
+use InvalidArgumentException;
 use PDepend\Source\AST\ASTDoWhileStatement;
 use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTForStatement;
 use PDepend\Source\AST\ASTFunctionPostfix;
+use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTWhileStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -32,6 +33,7 @@ use PHPMD\Node\TraitNode;
 use PHPMD\Rule\ClassAware;
 use PHPMD\Rule\EnumAware;
 use PHPMD\Rule\TraitAware;
+use RuntimeException;
 
 /**
  * Count In Loop Expression Rule
@@ -45,6 +47,7 @@ use PHPMD\Rule\TraitAware;
  * - do-while() loops
  *
  * @author Kamil Szymanski <kamilszymanski@gmail.com>
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAware, EnumAware
 {
@@ -71,6 +74,9 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
 
     /**
      * Gets a list of loops in a node and iterates over them
+     *
+     * @throws RuntimeException
+     * @throws InvalidArgumentException
      */
     public function apply(AbstractNode $node): void
     {
@@ -145,7 +151,7 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
      *
      * @return string
      */
-    protected function getHash(AbstractASTNode $node)
+    protected function getHash(PDependNode $node)
     {
         return sprintf(
             '%s:%s:%s:%s:%s',

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -57,21 +57,21 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
      *
      * @var list<string>
      */
-    protected $unwantedFunctions = ['count', 'sizeof'];
+    private $unwantedFunctions = ['count', 'sizeof'];
 
     /**
      * List of already processed functions
      *
      * @var array<string, bool>
      */
-    protected $processedFunctions = [];
+    private $processedFunctions = [];
 
     /**
      * Functions in classes tends to be name-spaced
      *
      * @var string
      */
-    protected $currentNamespace = '';
+    private $currentNamespace = '';
 
     /**
      * Gets a list of loops in a node and iterates over them
@@ -105,7 +105,7 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
      *
      * @param AbstractNode<ASTStatement> $loop Loop statement to look against
      */
-    protected function findViolations(AbstractNode $loop): void
+    private function findViolations(AbstractNode $loop): void
     {
         foreach ($loop->findChildrenOfType(ASTExpression::class) as $expression) {
             if ($this->isDirectChild($loop, $expression)) {
@@ -135,7 +135,7 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
      * @param ASTNode<ASTExpression> $expression
      * @return bool
      */
-    protected function isDirectChild(AbstractNode $loop, ASTNode $expression)
+    private function isDirectChild(AbstractNode $loop, ASTNode $expression)
     {
         return $this->getHash($expression->getParent()->getNode()) !== $this->getHash($loop->getNode());
     }
@@ -153,7 +153,7 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
      *
      * @return string
      */
-    protected function getHash(PDependNode $node)
+    private function getHash(PDependNode $node)
     {
         return sprintf(
             '%s:%s:%s:%s:%s',
@@ -171,7 +171,7 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, TraitAwa
      * @param ASTNode<ASTFunctionPostfix> $function
      * @return bool
      */
-    protected function isUnwantedFunction(ASTNode $function)
+    private function isUnwantedFunction(ASTNode $function)
     {
         $functionName = str_replace($this->currentNamespace, '', $function->getImage());
 

--- a/src/main/php/PHPMD/Rule/Design/CouplingBetweenObjects.php
+++ b/src/main/php/PHPMD/Rule/Design/CouplingBetweenObjects.php
@@ -37,7 +37,7 @@ class CouplingBetweenObjects extends AbstractRule implements ClassAware
         $cbo = $node->getMetric('cbo');
         $threshold = $this->getIntProperty('maximum');
         if ($cbo >= $threshold) {
-            $this->addViolation($node, [$node->getName(), $cbo, $threshold]);
+            $this->addViolation($node, [$node->getName(), (string) $cbo, (string) $threshold]);
         }
     }
 }

--- a/src/main/php/PHPMD/Rule/Design/DepthOfInheritance.php
+++ b/src/main/php/PHPMD/Rule/Design/DepthOfInheritance.php
@@ -50,8 +50,8 @@ class DepthOfInheritance extends AbstractRule implements ClassAware
                 [
                     $node->getType(),
                     $node->getName(),
-                    $dit,
-                    $threshold,
+                    (string) $dit,
+                    (string) $threshold,
                 ]
             );
         }

--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -69,7 +69,7 @@ class DevelopmentCodeFragment extends AbstractRule implements MethodAware, Funct
      * @return list<string>
      * @throws OutOfBoundsException
      */
-    protected function getSuspectImages()
+    private function getSuspectImages()
     {
         return array_map(
             'strtolower',

--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -66,7 +66,7 @@ class DevelopmentCodeFragment extends AbstractRule implements MethodAware, Funct
      * Returns an array with function images that are normally only used during
      * development.
      *
-     * @return array
+     * @return list<string>
      * @throws OutOfBoundsException
      */
     protected function getSuspectImages()

--- a/src/main/php/PHPMD/Rule/Design/LongClass.php
+++ b/src/main/php/PHPMD/Rule/Design/LongClass.php
@@ -46,6 +46,6 @@ class LongClass extends AbstractRule implements ClassAware
             return;
         }
 
-        $this->addViolation($node, [$node->getName(), $loc, $threshold]);
+        $this->addViolation($node, [$node->getName(), (string) $loc, (string) $threshold]);
     }
 }

--- a/src/main/php/PHPMD/Rule/Design/LongMethod.php
+++ b/src/main/php/PHPMD/Rule/Design/LongMethod.php
@@ -53,8 +53,8 @@ class LongMethod extends AbstractRule implements FunctionAware, MethodAware
             [
                 $node->getType(),
                 $node->getName(),
-                $loc,
-                $threshold,
+                (string) $loc,
+                (string) $threshold,
             ]
         );
     }

--- a/src/main/php/PHPMD/Rule/Design/LongParameterList.php
+++ b/src/main/php/PHPMD/Rule/Design/LongParameterList.php
@@ -49,8 +49,8 @@ class LongParameterList extends AbstractRule implements FunctionAware, MethodAwa
             [
                 $node->getType(),
                 $node->getName(),
-                $count,
-                $threshold,
+                (string) $count,
+                (string) $threshold,
             ]
         );
     }

--- a/src/main/php/PHPMD/Rule/Design/LongParameterList.php
+++ b/src/main/php/PHPMD/Rule/Design/LongParameterList.php
@@ -19,8 +19,7 @@ namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\FunctionNode;
-use PHPMD\Node\MethodNode;
+use PHPMD\Node\AbstractCallableNode;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
 
@@ -35,7 +34,7 @@ class LongParameterList extends AbstractRule implements FunctionAware, MethodAwa
      */
     public function apply(AbstractNode $node): void
     {
-        if (!$node instanceof FunctionNode && !$node instanceof MethodNode) {
+        if (!$node instanceof AbstractCallableNode) {
             return;
         }
 

--- a/src/main/php/PHPMD/Rule/Design/NpathComplexity.php
+++ b/src/main/php/PHPMD/Rule/Design/NpathComplexity.php
@@ -45,8 +45,8 @@ class NpathComplexity extends AbstractRule implements FunctionAware, MethodAware
             [
                 $node->getType(),
                 $node->getName(),
-                $npath,
-                $threshold,
+                (string) $npath,
+                (string) $threshold,
             ]
         );
     }

--- a/src/main/php/PHPMD/Rule/Design/NumberOfChildren.php
+++ b/src/main/php/PHPMD/Rule/Design/NumberOfChildren.php
@@ -40,8 +40,8 @@ class NumberOfChildren extends AbstractRule implements ClassAware
                 [
                     $node->getType(),
                     $node->getName(),
-                    $nocc,
-                    $threshold,
+                    (string) $nocc,
+                    (string) $threshold,
                 ]
             );
         }

--- a/src/main/php/PHPMD/Rule/Design/TooManyFields.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyFields.php
@@ -42,8 +42,8 @@ class TooManyFields extends AbstractRule implements ClassAware
             [
                 $node->getType(),
                 $node->getName(),
-                $vars,
-                $threshold,
+                (string) $vars,
+                (string) $threshold,
             ]
         );
     }

--- a/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
@@ -59,8 +59,8 @@ class TooManyMethods extends AbstractRule implements ClassAware
             [
                 $node->getType(),
                 $node->getName(),
-                $nom,
-                $threshold,
+                (string) $nom,
+                (string) $threshold,
             ]
         );
     }

--- a/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
@@ -19,7 +19,7 @@ namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\AbstractTypeNode;
+use PHPMD\Node\ClassNode;
 use PHPMD\Rule\ClassAware;
 
 /**
@@ -40,13 +40,16 @@ class TooManyMethods extends AbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node): void
     {
+        if (!$node instanceof ClassNode) {
+            return;
+        }
+
         $this->ignoreRegexp = $this->getStringProperty('ignorepattern');
 
         $threshold = $this->getIntProperty('maxmethods');
         if ($node->getMetric('nom') <= $threshold) {
             return;
         }
-        /** @var AbstractTypeNode $node */
         $nom = $this->countMethods($node);
         if ($nom <= $threshold) {
             return;
@@ -67,7 +70,7 @@ class TooManyMethods extends AbstractRule implements ClassAware
      *
      * @return int
      */
-    protected function countMethods(AbstractTypeNode $node)
+    protected function countMethods(ClassNode $node)
     {
         $count = 0;
         foreach ($node->getMethodNames() as $name) {

--- a/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
@@ -32,7 +32,7 @@ class TooManyMethods extends AbstractRule implements ClassAware
      *
      * @var string
      */
-    protected $ignoreRegexp;
+    private $ignoreRegexp;
 
     /**
      * This method checks the number of methods with in a given class and checks
@@ -70,7 +70,7 @@ class TooManyMethods extends AbstractRule implements ClassAware
      *
      * @return int
      */
-    protected function countMethods(ClassNode $node)
+    private function countMethods(ClassNode $node)
     {
         $count = 0;
         foreach ($node->getMethodNames() as $name) {

--- a/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
@@ -19,7 +19,7 @@ namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\AbstractTypeNode;
+use PHPMD\Node\ClassNode;
 use PHPMD\Rule\ClassAware;
 
 /**
@@ -40,6 +40,10 @@ class TooManyPublicMethods extends AbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node): void
     {
+        if (!$node instanceof ClassNode) {
+            return;
+        }
+
         $this->ignoreRegexp = $this->getStringProperty('ignorepattern');
 
         $threshold = $this->getIntProperty('maxmethods');
@@ -49,7 +53,6 @@ class TooManyPublicMethods extends AbstractRule implements ClassAware
             return;
         }
 
-        /** @var AbstractTypeNode $node */
         $nom = $this->countMethods($node);
 
         if ($nom <= $threshold) {
@@ -72,7 +75,7 @@ class TooManyPublicMethods extends AbstractRule implements ClassAware
      *
      * @return int
      */
-    protected function countMethods(AbstractTypeNode $node)
+    protected function countMethods(ClassNode $node)
     {
         $count = 0;
         foreach ($node->getMethods() as $method) {

--- a/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
@@ -32,7 +32,7 @@ class TooManyPublicMethods extends AbstractRule implements ClassAware
      *
      * @var string
      */
-    protected $ignoreRegexp;
+    private $ignoreRegexp;
 
     /**
      * This method checks the number of public methods with in a given class and checks
@@ -75,7 +75,7 @@ class TooManyPublicMethods extends AbstractRule implements ClassAware
      *
      * @return int
      */
-    protected function countMethods(ClassNode $node)
+    private function countMethods(ClassNode $node)
     {
         $count = 0;
         foreach ($node->getMethods() as $method) {

--- a/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
@@ -64,8 +64,8 @@ class TooManyPublicMethods extends AbstractRule implements ClassAware
             [
                 $node->getType(),
                 $node->getName(),
-                $nom,
-                $threshold,
+                (string) $nom,
+                (string) $threshold,
             ]
         );
     }

--- a/src/main/php/PHPMD/Rule/Design/WeightedMethodCount.php
+++ b/src/main/php/PHPMD/Rule/Design/WeightedMethodCount.php
@@ -39,7 +39,7 @@ class WeightedMethodCount extends AbstractRule implements ClassAware
         $actual = $node->getMetric('wmc');
 
         if ($actual >= $threshold) {
-            $this->addViolation($node, [$node->getName(), $actual, $threshold]);
+            $this->addViolation($node, [$node->getName(), (string) $actual, (string) $threshold]);
         }
     }
 }

--- a/src/main/php/PHPMD/Rule/ExcessivePublicCount.php
+++ b/src/main/php/PHPMD/Rule/ExcessivePublicCount.php
@@ -42,8 +42,8 @@ class ExcessivePublicCount extends AbstractRule implements ClassAware, TraitAwar
             [
                 $node->getType(),
                 $node->getName(),
-                $cis,
-                $threshold,
+                (string) $cis,
+                (string) $threshold,
             ]
         );
     }

--- a/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
@@ -36,7 +36,10 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
      */
     public function apply(AbstractNode $node): void
     {
-        /** @var MethodNode $node */
+        if (!$node instanceof MethodNode) {
+            return;
+        }
+
         if ($this->isBooleanGetMethod($node)) {
             $this->addViolation($node, [$node->getImage()]);
         }

--- a/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
@@ -52,7 +52,7 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
      * @return bool
      * @throws OutOfBoundsException
      */
-    protected function isBooleanGetMethod(MethodNode $node)
+    private function isBooleanGetMethod(MethodNode $node)
     {
         return $this->isGetterMethodName($node)
             && $this->isReturnTypeBoolean($node)
@@ -64,7 +64,7 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
      *
      * @return bool
      */
-    protected function isGetterMethodName(MethodNode $node)
+    private function isGetterMethodName(MethodNode $node)
     {
         return (preg_match('(^_?get)i', $node->getImage()) > 0);
     }
@@ -74,7 +74,7 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
      *
      * @return bool
      */
-    protected function isReturnTypeBoolean(MethodNode $node)
+    private function isReturnTypeBoolean(MethodNode $node)
     {
         $comment = $node->getComment();
         if ($comment === null) {
@@ -91,7 +91,7 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
      * @return bool
      * @throws OutOfBoundsException
      */
-    protected function isParameterizedOrIgnored(MethodNode $node)
+    private function isParameterizedOrIgnored(MethodNode $node)
     {
         if ($this->getBooleanProperty('checkParameterizedMethods')) {
             return $node->getParameterCount() === 0;

--- a/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
@@ -23,6 +23,7 @@ use PHPMD\AbstractRule;
 use PHPMD\Node\InterfaceNode;
 use PHPMD\Node\MethodNode;
 use PHPMD\Rule\MethodAware;
+use RuntimeException;
 
 /**
  * This rule class will detect methods that define a php4 style constructor
@@ -33,6 +34,8 @@ class ConstructorWithNameAsEnclosingClass extends AbstractRule implements Method
     /**
      * Is method has the same name as the enclosing class
      * (php4 style constructor).
+     *
+     * @throws RuntimeException
      */
     public function apply(AbstractNode $node): void
     {

--- a/src/main/php/PHPMD/Rule/Naming/LongClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongClassName.php
@@ -38,14 +38,14 @@ class LongClassName extends AbstractRule implements ClassAware, InterfaceAware, 
      *
      * @var string[]|null
      */
-    protected $subtractPrefixes;
+    private $subtractPrefixes;
 
     /**
      * Temporary cache of configured suffixes to subtract
      *
      * @var string[]|null
      */
-    protected $subtractSuffixes;
+    private $subtractSuffixes;
 
     /**
      * Check if a class name exceeds the configured maximum length and emit a rule violation
@@ -73,7 +73,7 @@ class LongClassName extends AbstractRule implements ClassAware, InterfaceAware, 
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
-    protected function getSubtractPrefixList()
+    private function getSubtractPrefixList()
     {
         if ($this->subtractPrefixes === null) {
             $this->subtractPrefixes = Strings::splitToList(
@@ -92,7 +92,7 @@ class LongClassName extends AbstractRule implements ClassAware, InterfaceAware, 
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
-    protected function getSubtractSuffixList()
+    private function getSubtractSuffixList()
     {
         if ($this->subtractSuffixes === null) {
             $this->subtractSuffixes = Strings::splitToList(

--- a/src/main/php/PHPMD/Rule/Naming/LongClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongClassName.php
@@ -63,7 +63,7 @@ class LongClassName extends AbstractRule implements ClassAware, InterfaceAware, 
         if ($length <= $threshold) {
             return;
         }
-        $this->addViolation($node, [$classOrInterfaceName, $threshold]);
+        $this->addViolation($node, [$classOrInterfaceName, (string) $threshold]);
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -21,6 +21,7 @@ use InvalidArgumentException;
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -54,7 +55,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * Temporary map holding variables that were already processed in the
      * current context.
      *
-     * @var array(string=>boolean)
+     * @var array<string, bool>
      */
     protected $processedVariables = [];
 
@@ -96,6 +97,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * Checks if the variable name of the given node is smaller/equal to the
      * configured threshold.
      *
+     * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
@@ -110,6 +112,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
     /**
      * Template method that performs the real node image check.
      *
+     * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      * @SuppressWarnings(PHPMD.LongVariable)
@@ -136,6 +139,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * Checks if a short name is acceptable in the current context. For the
      * moment the only context is a static member.
      *
+     * @param AbstractNode<ASTNode> $node
      * @return bool
      */
     protected function isNameAllowedInContext(AbstractNode $node)
@@ -153,6 +157,8 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
 
     /**
      * Flags the given node as already processed.
+     *
+     * @param AbstractNode<ASTNode> $node
      */
     protected function addProcessed(AbstractNode $node): void
     {
@@ -162,6 +168,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
     /**
      * Checks if the given node was already processed.
      *
+     * @param AbstractNode<ASTNode> $node
      * @return bool
      */
     protected function isNotProcessed(AbstractNode $node)

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -132,7 +132,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
         if ($this->isNameAllowedInContext($node)) {
             return;
         }
-        $this->addViolation($node, [$variableName, $threshold]);
+        $this->addViolation($node, [$variableName, (string) $threshold]);
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -140,27 +140,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      */
     protected function isNameAllowedInContext(AbstractNode $node)
     {
-        return $this->isChildOf($node, ASTMemberPrimaryPrefix::class);
-    }
-
-    /**
-     * Checks if the given node is a direct or indirect child of a node with
-     * the given type.
-     *
-     * @param string $type
-     * @return bool
-     */
-    protected function isChildOf(AbstractNode $node, $type)
-    {
-        $parent = $node->getParent();
-        while (is_object($parent)) {
-            if ($parent->isInstanceOf($type)) {
-                return true;
-            }
-            $parent = $parent->getParent();
-        }
-
-        return false;
+        return $node->getParentOfType(ASTMemberPrimaryPrefix::class) !== null;
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -42,14 +42,14 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      *
      * @var string[]|null
      */
-    protected $subtractPrefixes;
+    private $subtractPrefixes;
 
     /**
      * Temporary cache of configured suffixes to subtract
      *
      * @var string[]|null
      */
-    protected $subtractSuffixes;
+    private $subtractSuffixes;
 
     /**
      * Temporary map holding variables that were already processed in the
@@ -57,7 +57,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      *
      * @var array<string, bool>
      */
-    protected $processedVariables = [];
+    private $processedVariables = [];
 
     /**
      * Extracts all variable and variable declarator nodes from the given node
@@ -101,7 +101,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
-    protected function checkNodeImage(AbstractNode $node): void
+    private function checkNodeImage(AbstractNode $node): void
     {
         if ($this->isNotProcessed($node)) {
             $this->addProcessed($node);
@@ -117,7 +117,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * @throws OutOfBoundsException
      * @SuppressWarnings(PHPMD.LongVariable)
      */
-    protected function checkMaximumLength(AbstractNode $node): void
+    private function checkMaximumLength(AbstractNode $node): void
     {
         $threshold = $this->getIntProperty('maximum');
         $variableName = $node->getImage();
@@ -142,7 +142,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * @param AbstractNode<ASTNode> $node
      * @return bool
      */
-    protected function isNameAllowedInContext(AbstractNode $node)
+    private function isNameAllowedInContext(AbstractNode $node)
     {
         return $node->getParentOfType(ASTMemberPrimaryPrefix::class) !== null;
     }
@@ -150,7 +150,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
     /**
      * Resets the already processed nodes.
      */
-    protected function resetProcessed(): void
+    private function resetProcessed(): void
     {
         $this->processedVariables = [];
     }
@@ -160,7 +160,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      *
      * @param AbstractNode<ASTNode> $node
      */
-    protected function addProcessed(AbstractNode $node): void
+    private function addProcessed(AbstractNode $node): void
     {
         $this->processedVariables[$node->getImage()] = true;
     }
@@ -171,7 +171,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * @param AbstractNode<ASTNode> $node
      * @return bool
      */
-    protected function isNotProcessed(AbstractNode $node)
+    private function isNotProcessed(AbstractNode $node)
     {
         return !isset($this->processedVariables[$node->getImage()]);
     }
@@ -183,7 +183,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException
      */
-    protected function getSubtractPrefixList()
+    private function getSubtractPrefixList()
     {
         if ($this->subtractPrefixes === null) {
             $this->subtractPrefixes = Strings::splitToList($this->getStringProperty('subtract-prefixes', ''), ',');
@@ -199,7 +199,7 @@ class LongVariable extends AbstractRule implements ClassAware, MethodAware, Func
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException
      */
-    protected function getSubtractSuffixList()
+    private function getSubtractSuffixList()
     {
         if ($this->subtractSuffixes === null) {
             $this->subtractSuffixes = Strings::splitToList($this->getStringProperty('subtract-suffixes', ''));

--- a/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
@@ -52,7 +52,7 @@ class ShortClassName extends AbstractRule implements ClassAware, InterfaceAware,
             return;
         }
 
-        $this->addViolation($node, [$classOrInterfaceName, $threshold]);
+        $this->addViolation($node, [$classOrInterfaceName, (string) $threshold]);
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
@@ -35,7 +35,7 @@ class ShortClassName extends AbstractRule implements ClassAware, InterfaceAware,
      *
      * @var ExceptionsList|null
      */
-    protected $exceptions;
+    private $exceptions;
 
     /**
      * Check if a class or interface name is below the minimum configured length and emit a rule violation
@@ -60,7 +60,7 @@ class ShortClassName extends AbstractRule implements ClassAware, InterfaceAware,
      *
      * @return ExceptionsList
      */
-    protected function getExceptionsList()
+    private function getExceptionsList()
     {
         if ($this->exceptions === null) {
             $this->exceptions = new ExceptionsList($this, '\\');

--- a/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
@@ -33,7 +33,7 @@ class ShortMethodName extends AbstractRule implements MethodAware, FunctionAware
      *
      * @var ExceptionsList|null
      */
-    protected $exceptions;
+    private $exceptions;
 
     /**
      * Extracts all variable and variable declarator nodes from the given node
@@ -72,7 +72,7 @@ class ShortMethodName extends AbstractRule implements MethodAware, FunctionAware
      *
      * @return ExceptionsList
      */
-    protected function getExceptionsList()
+    private function getExceptionsList()
     {
         if ($this->exceptions === null) {
             $this->exceptions = new ExceptionsList($this);

--- a/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
@@ -62,7 +62,7 @@ class ShortMethodName extends AbstractRule implements MethodAware, FunctionAware
             [
                 $node->getParentName(),
                 $node->getName(),
-                $threshold,
+                (string) $threshold,
             ]
         );
     }

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -250,15 +250,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      */
     protected function isChildOf(AbstractNode $node, $type)
     {
-        $parent = $node->getParent();
-        while (is_object($parent)) {
-            if ($parent->isInstanceOf($type)) {
-                return true;
-            }
-            $parent = $parent->getParent();
-        }
-
-        return false;
+        return $node->getParentOfType($type) !== null;
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -24,6 +24,7 @@ use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTForeachStatement;
 use PDepend\Source\AST\ASTForInit;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -43,7 +44,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * Temporary map holding variables that were already processed in the
      * current context.
      *
-     * @var array(string=>boolean)
+     * @var array<string, bool>
      */
     protected $processedVariables = [];
 
@@ -79,6 +80,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * Checks the variable name length against the configured minimum
      * length.
      *
+     * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
@@ -100,6 +102,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * Checks the variable name length against the configured minimum
      * length.
      *
+     * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
@@ -121,6 +124,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * Checks if the variable name of the given node is greater/equal to the
      * configured threshold or if the given node is an allowed context.
      *
+     * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
@@ -135,6 +139,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
     /**
      * Template method that performs the real node image check.
      *
+     * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
@@ -178,6 +183,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * moment these contexts are the init section of a for-loop and short
      * variable names in catch-statements.
      *
+     * @param AbstractNode<ASTNode> $node
      * @return bool
      * @throws OutOfBoundsException
      */
@@ -197,6 +203,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
     /**
      * Checks if a short name is initialized within a foreach loop statement
      *
+     * @param AbstractNode<ASTNode> $node
      * @return bool
      * @throws OutOfBoundsException
      */
@@ -223,7 +230,10 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
     /**
      * Returns an array of parent nodes of the specified type
      *
-     * @return array
+     * @template T of ASTNode
+     * @param AbstractNode<ASTNode> $node
+     * @param class-string<T> $type
+     * @return list<AbstractNode<T>>
      */
     protected function getParentsOfType(AbstractNode $node, $type)
     {
@@ -245,7 +255,8 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * Checks if the given node is a direct or indirect child of a node with
      * the given type.
      *
-     * @param string $type
+     * @param AbstractNode<ASTNode> $node
+     * @param class-string<ASTNode> $type
      * @return bool
      */
     protected function isChildOf(AbstractNode $node, $type)
@@ -263,6 +274,8 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
 
     /**
      * Flags the given node as already processed.
+     *
+     * @param AbstractNode<ASTNode> $node
      */
     protected function addProcessed(AbstractNode $node): void
     {
@@ -272,6 +285,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
     /**
      * Checks if the given node was already processed.
      *
+     * @param AbstractNode<ASTNode> $node
      * @return bool
      */
     protected function isNotProcessed(AbstractNode $node)

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -161,7 +161,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
             return;
         }
 
-        $this->addViolation($node, [$node->getImage(), $threshold]);
+        $this->addViolation($node, [$node->getImage(), (string) $threshold]);
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -46,14 +46,14 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      *
      * @var array<string, bool>
      */
-    protected $processedVariables = [];
+    private $processedVariables = [];
 
     /**
      * Temporary cache of configured exceptions.
      *
      * @var ExceptionsList|null
      */
-    protected $exceptions;
+    private $exceptions;
 
     /**
      * Extracts all variable and variable declarator nodes from the given node
@@ -84,7 +84,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
-    protected function applyClass(AbstractNode $node): void
+    private function applyClass(AbstractNode $node): void
     {
         $fields = $node->findChildrenOfType(ASTFieldDeclaration::class);
         foreach ($fields as $field) {
@@ -106,7 +106,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
-    protected function applyNonClass(AbstractNode $node): void
+    private function applyNonClass(AbstractNode $node): void
     {
         $declarators = $node->findChildrenOfType(ASTVariableDeclarator::class);
         foreach ($declarators as $declarator) {
@@ -128,7 +128,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
-    protected function checkNodeImage(AbstractNode $node): void
+    private function checkNodeImage(AbstractNode $node): void
     {
         if ($this->isNotProcessed($node)) {
             $this->addProcessed($node);
@@ -143,7 +143,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
-    protected function checkMinimumLength(AbstractNode $node): void
+    private function checkMinimumLength(AbstractNode $node): void
     {
         $threshold = $this->getIntProperty('minimum');
 
@@ -169,7 +169,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      *
      * @return ExceptionsList
      */
-    protected function getExceptionsList()
+    private function getExceptionsList()
     {
         if ($this->exceptions === null) {
             $this->exceptions = new ExceptionsList($this);
@@ -187,7 +187,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * @return bool
      * @throws OutOfBoundsException
      */
-    protected function isNameAllowedInContext(AbstractNode $node)
+    private function isNameAllowedInContext(AbstractNode $node)
     {
         $parent = $node->getParent();
 
@@ -207,7 +207,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * @return bool
      * @throws OutOfBoundsException
      */
-    protected function isInitializedInLoop(AbstractNode $node)
+    private function isInitializedInLoop(AbstractNode $node)
     {
         if (!$this->getBooleanProperty('allow-short-variables-in-loop', true)) {
             return false;
@@ -235,7 +235,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * @param class-string<T> $type
      * @return list<AbstractNode<T>>
      */
-    protected function getParentsOfType(AbstractNode $node, $type)
+    private function getParentsOfType(AbstractNode $node, $type)
     {
         $parents = [];
 
@@ -259,7 +259,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * @param class-string<ASTNode> $type
      * @return bool
      */
-    protected function isChildOf(AbstractNode $node, $type)
+    private function isChildOf(AbstractNode $node, $type)
     {
         return $node->getParentOfType($type) !== null;
     }
@@ -267,7 +267,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
     /**
      * Resets the already processed nodes.
      */
-    protected function resetProcessed(): void
+    private function resetProcessed(): void
     {
         $this->processedVariables = [];
     }
@@ -277,7 +277,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      *
      * @param AbstractNode<ASTNode> $node
      */
-    protected function addProcessed(AbstractNode $node): void
+    private function addProcessed(AbstractNode $node): void
     {
         $this->processedVariables[$node->getImage()] = true;
     }
@@ -288,7 +288,7 @@ class ShortVariable extends AbstractRule implements ClassAware, MethodAware, Fun
      * @param AbstractNode<ASTNode> $node
      * @return bool
      */
-    protected function isNotProcessed(AbstractNode $node)
+    private function isNotProcessed(AbstractNode $node)
     {
         return !isset($this->processedVariables[$node->getImage()]);
     }

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -45,7 +45,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      *
      * @var array<string, ASTNode<ASTVariableDeclarator>>
      */
-    protected $nodes = [];
+    private $nodes = [];
 
     /**
      * This method checks that all parameters of a given function or method are
@@ -90,7 +90,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @return bool
      */
-    protected function isAbstractMethod(AbstractCallableNode $node)
+    private function isAbstractMethod(AbstractCallableNode $node)
     {
         if ($node instanceof MethodNode) {
             return $node->isAbstract();
@@ -106,7 +106,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @return bool
      */
-    protected function isInheritedSignature(AbstractCallableNode $node)
+    private function isInheritedSignature(AbstractCallableNode $node)
     {
         if ($node instanceof MethodNode) {
             $comment = $node->getComment();
@@ -123,7 +123,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @return bool
      */
-    protected function isMagicMethod(AbstractCallableNode $node)
+    private function isMagicMethod(AbstractCallableNode $node)
     {
         if (!($node instanceof MethodNode)) {
             return false;
@@ -155,7 +155,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @since 1.2.1
      */
-    protected function isNotDeclaration(AbstractCallableNode $node)
+    private function isNotDeclaration(AbstractCallableNode $node)
     {
         if ($node instanceof MethodNode) {
             return !$node->isDeclaration();
@@ -170,7 +170,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      *
      * @param AbstractCallableNode<AbstractASTCallable> $node
      */
-    protected function collectParameters(AbstractCallableNode $node): void
+    private function collectParameters(AbstractCallableNode $node): void
     {
         // First collect the formal parameters containers
         foreach ($node->findChildrenOfType(ASTFormalParameters::class) as $parameters) {
@@ -196,7 +196,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
-    protected function removeUsedParameters(AbstractCallableNode $node): void
+    private function removeUsedParameters(AbstractCallableNode $node): void
     {
         $this->removeRegularVariables($node);
         $this->removeCompoundVariables($node);
@@ -210,7 +210,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      * @param AbstractCallableNode<AbstractASTCallable> $node The node to remove the regular variables from.
      * @throws OutOfBoundsException
      */
-    protected function removeRegularVariables(AbstractCallableNode $node): void
+    private function removeRegularVariables(AbstractCallableNode $node): void
     {
         $variables = $node->findChildrenOfTypeVariable();
 
@@ -238,7 +238,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      *
      * @param AbstractCallableNode<AbstractASTCallable> $node The node to remove the compound variables from.
      */
-    protected function removeCompoundVariables(AbstractCallableNode $node): void
+    private function removeCompoundVariables(AbstractCallableNode $node): void
     {
         $compoundVariables = $node->findChildrenOfType(ASTCompoundVariable::class);
 
@@ -262,7 +262,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      *
      * @param AbstractCallableNode<AbstractASTCallable> $node The node to remove the referenced variables from.
      */
-    protected function removeVariablesUsedByFuncGetArgs(AbstractCallableNode $node): void
+    private function removeVariablesUsedByFuncGetArgs(AbstractCallableNode $node): void
     {
         $functionCalls = $node->findChildrenOfType(ASTFunctionPostfix::class);
 
@@ -284,7 +284,7 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
      *
      * @param AbstractCallableNode<AbstractASTCallable> $node The node to remove the property promotion parameters from.
      */
-    protected function removePropertyPromotionVariables(AbstractCallableNode $node): void
+    private function removePropertyPromotionVariables(AbstractCallableNode $node): void
     {
         if (! $node instanceof MethodNode) {
             return;

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -18,6 +18,7 @@
 namespace PHPMD\Rule;
 
 use OutOfBoundsException;
+use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PDepend\Source\AST\ASTCompoundVariable;
 use PDepend\Source\AST\ASTExpression;
@@ -33,6 +34,8 @@ use PHPMD\Node\MethodNode;
 /**
  * This rule collects all formal parameters of a given function or method that
  * are not used in a statement of the artifact's body.
+ *
+ * @SuppressWarnings("PMD.CouplingBetweenObjects")
  */
 class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAware, MethodAware
 {
@@ -160,6 +163,11 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
     {
         // First collect the formal parameters containers
         foreach ($node->findChildrenOfType(ASTFormalParameters::class) as $parameters) {
+            $parent = $parameters->getParentOfType(AbstractASTCallable::class);
+            if ($parent->getNode() !== $node->getNode()) {
+                continue;
+            }
+
             // Now get all declarators in the formal parameters container
             $declarators = $parameters->findChildrenOfType(ASTVariableDeclarator::class);
 

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -19,6 +19,7 @@ namespace PHPMD\Rule;
 
 use InvalidArgumentException;
 use OutOfBoundsException;
+use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\ASTAssignmentExpression;
 use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTCompoundVariable;
@@ -142,7 +143,10 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
         }
 
         foreach ($node->findChildrenOfType(ASTVariableDeclarator::class) as $variable) {
-            $this->collectVariable($variable);
+            $parent = $variable->getParentOfType(AbstractASTCallable::class);
+            if ($parent->getNode() === $node->getNode()) {
+                $this->collectVariable($variable);
+            }
         }
 
         foreach ($node->findChildrenOfType(ASTFunctionPostfix::class) as $func) {

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -50,14 +50,14 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      *
      * @var array<string, list<ASTNode<AbstractASTNode>>>
      */
-    protected $images = [];
+    private $images = [];
 
     /**
      * Temporary cache of configured exceptions.
      *
      * @var ExceptionsList|null
      */
-    protected $exceptions;
+    private $exceptions;
 
     /**
      * This method checks that all local variables within the given function or
@@ -87,7 +87,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * @param array<int, ASTNode<AbstractASTNode>> $nodes
      * @return bool
      */
-    protected function containsUsages(array $nodes)
+    private function containsUsages(array $nodes)
     {
         if (count($nodes) === 1) {
             return false;
@@ -116,7 +116,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
-    protected function removeParameters(AbstractCallableNode $node): void
+    private function removeParameters(AbstractCallableNode $node): void
     {
         // Get formal parameter container
         $parameters = $node->getFirstChildOfType(ASTFormalParameters::class);
@@ -137,7 +137,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
-    protected function collectVariables(AbstractCallableNode $node): void
+    private function collectVariables(AbstractCallableNode $node): void
     {
         foreach ($node->findChildrenOfTypeVariable() as $variable) {
             if ($this->isLocal($variable)) {
@@ -171,7 +171,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * @param ASTNode<ASTCompoundVariable> $node
      * @throws OutOfBoundsException
      */
-    protected function collectCompoundVariableInString(ASTNode $node): void
+    private function collectCompoundVariableInString(ASTNode $node): void
     {
         $parentNode = $node->getParent()->getNode();
         $candidateParentNodes = $node->getParentsOfType(ASTString::class);
@@ -194,7 +194,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * @param ASTNode<ASTExpression> $node
      * @throws OutOfBoundsException
      */
-    protected function collectVariable(ASTNode $node): void
+    private function collectVariable(ASTNode $node): void
     {
         $this->storeImage($this->getVariableImage($node->getNode()), $node);
     }
@@ -205,7 +205,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * @param string $imageName the name to store the node as
      * @param ASTNode<AbstractASTNode> $node the node being stored
      */
-    protected function storeImage($imageName, ASTNode $node): void
+    private function storeImage($imageName, ASTNode $node): void
     {
         if (!isset($this->images[$imageName])) {
             $this->images[$imageName] = [];
@@ -219,7 +219,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      *
      * @param ASTNode<ASTLiteral> $node
      */
-    protected function collectLiteral(ASTNode $node): void
+    private function collectLiteral(ASTNode $node): void
     {
         $variable = '$' . trim($node->getImage(), '\'"');
 
@@ -237,7 +237,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
-    protected function doCheckNodeImage(ASTNode $node): void
+    private function doCheckNodeImage(ASTNode $node): void
     {
         if ($this->isNameAllowedInContext($node)) {
             return;
@@ -271,7 +271,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * @param AbstractNode<AbstractASTNode> $node
      * @return bool
      */
-    protected function isNameAllowedInContext(AbstractNode $node)
+    private function isNameAllowedInContext(AbstractNode $node)
     {
         return $this->isChildOf($node, ASTCatchStatement::class);
     }
@@ -285,7 +285,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * @return bool True if allowed, else false.
      * @throws OutOfBoundsException
      */
-    protected function isUnusedForeachVariableAllowed(ASTNode $variable)
+    private function isUnusedForeachVariableAllowed(ASTNode $variable)
     {
         $isForeachVariable = $this->isChildOf($variable, ASTForeachStatement::class);
 
@@ -304,7 +304,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * @param class-string<AbstractASTNode> $type
      * @return bool
      */
-    protected function isChildOf(AbstractNode $node, $type)
+    private function isChildOf(AbstractNode $node, $type)
     {
         $parent = $node->getParent();
 
@@ -316,7 +316,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      *
      * @return ExceptionsList
      */
-    protected function getExceptionsList()
+    private function getExceptionsList()
     {
         if ($this->exceptions === null) {
             $this->exceptions = new ExceptionsList($this);

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -20,6 +20,7 @@ namespace PHPMD\Rule;
 use InvalidArgumentException;
 use OutOfBoundsException;
 use PDepend\Source\AST\AbstractASTCallable;
+use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTAssignmentExpression;
 use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTCompoundVariable;
@@ -47,7 +48,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Found variable images within a single method or function.
      *
-     * @var array(string)
+     * @var array<string, list<ASTNode<AbstractASTNode>>>
      */
     protected $images = [];
 
@@ -64,9 +65,12 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      */
     public function apply(AbstractNode $node): void
     {
+        if (!$node instanceof AbstractCallableNode) {
+            return;
+        }
+
         $this->images = [];
 
-        /** @var AbstractCallableNode $node */
         $this->collectVariables($node);
         $this->removeParameters($node);
 
@@ -80,6 +84,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Return true if one of the passed nodes contains variables usages.
      *
+     * @param array<int, ASTNode<AbstractASTNode>> $nodes
      * @return bool
      */
     protected function containsUsages(array $nodes)
@@ -108,6 +113,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * are also found in the formal parameters of the given method or/and
      * function node.
      *
+     * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
     protected function removeParameters(AbstractCallableNode $node): void
@@ -128,6 +134,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * method/function node and stores their image in the <b>$_images</b>
      * property.
      *
+     * @param AbstractCallableNode<AbstractASTCallable> $node
      * @throws OutOfBoundsException
      */
     protected function collectVariables(AbstractCallableNode $node): void
@@ -161,6 +168,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Stores the given compound variable node in an internal list of found variables.
      *
+     * @param ASTNode<ASTCompoundVariable> $node
      * @throws OutOfBoundsException
      */
     protected function collectCompoundVariableInString(ASTNode $node): void
@@ -183,18 +191,19 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Stores the given variable node in an internal list of found variables.
      *
+     * @param ASTNode<ASTExpression> $node
      * @throws OutOfBoundsException
      */
     protected function collectVariable(ASTNode $node): void
     {
-        $this->storeImage($this->getVariableImage($node), $node);
+        $this->storeImage($this->getVariableImage($node->getNode()), $node);
     }
 
     /**
      * Safely add node to $this->images.
      *
      * @param string $imageName the name to store the node as
-     * @param ASTNode $node the node being stored
+     * @param ASTNode<AbstractASTNode> $node the node being stored
      */
     protected function storeImage($imageName, ASTNode $node): void
     {
@@ -207,6 +216,8 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
 
     /**
      * Stores the given literal node in an internal list of found variables.
+     *
+     * @param ASTNode<ASTLiteral> $node
      */
     protected function collectLiteral(ASTNode $node): void
     {
@@ -222,6 +233,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Template method that performs the real node image check.
      *
+     * @param ASTNode<AbstractASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
@@ -256,6 +268,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * moment these contexts are the init section of a for-loop and short
      * variable names in catch-statements.
      *
+     * @param AbstractNode<AbstractASTNode> $node
      * @return bool
      */
     protected function isNameAllowedInContext(AbstractNode $node)
@@ -268,7 +281,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      *
      * If it's not a foreach variable, it returns always false.
      *
-     * @param ASTNode $variable The variable to check.
+     * @param ASTNode<AbstractASTNode> $variable The variable to check.
      * @return bool True if allowed, else false.
      * @throws OutOfBoundsException
      */
@@ -287,7 +300,8 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * Checks if the given node is a direct or indirect child of a node with
      * the given type.
      *
-     * @param string $type
+     * @param AbstractNode<AbstractASTNode> $node
+     * @param class-string<AbstractASTNode> $type
      * @return bool
      */
     protected function isChildOf(AbstractNode $node, $type)

--- a/src/main/php/PHPMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateField.php
@@ -25,7 +25,6 @@ use PDepend\Source\AST\ASTIdentifier;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTPropertyPostfix;
 use PDepend\Source\AST\ASTSelfReference;
-use PDepend\Source\AST\ASTStaticReference;
 use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
@@ -55,7 +54,10 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node): void
     {
-        /** @var ClassNode $field */
+        if (!$node instanceof ClassNode) {
+            return;
+        }
+
         foreach ($this->collectUnusedPrivateFields($node) as $field) {
             $this->addViolation($field, [$field->getImage()]);
         }
@@ -178,7 +180,6 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
 
         return (
             $owner->isInstanceOf(ASTSelfReference::class) ||
-            $owner->isInstanceOf(ASTStaticReference::class) ||
             strcasecmp($owner->getImage(), '$this') === 0 ||
             strcasecmp($owner->getImage(), $class->getImage()) === 0
         );

--- a/src/main/php/PHPMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateField.php
@@ -48,7 +48,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      *
      * @var array<string, ASTNode<ASTVariableDeclarator>>
      */
-    protected $fields = [];
+    private $fields = [];
 
     /**
      * This method checks that all private class properties are at least accessed
@@ -72,7 +72,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * @return array<string, ASTNode<ASTVariableDeclarator>>
      * @throws OutOfBoundsException
      */
-    protected function collectUnusedPrivateFields(ClassNode $class)
+    private function collectUnusedPrivateFields(ClassNode $class)
     {
         $this->fields = [];
 
@@ -86,7 +86,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * This method collects all private fields in the given class and stores
      * them in the <b>$_fields</b> property.
      */
-    protected function collectPrivateFields(ClassNode $class): void
+    private function collectPrivateFields(ClassNode $class): void
     {
         foreach ($class->findChildrenOfType(ASTFieldDeclaration::class) as $declaration) {
             if ($declaration->isPrivate()) {
@@ -101,7 +101,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      *
      * @param ASTNode<ASTFieldDeclaration> $declaration
      */
-    protected function collectPrivateField(ASTNode $declaration): void
+    private function collectPrivateField(ASTNode $declaration): void
     {
         $fields = $declaration->findChildrenOfType(ASTVariableDeclarator::class);
         foreach ($fields as $field) {
@@ -116,7 +116,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      *
      * @throws OutOfBoundsException
      */
-    protected function removeUsedFields(ClassNode $class): void
+    private function removeUsedFields(ClassNode $class): void
     {
         foreach ($class->findChildrenOfType(ASTPropertyPostfix::class) as $postfix) {
             if ($this->isInScopeOfClass($class, $postfix)) {
@@ -131,7 +131,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      *
      * @param ASTNode<ASTPropertyPostfix> $postfix
      */
-    protected function removeUsedField(ASTNode $postfix): void
+    private function removeUsedField(ASTNode $postfix): void
     {
         $image = '$';
         $child = $postfix->getFirstChildOfType(ASTIdentifier::class);
@@ -154,7 +154,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * @return bool
      * @since 0.2.6
      */
-    protected function isValidPropertyNode(ASTNode $node)
+    private function isValidPropertyNode(ASTNode $node)
     {
         $parent = $node->getParent();
         while (!$parent->isInstanceOf(ASTPropertyPostfix::class)) {
@@ -178,7 +178,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * @return bool
      * @throws OutOfBoundsException
      */
-    protected function isInScopeOfClass(ClassNode $class, ASTNode $postfix)
+    private function isInScopeOfClass(ClassNode $class, ASTNode $postfix)
     {
         $owner = $this->getOwner($postfix);
 
@@ -196,7 +196,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * @return AbstractNode<PDependNode>
      * @throws OutOfBoundsException
      */
-    protected function getOwner(ASTNode $postfix)
+    private function getOwner(ASTNode $postfix)
     {
         $owner = $postfix->getParent()->getChild(0);
         if ($owner->isInstanceOf(ASTPropertyPostfix::class)) {

--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -23,13 +23,13 @@ use PDepend\Source\AST\ASTArrayElement;
 use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTMethodPostfix;
 use PDepend\Source\AST\ASTSelfReference;
-use PDepend\Source\AST\ASTStaticReference;
 use PDepend\Source\AST\ASTVariable;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ASTNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\MethodNode;
+use RuntimeException;
 
 /**
  * This rule collects all private methods in a class that aren't used in any
@@ -40,9 +40,15 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
     /**
      * This method checks that all private class methods are at least accessed
      * by one method.
+     *
+     * @throws RuntimeException
      */
     public function apply(AbstractNode $class): void
     {
+        if (!$class instanceof ClassNode) {
+            return;
+        }
+
         foreach ($this->collectUnusedPrivateMethods($class) as $node) {
             $this->addViolation($node, [$node->getImage()]);
         }
@@ -54,6 +60,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      *
      * @return array<string, MethodNode>
      * @throws OutOfBoundsException
+     * @throws RuntimeException
      */
     protected function collectUnusedPrivateMethods(ClassNode $class)
     {
@@ -65,7 +72,8 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
     /**
      * Collects all private methods declared in the given class node.
      *
-     * @return AbstractNode[]
+     * @return array<string, MethodNode>
+     * @throws RuntimeException
      */
     protected function collectPrivateMethods(ClassNode $class)
     {
@@ -85,6 +93,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * analysis.
      *
      * @return bool
+     * @throws RuntimeException
      */
     protected function acceptMethod(ClassNode $class, MethodNode $method)
     {
@@ -194,7 +203,6 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
         return (
             $owner->isInstanceOf(ASTMethodPostfix::class) ||
             $owner->isInstanceOf(ASTSelfReference::class) ||
-            $owner->isInstanceOf(ASTStaticReference::class) ||
             strcasecmp($owner->getImage(), '$this') === 0 ||
             strcasecmp($owner->getImage(), $class->getImage()) === 0
         );

--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -65,7 +65,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * @throws OutOfBoundsException
      * @throws RuntimeException
      */
-    protected function collectUnusedPrivateMethods(ClassNode $class)
+    private function collectUnusedPrivateMethods(ClassNode $class)
     {
         $methods = $this->collectPrivateMethods($class);
 
@@ -78,7 +78,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * @return array<string, MethodNode>
      * @throws RuntimeException
      */
-    protected function collectPrivateMethods(ClassNode $class)
+    private function collectPrivateMethods(ClassNode $class)
     {
         $methods = [];
 
@@ -98,7 +98,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * @return bool
      * @throws RuntimeException
      */
-    protected function acceptMethod(ClassNode $class, MethodNode $method)
+    private function acceptMethod(ClassNode $class, MethodNode $method)
     {
         return (
             $method->isPrivate() &&
@@ -117,7 +117,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * @return array<string, MethodNode>
      * @throws OutOfBoundsException
      */
-    protected function removeUsedMethods(ClassNode $class, array $methods)
+    private function removeUsedMethods(ClassNode $class, array $methods)
     {
         $methods = $this->removeExplicitCalls($class, $methods);
         $methods = $this->removeCallableArrayRepresentations($class, $methods);
@@ -132,7 +132,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * @return array<string, MethodNode>
      * @throws OutOfBoundsException
      */
-    protected function removeExplicitCalls(ClassNode $class, array $methods)
+    private function removeExplicitCalls(ClassNode $class, array $methods)
     {
         foreach ($class->findChildrenOfType(ASTMethodPostfix::class) as $postfix) {
             if ($this->isClassScope($class, $postfix)) {
@@ -150,7 +150,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * @return array<string, MethodNode>
      * @throws OutOfBoundsException
      */
-    protected function removeCallableArrayRepresentations(ClassNode $class, array $methods)
+    private function removeCallableArrayRepresentations(ClassNode $class, array $methods)
     {
         foreach ($class->findChildrenOfType(ASTVariable::class) as $variable) {
             $parent = $variable->getParent();
@@ -174,7 +174,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * @return string|null
      * @throws OutOfBoundsException
      */
-    protected function getMethodNameFromArraySecondElement(AbstractNode $parent)
+    private function getMethodNameFromArraySecondElement(AbstractNode $parent)
     {
         if ($parent->isInstanceOf(ASTArrayElement::class)) {
             $array = $parent->getParent();
@@ -201,7 +201,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * @return bool
      * @throws OutOfBoundsException
      */
-    protected function isClassScope(ClassNode $class, ASTNode $postfix)
+    private function isClassScope(ClassNode $class, ASTNode $postfix)
     {
         $owner = $postfix->getParent()->getChild(0);
 

--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -20,8 +20,10 @@ namespace PHPMD\Rule;
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTArray;
 use PDepend\Source\AST\ASTArrayElement;
+use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTMethodPostfix;
+use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTSelfReference;
 use PDepend\Source\AST\ASTVariable;
 use PHPMD\AbstractNode;
@@ -41,6 +43,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * This method checks that all private class methods are at least accessed
      * by one method.
      *
+     * @param AbstractNode<PDependNode> $class
      * @throws RuntimeException
      */
     public function apply(AbstractNode $class): void
@@ -167,6 +170,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * Return represented method name if the given element is a 2-items array
      * and that the second one is a literal static string.
      *
+     * @param AbstractNode<PDependNode> $parent
      * @return string|null
      * @throws OutOfBoundsException
      */
@@ -193,6 +197,7 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * This method checks that the given method postfix is accessed on an
      * instance or static reference to the given class.
      *
+     * @param ASTNode<ASTExpression> $postfix
      * @return bool
      * @throws OutOfBoundsException
      */

--- a/src/main/php/PHPMD/RuleSet.php
+++ b/src/main/php/PHPMD/RuleSet.php
@@ -21,8 +21,9 @@ use ArrayIterator;
 use InvalidArgumentException;
 use IteratorAggregate;
 use OutOfBoundsException;
+use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
-use PHPMD\Node\AbstractTypeNode;
+use PHPMD\Node\AbstractNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\EnumNode;
 use PHPMD\Node\FunctionNode;
@@ -38,6 +39,8 @@ use PHPMD\Rule\TraitAware;
 
 /**
  * This class is a collection of concrete source analysis rules.
+ *
+ * @implements IteratorAggregate<int, Rule>
  */
 class RuleSet implements IteratorAggregate
 {
@@ -71,7 +74,7 @@ class RuleSet implements IteratorAggregate
     /**
      * Mapping between marker interfaces and concrete context code node classes.
      *
-     * @var array<class-string, class-string<AbstractTypeNode>>
+     * @var array<class-string, class-string<AbstractNode<ASTArtifact>>>
      */
     private array $applyTo = [
         ClassAware::class => ClassNode::class,
@@ -85,7 +88,7 @@ class RuleSet implements IteratorAggregate
     /**
      * Mapping of rules that apply to a concrete code node type.
      *
-     * @var array<class-string<AbstractTypeNode>, array<int, Rule>>
+     * @var array<class-string<AbstractNode<ASTArtifact>>, list<Rule>>
      */
     private $rules = [
         ClassNode::class => [],
@@ -204,6 +207,8 @@ class RuleSet implements IteratorAggregate
     /**
      * This method returns an iterator will all rules that belong to this
      * rule-set.
+     *
+     * @return ArrayIterator<int, Rule>
      */
     public function getRules(): ArrayIterator
     {
@@ -234,6 +239,7 @@ class RuleSet implements IteratorAggregate
     /**
      * Applies all registered rules that match against the concrete node type.
      *
+     * @param AbstractNode<ASTArtifact> $node
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException
@@ -250,7 +256,6 @@ class RuleSet implements IteratorAggregate
 
         // Apply all rules to this node
         foreach ($this->rules[$className] as $rule) {
-            /** @var Rule $rule */
             if ($node->hasSuppressWarningsAnnotationFor($rule) && !$this->strict) {
                 continue;
             }
@@ -264,6 +269,8 @@ class RuleSet implements IteratorAggregate
 
     /**
      * Returns an iterator with all rules that are part of this rule-set.
+     *
+     * @return ArrayIterator<int, Rule>
      */
     public function getIterator(): ArrayIterator
     {

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -100,7 +100,7 @@ class RuleSetFactory
      * Creates an array of rule-set instances for the given argument.
      *
      * @param string $ruleSetFileNames Comma-separated string of rule-set filenames or identifier.
-     * @return RuleSet[]
+     * @return list<RuleSet>
      * @throws RuntimeException
      */
     public function createRuleSets($ruleSetFileNames)
@@ -168,7 +168,7 @@ class RuleSetFactory
      * Lists available rule-set identifiers in given directory.
      *
      * @param string $directory The directory to scan for rule-sets.
-     * @return string[]
+     * @return list<string>
      */
     private static function listRuleSetsInDirectory($directory)
     {
@@ -497,7 +497,7 @@ class RuleSetFactory
      * http://pmd.sourceforge.net/pmd-5.0.4/howtomakearuleset.html#Excluding_files_from_a_ruleset
      *
      * @param string $fileName The filename of a rule-set definition.
-     * @return array|null
+     * @return list<string>|null
      * @throws RuntimeException Thrown if file is not proper xml
      */
     public function getIgnorePattern($fileName)
@@ -548,7 +548,7 @@ class RuleSetFactory
      * Returns list of possible file paths to search against code rules
      *
      * @param string $fileName Rule set file name
-     * @return array Array of possible file locations
+     * @return list<string> Array of possible file locations
      */
     private function filePaths($fileName)
     {

--- a/src/main/php/PHPMD/RuleViolation.php
+++ b/src/main/php/PHPMD/RuleViolation.php
@@ -50,7 +50,7 @@ class RuleViolation
      * The arguments for the description/message text or <b>null</b>
      * when the arguments are unknown.
      *
-     * @var array|null
+     * @var array<int, string>|null
      */
     private $args = null;
 
@@ -64,7 +64,7 @@ class RuleViolation
     /**
      * Constructs a new rule violation instance.
      *
-     * @param array|string $violationMessage
+     * @param array<string, mixed>|string $violationMessage
      * @param ?numeric $metric
      */
     public function __construct(Rule $rule, NodeInfo $nodeInfo, $violationMessage, $metric = null)
@@ -112,7 +112,7 @@ class RuleViolation
      * Returns the arguments for the description/message text or <b>null</b>
      * when the arguments are unknown.
      *
-     * @return array|null
+     * @return array<int, string>|null
      */
     public function getArgs()
     {

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -147,14 +147,16 @@ class Command
         $ignorePattern = $ruleSetFactory->getIgnorePattern($opts->getRuleSets());
         $ruleSetList = $ruleSetFactory->createRuleSets($opts->getRuleSets());
 
+        $cwd = getcwd() ?: '';
+
         // Configure Result Cache Engine
         if ($opts->generateBaseline() === BaselineMode::NONE) {
             $cacheEngineFactory = new ResultCacheEngineFactory(
                 $this->output,
-                new ResultCacheKeyFactory(getcwd(), $baselineFile),
+                new ResultCacheKeyFactory($cwd, $baselineFile),
                 new ResultCacheStateFactory()
             );
-            $phpmd->setResultCache($cacheEngineFactory->create(getcwd(), $opts, $ruleSetList));
+            $phpmd->setResultCache($cacheEngineFactory->create($cwd, $opts, $ruleSetList));
         }
 
         $phpmd->processFiles(
@@ -190,7 +192,7 @@ class Command
         $version = '@package_version@';
         if (file_exists($build)) {
             $data = @parse_ini_file($build);
-            $version = $data['project.version'];
+            $version = $data['project.version'] ?? $version;
         }
 
         return $version;

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -54,77 +54,77 @@ class CommandLineOptions
      *
      * @var int
      */
-    protected $minimumPriority = Rule::LOWEST_PRIORITY;
+    private $minimumPriority = Rule::LOWEST_PRIORITY;
 
     /**
      * The maximum rule priority.
      *
      * @var int
      */
-    protected $maximumPriority = Rule::HIGHEST_PRIORITY;
+    private $maximumPriority = Rule::HIGHEST_PRIORITY;
 
     /**
      * A php source code filename or directory.
      *
      * @var string
      */
-    protected $inputPath;
+    private $inputPath;
 
     /**
      * The specified report format.
      *
      * @var ?class-string<AbstractRenderer>
      */
-    protected $reportFormat;
+    private $reportFormat;
 
     /**
      * An optional filename for the generated report.
      *
      * @var string
      */
-    protected $reportFile;
+    private $reportFile;
 
     /**
      * An optional filename to collect errors.
      *
      * @var string
      */
-    protected $errorFile;
+    private $errorFile;
 
     /**
      * Additional report files.
      *
      * @var array<string, string>
      */
-    protected $reportFiles = [];
+    private $reportFiles = [];
 
     /**
      * List of deprecations.
      *
      * @var list<string>
      */
-    protected $deprecations = [];
+    private $deprecations = [];
 
     /**
      * A ruleset filename or a comma-separated string of ruleset filenames.
      *
      * @var string
      */
-    protected $ruleSets;
+    private $ruleSets;
 
     /**
      * File name of a PHPUnit code coverage report.
      *
      * @var string
      */
-    protected $coverageReport;
+    private $coverageReport;
 
     /**
      * A string of comma-separated extensions for valid php source code filenames.
      *
      * @var string
      */
-    protected $extensions;
+    private $extensions;
 
     /**
      * A string of comma-separated pattern that is used to exclude directories.
@@ -133,14 +133,14 @@ class CommandLineOptions
      *
      * @var string
      */
-    protected $ignore;
+    private $ignore;
 
     /**
      * Should the shell show the current phpmd version?
      *
      * @var bool
      */
-    protected $version = false;
+    private $version = false;
 
     /**
      * Should PHPMD run in strict mode?
@@ -148,10 +148,10 @@ class CommandLineOptions
      * @var bool
      * @since 1.2.0
      */
-    protected $strict = false;
+    private $strict = false;
 
     /** @var int */
-    protected $verbosity = OutputInterface::VERBOSITY_NORMAL;
+    private $verbosity = OutputInterface::VERBOSITY_NORMAL;
 
     /**
      * Should PHPMD exit without error code even if error is found?
@@ -159,65 +159,65 @@ class CommandLineOptions
      * @var bool
      * @since 2.10.0
      */
-    protected $ignoreErrorsOnExit = false;
+    private $ignoreErrorsOnExit = false;
 
     /**
      * Should PHPMD exit without error code even if violation is found?
      *
      * @var bool
      */
-    protected $ignoreViolationsOnExit = false;
+    private $ignoreViolationsOnExit = false;
 
     /**
      * List of available rule-sets.
      *
      * @var array<int, string>
      */
-    protected $availableRuleSets = [];
+    private $availableRuleSets = [];
 
     /**
      * Should PHPMD baseline the existing violations and write them to the $baselineFile
      * @var string allowed modes: NONE, GENERATE or UPDATE
      */
-    protected $generateBaseline = BaselineMode::NONE;
+    private $generateBaseline = BaselineMode::NONE;
 
     /**
      * The baseline source file to read the baseline violations from.
      * Defaults to the path of the (first) ruleset file as phpmd.baseline.xml
      * @var string|null
      */
-    protected $baselineFile;
+    private $baselineFile;
 
     /**
      * Should PHPMD read or write the result cache state from the cache file
      * @var bool
      */
-    protected $cacheEnabled = false;
+    private $cacheEnabled = false;
 
     /**
      * If set the path to read and write the result cache state from and to.
      * @var string|null
      */
-    protected $cacheFile;
+    private $cacheFile;
 
     /**
      * If set determine the cache strategy. Either `content` or `timestamp`. Defaults to `content`.
      * @var string|null
      */
-    protected $cacheStrategy;
+    private $cacheStrategy;
 
     /**
      * Either the output should be colored.
      *
      * @var bool
      */
-    protected $colored = false;
+    private $colored = false;
 
     /**
      * Specify how many extra lines are added to a code snippet
      * @var int|null
      */
-    protected $extraLineInExcerpt;
+    private $extraLineInExcerpt;
 
     /**
      * Constructs a new command line options instance.
@@ -674,7 +674,7 @@ class CommandLineOptions
      * @return AbstractRenderer
      * @throws InvalidArgumentException When the specified renderer does not exist.
      */
-    protected function createRendererWithoutOptions($reportFormat = null)
+    private function createRendererWithoutOptions($reportFormat = null)
     {
         $reportFormat = $reportFormat ?: $this->reportFormat;
 
@@ -705,7 +705,7 @@ class CommandLineOptions
     /**
      * @return XMLRenderer
      */
-    protected function createXmlRenderer()
+    private function createXmlRenderer()
     {
         return new XMLRenderer();
     }
@@ -713,7 +713,7 @@ class CommandLineOptions
     /**
      * @return TextRenderer
      */
-    protected function createTextRenderer()
+    private function createTextRenderer()
     {
         return new TextRenderer();
     }
@@ -721,7 +721,7 @@ class CommandLineOptions
     /**
      * @return AnsiRenderer
      */
-    protected function createAnsiRenderer()
+    private function createAnsiRenderer()
     {
         return new AnsiRenderer();
     }
@@ -729,7 +729,7 @@ class CommandLineOptions
     /**
      * @return GitLabRenderer
      */
-    protected function createGitLabRenderer()
+    private function createGitLabRenderer()
     {
         return new GitLabRenderer();
     }
@@ -737,7 +737,7 @@ class CommandLineOptions
     /**
      * @return GitHubRenderer
      */
-    protected function createGitHubRenderer()
+    private function createGitHubRenderer()
     {
         return new GitHubRenderer();
     }
@@ -745,7 +745,7 @@ class CommandLineOptions
     /**
      * @return HTMLRenderer
      */
-    protected function createHtmlRenderer()
+    private function createHtmlRenderer()
     {
         return new HTMLRenderer($this->extraLineInExcerpt);
     }
@@ -753,7 +753,7 @@ class CommandLineOptions
     /**
      * @return JSONRenderer
      */
-    protected function createJsonRenderer()
+    private function createJsonRenderer()
     {
         return new JSONRenderer();
     }
@@ -761,7 +761,7 @@ class CommandLineOptions
     /**
      * @return CheckStyleRenderer
      */
-    protected function createCheckStyleRenderer()
+    private function createCheckStyleRenderer()
     {
         return new CheckStyleRenderer();
     }
@@ -769,7 +769,7 @@ class CommandLineOptions
     /**
      * @return SARIFRenderer
      */
-    protected function createSarifRenderer()
+    private function createSarifRenderer()
     {
         return new SARIFRenderer();
     }
@@ -778,7 +778,7 @@ class CommandLineOptions
      * @return AbstractRenderer
      * @throws InvalidArgumentException
      */
-    protected function createCustomRenderer()
+    private function createCustomRenderer()
     {
         if (!$this->reportFormat) {
             throw new InvalidArgumentException(
@@ -876,7 +876,7 @@ class CommandLineOptions
      * @return string|null The list of renderers found separated by comma, or null if none.
      * @throws InvalidArgumentException
      */
-    protected function getListOfAvailableRenderers()
+    private function getListOfAvailableRenderers()
     {
         $renderersDirPathName = __DIR__ . '/../Renderer';
         $renderers = [];
@@ -904,7 +904,7 @@ class CommandLineOptions
      * @param string $deprecatedName
      * @param string $newName
      */
-    protected function logDeprecated($deprecatedName, $newName): void
+    private function logDeprecated($deprecatedName, $newName): void
     {
         $this->deprecations[] = sprintf(
             'The --%s option is deprecated, please use --%s instead.',
@@ -924,7 +924,7 @@ class CommandLineOptions
      * @throws InvalidArgumentException If the specified input file does not exist.
      * @since 1.1.0
      */
-    protected function readInputFile($inputFile)
+    private function readInputFile($inputFile)
     {
         $content = file($inputFile);
         if ($content === false) {

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -94,14 +94,14 @@ class CommandLineOptions
     /**
      * Additional report files.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $reportFiles = [];
 
     /**
      * List of deprecations.
      *
-     * @var array
+     * @var list<string>
      */
     protected $deprecations = [];
 
@@ -171,7 +171,7 @@ class CommandLineOptions
     /**
      * List of available rule-sets.
      *
-     * @var array(string)
+     * @var array<int, string>
      */
     protected $availableRuleSets = [];
 
@@ -454,7 +454,7 @@ class CommandLineOptions
      * Returns a hash with report files specified for different renderers. The
      * key represents the report format and the value the report file location.
      *
-     * @return array
+     * @return array<string, string|null>
      */
     public function getReportFiles()
     {

--- a/src/main/php/PHPMD/Utility/ArgumentsValidator.php
+++ b/src/main/php/PHPMD/Utility/ArgumentsValidator.php
@@ -6,20 +6,15 @@ use InvalidArgumentException;
 
 class ArgumentsValidator
 {
-    /** @var bool */
-    private $hasImplicitArguments;
-
-    /** @var string[] */
-    private $originalArguments;
-
-    /** @var string[] */
-    private $arguments;
-
-    public function __construct($hasImplicitArguments, $originalArguments, $arguments)
-    {
-        $this->hasImplicitArguments = $hasImplicitArguments;
-        $this->originalArguments = $originalArguments;
-        $this->arguments = $arguments;
+    /**
+     * @param string[] $originalArguments
+     * @param string[] $arguments
+     */
+    public function __construct(
+        private bool $hasImplicitArguments,
+        private array $originalArguments,
+        private array $arguments,
+    ) {
     }
 
     /**

--- a/src/main/php/PHPMD/Utility/ExceptionsList.php
+++ b/src/main/php/PHPMD/Utility/ExceptionsList.php
@@ -32,26 +32,25 @@ use RuntimeException;
 class ExceptionsList implements IteratorAggregate, ArrayAccess
 {
     /**
+     * Separator used to join exception in the property string.
+     */
+    protected string $separator;
+    /**
      * Temporary cache of configured exceptions. Have name as key
      *
      * @var array<string, string>
      */
-    protected array $exceptions;
+    private array $exceptions;
 
     /**
      * Rule to which the exception list apply.
      */
-    protected Rule $rule;
+    private Rule $rule;
 
     /**
      * Extra characters to be trimmed with whitespace at beginning and ending of each exception.
      */
-    protected string $trim;
-
-    /**
-     * Separator used to join exception in the property string.
-     */
-    protected string $separator;
+    private string $trim;
 
     public function __construct(Rule $rule, string $trim = '', string $separator = ',')
     {

--- a/src/main/php/PHPMD/Utility/ExceptionsList.php
+++ b/src/main/php/PHPMD/Utility/ExceptionsList.php
@@ -25,12 +25,16 @@ use OutOfBoundsException;
 use PHPMD\Rule;
 use RuntimeException;
 
+/**
+ * @implements IteratorAggregate<string, string>
+ * @implements ArrayAccess<string, string>
+ */
 class ExceptionsList implements IteratorAggregate, ArrayAccess
 {
     /**
      * Temporary cache of configured exceptions. Have name as key
      *
-     * @var array<string, int>
+     * @var array<string, string>
      */
     protected array $exceptions;
 
@@ -70,34 +74,33 @@ class ExceptionsList implements IteratorAggregate, ArrayAccess
     /**
      * Gets array of exceptions from property
      *
-     * @return array<string, int>
+     * @return array<string, string>
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
     protected function getExceptionsList(): array
     {
         if (!isset($this->exceptions)) {
-            $this->exceptions = array_flip(
-                Strings::splitToList(
-                    $this->rule->getStringProperty('exceptions', ''),
-                    $this->separator,
-                    $this->trim
-                )
+            $values = Strings::splitToList(
+                $this->rule->getStringProperty('exceptions', ''),
+                $this->separator,
+                $this->trim
             );
+
+            $this->exceptions = array_combine($values, $values);
         }
 
         return $this->exceptions;
     }
 
     /**
+     * @return ArrayIterator<string, string>
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
     public function getIterator(): ArrayIterator
     {
-        $keys = array_keys($this->getExceptionsList());
-
-        return new ArrayIterator(array_combine($keys, $keys));
+        return new ArrayIterator($this->getExceptionsList());
     }
 
     /**
@@ -113,7 +116,7 @@ class ExceptionsList implements IteratorAggregate, ArrayAccess
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
-    public function offsetGet($offset): int
+    public function offsetGet($offset): string
     {
         $exceptions = $this->getExceptionsList();
         $value = $exceptions[Strings::trim($offset, $this->trim)] ?? null;

--- a/src/main/php/PHPMD/Utility/Strings.php
+++ b/src/main/php/PHPMD/Utility/Strings.php
@@ -28,7 +28,7 @@ class Strings
      * Returns the length of the given string, excluding at most one suffix
      *
      * @param string $stringName String to calculate the length for.
-     * @param array $subtractSuffixes List of suffixes to exclude from the calculated length.
+     * @param array<int, string> $subtractSuffixes List of suffixes to exclude from the calculated length.
      * @return int The length of the string, without suffix, if applicable.
      */
     public static function lengthWithoutSuffixes($stringName, array $subtractSuffixes)
@@ -40,8 +40,8 @@ class Strings
      * Returns the length of the given string, excluding at most one suffix
      *
      * @param string $stringName String to calculate the length for.
-     * @param array $subtractPrefixes List of prefixes to exclude from the calculated length.
-     * @param array $subtractSuffixes List of suffixes to exclude from the calculated length.
+     * @param array<int, string> $subtractPrefixes List of prefixes to exclude from the calculated length.
+     * @param array<int, string> $subtractSuffixes List of suffixes to exclude from the calculated length.
      * @return int The length of the string, without suffix, if applicable.
      */
     public static function lengthWithoutPrefixesAndSuffixes(
@@ -77,7 +77,7 @@ class Strings
      * @param string $listAsString The string to split.
      * @param string $separator The separator to split the string with, similar to explode.
      * @param string $trim Extra character to be trimmed off of each value.
-     * @return array The list of trimmed and filtered parts of the string.
+     * @return array<int, string> The list of trimmed and filtered parts of the string.
      * @throws InvalidArgumentException When the separator is an empty string.
      */
     public static function splitToList($listAsString, $separator = ',', $trim = '')

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -54,7 +54,7 @@ class StreamWriter extends AbstractWriter
             throw new RuntimeException($message);
         }
 
-        $this->stream = fopen($streamResourceOrUri, 'wb');
+        $this->stream = fopen($streamResourceOrUri, 'wb') ?: null;
     }
 
     /**

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -43,7 +43,7 @@ abstract class AbstractStaticTestCase extends TestCase
     /**
      * Temporary files created by a test.
      *
-     * @var array(string)
+     * @var list<string>
      */
     private static $tempFiles = [];
 

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -23,6 +23,7 @@ use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Source\Language\PHP\PHPParserGeneric;
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
@@ -523,7 +524,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Creates a mocked rule-set instance.
      *
-     * @param string $expectedClass Optional class name for apply() expected at least once.
+     * @param class-string<ASTNode> $expectedClass Optional class name for apply() expected at least once.
      * @param int|string $count How often should apply() be called?
      * @return MockObject|RuleSet
      */

--- a/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
+++ b/src/test/php/PHPMD/Baseline/BaselineSetFactoryTest.php
@@ -48,7 +48,7 @@ class BaselineSetFactoryTest extends AbstractTestCase
     public function testFromFileShouldThrowExceptionForMissingFile()
     {
         self::expectExceptionObject(new RuntimeException(
-            'Unable to locate the baseline file at',
+            'Unable to load the baseline file at: ',
         ));
 
         BaselineSetFactory::fromFile('foobar.xml');

--- a/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
@@ -229,7 +229,7 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *
      * <code>
      * class Foo {
-     *     private $bar = array();
+     *     private $bar = [];
      *     // ...
      *     public function baz() {
      *         return $this->bar[42];

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -306,7 +306,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     public function testThrowsExpectedExceptionWhenInputFileNotExists()
     {
         self::expectExceptionObject(new InvalidArgumentException(
-            "Input file 'inputfail.txt' not exists.",
+            "Unable to load 'inputfail.txt'.",
         ));
 
         $args = ['foo.php', 'text', 'design', '--inputfile', 'inputfail.txt'];

--- a/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleNotAppliesToMethodWithReturnTypeNotBoolean.php
+++ b/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleNotAppliesToMethodWithReturnTypeNotBoolean.php
@@ -18,7 +18,7 @@
 class testRuleNotAppliesToMethodWithReturnTypeNotBoolean
 {
     /**
-     * @return array(boolean)
+     * @return array<boolean>
      */
     function getFooBar()
     {


### PR DESCRIPTION
Type: refactoring
Breaking change: yes

Depends on:
- https://github.com/phpmd/phpmd/pull/1144

Seal up properties and functions that do not need to be protected. This will allow us more flexibility in terms of refactoring in the future. We can always expose things that makes sens rather then everything by default.
This also lets tools better detected unreachable conditions or dead code.