### PR TITLE
Update PHPStan to version 1.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     "friendsofphp/php-cs-fixer": "^3.54",
     "gregwar/rst": "^1.0",
     "mikey179/vfsstream": "^1.6.8",
-    "phpstan/phpstan": "~1.10.67",
+    "phpstan/phpstan": "~1.11.0",
     "phpunit/phpunit": "^10.5.20",
     "squizlabs/php_codesniffer": "^3.8.0"
   },


### PR DESCRIPTION
Breaking change: no

Update PHPStan. There where no new issues found, but it still has useful features and will prevent more issues from being introduced.