### PR TITLE
[2.x] Ruleset XML Schema Definition #546

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,12 +59,12 @@ While the ``rulesets.xml`` ruleset file could look like this:
 
   <?xml version="1.0"?>
   <ruleset name="My first PHPMD rule set"
-           xmlns="http://pmd.sf.net/ruleset/1.0.0"
+           xmlns="https://phpmd.org/xml/ruleset/1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
-                         http://pmd.sf.net/ruleset_xml_schema.xsd"
+           xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0
+                         http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
            xsi:noNamespaceSchemaLocation="
-                         http://pmd.sf.net/ruleset_xml_schema.xsd">
+                         http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
     <description>
       My custom rule set that checks my code...
     </description>

--- a/src/main/resources/rulesets/cleancode.xml
+++ b/src/main/resources/rulesets/cleancode.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 
 <ruleset name="Clean Code Rules"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>
 The Clean Code ruleset contains rules that enforce a clean code base. This includes rules from SOLID and object calisthenics.

--- a/src/main/resources/rulesets/codesize.xml
+++ b/src/main/resources/rulesets/codesize.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <ruleset name="Code Size Rules"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>
 The Code Size Ruleset contains a collection of rules that find code size related problems.

--- a/src/main/resources/rulesets/controversial.xml
+++ b/src/main/resources/rulesets/controversial.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 
 <ruleset name="Controversial Rules"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>
 This ruleset contains a collection of controversial rules.

--- a/src/main/resources/rulesets/design.xml
+++ b/src/main/resources/rulesets/design.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 
 <ruleset name="Design Rules"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>
 The Design Ruleset contains a collection of rules that find software design related problems.

--- a/src/main/resources/rulesets/naming.xml
+++ b/src/main/resources/rulesets/naming.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="Naming Rules"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
     <description>
 The Naming Ruleset contains a collection of rules about names - too long, too short, and so forth.
     </description>

--- a/src/main/resources/rulesets/unusedcode.xml
+++ b/src/main/resources/rulesets/unusedcode.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 
 <ruleset name="Unused Code Rules"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
     <description>
 The Unused Code Ruleset contains a collection of rules that find unused code.
     </description>

--- a/src/site/resources/web/xml/ruleset_xml_schema_1.0.0.xsd
+++ b/src/site/resources/web/xml/ruleset_xml_schema_1.0.0.xsd
@@ -1,0 +1,88 @@
+<?xml version="1.0"?>
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns="https://phpmd.org/xml/ruleset/1.0.0"
+        targetNamespace="https://phpmd.org/xml/ruleset/1.0.0"
+        elementFormDefault="qualified">
+
+    <xs:element name="ruleset">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="description" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="exclude-pattern" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="include-pattern" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="rule" minOccurs="1" maxOccurs="unbounded"/>
+                <xs:element ref="php-includepath" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="php-includepath" type="xs:string">
+    </xs:element>
+
+    <xs:element name="description" type="xs:string">
+    </xs:element>
+
+    <xs:element name="include-pattern" type="xs:string">
+    </xs:element>
+
+    <xs:element name="exclude-pattern" type="xs:string">
+    </xs:element>
+
+    <xs:element name="rule">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="description" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="priority" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="exclude" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="example" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:ID" use="optional"/>
+            <xs:attribute name="file" type="xs:string" use="optional"/>
+            <xs:attribute name="since" type="xs:string" use="optional"/>
+            <xs:attribute name="ref" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+            <xs:attribute name="externalInfoUrl" type="xs:string" use="optional"/>
+            <xs:attribute name="class" type="xs:NMTOKEN" use="optional"/>
+            <xs:attribute name="dfa" type="xs:boolean" use="optional"/>  <!-- rule uses dataflow analysis -->
+            <xs:attribute name="typeResolution" type="xs:boolean" default="false" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="example" type="xs:string"/>
+
+    <!-- Default priority is the lowest -->
+    <xs:element name="priority" type="xs:int" default="5"/>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" minOccurs="1" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="value" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
+            <xs:attribute name="pluginname" type="xs:NMTOKEN" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="value" type="xs:string">
+    </xs:element>
+
+    <xs:element name="exclude">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>

--- a/src/site/rst/documentation/creating-a-ruleset.rst
+++ b/src/site/rst/documentation/creating-a-ruleset.rst
@@ -19,12 +19,12 @@ of this set. ::
 
   <?xml version="1.0"?>
   <ruleset name="My first PHPMD rule set"
-           xmlns="http://pmd.sf.net/ruleset/1.0.0"
+           xmlns="https://phpmd.org/xml/ruleset/1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
-                       http://pmd.sf.net/ruleset_xml_schema.xsd"
+           xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0
+                       http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
            xsi:noNamespaceSchemaLocation="
-                       http://pmd.sf.net/ruleset_xml_schema.xsd">
+                       http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
       <description>
           My custom rule set that checks my code...
       </description>
@@ -45,12 +45,12 @@ __ /rules/unusedcode.html
 
   <?xml version="1.0"?>
   <ruleset name="My first PHPMD rule set"
-           xmlns="http://pmd.sf.net/ruleset/1.0.0"
+           xmlns="https://phpmd.org/xml/ruleset/1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
-                       http://pmd.sf.net/ruleset_xml_schema.xsd"
+           xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0
+                       http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
            xsi:noNamespaceSchemaLocation="
-                       http://pmd.sf.net/ruleset_xml_schema.xsd">
+                       http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
       <description>
           My custom rule set that checks my code...
       </description>
@@ -75,12 +75,12 @@ __ /rules/codesize.html
 
   <?xml version="1.0"?>
   <ruleset name="My first PHPMD rule set"
-           xmlns="http://pmd.sf.net/ruleset/1.0.0"
+           xmlns="https://phpmd.org/xml/ruleset/1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
-                       http://pmd.sf.net/ruleset_xml_schema.xsd"
+           xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0
+                       http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
            xsi:noNamespaceSchemaLocation="
-                       http://pmd.sf.net/ruleset_xml_schema.xsd">
+                       http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
       <description>
           My custom rule set that checks my code...
       </description>
@@ -106,12 +106,12 @@ __ /rules/codesize.html#cyclomaticcomplexity
 
   <?xml version="1.0"?>
   <ruleset name="My first PHPMD rule set"
-           xmlns="http://pmd.sf.net/ruleset/1.0.0"
+           xmlns="https://phpmd.org/xml/ruleset/1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
-                       http://pmd.sf.net/ruleset_xml_schema.xsd"
+           xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0
+                       http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
            xsi:noNamespaceSchemaLocation="
-                       http://pmd.sf.net/ruleset_xml_schema.xsd">
+                       http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
       <description>
           My custom rule set that checks my code...
       </description>
@@ -150,12 +150,12 @@ __ /rules/naming.html
 
   <?xml version="1.0"?>
   <ruleset name="My first PHPMD rule set"
-           xmlns="http://pmd.sf.net/ruleset/1.0.0"
+           xmlns="https://phpmd.org/xml/ruleset/1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
-                       http://pmd.sf.net/ruleset_xml_schema.xsd"
+           xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0
+                       http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
            xsi:noNamespaceSchemaLocation="
-                       http://pmd.sf.net/ruleset_xml_schema.xsd">
+                       http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
       <description>
           My custom rule set that checks my code...
       </description>
@@ -199,12 +199,12 @@ __ /rules/cleancode.html
 
   <?xml version="1.0"?>
   <ruleset name="My first PHPMD rule set"
-           xmlns="http://pmd.sf.net/ruleset/1.0.0"
+           xmlns="https://phpmd.org/xml/ruleset/1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
-                       http://pmd.sf.net/ruleset_xml_schema.xsd"
+           xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0
+                       http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
            xsi:noNamespaceSchemaLocation="
-                       http://pmd.sf.net/ruleset_xml_schema.xsd">
+                       http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
       <description>
           My custom rule set that checks my code...
       </description>

--- a/src/site/rst/documentation/writing-a-phpmd-rule.rst
+++ b/src/site/rst/documentation/writing-a-phpmd-rule.rst
@@ -95,10 +95,10 @@ rule. The most important elements of a rule configuration are:
 ::
 
   <ruleset name="example.com rules"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
       <rule name="FunctionRule"
             message = "Please do not use functions."
@@ -194,10 +194,10 @@ to a rule set file.
 ::
 
   <ruleset name="example.com rules"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
       <!-- ... -->
 
@@ -218,10 +218,10 @@ and ``MAXIMUM`` with properties that can be configured in the rule set file.
 So let us start with the modified rule set file. ::
 
   <ruleset name="example.com rules"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
       <!-- ... -->
 
@@ -278,10 +278,10 @@ define violation messages with placeholders, that will be replaced with actual
 values. The format for such placeholders is ``'{' + \d+ '}'``. ::
 
   <ruleset name="example.com rules"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
       <!-- ... -->
 

--- a/src/site/rst/documentation/writing-a-phpmd-rule.rst
+++ b/src/site/rst/documentation/writing-a-phpmd-rule.rst
@@ -400,7 +400,7 @@ __ https://github.com/phpmd/phpmd/blob/master/src/main/php/PHPMD/Rule/FunctionAw
 __ https://github.com/phpmd/phpmd/blob/master/src/main/php/PHPMD/Rule/InterfaceAware.php
 __ https://github.com/phpmd/phpmd/blob/master/src/main/php/PHPMD/Rule/MethodAware.php
 __ https://github.com/phpmd/phpmd/blob/master/src/main/php/PHPMD/AbstractRule.php
-__ http://pmd.sf.net/
+__ https://pmd.github.io/
 __ https://github.com/phpmd/phpmd/tree/master/src/main/resources/rulesets
 __ https://phpmd.org/documentation/creating-a-ruleset.html
 

--- a/src/test/resources/files/rulesets/alternative-property-value-syntax.xml
+++ b/src/test/resources/files/rulesets/alternative-property-value-syntax.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Alternative Property Value Syntax RuleSet"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>First description...</description>
     <rule name="AlternativePropertySyntaxRule"

--- a/src/test/resources/files/rulesets/exclude-pattern.xml
+++ b/src/test/resources/files/rulesets/exclude-pattern.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="First Test RuleSet"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>Test exclude-pattern</description>
     <rule ref="rulesets/codesize.xml/CyclomaticComplexity" />

--- a/src/test/resources/files/rulesets/pmd-refset1.xml
+++ b/src/test/resources/files/rulesets/pmd-refset1.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="PMD Test RuleSet"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>First description...</description>
 

--- a/src/test/resources/files/rulesets/refset-exclude-all.xml
+++ b/src/test/resources/files/rulesets/refset-exclude-all.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Fourth Test RuleSet"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>First description...</description>
 

--- a/src/test/resources/files/rulesets/refset-exclude-one.xml
+++ b/src/test/resources/files/rulesets/refset-exclude-one.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Fourth Test RuleSet"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>First description...</description>
 

--- a/src/test/resources/files/rulesets/refset1.xml
+++ b/src/test/resources/files/rulesets/refset1.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="First Test RuleSet"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>First description...</description>
 

--- a/src/test/resources/files/rulesets/refset2.xml
+++ b/src/test/resources/files/rulesets/refset2.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Second Test RuleSet"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>First description...</description>
 

--- a/src/test/resources/files/rulesets/refset3.xml
+++ b/src/test/resources/files/rulesets/refset3.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Third Test RuleSet"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>First description...</description>
 

--- a/src/test/resources/files/rulesets/refset4.xml
+++ b/src/test/resources/files/rulesets/refset4.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Fourth Test RuleSet"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>First description...</description>
 

--- a/src/test/resources/files/rulesets/ruleset-refs.xml
+++ b/src/test/resources/files/rulesets/ruleset-refs.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset 
     name="phpmd-phpincludepath-test" 
-    xmlns="http://www.addiks.net/xmlns/pmd" 
+    xmlns="https://phpmd.org/xml/ruleset/1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://www.addiks.net/xmlns/pmd http://files.addiks.de/xmlns/phpmd.xsd" 
-    xsi:noNamespaceSchemaLocation=" http://files.addiks.de/xmlns/phpmd.xsd"> 
+    xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+    xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
     <description>First description...</description>
     
     <php-includepath>/foo/bar/baz</php-includepath>

--- a/src/test/resources/files/rulesets/set-class-file-not-found.xml
+++ b/src/test/resources/files/rulesets/set-class-file-not-found.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="Class File Not Found RuleSet"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>First description...</description>
     <rule name="ClassFileNotFoundRule"

--- a/src/test/resources/files/rulesets/set-class-not-found.xml
+++ b/src/test/resources/files/rulesets/set-class-not-found.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="Class Not Found RuleSet"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>First description...</description>
     <rule name="ClassNotFoundRule"

--- a/src/test/resources/files/rulesets/set1.xml
+++ b/src/test/resources/files/rulesets/set1.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="First Test RuleSet"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>First description...</description>
     <rule name="RuleOneInFirstRuleSet"

--- a/src/test/resources/files/rulesets/set2.xml
+++ b/src/test/resources/files/rulesets/set2.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Second Test RuleSet"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns="https://phpmd.org/xml/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="https://phpmd.org/xml/ruleset/1.0.0 http://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd"
+         xsi:noNamespaceSchemaLocation="https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd">
 
     <description>Second description...</description>
     


### PR DESCRIPTION
Type: refactoring & documentation update
Issue: Resolves #546
Breaking change: no

The original [PMD](https://pmd.github.io/) XML schema definition ``http://pmd.sourceforge.net/ruleset_xml_schema.xsd``  (or ``http://pmd.sf.net/ruleset_xml_schema.xsd``) do not contain @addiks' extensions from PR #232.

In #545 @addiks provided an updated XSD https://gist.github.com/addiks/b5f015e833634b5bccacfc0f4699d7d5

Since we only support PHP, I removed the XML element ``ruleset.language`` and its children.

The previous XML namespace
``http://pmd.sf.net/ruleset/1.0.0``
becomes
``https://phpmd.org/xml/ruleset/1.0.0``

The previous XML schema definition URI
``http://pmd.sf.net/ruleset_xml_schema.xsd``
becomes
``https://phpmd.org/xml/ruleset_xml_schema_1.0.0.xsd``

To be able to link to this new PHPMD Ruleset XSD, we also deploy it to to the website.

Side-note: This XSD would need to stay there even if newer major versions of PHPMD would not use XML, anymore. Otherwise, the XML schema validation breaks again.

When this gets relased, we should notifiy PHPMD users through all possible channnels (GH relase notes, Twitter, PHP

Fixes #545, too.