### PR TITLE
Seal up constants

### DIFF
--- a/src/main/php/PHPMD/Baseline/BaselineMode.php
+++ b/src/main/php/PHPMD/Baseline/BaselineMode.php
@@ -5,11 +5,11 @@ namespace PHPMD\Baseline;
 class BaselineMode
 {
     /** Do not generate or update any baseline file */
-    public const NONE = 'none';
+    final public const NONE = 'none';
 
     /** Generate a baseline file for _all_ current violations */
-    public const GENERATE = 'generate';
+    final public const GENERATE = 'generate';
 
     /** Remove any non existing violations from the baseline file. Do not baseline any new violations. */
-    public const UPDATE = 'update';
+    final public const UPDATE = 'update';
 }

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheStrategy.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheStrategy.php
@@ -5,8 +5,8 @@ namespace PHPMD\Cache\Model;
 class ResultCacheStrategy
 {
     /** Determine the file cache freshness based on sha hash of the contents of the file */
-    public const CONTENT = 'content';
+    final public const CONTENT = 'content';
 
     /** Determine the file cache freshness based on the file modified timestamp */
-    public const TIMESTAMP = 'timestamp';
+    final public const TIMESTAMP = 'timestamp';
 }

--- a/src/main/php/PHPMD/Console/OutputInterface.php
+++ b/src/main/php/PHPMD/Console/OutputInterface.php
@@ -8,11 +8,11 @@ namespace PHPMD\Console;
  */
 interface OutputInterface
 {
-    public const VERBOSITY_QUIET = 16;
-    public const VERBOSITY_NORMAL = 32;
-    public const VERBOSITY_VERBOSE = 64;
-    public const VERBOSITY_VERY_VERBOSE = 128;
-    public const VERBOSITY_DEBUG = 256;
+    final public const VERBOSITY_QUIET = 16;
+    final public const VERBOSITY_NORMAL = 32;
+    final public const VERBOSITY_VERBOSE = 64;
+    final public const VERBOSITY_VERY_VERBOSE = 128;
+    final public const VERBOSITY_DEBUG = 256;
 
     /**
      * @param string|string[] $messages

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -26,7 +26,7 @@ use PHPMD\Cache\ResultCacheEngine;
 class PHPMD
 {
     /** The current PHPMD version. */
-    public const VERSION = '@package_version@';
+    final public const VERSION = '@package_version@';
 
     /**
      * This property will be set to <b>true</b> when an error

--- a/src/main/php/PHPMD/Rule.php
+++ b/src/main/php/PHPMD/Rule.php
@@ -30,10 +30,10 @@ use PDepend\Source\AST\ASTNode;
 interface Rule
 {
     /** The default lowest rule priority. */
-    public const LOWEST_PRIORITY = 5;
+    final public const LOWEST_PRIORITY = 5;
 
     /** The default highest rule priority. */
-    public const HIGHEST_PRIORITY = 1;
+    final public const HIGHEST_PRIORITY = 1;
 
     /**
      * Returns the name for this rule instance.

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -42,7 +42,7 @@ use RuntimeException;
 class Command
 {
     /** Exit codes used by the phpmd command line tool. */
-    public const EXIT_SUCCESS = 0,
+    final public const EXIT_SUCCESS = 0,
         EXIT_EXCEPTION = 1,
         EXIT_VIOLATION = 2,
         EXIT_ERROR = 3;


### PR DESCRIPTION
Type: refactoring
Breaking change: yes

Marks non-private consts as final. This makes it easier to reason about both for humans and tools. And it lets us know that they are not changed by users allowing us more flexibility when refactoring.