### PR TITLE
Mark classes as final

### DIFF
--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -76,7 +76,7 @@ abstract class AbstractNode
      * Returns the parent of this node or <b>null</b> when no parent node
      * exists.
      *
-     * @return ASTNode<PDependNode>|null
+     * @return AbstractNode<PDependNode>|null
      */
     public function getParent()
     {
@@ -94,7 +94,7 @@ abstract class AbstractNode
      * @template T of PDependNode
      *
      * @param class-string<T> $type The searched parent type.
-     * @return ASTNode<T>|null
+     * @return AbstractNode<T>|null
      */
     public function getParentOfType($type)
     {
@@ -114,7 +114,7 @@ abstract class AbstractNode
      * Returns a child node at the given index.
      *
      * @param int $index The child offset.
-     * @return ASTNode<PDependNode>
+     * @return AbstractNode<PDependNode>
      * @throws OutOfBoundsException
      */
     public function getChild($index)
@@ -132,7 +132,7 @@ abstract class AbstractNode
      * @template T of PDependNode
      *
      * @param class-string<T> $type The searched child type.
-     * @return ASTNode<T>|null
+     * @return AbstractNode<T>|null
      */
     public function getFirstChildOfType($type)
     {
@@ -151,7 +151,7 @@ abstract class AbstractNode
      *
      * @template T of PDependNode
      * @param class-string<T> $type The searched child type.
-     * @return list<ASTNode<T>>
+     * @return list<AbstractNode<T>>
      */
     public function findChildrenOfType($type)
     {
@@ -191,7 +191,7 @@ abstract class AbstractNode
     /**
      * Searches recursive for all children of this node that are of variable.
      *
-     * @return array<int, ASTNode<ASTVariable>>
+     * @return array<int, AbstractNode<ASTVariable>>
      * @todo Cover by a test.
      */
     public function findChildrenOfTypeVariable()

--- a/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
+++ b/src/main/php/PHPMD/Baseline/BaselineFileFinder.php
@@ -5,7 +5,7 @@ namespace PHPMD\Baseline;
 use PHPMD\TextUI\CommandLineOptions;
 use RuntimeException;
 
-class BaselineFileFinder
+final class BaselineFileFinder
 {
     private const DEFAULT_FILENAME = 'phpmd.baseline.xml';
 

--- a/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
+++ b/src/main/php/PHPMD/Baseline/BaselineSetFactory.php
@@ -4,7 +4,7 @@ namespace PHPMD\Baseline;
 
 use RuntimeException;
 
-class BaselineSetFactory
+final class BaselineSetFactory
 {
     /**
      * Read the baseline violations from the given filename path. Append the baseDir to all the filepaths within

--- a/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheEngineFactory.php
@@ -6,7 +6,7 @@ use PHPMD\Console\OutputInterface;
 use PHPMD\RuleSet;
 use PHPMD\TextUI\CommandLineOptions;
 
-class ResultCacheEngineFactory
+final class ResultCacheEngineFactory
 {
     public function __construct(
         private OutputInterface $output,

--- a/src/main/php/PHPMD/Console/NullOutput.php
+++ b/src/main/php/PHPMD/Console/NullOutput.php
@@ -2,7 +2,7 @@
 
 namespace PHPMD\Console;
 
-class NullOutput extends Output
+final class NullOutput extends Output
 {
     /**
      * @inheritDoc

--- a/src/main/php/PHPMD/Console/StreamOutput.php
+++ b/src/main/php/PHPMD/Console/StreamOutput.php
@@ -2,7 +2,7 @@
 
 namespace PHPMD\Console;
 
-class StreamOutput extends Output
+final class StreamOutput extends Output
 {
     /**
      * @param resource $stream

--- a/src/main/php/PHPMD/Exception/RuleClassFileNotFoundException.php
+++ b/src/main/php/PHPMD/Exception/RuleClassFileNotFoundException.php
@@ -23,7 +23,7 @@ use RuntimeException;
  * This type of exception is thrown when the class file for a configured rule
  * does not exist within php's include path.
  */
-class RuleClassFileNotFoundException extends RuntimeException
+final class RuleClassFileNotFoundException extends RuntimeException
 {
     /**
      * Constructs a new class file not found exception.

--- a/src/main/php/PHPMD/Exception/RuleClassNotFoundException.php
+++ b/src/main/php/PHPMD/Exception/RuleClassNotFoundException.php
@@ -22,7 +22,7 @@ use RuntimeException;
 /**
  * When a configured rule class does not exist.
  */
-class RuleClassNotFoundException extends RuntimeException
+final class RuleClassNotFoundException extends RuntimeException
 {
     /**
      * Constructs a new class not found exception.

--- a/src/main/php/PHPMD/Exception/RuleSetNotFoundException.php
+++ b/src/main/php/PHPMD/Exception/RuleSetNotFoundException.php
@@ -22,7 +22,7 @@ use RuntimeException;
 /**
  * This type of exception is thrown when a not existing rule-set was specified.
  */
-class RuleSetNotFoundException extends RuntimeException
+final class RuleSetNotFoundException extends RuntimeException
 {
     /**
      * Constructs a new exception for the given rule-set identifier or file name.

--- a/src/main/php/PHPMD/Node/ASTNode.php
+++ b/src/main/php/PHPMD/Node/ASTNode.php
@@ -28,7 +28,7 @@ use PHPMD\Rule;
  *
  * @extends AbstractNode<TNode>
  */
-class ASTNode extends AbstractNode
+final class ASTNode extends AbstractNode
 {
     /**
      * Constructs a new ast node instance.

--- a/src/main/php/PHPMD/Node/Annotation.php
+++ b/src/main/php/PHPMD/Node/Annotation.php
@@ -22,7 +22,7 @@ use PHPMD\Rule;
 /**
  * Simple code annotation class.
  */
-class Annotation
+final class Annotation
 {
     /** Name of the suppress warnings annotation. */
     private const SUPPRESS_ANNOTATION = 'suppressWarnings';

--- a/src/main/php/PHPMD/Node/Annotations.php
+++ b/src/main/php/PHPMD/Node/Annotations.php
@@ -24,7 +24,7 @@ use PHPMD\Rule;
 /**
  * Collection of code annotations.
  */
-class Annotations
+final class Annotations
 {
     /**
      * Detected annotations.

--- a/src/main/php/PHPMD/Node/EnumNode.php
+++ b/src/main/php/PHPMD/Node/EnumNode.php
@@ -24,6 +24,6 @@ use PDepend\Source\AST\ASTEnum;
  *
  * @extends AbstractTypeNode<ASTEnum>
  */
-class EnumNode extends AbstractTypeNode
+final class EnumNode extends AbstractTypeNode
 {
 }

--- a/src/main/php/PHPMD/Node/InterfaceNode.php
+++ b/src/main/php/PHPMD/Node/InterfaceNode.php
@@ -24,6 +24,6 @@ use PDepend\Source\AST\ASTInterface;
  *
  * @extends AbstractTypeNode<ASTInterface>
  */
-class InterfaceNode extends AbstractTypeNode
+final class InterfaceNode extends AbstractTypeNode
 {
 }

--- a/src/main/php/PHPMD/Node/NodeInfoFactory.php
+++ b/src/main/php/PHPMD/Node/NodeInfoFactory.php
@@ -5,7 +5,7 @@ namespace PHPMD\Node;
 use PDepend\Source\AST\ASTNode;
 use PHPMD\AbstractNode as PHPMDAbstractNode;
 
-class NodeInfoFactory
+final class NodeInfoFactory
 {
     /**
      * @param PHPMDAbstractNode<ASTNode> $node

--- a/src/main/php/PHPMD/Node/TraitNode.php
+++ b/src/main/php/PHPMD/Node/TraitNode.php
@@ -24,6 +24,6 @@ use PDepend\Source\AST\ASTTrait;
  *
  * @extends AbstractTypeNode<ASTTrait>
  */
-class TraitNode extends AbstractTypeNode
+final class TraitNode extends AbstractTypeNode
 {
 }

--- a/src/main/php/PHPMD/Parser.php
+++ b/src/main/php/PHPMD/Parser.php
@@ -46,7 +46,7 @@ use PHPMD\Node\TraitNode;
 /**
  * Simple wrapper around the php depend engine.
  */
-class Parser extends AbstractASTVisitor implements CodeAwareGenerator
+final class Parser extends AbstractASTVisitor implements CodeAwareGenerator
 {
     /**
      * The analysing rule-set instance.

--- a/src/main/php/PHPMD/ParserFactory.php
+++ b/src/main/php/PHPMD/ParserFactory.php
@@ -27,7 +27,7 @@ use PDepend\Input\ExtensionFilter;
 /**
  * Simple factory that is used to return a ready to use PDepend instance.
  */
-class ParserFactory
+final class ParserFactory
 {
     /** @var string The default config file name */
     private const PDEPEND_CONFIG_FILE_NAME = '/pdepend.xml';

--- a/src/main/php/PHPMD/Renderer/AnsiRenderer.php
+++ b/src/main/php/PHPMD/Renderer/AnsiRenderer.php
@@ -10,7 +10,7 @@ use PHPMD\RuleViolation;
  * This renderer output a command line friendly log with all found violations
  * and suspect software artifacts.
  */
-class AnsiRenderer extends AbstractRenderer
+final class AnsiRenderer extends AbstractRenderer
 {
     public function renderReport(Report $report): void
     {

--- a/src/main/php/PHPMD/Renderer/BaselineRenderer.php
+++ b/src/main/php/PHPMD/Renderer/BaselineRenderer.php
@@ -6,7 +6,7 @@ use PHPMD\AbstractRenderer;
 use PHPMD\Report;
 use PHPMD\Utility\Paths;
 
-class BaselineRenderer extends AbstractRenderer
+final class BaselineRenderer extends AbstractRenderer
 {
     public function __construct(
         private string $basePath,

--- a/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
+++ b/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
@@ -8,7 +8,7 @@ use PHPMD\Report;
  * This class will render a Java-checkstyle compatible xml-report.
  * for use with cs2pr and others
  */
-class CheckStyleRenderer extends XMLRenderer
+final class CheckStyleRenderer extends XMLRenderer
 {
     /**
      * Temporary property that holds the name of the last rendered file, it is

--- a/src/main/php/PHPMD/Renderer/GitHubRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitHubRenderer.php
@@ -24,7 +24,7 @@ use PHPMD\Report;
  * This renderer outputs all violations in a format that GitHub Actions
  * understands to display and highlight as problems.
  */
-class GitHubRenderer extends AbstractRenderer
+final class GitHubRenderer extends AbstractRenderer
 {
     /**
      * This method will be called when the engine has finished the source analysis

--- a/src/main/php/PHPMD/Renderer/GitLabRenderer.php
+++ b/src/main/php/PHPMD/Renderer/GitLabRenderer.php
@@ -24,7 +24,7 @@ use PHPMD\Report;
 /**
  * This class will render a GitLab compatible JSON report.
  */
-class GitLabRenderer extends AbstractRenderer
+final class GitLabRenderer extends AbstractRenderer
 {
     /**
      * {@inheritDoc}

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -31,7 +31,7 @@ use SplFileObject;
  * @copyright 2017 Premysl Karbula. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-class HTMLRenderer extends AbstractRenderer
+final class HTMLRenderer extends AbstractRenderer
 {
     private const CATEGORY_PRIORITY = 'category_priority';
 

--- a/src/main/php/PHPMD/Renderer/RendererFactory.php
+++ b/src/main/php/PHPMD/Renderer/RendererFactory.php
@@ -2,14 +2,14 @@
 
 namespace PHPMD\Renderer;
 
-use PHPMD\Writer\StreamWriter;
+use PHPMD\AbstractWriter;
 
-class RendererFactory
+final class RendererFactory
 {
     /**
      * @return BaselineRenderer
      */
-    public static function createBaselineRenderer(StreamWriter $writer)
+    public static function createBaselineRenderer(AbstractWriter $writer)
     {
         // set base path to current working directory
         $renderer = new BaselineRenderer(getcwd() ?: '');

--- a/src/main/php/PHPMD/Renderer/SARIFRenderer.php
+++ b/src/main/php/PHPMD/Renderer/SARIFRenderer.php
@@ -24,7 +24,7 @@ use PHPMD\Report;
  * This class will render a SARIF (Static Analysis
  * Results Interchange Format) report.
  */
-class SARIFRenderer extends JSONRenderer
+final class SARIFRenderer extends JSONRenderer
 {
     /**
      * Create report data and add renderer meta properties

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -28,7 +28,6 @@ use PDepend\Source\AST\ASTStringIndexExpression;
 use PDepend\Source\AST\ASTVariable;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\ASTNode;
 use ReflectionException;
 use ReflectionFunction;
 
@@ -82,11 +81,11 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Tests if the given variable node is a regular variable an not property
      * or method postfix.
      *
-     * @param ASTNode<ASTVariable> $variable
+     * @param AbstractNode<ASTVariable> $variable
      * @return bool
      * @throws OutOfBoundsException
      */
-    protected function isRegularVariable(ASTNode $variable)
+    protected function isRegularVariable(AbstractNode $variable)
     {
         $node = $this->stripWrappedIndexExpression($variable);
         $parent = $node->getParent();
@@ -110,11 +109,11 @@ abstract class AbstractLocalVariable extends AbstractRule
      * Removes all index expressions that are wrapped around the given node
      * instance.
      *
-     * @param ASTNode<PDependNode> $node
-     * @return ASTNode<PDependNode>
+     * @param AbstractNode<PDependNode> $node
+     * @return AbstractNode<PDependNode>
      * @throws OutOfBoundsException
      */
-    private function stripWrappedIndexExpression(ASTNode $node)
+    private function stripWrappedIndexExpression(AbstractNode $node)
     {
         if (!$this->isWrappedByIndexExpression($node)) {
             return $node;
@@ -131,10 +130,10 @@ abstract class AbstractLocalVariable extends AbstractRule
     /**
      * Tests if the given variable node os part of an index expression.
      *
-     * @param ASTNode<PDependNode> $node
+     * @param AbstractNode<PDependNode> $node
      * @return bool
      */
-    private function isWrappedByIndexExpression(ASTNode $node)
+    private function isWrappedByIndexExpression(AbstractNode $node)
     {
         return ($node->getParent()->isInstanceOf(ASTArrayIndexExpression::class)
             || $node->getParent()->isInstanceOf(ASTStringIndexExpression::class)

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -33,7 +33,7 @@ use PHPMD\Utility\ExceptionsList;
  *
  * Boolean flags are signs for single responsibility principle violations.
  */
-class BooleanArgumentFlag extends AbstractRule implements FunctionAware, MethodAware
+final class BooleanArgumentFlag extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * Temporary cache of configured exceptions.

--- a/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/DuplicatedArrayKey.php
@@ -24,7 +24,6 @@ use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTNode as PDependASTNode;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\ASTNode;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
 
@@ -36,7 +35,7 @@ use PHPMD\Rule\MethodAware;
  * @author Rafał Wrzeszcz <rafal.wrzeszcz@wrzasq.pl>
  * @author Kamil Szymanaski <kamil.szymanski@gmail.com>
  */
-class DuplicatedArrayKey extends AbstractRule implements FunctionAware, MethodAware
+final class DuplicatedArrayKey extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * Retrieves all arrays from single node and performs comparison logic on it
@@ -52,10 +51,10 @@ class DuplicatedArrayKey extends AbstractRule implements FunctionAware, MethodAw
      * This method checks if a given function or method contains an array literal
      * with duplicated entries for any key and emits a rule violation if so.
      *
-     * @param ASTNode<ASTArray> $node Array node.
+     * @param AbstractNode<ASTArray> $node Array node.
      * @throws OutOfBoundsException
      */
-    private function checkForDuplicatedArrayKeys(ASTNode $node): void
+    private function checkForDuplicatedArrayKeys(AbstractNode $node): void
     {
         $keys = [];
         foreach ($node->getChildren() as $index => $arrayElement) {

--- a/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ElseExpression.php
@@ -22,7 +22,6 @@ use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTScopeStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\ASTNode;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
 
@@ -33,7 +32,7 @@ use PHPMD\Rule\MethodAware;
  * Object Calisthenics teaches us, that an else expression can always be
  * avoided by simple guard clause or return statements.
  */
-class ElseExpression extends AbstractRule implements FunctionAware, MethodAware
+final class ElseExpression extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if a method/function uses an else expression and add a violation for each one found.
@@ -63,11 +62,11 @@ class ElseExpression extends AbstractRule implements FunctionAware, MethodAware
      * Whether the given scope is an else clause
      *
      * @param AbstractNode<ASTScopeStatement> $scope
-     * @param ASTNode<PDependNode> $parent
+     * @param AbstractNode<PDependNode> $parent
      * @return bool
      * @throws OutOfBoundsException
      */
-    private function isElseScope(AbstractNode $scope, ASTNode $parent)
+    private function isElseScope(AbstractNode $scope, AbstractNode $parent)
     {
         return (
             count($parent->getChildren()) === 3 &&
@@ -78,10 +77,10 @@ class ElseExpression extends AbstractRule implements FunctionAware, MethodAware
     /**
      * Whether the parent node is an if or an elseif clause
      *
-     * @param ASTNode<PDependNode> $parent
+     * @param AbstractNode<PDependNode> $parent
      * @return bool
      */
-    private function isIfOrElseIfStatement(ASTNode $parent)
+    private function isIfOrElseIfStatement(AbstractNode $parent)
     {
         return ($parent->getName() === 'if' || $parent->getName() === 'elseif');
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/ErrorControlOperator.php
@@ -31,7 +31,7 @@ use PHPMD\Rule\MethodAware;
  * @author Kamil Szymanaski <kamil.szymanski@gmail.com>
  * @link http://php.net/manual/en/language.operators.errorcontrol.php
  */
-class ErrorControlOperator extends AbstractRule implements FunctionAware, MethodAware
+final class ErrorControlOperator extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * Loops trough all class or function nodes and looks for '@' sign.

--- a/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/IfStatementAssignment.php
@@ -26,7 +26,6 @@ use PDepend\Source\AST\ASTStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\AbstractCallableNode;
-use PHPMD\Node\ASTNode;
 use PHPMD\Node\FunctionNode;
 use PHPMD\Node\MethodNode;
 use PHPMD\Rule\FunctionAware;
@@ -44,7 +43,7 @@ use PHPMD\Rule\MethodAware;
  *
  * Empty if clauses are skipped
  */
-class IfStatementAssignment extends AbstractRule implements FunctionAware, MethodAware
+final class IfStatementAssignment extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if method/function has if clauses
@@ -67,7 +66,7 @@ class IfStatementAssignment extends AbstractRule implements FunctionAware, Metho
      * Extracts if and elseif statements from method/function body
      *
      * @param AbstractCallableNode<AbstractASTCallable> $node
-     * @return array<int, ASTNode<ASTStatement>>
+     * @return array<int, AbstractNode<ASTStatement>>
      */
     private function getStatements(AbstractCallableNode $node)
     {
@@ -80,8 +79,8 @@ class IfStatementAssignment extends AbstractRule implements FunctionAware, Metho
     /**
      * Extracts all expression from statements array
      *
-     * @param array<ASTNode<ASTStatement>> $statements Array of if and elseif clauses
-     * @return list<ASTNode<ASTExpression>>
+     * @param array<AbstractNode<ASTStatement>> $statements Array of if and elseif clauses
+     * @return list<AbstractNode<ASTExpression>>
      */
     private function getExpressions(array $statements)
     {
@@ -101,8 +100,8 @@ class IfStatementAssignment extends AbstractRule implements FunctionAware, Metho
     /**
      * Extracts all assignments from expressions array
      *
-     * @param array<int, ASTNode<ASTExpression>> $expressions Array of expressions
-     * @return array<int, ASTNode<ASTAssignmentExpression>>
+     * @param array<int, AbstractNode<ASTExpression>> $expressions Array of expressions
+     * @return array<int, AbstractNode<ASTAssignmentExpression>>
      */
     private function getAssignments(array $expressions)
     {
@@ -121,7 +120,7 @@ class IfStatementAssignment extends AbstractRule implements FunctionAware, Metho
      * Signals if any violations have been found in given method or function
      *
      * @param AbstractCallableNode<AbstractASTCallable> $node An instance of MethodNode or FunctionNode class
-     * @param array<ASTNode<ASTAssignmentExpression>> $assignments Array of assignments
+     * @param array<AbstractNode<ASTAssignmentExpression>> $assignments Array of assignments
      */
     private function addViolations(AbstractCallableNode $node, array $assignments): void
     {

--- a/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/MissingImport.php
@@ -30,7 +30,7 @@ use PHPMD\Rule\MethodAware;
  *
  * This rule can be used to prevent use of fully qualified class names.
  */
-class MissingImport extends AbstractRule implements FunctionAware, MethodAware
+final class MissingImport extends AbstractRule implements FunctionAware, MethodAware
 {
     /** @var list<string> Self reference class names. */
     private $selfReferences = ['self', 'static'];
@@ -72,10 +72,10 @@ class MissingImport extends AbstractRule implements FunctionAware, MethodAware
     /**
      * Check whether a given class node is a self reference
      *
-     * @param ASTNode<PDependNode> $classNode A class node to check.
+     * @param AbstractNode<PDependNode> $classNode A class node to check.
      * @return bool Whether the given class node is a self reference.
      */
-    private function isSelfReference(ASTNode $classNode)
+    private function isSelfReference(AbstractNode $classNode)
     {
         return in_array($classNode->getImage(), $this->selfReferences, true);
     }
@@ -83,10 +83,10 @@ class MissingImport extends AbstractRule implements FunctionAware, MethodAware
     /**
      * Check whether a given class node is in the global namespace
      *
-     * @param ASTNode<PDependNode> $classNode A class node to check.
+     * @param AbstractNode<PDependNode> $classNode A class node to check.
      * @return bool Whether the given class node is in the global namespace.
      */
-    private function isGlobalNamespace(ASTNode $classNode)
+    private function isGlobalNamespace(AbstractNode $classNode)
     {
         return $classNode->getImage() !== '' && !strpos($classNode->getImage(), '\\', 1);
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -35,7 +35,7 @@ use PHPMD\Utility\ExceptionsList;
  * Static access is known to cause hard dependencies between classes
  * and is a bad practice.
  */
-class StaticAccess extends AbstractRule implements FunctionAware, MethodAware
+final class StaticAccess extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * Temporary cache of configured exceptions.

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -38,7 +38,6 @@ use PDepend\Source\AST\ASTVariableDeclarator;
 use PDepend\Source\AST\State;
 use PHPMD\AbstractNode;
 use PHPMD\Node\AbstractCallableNode;
-use PHPMD\Node\ASTNode;
 use PHPMD\Node\MethodNode;
 use PHPMD\Rule\AbstractLocalVariable;
 use PHPMD\Rule\FunctionAware;
@@ -50,7 +49,7 @@ use PHPMD\Rule\MethodAware;
  *
  * @SuppressWarnings("PMD.CouplingBetweenObjects")
  */
-class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, MethodAware
+final class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, MethodAware
 {
     /**
      * Found variable images within a single method or function.
@@ -212,12 +211,12 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
     /**
      * Check if the given variable was defined in the current context before usage.
      *
-     * @param ASTNode<ASTVariable> $variable
+     * @param AbstractNode<ASTVariable> $variable
      * @param AbstractCallableNode<AbstractASTCallable> $parentNode
      * @return bool
      * @throws OutOfBoundsException
      */
-    private function checkVariableDefined(ASTNode $variable, AbstractCallableNode $parentNode)
+    private function checkVariableDefined(AbstractNode $variable, AbstractCallableNode $parentNode)
     {
         $image = $this->getVariableImage($variable);
 
@@ -305,10 +304,10 @@ class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, 
      * Checks if a short name is acceptable in the current context.
      *
      * @param AbstractCallableNode<AbstractASTCallable> $node
-     * @param ASTNode<ASTVariable> $variable
+     * @param AbstractNode<ASTVariable> $variable
      * @return bool
      */
-    private function isNameAllowedInContext(AbstractCallableNode $node, ASTNode $variable)
+    private function isNameAllowedInContext(AbstractCallableNode $node, AbstractNode $variable)
     {
         return (
             $node instanceof MethodNode &&

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseClassName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseClassName.php
@@ -30,7 +30,7 @@ use PHPMD\Rule\TraitAware;
  * @author Francis Besset <francis.besset@gmail.com>
  * @since 1.1.0
  */
-class CamelCaseClassName extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
+final class CamelCaseClassName extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
 {
     /**
      * This method checks if a class is not named in CamelCase

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -28,7 +28,7 @@ use PHPMD\Rule\MethodAware;
  * @author Francis Besset <francis.besset@gmail.com>
  * @since 1.1.0
  */
-class CamelCaseMethodName extends AbstractRule implements MethodAware
+final class CamelCaseMethodName extends AbstractRule implements MethodAware
 {
     /** @var list<string> */
     private $ignoredMethods = [

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
@@ -27,7 +27,7 @@ use PHPMD\Utility\Strings;
 /**
  * This rule class detects namespace parts that are not named in CamelCase.
  */
-class CamelCaseNamespace extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
+final class CamelCaseNamespace extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
 {
     /** @var array<string, int>|null */
     private $exceptions;

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -30,7 +30,7 @@ use PHPMD\Rule\MethodAware;
  * @author Francis Besset <francis.besset@gmail.com>
  * @since 1.1.0
  */
-class CamelCaseParameterName extends AbstractRule implements FunctionAware, MethodAware
+final class CamelCaseParameterName extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if a parameter is not named in camelCase

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
@@ -31,7 +31,7 @@ use PHPMD\Rule\TraitAware;
  * @author Francis Besset <francis.besset@gmail.com>
  * @since 1.1.0
  */
-class CamelCasePropertyName extends AbstractRule implements ClassAware, TraitAware
+final class CamelCasePropertyName extends AbstractRule implements ClassAware, TraitAware
 {
     /**
      * This method checks if a property is not named in camelCase

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseVariableName.php
@@ -31,7 +31,7 @@ use PHPMD\Rule\MethodAware;
  * @author Francis Besset <francis.besset@gmail.com>
  * @since 1.1.0
  */
-class CamelCaseVariableName extends AbstractRule implements FunctionAware, MethodAware
+final class CamelCaseVariableName extends AbstractRule implements FunctionAware, MethodAware
 {
     /** @var list<string> */
     private $exceptions = [

--- a/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
+++ b/src/main/php/PHPMD/Rule/Controversial/Superglobals.php
@@ -28,7 +28,7 @@ use PHPMD\Rule\MethodAware;
  * @author Francis Besset <francis.besset@gmail.com>
  * @since 1.1.0
  */
-class Superglobals extends AbstractRule implements FunctionAware, MethodAware
+final class Superglobals extends AbstractRule implements FunctionAware, MethodAware
 {
     /** @var list<string> */
     private $superglobals = [

--- a/src/main/php/PHPMD/Rule/CyclomaticComplexity.php
+++ b/src/main/php/PHPMD/Rule/CyclomaticComplexity.php
@@ -24,7 +24,7 @@ use PHPMD\AbstractRule;
  * This rule checks a given method or function against the configured cyclomatic
  * complexity threshold.
  */
-class CyclomaticComplexity extends AbstractRule implements FunctionAware, MethodAware
+final class CyclomaticComplexity extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks the cyclomatic complexity for the given node against

--- a/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/CountInLoopExpression.php
@@ -27,7 +27,6 @@ use PDepend\Source\AST\ASTStatement;
 use PDepend\Source\AST\ASTWhileStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\ASTNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\EnumNode;
 use PHPMD\Node\TraitNode;
@@ -50,7 +49,7 @@ use RuntimeException;
  * @author Kamil Szymanski <kamilszymanski@gmail.com>
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class CountInLoopExpression extends AbstractRule implements ClassAware, EnumAware, TraitAware
+final class CountInLoopExpression extends AbstractRule implements ClassAware, EnumAware, TraitAware
 {
     /**
      * List of functions to search against
@@ -132,10 +131,10 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, EnumAwar
      * Checks whether node in a direct child of the loop
      *
      * @param AbstractNode<ASTStatement> $loop
-     * @param ASTNode<ASTExpression> $expression
+     * @param AbstractNode<ASTExpression> $expression
      * @return bool
      */
-    private function isDirectChild(AbstractNode $loop, ASTNode $expression)
+    private function isDirectChild(AbstractNode $loop, AbstractNode $expression)
     {
         return $this->getHash($expression->getParent()->getNode()) !== $this->getHash($loop->getNode());
     }
@@ -168,10 +167,10 @@ class CountInLoopExpression extends AbstractRule implements ClassAware, EnumAwar
     /**
      * Checks the given function against the list of unwanted functions
      *
-     * @param ASTNode<ASTFunctionPostfix> $function
+     * @param AbstractNode<ASTFunctionPostfix> $function
      * @return bool
      */
-    private function isUnwantedFunction(ASTNode $function)
+    private function isUnwantedFunction(AbstractNode $function)
     {
         $functionName = str_replace($this->currentNamespace, '', $function->getImage());
 

--- a/src/main/php/PHPMD/Rule/Design/CouplingBetweenObjects.php
+++ b/src/main/php/PHPMD/Rule/Design/CouplingBetweenObjects.php
@@ -26,7 +26,7 @@ use PHPMD\Rule\ClassAware;
  *
  * @since 1.1.0
  */
-class CouplingBetweenObjects extends AbstractRule implements ClassAware
+final class CouplingBetweenObjects extends AbstractRule implements ClassAware
 {
     /**
      * This method should implement the violation analysis algorithm of concrete

--- a/src/main/php/PHPMD/Rule/Design/DepthOfInheritance.php
+++ b/src/main/php/PHPMD/Rule/Design/DepthOfInheritance.php
@@ -25,7 +25,7 @@ use PHPMD\Rule\ClassAware;
 /**
  * This rule will detect classes that are too deep in the inheritance tree.
  */
-class DepthOfInheritance extends AbstractRule implements ClassAware
+final class DepthOfInheritance extends AbstractRule implements ClassAware
 {
     /**
      * This method checks the number of parents for the given class

--- a/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
+++ b/src/main/php/PHPMD/Rule/Design/DevelopmentCodeFragment.php
@@ -32,7 +32,7 @@ use PHPMD\Rule\MethodAware;
  * @link https://github.com/phpmd/phpmd/issues/265
  * @since 2.3.0
  */
-class DevelopmentCodeFragment extends AbstractRule implements FunctionAware, MethodAware
+final class DevelopmentCodeFragment extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if a given function or method contains an eval-expression

--- a/src/main/php/PHPMD/Rule/Design/EmptyCatchBlock.php
+++ b/src/main/php/PHPMD/Rule/Design/EmptyCatchBlock.php
@@ -30,7 +30,7 @@ use PHPMD\Rule\MethodAware;
  * @author Grégoire Paris <postmaster@greg0ire.fr>
  * @author Kamil Szymanski <kamilszymanski@gmail.com>
  */
-class EmptyCatchBlock extends AbstractRule implements FunctionAware, MethodAware
+final class EmptyCatchBlock extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if a given function or method contains an empty catch block

--- a/src/main/php/PHPMD/Rule/Design/EvalExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/EvalExpression.php
@@ -26,7 +26,7 @@ use PHPMD\Rule\MethodAware;
 /**
  * This rule class detects the usage of PHP's eval-expression.
  */
-class EvalExpression extends AbstractRule implements FunctionAware, MethodAware
+final class EvalExpression extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if a given function or method contains an eval-expression

--- a/src/main/php/PHPMD/Rule/Design/ExitExpression.php
+++ b/src/main/php/PHPMD/Rule/Design/ExitExpression.php
@@ -26,7 +26,7 @@ use PHPMD\Rule\MethodAware;
 /**
  * This rule class detects the usage of PHP's exit statement.
  */
-class ExitExpression extends AbstractRule implements FunctionAware, MethodAware
+final class ExitExpression extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks if a given function or method contains an exit-expression

--- a/src/main/php/PHPMD/Rule/Design/GotoStatement.php
+++ b/src/main/php/PHPMD/Rule/Design/GotoStatement.php
@@ -28,7 +28,7 @@ use PHPMD\Rule\MethodAware;
  *
  * @since 1.1.0
  */
-class GotoStatement extends AbstractRule implements FunctionAware, MethodAware
+final class GotoStatement extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method should implement the violation analysis algorithm of concrete

--- a/src/main/php/PHPMD/Rule/Design/LongClass.php
+++ b/src/main/php/PHPMD/Rule/Design/LongClass.php
@@ -24,7 +24,7 @@ use PHPMD\Rule\ClassAware;
 /**
  * This rule class will detect excessive long classes.
  */
-class LongClass extends AbstractRule implements ClassAware
+final class LongClass extends AbstractRule implements ClassAware
 {
     /**
      * This method checks the length of the given class node against a configured

--- a/src/main/php/PHPMD/Rule/Design/LongMethod.php
+++ b/src/main/php/PHPMD/Rule/Design/LongMethod.php
@@ -26,7 +26,7 @@ use PHPMD\Rule\MethodAware;
  * This rule will detect to long methods, those methods are unreadable and in
  * many cases the result of copy and paste coding.
  */
-class LongMethod extends AbstractRule implements FunctionAware, MethodAware
+final class LongMethod extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks the lines of code length for the given function or

--- a/src/main/php/PHPMD/Rule/Design/LongParameterList.php
+++ b/src/main/php/PHPMD/Rule/Design/LongParameterList.php
@@ -26,7 +26,7 @@ use PHPMD\Rule\MethodAware;
 /**
  * This rule class checks for excessive long function and method parameter lists.
  */
-class LongParameterList extends AbstractRule implements FunctionAware, MethodAware
+final class LongParameterList extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks the number of arguments for the given function or method

--- a/src/main/php/PHPMD/Rule/Design/NpathComplexity.php
+++ b/src/main/php/PHPMD/Rule/Design/NpathComplexity.php
@@ -26,7 +26,7 @@ use PHPMD\Rule\MethodAware;
  * This rule will check the NPath-complexity of a method or function against the
  * configured threshold.
  */
-class NpathComplexity extends AbstractRule implements FunctionAware, MethodAware
+final class NpathComplexity extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * This method checks the acyclic complexity for the given node against a

--- a/src/main/php/PHPMD/Rule/Design/NumberOfChildren.php
+++ b/src/main/php/PHPMD/Rule/Design/NumberOfChildren.php
@@ -24,7 +24,7 @@ use PHPMD\Rule\ClassAware;
 /**
  * This rule will detect class that have to much direct child classes.
  */
-class NumberOfChildren extends AbstractRule implements ClassAware
+final class NumberOfChildren extends AbstractRule implements ClassAware
 {
     /**
      * This method checks the number of classes derived from the given class

--- a/src/main/php/PHPMD/Rule/Design/TooManyFields.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyFields.php
@@ -24,7 +24,7 @@ use PHPMD\Rule\ClassAware;
 /**
  * This rule class will detect all classes with too much fields.
  */
-class TooManyFields extends AbstractRule implements ClassAware
+final class TooManyFields extends AbstractRule implements ClassAware
 {
     /**
      * This method checks the number of methods with in a given class and checks

--- a/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyMethods.php
@@ -25,7 +25,7 @@ use PHPMD\Rule\ClassAware;
 /**
  * This rule class will detect all classes with too many methods.
  */
-class TooManyMethods extends AbstractRule implements ClassAware
+final class TooManyMethods extends AbstractRule implements ClassAware
 {
     /**
      * Regular expression that filters all methods that are ignored by this rule.

--- a/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
+++ b/src/main/php/PHPMD/Rule/Design/TooManyPublicMethods.php
@@ -25,7 +25,7 @@ use PHPMD\Rule\ClassAware;
 /**
  * This rule class will detect all classes with too much public methods.
  */
-class TooManyPublicMethods extends AbstractRule implements ClassAware
+final class TooManyPublicMethods extends AbstractRule implements ClassAware
 {
     /**
      * Regular expression that filters all methods that are ignored by this rule.

--- a/src/main/php/PHPMD/Rule/Design/WeightedMethodCount.php
+++ b/src/main/php/PHPMD/Rule/Design/WeightedMethodCount.php
@@ -27,7 +27,7 @@ use PHPMD\Rule\ClassAware;
  *
  * @since 0.2.5
  */
-class WeightedMethodCount extends AbstractRule implements ClassAware
+final class WeightedMethodCount extends AbstractRule implements ClassAware
 {
     /**
      * This method checks the weighted method count for the given class against

--- a/src/main/php/PHPMD/Rule/ExcessivePublicCount.php
+++ b/src/main/php/PHPMD/Rule/ExcessivePublicCount.php
@@ -24,7 +24,7 @@ use PHPMD\AbstractRule;
  * This rule checks the number of public methods and fields in a given class.
  * Then it compares the number of public members against a configured threshold.
  */
-class ExcessivePublicCount extends AbstractRule implements ClassAware, TraitAware
+final class ExcessivePublicCount extends AbstractRule implements ClassAware, TraitAware
 {
     /**
      * This method checks the number of public fields and methods in the given

--- a/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
@@ -27,7 +27,7 @@ use PHPMD\Rule\MethodAware;
  * This rule tests that a method which returns a boolean value does not start
  * with <b>get</b> or <b>_get</b> for a getter.
  */
-class BooleanGetMethodName extends AbstractRule implements MethodAware
+final class BooleanGetMethodName extends AbstractRule implements MethodAware
 {
     /**
      * Extracts all variable and variable declarator nodes from the given node

--- a/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstantNamingConventions.php
@@ -29,7 +29,7 @@ use PHPMD\Rule\TraitAware;
  * This rule detects class/interface constants that do not follow the upper
  * case convention.
  */
-class ConstantNamingConventions extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
+final class ConstantNamingConventions extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
 {
     /**
      * Extracts all constant declarations from the given node and tests that

--- a/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
+++ b/src/main/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClass.php
@@ -29,7 +29,7 @@ use RuntimeException;
  * This rule class will detect methods that define a php4 style constructor
  * method while has the same name as the enclosing class.
  */
-class ConstructorWithNameAsEnclosingClass extends AbstractRule implements MethodAware
+final class ConstructorWithNameAsEnclosingClass extends AbstractRule implements MethodAware
 {
     /**
      * Is method has the same name as the enclosing class

--- a/src/main/php/PHPMD/Rule/Naming/LongClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongClassName.php
@@ -31,7 +31,7 @@ use PHPMD\Utility\Strings;
  * This rule checks if an interface or class name exceeds the configured length
  * excluding certain configured prefixes and suffixes
  */
-class LongClassName extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
+final class LongClassName extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
 {
     /**
      * Temporary cache of configured prefixes to subtract

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -35,7 +35,7 @@ use PHPMD\Utility\Strings;
  * This rule class will detect variables, parameters and properties with really
  * long names.
  */
-class LongVariable extends AbstractRule implements ClassAware, FunctionAware, MethodAware, TraitAware
+final class LongVariable extends AbstractRule implements ClassAware, FunctionAware, MethodAware, TraitAware
 {
     /**
      * Temporary cache of configured prefixes to subtract

--- a/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
@@ -28,7 +28,7 @@ use PHPMD\Utility\ExceptionsList;
 /**
  * This rule will detect classes and interfaces with names that are too short.
  */
-class ShortClassName extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
+final class ShortClassName extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
 {
     /**
      * Temporary cache of configured exceptions. Have name as key

--- a/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
@@ -26,7 +26,7 @@ use PHPMD\Utility\ExceptionsList;
 /**
  * This rule class will detect methods and functions with very short names.
  */
-class ShortMethodName extends AbstractRule implements FunctionAware, MethodAware
+final class ShortMethodName extends AbstractRule implements FunctionAware, MethodAware
 {
     /**
      * Temporary cache of configured exceptions.

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -38,7 +38,7 @@ use PHPMD\Utility\ExceptionsList;
  * This rule class will detect variables, parameters and properties with short
  * names.
  */
-class ShortVariable extends AbstractRule implements ClassAware, FunctionAware, MethodAware, TraitAware
+final class ShortVariable extends AbstractRule implements ClassAware, FunctionAware, MethodAware, TraitAware
 {
     /**
      * Temporary map holding variables that were already processed in the

--- a/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
+++ b/src/main/php/PHPMD/Rule/UnusedFormalParameter.php
@@ -30,7 +30,6 @@ use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\Node\AbstractCallableNode;
-use PHPMD\Node\ASTNode;
 use PHPMD\Node\MethodNode;
 
 /**
@@ -39,12 +38,12 @@ use PHPMD\Node\MethodNode;
  *
  * @SuppressWarnings("PMD.CouplingBetweenObjects")
  */
-class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAware, MethodAware
+final class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAware, MethodAware
 {
     /**
      * Collected ast nodes.
      *
-     * @var array<string, ASTNode<ASTVariableDeclarator>>
+     * @var array<string, AbstractNode<ASTVariableDeclarator>>
      */
     private $nodes = [];
 

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -35,7 +35,6 @@ use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\Node\AbstractCallableNode;
-use PHPMD\Node\ASTNode;
 use PHPMD\Utility\ExceptionsList;
 
 /**
@@ -44,12 +43,12 @@ use PHPMD\Utility\ExceptionsList;
  *
  * @SuppressWarnings("PMD.CouplingBetweenObjects")
  */
-class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware, MethodAware
+final class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware, MethodAware
 {
     /**
      * Found variable images within a single method or function.
      *
-     * @var array<string, list<ASTNode<AbstractASTNode>>>
+     * @var array<string, list<AbstractNode<AbstractASTNode>>>
      */
     private $images = [];
 
@@ -86,11 +85,11 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * Tests if the given variable node represents a local variable or if it is
      * a static object property or something similar.
      *
-     * @param ASTNode<ASTVariable> $variable The variable to check.
+     * @param AbstractNode<ASTVariable> $variable The variable to check.
      * @return bool
      * @throws OutOfBoundsException
      */
-    private function isLocal(ASTNode $variable)
+    private function isLocal(AbstractNode $variable)
     {
         return (!$variable->isThis()
             && $this->isNotSuperGlobal($variable)
@@ -113,7 +112,7 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Return true if one of the passed nodes contains variables usages.
      *
-     * @param array<int, ASTNode<AbstractASTNode>> $nodes
+     * @param array<int, AbstractNode<AbstractASTNode>> $nodes
      * @return bool
      */
     private function containsUsages(array $nodes)
@@ -197,10 +196,10 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Stores the given compound variable node in an internal list of found variables.
      *
-     * @param ASTNode<ASTCompoundVariable> $node
+     * @param AbstractNode<ASTCompoundVariable> $node
      * @throws OutOfBoundsException
      */
-    private function collectCompoundVariableInString(ASTNode $node): void
+    private function collectCompoundVariableInString(AbstractNode $node): void
     {
         $parentNode = $node->getParent()->getNode();
         $candidateParentNodes = $node->getParentsOfType(ASTString::class);
@@ -220,10 +219,10 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Stores the given variable node in an internal list of found variables.
      *
-     * @param ASTNode<ASTExpression> $node
+     * @param AbstractNode<ASTExpression> $node
      * @throws OutOfBoundsException
      */
-    private function collectVariable(ASTNode $node): void
+    private function collectVariable(AbstractNode $node): void
     {
         $this->storeImage($this->getVariableImage($node->getNode()), $node);
     }
@@ -232,9 +231,9 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      * Safely add node to $this->images.
      *
      * @param string $imageName the name to store the node as
-     * @param ASTNode<AbstractASTNode> $node the node being stored
+     * @param AbstractNode<AbstractASTNode> $node the node being stored
      */
-    private function storeImage($imageName, ASTNode $node): void
+    private function storeImage($imageName, AbstractNode $node): void
     {
         if (!isset($this->images[$imageName])) {
             $this->images[$imageName] = [];
@@ -246,9 +245,9 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Stores the given literal node in an internal list of found variables.
      *
-     * @param ASTNode<ASTLiteral> $node
+     * @param AbstractNode<ASTLiteral> $node
      */
-    private function collectLiteral(ASTNode $node): void
+    private function collectLiteral(AbstractNode $node): void
     {
         $variable = '$' . trim($node->getImage(), '\'"');
 
@@ -262,11 +261,11 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
     /**
      * Template method that performs the real node image check.
      *
-     * @param ASTNode<AbstractASTNode> $node
+     * @param AbstractNode<AbstractASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      */
-    private function doCheckNodeImage(ASTNode $node): void
+    private function doCheckNodeImage(AbstractNode $node): void
     {
         if ($this->isNameAllowedInContext($node)) {
             return;
@@ -310,11 +309,11 @@ class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware
      *
      * If it's not a foreach variable, it returns always false.
      *
-     * @param ASTNode<AbstractASTNode> $variable The variable to check.
+     * @param AbstractNode<AbstractASTNode> $variable The variable to check.
      * @return bool True if allowed, else false.
      * @throws OutOfBoundsException
      */
-    private function isUnusedForeachVariableAllowed(ASTNode $variable)
+    private function isUnusedForeachVariableAllowed(AbstractNode $variable)
     {
         $isForeachVariable = $this->isChildOf($variable, ASTForeachStatement::class);
 

--- a/src/main/php/PHPMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateField.php
@@ -31,7 +31,6 @@ use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\ASTNode;
 use PHPMD\Node\ClassNode;
 
 /**
@@ -40,13 +39,13 @@ use PHPMD\Node\ClassNode;
  *
  * @SuppressWarnings("PMD.CouplingBetweenObjects")
  */
-class UnusedPrivateField extends AbstractRule implements ClassAware
+final class UnusedPrivateField extends AbstractRule implements ClassAware
 {
     /**
      * Collected private fields/variable declarators in the currently processed
      * class.
      *
-     * @var array<string, ASTNode<ASTVariableDeclarator>>
+     * @var array<string, AbstractNode<ASTVariableDeclarator>>
      */
     private $fields = [];
 
@@ -69,7 +68,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * This method collects all private fields that aren't used by any class
      * method.
      *
-     * @return array<string, ASTNode<ASTVariableDeclarator>>
+     * @return array<string, AbstractNode<ASTVariableDeclarator>>
      * @throws OutOfBoundsException
      */
     private function collectUnusedPrivateFields(ClassNode $class)
@@ -99,9 +98,9 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * This method extracts all variable declarators from the given field
      * declaration and stores them in the <b>$_fields</b> property.
      *
-     * @param ASTNode<ASTFieldDeclaration> $declaration
+     * @param AbstractNode<ASTFieldDeclaration> $declaration
      */
-    private function collectPrivateField(ASTNode $declaration): void
+    private function collectPrivateField(AbstractNode $declaration): void
     {
         $fields = $declaration->findChildrenOfType(ASTVariableDeclarator::class);
         foreach ($fields as $field) {
@@ -129,9 +128,9 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * This method removes the field from the <b>$_fields</b> property that is
      * accessed through the given property postfix node.
      *
-     * @param ASTNode<ASTPropertyPostfix> $postfix
+     * @param AbstractNode<ASTPropertyPostfix> $postfix
      */
-    private function removeUsedField(ASTNode $postfix): void
+    private function removeUsedField(AbstractNode $postfix): void
     {
         $image = '$';
         $child = $postfix->getFirstChildOfType(ASTIdentifier::class);
@@ -150,11 +149,11 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
     /**
      * Checks if the given node is a valid property node.
      *
-     * @param ASTNode<ASTExpression> $node
+     * @param AbstractNode<ASTExpression> $node
      * @return bool
      * @since 0.2.6
      */
-    private function isValidPropertyNode(ASTNode $node)
+    private function isValidPropertyNode(AbstractNode $node)
     {
         $parent = $node->getParent();
         while (!$parent->isInstanceOf(ASTPropertyPostfix::class)) {
@@ -174,11 +173,11 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * This method checks that the given property postfix is accessed on an
      * instance or static reference to the given class.
      *
-     * @param ASTNode<ASTPropertyPostfix> $postfix
+     * @param AbstractNode<ASTPropertyPostfix> $postfix
      * @return bool
      * @throws OutOfBoundsException
      */
-    private function isInScopeOfClass(ClassNode $class, ASTNode $postfix)
+    private function isInScopeOfClass(ClassNode $class, AbstractNode $postfix)
     {
         $owner = $this->getOwner($postfix);
 
@@ -192,11 +191,11 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
     /**
      * Looks for owner of the given variable.
      *
-     * @param ASTNode<ASTPropertyPostfix> $postfix
+     * @param AbstractNode<ASTPropertyPostfix> $postfix
      * @return AbstractNode<PDependNode>
      * @throws OutOfBoundsException
      */
-    private function getOwner(ASTNode $postfix)
+    private function getOwner(AbstractNode $postfix)
     {
         $owner = $postfix->getParent()->getChild(0);
         if ($owner->isInstanceOf(ASTPropertyPostfix::class)) {

--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -28,7 +28,6 @@ use PDepend\Source\AST\ASTSelfReference;
 use PDepend\Source\AST\ASTVariable;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
-use PHPMD\Node\ASTNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\MethodNode;
 use RuntimeException;
@@ -37,7 +36,7 @@ use RuntimeException;
  * This rule collects all private methods in a class that aren't used in any
  * method of the analyzed class.
  */
-class UnusedPrivateMethod extends AbstractRule implements ClassAware
+final class UnusedPrivateMethod extends AbstractRule implements ClassAware
 {
     /**
      * This method checks that all private class methods are at least accessed
@@ -197,11 +196,11 @@ class UnusedPrivateMethod extends AbstractRule implements ClassAware
      * This method checks that the given method postfix is accessed on an
      * instance or static reference to the given class.
      *
-     * @param ASTNode<ASTExpression> $postfix
+     * @param AbstractNode<ASTExpression> $postfix
      * @return bool
      * @throws OutOfBoundsException
      */
-    private function isClassScope(ClassNode $class, ASTNode $postfix)
+    private function isClassScope(ClassNode $class, AbstractNode $postfix)
     {
         $owner = $postfix->getParent()->getChild(0);
 

--- a/src/main/php/PHPMD/RuleByNameNotFoundException.php
+++ b/src/main/php/PHPMD/RuleByNameNotFoundException.php
@@ -22,7 +22,7 @@ use RuntimeException;
 /**
  * When a configured rule was not found by name
  */
-class RuleByNameNotFoundException extends RuntimeException
+final class RuleByNameNotFoundException extends RuntimeException
 {
     /**
      * Constructs a new RuleByNameNotFoundException.

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -41,7 +41,7 @@ use ValueError;
 /**
  * This class provides a command line interface for PHPMD
  */
-class Command
+final class Command
 {
     public function __construct(
         private Output $output,

--- a/src/main/php/PHPMD/Utility/ArgumentsValidator.php
+++ b/src/main/php/PHPMD/Utility/ArgumentsValidator.php
@@ -4,7 +4,7 @@ namespace PHPMD\Utility;
 
 use InvalidArgumentException;
 
-class ArgumentsValidator
+final class ArgumentsValidator
 {
     /**
      * @param string[] $originalArguments

--- a/src/main/php/PHPMD/Utility/ExceptionsList.php
+++ b/src/main/php/PHPMD/Utility/ExceptionsList.php
@@ -29,7 +29,7 @@ use RuntimeException;
  * @implements IteratorAggregate<string, string>
  * @implements ArrayAccess<string, string>
  */
-class ExceptionsList implements ArrayAccess, IteratorAggregate
+final class ExceptionsList implements ArrayAccess, IteratorAggregate
 {
     /**
      * Temporary cache of configured exceptions. Have name as key

--- a/src/main/php/PHPMD/Utility/Paths.php
+++ b/src/main/php/PHPMD/Utility/Paths.php
@@ -4,7 +4,7 @@ namespace PHPMD\Utility;
 
 use RuntimeException;
 
-class Paths
+final class Paths
 {
     /**
      * Transform the given absolute path to the relative path based on the given base path.

--- a/src/main/php/PHPMD/Utility/Strings.php
+++ b/src/main/php/PHPMD/Utility/Strings.php
@@ -22,7 +22,7 @@ use InvalidArgumentException;
 /**
  * Utility class to provide string checks and manipulations
  */
-class Strings
+final class Strings
 {
     /**
      * Returns the length of the given string, excluding at most one suffix
@@ -33,7 +33,7 @@ class Strings
      */
     public static function lengthWithoutSuffixes($stringName, array $subtractSuffixes)
     {
-        return static::lengthWithoutPrefixesAndSuffixes($stringName, [], $subtractSuffixes);
+        return self::lengthWithoutPrefixesAndSuffixes($stringName, [], $subtractSuffixes);
     }
 
     /**

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -23,7 +23,7 @@ use RuntimeException;
 /**
  * This writer uses PHP's stream api as its output target.
  */
-class StreamWriter extends AbstractWriter
+final class StreamWriter extends AbstractWriter
 {
     /**
      * The stream resource handle


### PR DESCRIPTION
Type: refactoring
Breaking change: yes

A good article on the subject: https://ocramius.github.io/blog/when-to-declare-classes-final/

Marks classes we do not extend as final. This makes it easier to reason about both for humans and tools. And it lets us know that they are not changed by users allowing us more flexibility when refactoring, since the internals cannot have been manipulated by an extending class. This also slightly lowers coupling as it promotes using interfaces and abstracts when making hints (10 couplings got removed as part of this PR).

All classes marked as final in this PR either cannot be replaced, should not be extended, or is never used as types.