### PR TITLE
Feature/3.x custom renderer

### DIFF
--- a/src/main/php/PHPMD/AbstractRenderer.php
+++ b/src/main/php/PHPMD/AbstractRenderer.php
@@ -19,11 +19,12 @@
 namespace PHPMD;
 
 use Exception;
+use PHPMD\Renderer\RendererInterface;
 
 /**
  * Abstract base class for PHPMD rendering engines.
  */
-abstract class AbstractRenderer
+abstract class AbstractRenderer implements RendererInterface
 {
     /** The associated output writer instance. */
     private AbstractWriter $writer;

--- a/src/main/php/PHPMD/PHPMD.php
+++ b/src/main/php/PHPMD/PHPMD.php
@@ -20,6 +20,7 @@ namespace PHPMD;
 
 use Exception;
 use PHPMD\Cache\ResultCacheEngine;
+use PHPMD\Renderer\RendererInterface;
 
 /**
  * This is the main facade of the PHP PMD application
@@ -193,7 +194,7 @@ class PHPMD
      * argument. The result will be passed to all given renderer instances.
      *
      * @param string[]      $ignorePattern
-     * @param AbstractRenderer[] $renderers
+     * @param RendererInterface[] $renderers
      * @param RuleSet[]          $ruleSetList
      * @throws Exception
      */

--- a/src/main/php/PHPMD/Renderer/RendererFactory.php
+++ b/src/main/php/PHPMD/Renderer/RendererFactory.php
@@ -2,7 +2,9 @@
 
 namespace PHPMD\Renderer;
 
+use InvalidArgumentException;
 use PHPMD\AbstractWriter;
+use PHPMD\TextUI\CommandLineOptions;
 
 final class RendererFactory
 {
@@ -13,5 +15,34 @@ final class RendererFactory
         $renderer->setWriter($writer);
 
         return $renderer;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function getRenderer(string $format): RendererInterface
+    {
+        if (class_exists($format)) {
+            $renderer = new $format();
+            if ($renderer instanceof RendererInterface) {
+                return $renderer;
+            }
+        }
+
+        return match ($format) {
+            'ansi' => new AnsiRenderer(),
+            'checkstyle' => new CheckStyleRenderer(),
+            'github' => new GitHubRenderer(),
+            'gitlab' => new GitLabRenderer(),
+            'html' => new HTMLRenderer(),
+            'json' => new JSONRenderer(),
+            'sarif' => new SARIFRenderer(),
+            'text' => new TextRenderer(),
+            'xml' => new XMLRenderer(),
+            default => throw new InvalidArgumentException(
+                sprintf('No renderer supports the format "%s".', $format),
+                RendererInterface::INPUT_ERROR
+            ),
+        };
     }
 }

--- a/src/main/php/PHPMD/Renderer/RendererFactory.php
+++ b/src/main/php/PHPMD/Renderer/RendererFactory.php
@@ -16,6 +16,9 @@ final class RendererFactory
         return $renderer;
     }
 
+    /**
+     * @throws InvalidArgumentException
+     */
     public function getRenderer(string $format): RendererInterface
     {
         return match ($format) {

--- a/src/main/php/PHPMD/Renderer/RendererInterface.php
+++ b/src/main/php/PHPMD/Renderer/RendererInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PHPMD\Renderer;
+
+use PHPMD\AbstractWriter;
+use PHPMD\Report;
+
+interface RendererInterface
+{
+    public const INPUT_ERROR = 23;
+
+    public function setWriter(AbstractWriter $writer): void;
+
+    public function start(): void;
+
+    public function renderReport(Report $report): void;
+
+    public function end(): void;
+}

--- a/src/main/php/PHPMD/TextUI/Command.php
+++ b/src/main/php/PHPMD/TextUI/Command.php
@@ -219,6 +219,11 @@ final class Command
                 $output->write($deprecation . PHP_EOL . PHP_EOL);
             }
 
+            $bootstrapFile = $options->getBootstrapFile();
+            if (is_string($bootstrapFile) && file_exists($bootstrapFile)) {
+                require_once $bootstrapFile;
+            }
+
             $exitCode = $command->run($options, $ruleSetFactory);
             unset($errorStream);
         } catch (Exception $e) {

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -616,7 +616,7 @@ class CommandLineOptions
      */
     private function createRendererWithoutOptions(?string $reportFormat = null): RendererInterface
     {
-        $reportFormat ??= $this->reportFormat ?? '';
+        $reportFormat = $reportFormat ?: $this->reportFormat ?: '';
 
         return (new RendererFactory())->getRenderer($reportFormat);
     }

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -616,7 +616,7 @@ class CommandLineOptions
      */
     private function createRendererWithoutOptions(?string $reportFormat = null): RendererInterface
     {
-        $reportFormat = $reportFormat ?: $this->reportFormat;
+        $reportFormat = $reportFormat ?? $this->reportFormat ?? '';
 
         return (new RendererFactory())->getRenderer($reportFormat);
     }

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -616,7 +616,7 @@ class CommandLineOptions
      */
     private function createRendererWithoutOptions(?string $reportFormat = null): RendererInterface
     {
-        $reportFormat = $reportFormat ?? $this->reportFormat ?? '';
+        $reportFormat ??= $this->reportFormat ?? '';
 
         return (new RendererFactory())->getRenderer($reportFormat);
     }

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -23,17 +23,10 @@ use PHPMD\AbstractRenderer;
 use PHPMD\Baseline\BaselineMode;
 use PHPMD\Cache\Model\ResultCacheStrategy;
 use PHPMD\Console\OutputInterface;
-use PHPMD\Renderer\AnsiRenderer;
-use PHPMD\Renderer\CheckStyleRenderer;
-use PHPMD\Renderer\GitHubRenderer;
-use PHPMD\Renderer\GitLabRenderer;
-use PHPMD\Renderer\HTMLRenderer;
-use PHPMD\Renderer\JSONRenderer;
 use PHPMD\Renderer\Option\Color;
 use PHPMD\Renderer\Option\Verbose;
-use PHPMD\Renderer\SARIFRenderer;
-use PHPMD\Renderer\TextRenderer;
-use PHPMD\Renderer\XMLRenderer;
+use PHPMD\Renderer\RendererFactory;
+use PHPMD\Renderer\RendererInterface;
 use PHPMD\Rule;
 use PHPMD\Utility\ArgumentsValidator;
 use TypeError;
@@ -68,6 +61,9 @@ class CommandLineOptions
 
     /** An optional filename for the generated report. */
     private ?string $reportFile = null;
+
+    /** An optional script to load before running analysis */
+    private ?string $bootstrap = null;
 
     /** An optional filename to collect errors. */
     private ?string $errorFile = null;
@@ -222,6 +218,11 @@ class CommandLineOptions
                 case '--report-file':
                 case '--reportfile':
                     $this->reportFile = (string) $this->readValue($equalChunk, $args);
+
+                    break;
+
+                case '--bootstrap':
+                    $this->bootstrap = (string) $this->readValue($equalChunk, $args);
 
                     break;
 
@@ -415,6 +416,14 @@ class CommandLineOptions
     }
 
     /**
+     * Returns the current bootstrap file (if available) to load extra resources before analysis.
+     */
+    public function getBootstrapFile(): ?string
+    {
+        return $this->bootstrap;
+    }
+
+    /**
      * Returns the output filename for the errors or <b>null</b> when
      * the report should be displayed in STDERR.
      */
@@ -585,17 +594,9 @@ class CommandLineOptions
      * Creates a report renderer instance based on the user's command line
      * argument.
      *
-     * Valid renderers are:
-     * <ul>
-     *   <li>xml</li>
-     *   <li>html</li>
-     *   <li>text</li>
-     *   <li>json</li>
-     * </ul>
-     *
      * @throws InvalidArgumentException When the specified renderer does not exist.
      */
-    public function createRenderer(?string $reportFormat = null): AbstractRenderer
+    public function createRenderer(?string $reportFormat = null): RendererInterface
     {
         $renderer = $this->createRendererWithoutOptions($reportFormat);
 
@@ -613,103 +614,11 @@ class CommandLineOptions
     /**
      * @throws InvalidArgumentException When the specified renderer does not exist.
      */
-    private function createRendererWithoutOptions(?string $reportFormat = null): AbstractRenderer
+    private function createRendererWithoutOptions(?string $reportFormat = null): RendererInterface
     {
         $reportFormat = $reportFormat ?: $this->reportFormat;
 
-        return match ($reportFormat) {
-            'ansi' => $this->createAnsiRenderer(),
-            'checkstyle' => $this->createCheckStyleRenderer(),
-            'gitlab' => $this->createGitLabRenderer(),
-            'github' => $this->createGitHubRenderer(),
-            'html' => $this->createHtmlRenderer(),
-            'json' => $this->createJsonRenderer(),
-            'sarif' => $this->createSarifRenderer(),
-            'text' => $this->createTextRenderer(),
-            'xml' => $this->createXmlRenderer(),
-            default => $this->createCustomRenderer(),
-        };
-    }
-
-    private function createXmlRenderer(): XMLRenderer
-    {
-        return new XMLRenderer();
-    }
-
-    private function createTextRenderer(): TextRenderer
-    {
-        return new TextRenderer();
-    }
-
-    private function createAnsiRenderer(): AnsiRenderer
-    {
-        return new AnsiRenderer();
-    }
-
-    private function createGitLabRenderer(): GitLabRenderer
-    {
-        return new GitLabRenderer();
-    }
-
-    private function createGitHubRenderer(): GitHubRenderer
-    {
-        return new GitHubRenderer();
-    }
-
-    private function createHtmlRenderer(): HTMLRenderer
-    {
-        return new HTMLRenderer($this->extraLineInExcerpt);
-    }
-
-    private function createJsonRenderer(): JSONRenderer
-    {
-        return new JSONRenderer();
-    }
-
-    private function createCheckStyleRenderer(): CheckStyleRenderer
-    {
-        return new CheckStyleRenderer();
-    }
-
-    private function createSarifRenderer(): SARIFRenderer
-    {
-        return new SARIFRenderer();
-    }
-
-    /**
-     * @throws InvalidArgumentException
-     */
-    private function createCustomRenderer(): AbstractRenderer
-    {
-        if (!$this->reportFormat) {
-            throw new InvalidArgumentException(
-                'Can\'t create report with empty format.',
-                self::INPUT_ERROR
-            );
-        }
-
-        if (class_exists($this->reportFormat)) {
-            return new $this->reportFormat();
-        }
-
-        // Try to load a custom renderer
-        $fileName = strtr($this->reportFormat, '_\\', '//') . '.php';
-
-        $fileHandle = @fopen($fileName, 'rb', true);
-        if (!is_resource($fileHandle)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Can\'t find the custom report class: %s',
-                    $this->reportFormat
-                ),
-                self::INPUT_ERROR
-            );
-        }
-        @fclose($fileHandle);
-
-        include_once $fileName;
-
-        return new $this->reportFormat();
+        return (new RendererFactory())->getRenderer($reportFormat);
     }
 
     /**

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -29,7 +29,7 @@ use Throwable;
 abstract class AbstractStaticTestCase extends TestCase
 {
     /** Directory with test files. */
-    private static string $filesDirectory;
+    protected static string $filesDirectory;
 
     /**
      * Original directory is used to reset a changed working directory.

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -30,6 +30,7 @@ use PHPMD\Renderer\GitHubRenderer;
 use PHPMD\Renderer\GitLabRenderer;
 use PHPMD\Renderer\HTMLRenderer;
 use PHPMD\Renderer\JSONRenderer;
+use PHPMD\Renderer\RendererInterface;
 use PHPMD\Renderer\SARIFRenderer;
 use PHPMD\Renderer\TextRenderer;
 use PHPMD\Renderer\XMLRenderer;
@@ -739,7 +740,6 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * @throws Throwable
-     * @throws Throwable
      * @dataProvider dataProviderCreateRendererThrowsException
      */
     public function testCreateRendererThrowsException(string $reportFormat): void
@@ -759,9 +759,21 @@ class CommandLineOptionsTest extends AbstractTestCase
      */
     public static function dataProviderCreateRendererThrowsException(): array
     {
+        $defaultExceptionMessage = 'No renderer supports the format';
+
+        $invalidRendererClass = 'PHPMD\\Test\\Renderer\\InvalidRenderer';
+
         return [
-            [''],
-            ['PHPMD\\Test\\Renderer\\NotExistsRenderer'],
+            ['', $defaultExceptionMessage],
+            ['PHPMD\\Test\\Renderer\\NotExistsRenderer', $defaultExceptionMessage],
+            [
+                $invalidRendererClass,
+                sprintf(
+                    'Renderer class "%s" does not implement "%s".',
+                    $invalidRendererClass,
+                    RendererInterface::class
+                ),
+            ],
         ];
     }
 

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -704,6 +704,7 @@ class CommandLineOptionsTest extends AbstractTestCase
      * @param class-string $expectedClass
      * @throws Throwable
      * @dataProvider dataProviderCreateRenderer
+     * @covers \PHPMD\Renderer\RendererFactory::getRenderer
      */
     public function testCreateRenderer(string $reportFormat, $expectedClass): void
     {
@@ -742,6 +743,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @throws Throwable
      * @dataProvider dataProviderCreateRendererThrowsException
+     * @covers \PHPMD\Renderer\RendererFactory::getCustomRenderer
      */
     public function testCreateRendererThrowsException(string $reportFormat, string $expectedExceptionMessage): void
     {

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -742,12 +742,14 @@ class CommandLineOptionsTest extends AbstractTestCase
      * @throws Throwable
      * @dataProvider dataProviderCreateRendererThrowsException
      */
-    public function testCreateRendererThrowsException(string $reportFormat): void
+    public function testCreateRendererThrowsException(string $reportFormat, string $expectedExceptionMessage): void
     {
         self::expectExceptionObject(new InvalidArgumentException(
-            "No renderer supports the format",
-            code: 23,
+            $expectedExceptionMessage,
+            code: RendererInterface::INPUT_ERROR,
         ));
+
+        require_once self::$filesDirectory . '/PHPMD/Test/Renderer/InvalidRenderer.php';
 
         $args = [__FILE__, __FILE__, $reportFormat, 'codesize'];
         $opts = new CommandLineOptions($args);
@@ -759,13 +761,14 @@ class CommandLineOptionsTest extends AbstractTestCase
      */
     public static function dataProviderCreateRendererThrowsException(): array
     {
-        $defaultExceptionMessage = 'No renderer supports the format';
+        $defaultExceptionMessage = 'No renderer supports the format "%s".';
 
+        $notExistsRendererClass = 'PHPMD\\Test\\Renderer\\NotExistsRenderer';
         $invalidRendererClass = 'PHPMD\\Test\\Renderer\\InvalidRenderer';
 
         return [
-            ['', $defaultExceptionMessage],
-            ['PHPMD\\Test\\Renderer\\NotExistsRenderer', $defaultExceptionMessage],
+            ['', sprintf($defaultExceptionMessage, '')],
+            [$notExistsRendererClass, sprintf($defaultExceptionMessage, $notExistsRendererClass)],
             [
                 $invalidRendererClass,
                 sprintf(

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -708,6 +708,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     public function testCreateRenderer(string $reportFormat, $expectedClass): void
     {
         require_once self::$filesDirectory . '/PHPMD/Test/Renderer/NamespaceRenderer.php';
+
         require_once self::$filesDirectory . '/PHPMD/Test/Renderer/PEARRenderer.php';
 
         $args = [__FILE__, __FILE__, $reportFormat, 'codesize'];

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -66,12 +66,12 @@ class CommandLineOptionsTest extends AbstractTestCase
     {
         $args = ['foo.php', __FILE__, 'text', 'design', '-vvv'];
         $opts = new CommandLineOptions($args);
-        $renbderer = $opts->createRenderer();
+        $renderer = $opts->createRenderer();
 
         $verbosityExtractor = new ReflectionProperty(TextRenderer::class, 'verbosityLevel');
         $verbosityExtractor->setAccessible(true);
 
-        $verbosityLevel = $verbosityExtractor->getValue($renbderer);
+        $verbosityLevel = $verbosityExtractor->getValue($renderer);
 
         static::assertSame(OutputInterface::VERBOSITY_DEBUG, $verbosityLevel);
     }
@@ -702,11 +702,13 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @param class-string $expectedClass
      * @throws Throwable
-     * @throws Throwable
      * @dataProvider dataProviderCreateRenderer
      */
     public function testCreateRenderer(string $reportFormat, $expectedClass): void
     {
+        require_once self::$filesDirectory . '/PHPMD/Test/Renderer/NamespaceRenderer.php';
+        require_once self::$filesDirectory . '/PHPMD/Test/Renderer/PEARRenderer.php';
+
         $args = [__FILE__, __FILE__, $reportFormat, 'codesize'];
         $opts = new CommandLineOptions($args);
 
@@ -743,7 +745,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     public function testCreateRendererThrowsException(string $reportFormat): void
     {
         self::expectExceptionObject(new InvalidArgumentException(
-            "Can't",
+            "No renderer supports the format",
             code: 23,
         ));
 

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -329,17 +329,18 @@ class CommandTest extends AbstractTestCase
         static::assertIsResource($stream);
         $this->stderrStreamFilter = $stream;
 
+        $format = 'FORMAT';
         Command::main(
             [
                 __FILE__,
                 self::createFileUri('source/source_with_npath_violation.php'),
-                "''",
+                $format,
                 'naming',
             ]
         );
 
         static::assertStringContainsString(
-            'Can\'t find the custom report class: ',
+            sprintf('No renderer supports the format "%s"', $format),
             StreamFilter::$streamHandle
         );
     }
@@ -352,11 +353,12 @@ class CommandTest extends AbstractTestCase
         $file = tempnam(sys_get_temp_dir(), 'err');
         static::assertIsString($file);
 
+        $format = 'FORMAT';
         Command::main(
             [
                 __FILE__,
                 self::createFileUri('source/source_with_npath_violation.php'),
-                "''",
+                $format,
                 'naming',
                 '--error-file',
                 $file,
@@ -366,7 +368,7 @@ class CommandTest extends AbstractTestCase
         $errors = (string) file_get_contents($file);
         unlink($file);
 
-        static::assertSame("Can't find the custom report class: ''" . PHP_EOL, $errors);
+        static::assertSame(sprintf('No renderer supports the format "%s".' . PHP_EOL, $format), $errors);
 
         $file = tempnam(sys_get_temp_dir(), 'err');
         static::assertIsString($file);
@@ -375,7 +377,7 @@ class CommandTest extends AbstractTestCase
             [
                 __FILE__,
                 self::createFileUri('source/source_with_npath_violation.php'),
-                "''",
+                $format,
                 'naming',
                 '--error-file',
                 $file,
@@ -386,23 +388,7 @@ class CommandTest extends AbstractTestCase
         $errors = (string) file_get_contents($file);
         unlink($file);
 
-        static::assertStringStartsWith("Can't find the custom report class: ''" . PHP_EOL, $errors);
-        static::assertMatchesRegularExpression(
-            '`' . preg_quote(str_replace(
-                '/',
-                DIRECTORY_SEPARATOR,
-                'src/main/php/PHPMD/TextUI/CommandLineOptions.php:'
-            ), '`') . '\d+' . PHP_EOL . '`',
-            $errors
-        );
-        static::assertMatchesRegularExpression(
-            '`' . preg_quote(str_replace(
-                '/',
-                DIRECTORY_SEPARATOR,
-                'src/main/php/PHPMD/TextUI/CommandLineOptions.php'
-            ), '`') . '\(\d+\): PHPMD\\\\TextUI\\\\CommandLineOptions->createCustomRenderer\(\)`',
-            $errors
-        );
+        static::assertStringStartsWith(sprintf('No renderer supports the format "%s"', $format), $errors);
     }
 
     /**

--- a/src/test/resources/files/PHPMD/Test/Renderer/InvalidRenderer.php
+++ b/src/test/resources/files/PHPMD/Test/Renderer/InvalidRenderer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPMD\Test\Renderer;
+
+use PHPMD\AbstractRenderer;
+use PHPMD\Report;
+
+class InvalidRenderer extends AbstractRenderer
+{
+    public function renderReport(Report $report): void
+    {
+    }
+}

--- a/src/test/resources/files/PHPMD/Test/Renderer/InvalidRenderer.php
+++ b/src/test/resources/files/PHPMD/Test/Renderer/InvalidRenderer.php
@@ -2,10 +2,9 @@
 
 namespace PHPMD\Test\Renderer;
 
-use PHPMD\AbstractRenderer;
 use PHPMD\Report;
 
-class InvalidRenderer extends AbstractRenderer
+class InvalidRenderer
 {
     public function renderReport(Report $report): void
     {

--- a/src/test/resources/files/PHPMD/Test/Renderer/NamespaceRenderer.php
+++ b/src/test/resources/files/PHPMD/Test/Renderer/NamespaceRenderer.php
@@ -18,9 +18,10 @@
 namespace PHPMD\Test\Renderer;
 
 use PHPMD\AbstractRenderer;
+use PHPMD\Renderer\RendererInterface;
 use PHPMD\Report;
 
-class NamespaceRenderer extends AbstractRenderer
+class NamespaceRenderer extends AbstractRenderer implements RendererInterface
 {
     public function renderReport(Report $report): void
     {

--- a/src/test/resources/files/PHPMD/Test/Renderer/PEARRenderer.php
+++ b/src/test/resources/files/PHPMD/Test/Renderer/PEARRenderer.php
@@ -17,7 +17,7 @@
 
 use PHPMD\Report;
 
-class PHPMD_Test_Renderer_PEARRenderer extends PHPMD\AbstractRenderer
+class PHPMD_Test_Renderer_PEARRenderer extends PHPMD\AbstractRenderer implements PHPMD\Renderer\RendererInterface
 {
     public function renderReport(Report $report): void
     {


### PR DESCRIPTION
Type: feature / refactoring 
Issue: Resolves #1196 
Breaking change: yes/no (if yes explain why)

- Extract Renderer instance creation from `\PHPMD\TextUI\CommandLineOptions` and add it in `\PHPMD\Renderer\RendererFactory`
- Add `--bootstrap` option on  `\PHPMD\TextUI\CommandLineOptions` to have ability to load whatever we need before running analysis, that include of course external autoloader (in charge to load extra Renderer classes)
- Load any extra Custom Renderer that follow PSR4 rule by new method `\PHPMD\Renderer\RendererFactory::getRenderer()`
- Introduces a `\PHPMD\Renderer\RendererInterface` contract that all renderers should follow, even if they do not or can't extends the `\PHPMD\AbstractRenderer` class

