### PR TITLE
Handle some null values

### DIFF
--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -228,7 +228,7 @@ abstract class AbstractNode
      * Returns the source name for this node, maybe a class or interface name,
      * or a package, method, function name.
      *
-     * @return string|null
+     * @return string
      */
     public function getName()
     {
@@ -286,7 +286,9 @@ abstract class AbstractNode
     {
         $type = explode('\\', $this::class);
 
-        return preg_replace('(node$)', '', strtolower(array_pop($type)));
+        $type = strtolower(array_pop($type));
+
+        return preg_replace('(node$)', '', $type) ?? $type;
     }
 
     /**

--- a/src/main/php/PHPMD/AbstractRule.php
+++ b/src/main/php/PHPMD/AbstractRule.php
@@ -73,7 +73,7 @@ abstract class AbstractRule implements Rule
     private array $properties = [];
 
     /** The report for object for this rule. */
-    private ?Report $report = null;
+    private Report $report;
 
     /** Should this rule force the strict mode. */
     private bool $strict = false;
@@ -225,7 +225,7 @@ abstract class AbstractRule implements Rule
     /**
      * Returns the violation report for this rule.
      */
-    public function getReport(): ?Report
+    public function getReport(): Report
     {
         return $this->report;
     }
@@ -233,7 +233,7 @@ abstract class AbstractRule implements Rule
     /**
      * Sets the violation report for this rule.
      */
-    public function setReport(?Report $report): void
+    public function setReport(Report $report): void
     {
         $this->report = $report;
     }

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
@@ -2,6 +2,7 @@
 
 namespace PHPMD\Cache\Model;
 
+use OutOfBoundsException;
 use PHPMD\Node\NodeInfo;
 use PHPMD\Rule;
 use PHPMD\RuleSet;
@@ -72,6 +73,7 @@ class ResultCacheState
      * @param string $basePath
      * @param list<RuleSet> $ruleSetList
      * @return list<RuleViolation>
+     * @throws OutOfBoundsException
      */
     public function getRuleViolations($basePath, array $ruleSetList)
     {
@@ -146,7 +148,8 @@ class ResultCacheState
     /**
      * @param string    $ruleClassName
      * @param RuleSet[] $ruleSetList
-     * @return Rule|null
+     * @return Rule
+     * @throws OutOfBoundsException
      */
     private static function findRuleIn($ruleClassName, array $ruleSetList)
     {
@@ -158,6 +161,6 @@ class ResultCacheState
             }
         }
 
-        return null;
+        throw new OutOfBoundsException();
     }
 }

--- a/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheFileFilter.php
@@ -53,7 +53,7 @@ class ResultCacheFileFilter implements Filter
         if ($hash !== false) {
             $this->newState->setFileState($filePath, $hash);
         }
-        if (!$isModified) {
+        if (!$isModified && $this->state) {
             // File was not modified, transfer previous violations
             $this->newState->setViolations($filePath, $this->state->getViolations($filePath));
         }

--- a/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
+++ b/src/main/php/PHPMD/Cache/ResultCacheUpdater.php
@@ -2,6 +2,7 @@
 
 namespace PHPMD\Cache;
 
+use OutOfBoundsException;
 use PHPMD\Cache\Model\ResultCacheState;
 use PHPMD\Console\OutputInterface;
 use PHPMD\Report;
@@ -19,6 +20,7 @@ class ResultCacheUpdater
     /**
      * @param RuleSet[] $ruleSetList
      * @return ResultCacheState
+     * @throws OutOfBoundsException
      */
     public function update(array $ruleSetList, ResultCacheState $state, Report $report)
     {

--- a/src/main/php/PHPMD/Rule.php
+++ b/src/main/php/PHPMD/Rule.php
@@ -121,12 +121,12 @@ interface Rule
     /**
      * Returns the violation report for this rule.
      */
-    public function getReport(): ?Report;
+    public function getReport(): Report;
 
     /**
      * Sets the violation report for this rule.
      */
-    public function setReport(?Report $report): void;
+    public function setReport(Report $report): void;
 
     /**
      * Adds a configuration property to this rule instance.

--- a/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
@@ -61,7 +61,7 @@ final class ShortMethodName extends AbstractRule implements FunctionAware, Metho
         $this->addViolation(
             $node,
             [
-                $node->getParentName(),
+                (string) $node->getParentName(),
                 $node->getName(),
                 (string) $threshold,
             ]

--- a/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateMethod.php
@@ -204,7 +204,10 @@ final class UnusedPrivateMethod extends AbstractRule implements ClassAware
      */
     private function isClassScope(ClassNode $class, AbstractNode $postfix)
     {
-        $owner = $postfix->getParent()->getChild(0);
+        $owner = $postfix->getParent()?->getChild(0);
+        if (!$owner) {
+            return false;
+        }
 
         return (
             $owner->isInstanceOf(ASTMethodPostfix::class) ||

--- a/src/main/php/PHPMD/RuleSet.php
+++ b/src/main/php/PHPMD/RuleSet.php
@@ -62,7 +62,7 @@ class RuleSet implements IteratorAggregate
     private string $description = '';
 
     /** The violation report used by the rule-set. */
-    private ?Report $report = null;
+    private Report $report;
 
     /**
      * Mapping between marker interfaces and concrete context code node classes.
@@ -167,7 +167,7 @@ class RuleSet implements IteratorAggregate
     /**
      * Returns the violation report used by the rule-set.
      */
-    public function getReport(): ?Report
+    public function getReport(): Report
     {
         return $this->report;
     }

--- a/src/main/php/PHPMD/RuleSetFactory.php
+++ b/src/main/php/PHPMD/RuleSetFactory.php
@@ -474,7 +474,7 @@ class RuleSetFactory
      */
     private function addProperty(Rule $rule, SimpleXMLElement $node): void
     {
-        $name = trim($node['name']);
+        $name = trim((string) $node['name']);
         $value = trim($this->getPropertyValue($node));
         if ($name !== '' && $value !== '') {
             $rule->addProperty($name, $value);

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -502,7 +502,7 @@ class CommandLineOptions
      * Returns a hash with report files specified for different renderers. The
      * key represents the report format and the value the report file location.
      *
-     * @return array<string, string|null>
+     * @return array<string, string>
      */
     public function getReportFiles()
     {

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -29,9 +29,9 @@ final class StreamWriter extends AbstractWriter
     /**
      * The stream resource handle
      *
-     * @var ?resource
+     * @var resource
      */
-    private $stream = null;
+    private $stream;
 
     /**
      * Constructs a new stream writer instance.
@@ -56,7 +56,12 @@ final class StreamWriter extends AbstractWriter
             throw new RuntimeException($message);
         }
 
-        $this->stream = fopen($streamResourceOrUri, 'wb') ?: null;
+        $stream = fopen($streamResourceOrUri, 'wb');
+        if (!$stream) {
+            throw new RuntimeException('Cannot open "' . $streamResourceOrUri . '".');
+        }
+
+        $this->stream = $stream;
     }
 
     /**
@@ -67,7 +72,6 @@ final class StreamWriter extends AbstractWriter
         if ($this->stream !== STDOUT && $this->stream !== STDERR && is_resource($this->stream)) {
             @fclose($this->stream);
         }
-        $this->stream = null;
     }
 
     /**


### PR DESCRIPTION
Type: refactoring / documentation update

Explicitly handle null cases. This both prepares for converting PHPDoc in to type hints and helps to resolve PHPStan level 8.