### PR TITLE
Mark class internals as private

### DIFF
--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -257,7 +257,7 @@ abstract class AbstractRule implements Rule
      * @throws OutOfBoundsException When no property for <b>$name</b> exists and
      * no default value to fall back was given.
      */
-    protected function getProperty(string $name, mixed $default = null): mixed
+    private function getProperty(string $name, mixed $default = null): mixed
     {
         if (isset($this->properties[$name])) {
             return $this->properties[$name];

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -40,7 +40,7 @@ class BooleanArgumentFlag extends AbstractRule implements FunctionAware, MethodA
      *
      * @var ExceptionsList|null
      */
-    protected $exceptions;
+    private $exceptions;
 
     /**
      * This method checks if a method/function has boolean flag arguments and warns about them.
@@ -71,7 +71,7 @@ class BooleanArgumentFlag extends AbstractRule implements FunctionAware, MethodA
         $this->scanFormalParameters($node);
     }
 
-    protected function isBooleanValue(?ASTValue $value = null): bool
+    private function isBooleanValue(?ASTValue $value = null): bool
     {
         return $value?->isValueAvailable() && is_bool($value->getValue());
     }
@@ -81,7 +81,7 @@ class BooleanArgumentFlag extends AbstractRule implements FunctionAware, MethodA
      *
      * @return ExceptionsList
      */
-    protected function getExceptionsList()
+    private function getExceptionsList()
     {
         if ($this->exceptions === null) {
             $this->exceptions = new ExceptionsList($this);

--- a/src/main/php/PHPMD/Utility/ExceptionsList.php
+++ b/src/main/php/PHPMD/Utility/ExceptionsList.php
@@ -32,7 +32,7 @@ use RuntimeException;
 class ExceptionsList implements ArrayAccess, IteratorAggregate
 {
     /** Separator used to join exception in the property string. */
-    protected string $separator;
+    private string $separator;
 
     /**
      * Temporary cache of configured exceptions. Have name as key
@@ -72,7 +72,7 @@ class ExceptionsList implements ArrayAccess, IteratorAggregate
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
-    protected function getExceptionsList(): array
+    private function getExceptionsList(): array
     {
         if (!isset($this->exceptions)) {
             $values = Strings::splitToList(


### PR DESCRIPTION
Type: refactoring
Breaking change: yes

Mark methods that are not extended or used outside of the class they are declared in as private. This makes it easier to reason about both for humans and tools, and we can freely refactor them in the future.