### PR TITLE
Move functions to where they are used and mark them private

### DIFF
--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -67,22 +67,6 @@ abstract class AbstractLocalVariable extends AbstractRule
     ];
 
     /**
-     * Tests if the given variable node represents a local variable or if it is
-     * a static object property or something similar.
-     *
-     * @param ASTNode<ASTVariable> $variable The variable to check.
-     * @return bool
-     * @throws OutOfBoundsException
-     */
-    protected function isLocal(ASTNode $variable)
-    {
-        return (!$variable->isThis()
-            && $this->isNotSuperGlobal($variable)
-            && $this->isRegularVariable($variable)
-        );
-    }
-
-    /**
      * Tests if the given variable represents one of the PHP super globals
      * that are available in scopes.
      *
@@ -92,18 +76,6 @@ abstract class AbstractLocalVariable extends AbstractRule
     protected function isSuperGlobal(AbstractNode $variable)
     {
         return isset(self::$superGlobals[$variable->getImage()]);
-    }
-
-    /**
-     * Tests if the given variable does not represent one of the PHP super globals
-     * that are available in scopes.
-     *
-     * @param AbstractNode<ASTVariable> $variable
-     * @return bool
-     */
-    private function isNotSuperGlobal(AbstractNode $variable)
-    {
-        return !$this->isSuperGlobal($variable);
     }
 
     /**
@@ -167,19 +139,6 @@ abstract class AbstractLocalVariable extends AbstractRule
         return ($node->getParent()->isInstanceOf(ASTArrayIndexExpression::class)
             || $node->getParent()->isInstanceOf(ASTStringIndexExpression::class)
         );
-    }
-
-    /**
-     * PHP is case insensitive so we should compare function names case
-     * insensitive.
-     *
-     * @param AbstractNode<PDependNode> $node
-     * @param string $name
-     * @return bool
-     */
-    protected function isFunctionNameEqual(AbstractNode $node, $name)
-    {
-        return (0 === strcasecmp(trim($node->getImage(), '\\'), $name));
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -26,6 +26,7 @@ use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTFormalParameters;
 use PDepend\Source\AST\ASTFunctionPostfix;
 use PDepend\Source\AST\ASTLiteral;
+use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\Node\AbstractCallableNode;
@@ -82,6 +83,19 @@ class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAwa
         foreach ($this->nodes as $node) {
             $this->addViolation($node, [$node->getImage()]);
         }
+    }
+
+    /**
+     * PHP is case insensitive so we should compare function names case
+     * insensitive.
+     *
+     * @param AbstractNode<PDependNode> $node
+     * @param string $name
+     * @return bool
+     */
+    private function isFunctionNameEqual(AbstractNode $node, $name)
+    {
+        return (0 === strcasecmp(trim($node->getImage(), '\\'), $name));
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -31,6 +31,7 @@ use PDepend\Source\AST\ASTFormalParameters;
 use PDepend\Source\AST\ASTFunctionPostfix;
 use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTString;
+use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\Node\AbstractCallableNode;
@@ -79,6 +80,34 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
                 $this->doCheckNodeImage($nodes[0]);
             }
         }
+    }
+
+    /**
+     * Tests if the given variable node represents a local variable or if it is
+     * a static object property or something similar.
+     *
+     * @param ASTNode<ASTVariable> $variable The variable to check.
+     * @return bool
+     * @throws OutOfBoundsException
+     */
+    private function isLocal(ASTNode $variable)
+    {
+        return (!$variable->isThis()
+            && $this->isNotSuperGlobal($variable)
+            && $this->isRegularVariable($variable)
+        );
+    }
+
+    /**
+     * Tests if the given variable does not represent one of the PHP super globals
+     * that are available in scopes.
+     *
+     * @param AbstractNode<ASTVariable> $variable
+     * @return bool
+     */
+    private function isNotSuperGlobal(AbstractNode $variable)
+    {
+        return !$this->isSuperGlobal($variable);
     }
 
     /**


### PR DESCRIPTION
Type: refactoring
Breaking change: yes

Move 3 functions up the hierarchy to where they are used so they can be marked as private instead of protected.
Makes it easier to reason about both for humans and tools, and we can freely refactor them in the future.