### PR TITLE
Correct property types

### DIFF
--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -18,6 +18,7 @@
 
 namespace PHPMD;
 
+use LogicException;
 use OutOfBoundsException;
 use PDepend\Source\AST\AbstractASTArtifact;
 use PDepend\Source\AST\ASTNode as PDependNode;
@@ -39,7 +40,7 @@ abstract class AbstractNode
      *
      * @var array<string, numeric>
      */
-    private $metrics = null;
+    private array $metrics;
 
     /**
      * Constructs a new PHPMD node.
@@ -288,12 +289,15 @@ abstract class AbstractNode
      * This method will set the metrics for this node.
      *
      * @param array<string, numeric> $metrics The collected node metrics.
+     * @throws LogicException
      */
     public function setMetrics(array $metrics): void
     {
-        if ($this->metrics === null) {
-            $this->metrics = $metrics;
+        if (isset($this->metrics)) {
+            throw new LogicException('Metrics cannot be overridden');
         }
+
+        $this->metrics = $metrics;
     }
 
     /**

--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -25,12 +25,8 @@ use Exception;
  */
 abstract class AbstractRenderer
 {
-    /**
-     * The associated output writer instance.
-     *
-     * @var AbstractWriter
-     */
-    private $writer = null;
+    /** The associated output writer instance. */
+    private AbstractWriter $writer;
 
     /**
      * Returns the associated output writer instance.

--- a/src/main/php/PHPMD/Node/AbstractNode.php
+++ b/src/main/php/PHPMD/Node/AbstractNode.php
@@ -31,12 +31,8 @@ use PHPMD\Rule;
  */
 abstract class AbstractNode extends BaseNode
 {
-    /**
-     * Annotations associated with node instance.
-     *
-     * @var Annotations
-     */
-    private $annotations = null;
+    /** Annotations associated with node instance. */
+    private Annotations $annotations;
 
     /**
      * Checks if this node has a suppressed annotation for the given rule
@@ -44,9 +40,7 @@ abstract class AbstractNode extends BaseNode
      */
     public function hasSuppressWarningsAnnotationFor(Rule $rule): bool
     {
-        if ($this->annotations === null) {
-            $this->annotations = new Annotations($this);
-        }
+        $this->annotations ??= new Annotations($this);
 
         return $this->annotations->suppresses($rule);
     }

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -59,8 +59,7 @@ class PHPMD
      */
     private $input;
 
-    /** @var ResultCacheEngine|null */
-    private $resultCache;
+    private ?ResultCacheEngine $resultCache = null;
 
     /**
      * This property will be set to <b>true</b> when a violation

--- a/src/main/php/PHPMD/Parser.php
+++ b/src/main/php/PHPMD/Parser.php
@@ -19,6 +19,7 @@
 namespace PHPMD;
 
 use InvalidArgumentException;
+use LogicException;
 use OutOfBoundsException;
 use PDepend\Engine;
 use PDepend\Metrics\Analyzer;
@@ -68,14 +69,10 @@ final class Parser extends AbstractASTVisitor implements CodeAwareGenerator
      *
      * @var ASTArtifactList<ASTNamespace>
      */
-    private $artifacts = null;
+    private ASTArtifactList $artifacts;
 
-    /**
-     * The violation report used by this PDepend adapter.
-     *
-     * @var Report
-     */
-    private $report = null;
+    /** The violation report used by this PDepend adapter. */
+    private Report $report;
 
     /**
      * Constructs a new parser adapter instance.
@@ -179,6 +176,7 @@ final class Parser extends AbstractASTVisitor implements CodeAwareGenerator
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
+     * @throws LogicException
      */
     public function visitClass(ASTClass $node): void
     {
@@ -196,6 +194,7 @@ final class Parser extends AbstractASTVisitor implements CodeAwareGenerator
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
+     * @throws LogicException
      */
     public function visitTrait(ASTTrait $node): void
     {
@@ -213,6 +212,7 @@ final class Parser extends AbstractASTVisitor implements CodeAwareGenerator
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
+     * @throws LogicException
      */
     public function visitEnum(ASTEnum $node): void
     {
@@ -230,6 +230,7 @@ final class Parser extends AbstractASTVisitor implements CodeAwareGenerator
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
+     * @throws LogicException
      */
     public function visitFunction(ASTFunction $node): void
     {
@@ -246,6 +247,7 @@ final class Parser extends AbstractASTVisitor implements CodeAwareGenerator
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
+     * @throws LogicException
      */
     public function visitInterface(ASTInterface $node): void
     {
@@ -264,6 +266,7 @@ final class Parser extends AbstractASTVisitor implements CodeAwareGenerator
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
+     * @throws LogicException
      */
     public function visitMethod(ASTMethod $node): void
     {
@@ -289,6 +292,7 @@ final class Parser extends AbstractASTVisitor implements CodeAwareGenerator
      *
      * @param AbstractNode<ASTArtifact> $node
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
+     * @throws LogicException
      * @throws OutOfBoundsException
      * @throws InvalidArgumentException
      */
@@ -306,6 +310,7 @@ final class Parser extends AbstractASTVisitor implements CodeAwareGenerator
      * <b>$node</b>.
      *
      * @param AbstractNode<ASTArtifact> $node
+     * @throws LogicException
      */
     private function collectMetrics(AbstractNode $node): void
     {

--- a/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
+++ b/src/main/php/PHPMD/Renderer/CheckStyleRenderer.php
@@ -13,10 +13,8 @@ final class CheckStyleRenderer extends XMLRenderer
     /**
      * Temporary property that holds the name of the last rendered file, it is
      * used to detect the next processed file.
-     *
-     * @var string
      */
-    private $fileName;
+    private ?string $fileName = null;
 
     /**
      * Get a violation severity level according to the priority

--- a/src/main/php/PHPMD/Renderer/XMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/XMLRenderer.php
@@ -30,10 +30,8 @@ class XMLRenderer extends AbstractRenderer
     /**
      * Temporary property that holds the name of the last rendered file, it is
      * used to detect the next processed file.
-     *
-     * @var string
      */
-    private $fileName = null;
+    private ?string $fileName = null;
 
     /**
      * This method will be called on all renderers before the engine starts the

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -36,12 +36,8 @@ use PHPMD\Utility\ExceptionsList;
  */
 final class BooleanArgumentFlag extends AbstractRule implements FunctionAware, MethodAware
 {
-    /**
-     * Temporary cache of configured exceptions.
-     *
-     * @var ExceptionsList|null
-     */
-    private $exceptions;
+    /** Temporary cache of configured exceptions. */
+    private ExceptionsList $exceptions;
 
     /**
      * This method checks if a method/function has boolean flag arguments and warns about them.
@@ -83,9 +79,7 @@ final class BooleanArgumentFlag extends AbstractRule implements FunctionAware, M
      */
     private function getExceptionsList(): ExceptionsList
     {
-        if ($this->exceptions === null) {
-            $this->exceptions = new ExceptionsList($this);
-        }
+        $this->exceptions ??= new ExceptionsList($this);
 
         return $this->exceptions;
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -38,12 +38,8 @@ use PHPMD\Utility\ExceptionsList;
  */
 final class StaticAccess extends AbstractRule implements FunctionAware, MethodAware
 {
-    /**
-     * Temporary cache of configured exceptions.
-     *
-     * @var ExceptionsList|null
-     */
-    private $exceptions;
+    /** Temporary cache of configured exceptions. */
+    private ExceptionsList $exceptions;
 
     /**
      * Method checks for use of static access and warns about it.
@@ -121,9 +117,7 @@ final class StaticAccess extends AbstractRule implements FunctionAware, MethodAw
      */
     private function getExceptionsList(): ExceptionsList
     {
-        if ($this->exceptions === null) {
-            $this->exceptions = new ExceptionsList($this, '\\');
-        }
+        $this->exceptions ??= new ExceptionsList($this, '\\');
 
         return $this->exceptions;
     }

--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseNamespace.php
@@ -30,8 +30,8 @@ use PHPMD\Utility\Strings;
  */
 final class CamelCaseNamespace extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
 {
-    /** @var array<string, int>|null */
-    private $exceptions;
+    /** @var array<string, int> */
+    private array $exceptions;
 
     public function apply(AbstractNode $node): void
     {
@@ -67,11 +67,9 @@ final class CamelCaseNamespace extends AbstractRule implements ClassAware, EnumA
      */
     private function getExceptionsList(): array
     {
-        if ($this->exceptions === null) {
-            $this->exceptions = array_flip(
-                Strings::splitToList($this->getStringProperty('exceptions', ''), ',')
-            );
-        }
+        $this->exceptions ??= array_flip(
+            Strings::splitToList($this->getStringProperty('exceptions', ''), ',')
+        );
 
         return $this->exceptions;
     }

--- a/src/main/php/PHPMD/Rule/Naming/LongClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongClassName.php
@@ -37,16 +37,16 @@ final class LongClassName extends AbstractRule implements ClassAware, EnumAware,
     /**
      * Temporary cache of configured prefixes to subtract
      *
-     * @var string[]|null
+     * @var string[]
      */
-    private $subtractPrefixes;
+    private array $subtractPrefixes;
 
     /**
      * Temporary cache of configured suffixes to subtract
      *
-     * @var string[]|null
+     * @var string[]
      */
-    private $subtractSuffixes;
+    private array $subtractSuffixes;
 
     /**
      * Check if a class name exceeds the configured maximum length and emit a rule violation
@@ -76,12 +76,10 @@ final class LongClassName extends AbstractRule implements ClassAware, EnumAware,
      */
     private function getSubtractPrefixList(): array
     {
-        if ($this->subtractPrefixes === null) {
-            $this->subtractPrefixes = Strings::splitToList(
-                $this->getStringProperty('subtract-prefixes', ''),
-                ','
-            );
-        }
+        $this->subtractPrefixes ??= Strings::splitToList(
+            $this->getStringProperty('subtract-prefixes', ''),
+            ','
+        );
 
         return $this->subtractPrefixes;
     }
@@ -95,11 +93,9 @@ final class LongClassName extends AbstractRule implements ClassAware, EnumAware,
      */
     private function getSubtractSuffixList(): array
     {
-        if ($this->subtractSuffixes === null) {
-            $this->subtractSuffixes = Strings::splitToList(
-                $this->getStringProperty('subtract-suffixes', '')
-            );
-        }
+        $this->subtractSuffixes ??= Strings::splitToList(
+            $this->getStringProperty('subtract-suffixes', '')
+        );
 
         return $this->subtractSuffixes;
     }

--- a/src/main/php/PHPMD/Rule/Naming/LongVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/LongVariable.php
@@ -41,16 +41,16 @@ final class LongVariable extends AbstractRule implements ClassAware, FunctionAwa
     /**
      * Temporary cache of configured prefixes to subtract
      *
-     * @var string[]|null
+     * @var string[]
      */
-    private $subtractPrefixes;
+    private array $subtractPrefixes;
 
     /**
      * Temporary cache of configured suffixes to subtract
      *
-     * @var string[]|null
+     * @var string[]
      */
-    private $subtractSuffixes;
+    private array $subtractSuffixes;
 
     /**
      * Temporary map holding variables that were already processed in the
@@ -184,9 +184,7 @@ final class LongVariable extends AbstractRule implements ClassAware, FunctionAwa
      */
     private function getSubtractPrefixList(): array
     {
-        if ($this->subtractPrefixes === null) {
-            $this->subtractPrefixes = Strings::splitToList($this->getStringProperty('subtract-prefixes', ''), ',');
-        }
+        $this->subtractPrefixes ??= Strings::splitToList($this->getStringProperty('subtract-prefixes', ''), ',');
 
         return $this->subtractPrefixes;
     }
@@ -200,9 +198,7 @@ final class LongVariable extends AbstractRule implements ClassAware, FunctionAwa
      */
     private function getSubtractSuffixList(): array
     {
-        if ($this->subtractSuffixes === null) {
-            $this->subtractSuffixes = Strings::splitToList($this->getStringProperty('subtract-suffixes', ''));
-        }
+        $this->subtractSuffixes ??= Strings::splitToList($this->getStringProperty('subtract-suffixes', ''));
 
         return $this->subtractSuffixes;
     }

--- a/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortClassName.php
@@ -31,12 +31,8 @@ use PHPMD\Utility\ExceptionsList;
  */
 final class ShortClassName extends AbstractRule implements ClassAware, EnumAware, InterfaceAware, TraitAware
 {
-    /**
-     * Temporary cache of configured exceptions. Have name as key
-     *
-     * @var ExceptionsList|null
-     */
-    private $exceptions;
+    /** Temporary cache of configured exceptions. Have name as key */
+    private ExceptionsList $exceptions;
 
     /**
      * Check if a class or interface name is below the minimum configured length and emit a rule violation
@@ -61,9 +57,7 @@ final class ShortClassName extends AbstractRule implements ClassAware, EnumAware
      */
     private function getExceptionsList(): ExceptionsList
     {
-        if ($this->exceptions === null) {
-            $this->exceptions = new ExceptionsList($this, '\\');
-        }
+        $this->exceptions ??= new ExceptionsList($this, '\\');
 
         return $this->exceptions;
     }

--- a/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortMethodName.php
@@ -29,12 +29,8 @@ use PHPMD\Utility\ExceptionsList;
  */
 final class ShortMethodName extends AbstractRule implements FunctionAware, MethodAware
 {
-    /**
-     * Temporary cache of configured exceptions.
-     *
-     * @var ExceptionsList|null
-     */
-    private $exceptions;
+    /** Temporary cache of configured exceptions. */
+    private ExceptionsList $exceptions;
 
     /**
      * Extracts all variable and variable declarator nodes from the given node
@@ -73,9 +69,7 @@ final class ShortMethodName extends AbstractRule implements FunctionAware, Metho
      */
     private function getExceptionsList(): ExceptionsList
     {
-        if ($this->exceptions === null) {
-            $this->exceptions = new ExceptionsList($this);
-        }
+        $this->exceptions ??= new ExceptionsList($this);
 
         return $this->exceptions;
     }

--- a/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
+++ b/src/main/php/PHPMD/Rule/Naming/ShortVariable.php
@@ -49,12 +49,8 @@ final class ShortVariable extends AbstractRule implements ClassAware, FunctionAw
      */
     private $processedVariables = [];
 
-    /**
-     * Temporary cache of configured exceptions.
-     *
-     * @var ExceptionsList|null
-     */
-    private $exceptions;
+    /** Temporary cache of configured exceptions. */
+    private ExceptionsList $exceptions;
 
     /**
      * Extracts all variable and variable declarator nodes from the given node
@@ -170,9 +166,7 @@ final class ShortVariable extends AbstractRule implements ClassAware, FunctionAw
      */
     private function getExceptionsList(): ExceptionsList
     {
-        if ($this->exceptions === null) {
-            $this->exceptions = new ExceptionsList($this);
-        }
+        $this->exceptions ??= new ExceptionsList($this);
 
         return $this->exceptions;
     }

--- a/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/UnusedLocalVariable.php
@@ -53,12 +53,8 @@ final class UnusedLocalVariable extends AbstractLocalVariable implements Functio
      */
     private $images = [];
 
-    /**
-     * Temporary cache of configured exceptions.
-     *
-     * @var ExceptionsList|null
-     */
-    private $exceptions;
+    /** Temporary cache of configured exceptions. */
+    private ExceptionsList $exceptions;
 
     /**
      * This method checks that all local variables within the given function or
@@ -340,9 +336,7 @@ final class UnusedLocalVariable extends AbstractLocalVariable implements Functio
      */
     private function getExceptionsList(): ExceptionsList
     {
-        if ($this->exceptions === null) {
-            $this->exceptions = new ExceptionsList($this);
-        }
+        $this->exceptions ??= new ExceptionsList($this);
 
         return $this->exceptions;
     }

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -78,19 +78,11 @@ class CommandLineOptions
      */
     private $reportFormat;
 
-    /**
-     * An optional filename for the generated report.
-     *
-     * @var string
-     */
-    private $reportFile;
+    /** An optional filename for the generated report. */
+    private ?string $reportFile = null;
 
-    /**
-     * An optional filename to collect errors.
-     *
-     * @var string
-     */
-    private $errorFile;
+    /** An optional filename to collect errors. */
+    private ?string $errorFile = null;
 
     /**
      * Additional report files.
@@ -113,28 +105,18 @@ class CommandLineOptions
      */
     private $ruleSets;
 
-    /**
-     * File name of a PHPUnit code coverage report.
-     *
-     * @var string
-     */
-    private $coverageReport;
+    /** File name of a PHPUnit code coverage report. */
+    private ?string $coverageReport = null;
 
-    /**
-     * A string of comma-separated extensions for valid php source code filenames.
-     *
-     * @var string
-     */
-    private $extensions;
+    /** A string of comma-separated extensions for valid php source code filenames. */
+    private ?string $extensions = null;
 
     /**
      * A string of comma-separated pattern that is used to exclude directories.
      *
      * Use asterisks to exclude by pattern. For example *src/foo/*.php or *src/foo/*
-     *
-     * @var string
      */
-    private $ignore;
+    private ?string $ignore = null;
 
     /**
      * Should the shell show the current phpmd version?
@@ -175,9 +157,8 @@ class CommandLineOptions
     /**
      * The baseline source file to read the baseline violations from.
      * Defaults to the path of the (first) ruleset file as phpmd.baseline.xml
-     * @var string|null
      */
-    private $baselineFile;
+    private ?string $baselineFile = null;
 
     /**
      * Should PHPMD read or write the result cache state from the cache file
@@ -201,11 +182,8 @@ class CommandLineOptions
      */
     private $colored = false;
 
-    /**
-     * Specify how many extra lines are added to a code snippet
-     * @var int|null
-     */
-    private $extraLineInExcerpt;
+    /** Specify how many extra lines are added to a code snippet */
+    private ?int $extraLineInExcerpt = null;
 
     /**
      * Constructs a new command line options instance.

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -28,12 +28,8 @@ use Throwable;
  */
 abstract class AbstractStaticTestCase extends TestCase
 {
-    /**
-     * Directory with test files.
-     *
-     * @var string
-     */
-    private static $filesDirectory = null;
+    /** Directory with test files. */
+    private static string $filesDirectory;
 
     /**
      * Original directory is used to reset a changed working directory.


### PR DESCRIPTION
Type: refactoring

Make the needed adjustments nessesery for converting PHPDoc to property type hints.