### PR TITLE
Convert PHPCS result to native GitHub format and make it none failing

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -57,7 +57,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Run PHPCS for the codestyle
-        run: vendor/bin/phpcs
+        run: vendor/bin/phpcs --report=checkstyle -q | cs2pr || true
 
       - name: Run PHP Coding Standards Fixer Check
         run: |


### PR DESCRIPTION
Breaking change: no

Like we talked about in the chat, this will make PHPCS rules not fail the PR, but also make them appear as inline comments to make it easy to se what parts of the proposed code is not ideal.