### PR TITLE
Update to latest PDepend

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "php": "^8.1",
     "ext-xml": "*",
     "composer/xdebug-handler": "^3.0",
-    "pdepend/pdepend": "3.x-dev#bd4de6b346154c3b8e96dc41e5a84fe33b973970"
+    "pdepend/pdepend": "3.x-dev#e331edc038fd7332e69e803f2dacc65c6d31c40f"
   },
   "require-dev": {
     "ext-json": "*",

--- a/src/main/php/PHPMD/Node/AbstractTypeNode.php
+++ b/src/main/php/PHPMD/Node/AbstractTypeNode.php
@@ -54,7 +54,7 @@ abstract class AbstractTypeNode extends AbstractNode
     {
         $names = [];
         foreach ($this->getNode()->getMethods() as $method) {
-            $names[] = $method->getName();
+            $names[] = $method->getImage();
         }
 
         return $names;
@@ -75,7 +75,7 @@ abstract class AbstractTypeNode extends AbstractNode
      */
     public function getNamespaceName(): ?string
     {
-        return $this->getNode()->getNamespace()->getName();
+        return $this->getNode()->getNamespace()->getImage();
     }
 
     /**

--- a/src/main/php/PHPMD/Node/FunctionNode.php
+++ b/src/main/php/PHPMD/Node/FunctionNode.php
@@ -31,7 +31,7 @@ class FunctionNode extends AbstractCallableNode
      */
     public function getNamespaceName(): ?string
     {
-        return $this->getNode()->getNamespace()->getName();
+        return $this->getNode()->getNamespace()->getImage();
     }
 
     /**

--- a/src/main/php/PHPMD/Node/MethodNode.php
+++ b/src/main/php/PHPMD/Node/MethodNode.php
@@ -43,7 +43,7 @@ class MethodNode extends AbstractCallableNode
      */
     public function getNamespaceName(): ?string
     {
-        return $this->getNode()->getParent()->getNamespace()->getName();
+        return $this->getNode()->getParent()->getNamespace()->getImage();
     }
 
     /**
@@ -54,7 +54,7 @@ class MethodNode extends AbstractCallableNode
      */
     public function getParentName()
     {
-        return $this->getNode()->getParent()->getName();
+        return $this->getNode()->getParent()->getImage();
     }
 
     /**

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -62,7 +62,7 @@ final class BooleanArgumentFlag extends AbstractRule implements FunctionAware, M
 
         if ($parent &&
             ($parent instanceof AbstractASTClassOrInterface) &&
-            ($name = $parent->getName()) &&
+            ($name = $parent->getImage()) &&
             $this->getExceptionsList()->contains($name)
         ) {
             return;

--- a/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/UndefinedVariable.php
@@ -122,7 +122,7 @@ final class UndefinedVariable extends AbstractLocalVariable implements FunctionA
 
         foreach ($node->getProperties() as $property) {
             if ($property->isStatic()) {
-                $this->images['::' . $property->getName()] = $property;
+                $this->images['::' . $property->getImage()] = $property;
             }
         }
     }

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseParameterName.php
@@ -43,11 +43,11 @@ final class CamelCaseParameterName extends AbstractRule implements FunctionAware
         }
 
         foreach ($node->getParameters() as $parameter) {
-            if (!$this->isValid($parameter->getName())) {
+            if (!$this->isValid($parameter->getImage())) {
                 $this->addViolation(
                     $node,
                     [
-                        $parameter->getName(),
+                        $parameter->getImage(),
                     ]
                 );
             }

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCasePropertyName.php
@@ -44,7 +44,7 @@ final class CamelCasePropertyName extends AbstractRule implements ClassAware, Tr
         }
 
         foreach ($node->getProperties() as $property) {
-            $propertyName = $property->getName();
+            $propertyName = $property->getImage();
 
             if (!$this->isValid($propertyName)) {
                 $this->addViolation(

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -669,7 +669,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     private function getNodeByName(Iterator $nodes, $name)
     {
         foreach ($nodes as $node) {
-            if ($node->getName() === $name) {
+            if ($node->getImage() === $name) {
                 return $node;
             }
         }


### PR DESCRIPTION
Type: refactoring
Breaking change: no

`getName()` was deprecated and has been removed so we need to switch to `getImage()` instead.