### PR TITLE
Use unpacking inside arrays

### DIFF
--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -154,10 +154,10 @@ class PHPMD
      */
     public function addIgnorePatterns(array $ignorePatterns)
     {
-        $this->ignorePatterns = array_merge(
-            $this->ignorePatterns,
-            $ignorePatterns
-        );
+        $this->ignorePatterns = [
+            ...$this->ignorePatterns,
+            ...$ignorePatterns,
+        ];
 
         return $this;
     }

--- a/src/main/php/PHPMD/Parser.php
+++ b/src/main/php/PHPMD/Parser.php
@@ -312,7 +312,7 @@ class Parser extends AbstractASTVisitor implements CodeAwareGenerator
 
         $pdepend = $node->getNode();
         foreach ($this->analyzers as $analyzer) {
-            $metrics = array_merge($metrics, $analyzer->getNodeMetrics($pdepend));
+            $metrics = [...$metrics, ...$analyzer->getNodeMetrics($pdepend)];
         }
         $node->setMetrics($metrics);
     }

--- a/src/main/php/PHPMD/Renderer/SARIFRenderer.php
+++ b/src/main/php/PHPMD/Renderer/SARIFRenderer.php
@@ -146,7 +146,7 @@ class SARIFRenderer extends JSONRenderer
         }
 
         $data['runs'][0]['tool']['driver']['rules'] = $rules;
-        $data['runs'][0]['results'] = array_merge($data['runs'][0]['results'], $results);
+        $data['runs'][0]['results'] = $results + $data['runs'][0]['results'];
 
         return $data;
     }

--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -110,7 +110,7 @@ class Report
             ksort($violationInLine);
 
             foreach ($violationInLine as $violation) {
-                $violations = array_merge($violations, $violation);
+                $violations = [...$violations, ...$violation];
             }
         }
 

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -88,11 +88,11 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, EnumAwar
         }
 
         $this->currentNamespace = $node->getNamespaceName() . '\\';
-        $loops = array_merge(
-            $node->findChildrenOfType(ASTForStatement::class),
-            $node->findChildrenOfType(ASTWhileStatement::class),
-            $node->findChildrenOfType(ASTDoWhileStatement::class)
-        );
+        $loops = [
+            ...$node->findChildrenOfType(ASTForStatement::class),
+            ...$node->findChildrenOfType(ASTWhileStatement::class),
+            ...$node->findChildrenOfType(ASTDoWhileStatement::class),
+        ];
 
         foreach ($loops as $loop) {
             $this->findViolations($loop);

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -139,10 +139,10 @@ class RuleSetFactory
      */
     public function listAvailableRuleSets()
     {
-        return array_merge(
-            self::listRuleSetsInDirectory($this->location . '/rulesets/'),
-            self::listRuleSetsInDirectory(getcwd() . '/rulesets/')
-        );
+        return [
+            ...self::listRuleSetsInDirectory($this->location . '/rulesets/'),
+            ...self::listRuleSetsInDirectory(getcwd() . '/rulesets/'),
+        ];
     }
 
     /**

--- a/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -160,10 +160,10 @@ class TooManyPublicMethodsTest extends AbstractTestCase
 
         $class->expects(static::any())
             ->method('getMethods')
-            ->will(static::returnValue(array_merge(
-                array_map([$this, 'createPublicMethod'], $publicMethods),
-                array_map([$this, 'createPrivateMethod'], $privateMethods)
-            )));
+            ->will(static::returnValue([
+                ...array_map([$this, 'createPublicMethod'], $publicMethods),
+                ...array_map([$this, 'createPrivateMethod'], $privateMethods),
+            ]));
 
         return $class;
     }

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -725,7 +725,7 @@ class CommandLineOptionsTest extends AbstractTestCase
      */
     public function testGetReportFiles(array $options, array $expected): void
     {
-        $args = array_merge([__FILE__, __FILE__, 'text', 'codesize'], $options);
+        $args = [__FILE__, __FILE__, 'text', 'codesize', ...$options];
         $opts = new CommandLineOptions($args);
 
         static::assertEquals($expected, $opts->getReportFiles());

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -49,17 +49,15 @@ class CommandTest extends AbstractTestCase
         ?array $options = null
     ): void {
         $args = array_filter(
-            array_merge(
-                [
-                    __FILE__,
-                    self::createFileUri($sourceFile),
-                    'html',
-                    'codesize',
-                    '--reportfile',
-                    self::createTempFileUri(),
-                ],
-                (array) $options
-            )
+            [
+                __FILE__,
+                self::createFileUri($sourceFile),
+                'html',
+                'codesize',
+                '--reportfile',
+                self::createTempFileUri(),
+                ...($options ?? []),
+            ]
         );
 
         $exitCode = Command::main($args);


### PR DESCRIPTION
Type: refactoring
Breaking change: no

With unpacking in arrays (introduced in PHP 7.4) `array_merge()` can now be replaced by operators.