### PR TITLE
Add test for `MethodNode::isDeclaration()`

### DIFF
--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -239,4 +239,20 @@ class MethodNodeTest extends AbstractTest
 
         $this->assertSame('Sindelfingen\\MyClass::beer()', $node->getFullQualifiedName());
     }
+
+    /**
+     * @return void
+     */
+    public function testIsDeclarationReturnsFalseForInheritedDeclaration()
+    {
+        $class = $this->getClassNodeForTestFile(__DIR__.'/../../../resources/files/classes/inheritance/Baz.php');
+        $methods = $class->getMethods();
+
+        $this->assertCount(1, $methods);
+        $this->assertArrayHasKey(0, $methods);
+
+        $method = $methods[0];
+
+        $this->assertFalse($method->isDeclaration());
+    }
 }

--- a/src/test/resources/files/classes/inheritance/Bar.php
+++ b/src/test/resources/files/classes/inheritance/Bar.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Test\Inheritance;
+
+abstract class Bar implements Foo
+{
+}
+

--- a/src/test/resources/files/classes/inheritance/Baz.php
+++ b/src/test/resources/files/classes/inheritance/Baz.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Test\Inheritance;
+
+class Baz extends Bar
+{
+    public function doFoo()
+    {
+        // ...
+    }
+}

--- a/src/test/resources/files/classes/inheritance/Foo.php
+++ b/src/test/resources/files/classes/inheritance/Foo.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Test\Inheritance;
+
+interface Foo
+{
+    public function doFoo();
+}


### PR DESCRIPTION
Type: bug report
Issue: n/a
Breaking change: no (at least, not yet)

IIUC,  `MethodNode::isDeclaration()` is not working as expected, because methods overriding or implementing parent classes or interfaces are being interpreted as declarations.

The added test tries to expose the described issue.

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
  
 ## Adding a New Rule

- Add the new rule to the matching rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new rule, e.g. ``src/site/rst/rules/naming.rst``
- Implement the new rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new rule in the rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new rule *should* apply
-- Cover the case when the new rule *should not* apply
-- Cover edge cases of the new rule

## Adding a New Rule Property

- Add the new property to rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new property, e.g. ``src/site/rst/rules/naming.rst``
- Implement new property in rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new property in rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new property is not set and the rule *should not* apply
-- Cover the case when the new property is not set and the rule *should* apply
-- Cover case when the new property is set and the rule *should not* apply
-- Cover case when the new property is set and the rule *should* apply
-- Cover edge cases of the new property, if any
-->
