### PR TITLE
fix(bin): printing php setup for cli arguments message

### DIFF
--- a/src/bin/phpmd
+++ b/src/bin/phpmd
@@ -51,7 +51,7 @@ if (extension_loaded('suhosin') && is_numeric(ini_get('suhosin.memory_limit'))) 
 
 // Check php setup for cli arguments
 if (!isset($_SERVER['argv']) && !isset($argv)) {
-    fwrite(STDERR, 'Please enable the "register_argc_argv" directive in your php.ini', PHP_EOL);
+    fwrite(STDERR, 'Please enable the "register_argc_argv" directive in your php.ini' . PHP_EOL);
     exit(1);
 } elseif (!isset($argv)) {
     $argv = $_SERVER['argv'];


### PR DESCRIPTION
Type: bugfix
Breaking change: no 

Hi!

The third argument of ```fwrite``` function is length, so passing there an PHP_EOL const will work with strict types disabled, but it is a typo. I fixed this typo by concatenated message with constant, instead of passing it as a length