### PR TITLE
Correct return types

### DIFF
--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -272,7 +272,7 @@ abstract class AbstractNode
      *
      * @return TNode
      */
-    public function getNode()
+    public function getNode(): PDependNode
     {
         return $this->node;
     }
@@ -298,7 +298,7 @@ abstract class AbstractNode
      * @param string $name The metric name or abbreviation.
      * @return ?numeric $name
      */
-    public function getMetric($name)
+    public function getMetric($name): mixed
     {
         return $this->metrics[$name] ?? null;
     }

--- a/src/main/php/PHPMD/RuleViolation.php
+++ b/src/main/php/PHPMD/RuleViolation.php
@@ -100,9 +100,9 @@ class RuleViolation
     /**
      * Returns the raw metric value which caused this rule violation.
      *
-     * @return mixed|null
+     * @return ?numeric
      */
-    public function getMetric()
+    public function getMetric(): mixed
     {
         return $this->metric;
     }

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -675,7 +675,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * @return PHP_Depend_Code_AbstractItem
      * @throws ErrorException
      */
-    private function getNodeByName(Iterator $nodes, $name)
+    private function getNodeByName(Iterator $nodes, string $name): ASTNode
     {
         foreach ($nodes as $node) {
             if ($node->getImage() === $name) {
@@ -692,7 +692,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * @return PHP_Depend_Code_AbstractItem
      * @throws ErrorException
      */
-    private function getNodeForCallingTestCase(Iterator $nodes)
+    private function getNodeForCallingTestCase(Iterator $nodes): ASTNode
     {
         $frame = $this->getCallingTestCase();
 

--- a/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
+++ b/src/test/php/PHPMD/Cache/ResultCacheUpdaterTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPMD\Cache;
 
+use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\Cache\Model\ResultCacheState;
 use PHPMD\Console\NullOutput;
@@ -39,7 +40,7 @@ class ResultCacheUpdaterTest extends AbstractTestCase
         $violationA = $this->getRuleViolationMock('/base/path/violation/a');
         $violationB = $this->getRuleViolationMock('/base/path/violation/b');
 
-        $report->expects(static::once())->method('getRuleViolations')->willReturn([$violationA]);
+        $report->expects(static::once())->method('getRuleViolations')->willReturn(new ArrayIterator([$violationA]));
         $this->state->expects(static::once())
             ->method('getRuleViolations')
             ->with('/base/path/', [$ruleSet])

--- a/src/test/php/PHPMD/Node/ASTNodeTest.php
+++ b/src/test/php/PHPMD/Node/ASTNodeTest.php
@@ -35,7 +35,8 @@ class ASTNodeTest extends AbstractTestCase
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $mock->expects(static::once())
-            ->method('getImage');
+            ->method('getImage')
+            ->will(static::returnValue(''));
 
         $node = new ASTNode($mock, __FILE__);
         $node->getImage();
@@ -48,7 +49,8 @@ class ASTNodeTest extends AbstractTestCase
     {
         $mock = $this->getMockFromBuilder($this->getMockBuilder(PDependNode::class));
         $mock->expects(static::once())
-            ->method('getImage');
+            ->method('getImage')
+            ->will(static::returnValue(''));
 
         $node = new ASTNode($mock, __FILE__);
         $node->getName();


### PR DESCRIPTION
Type: refactoring / documentation update
Breaking change: yes

Correct return types to make it possible to convert PHPDoc to return value type hints.