### PR TITLE
feat: add wildcard option for static access

### DIFF
--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -76,8 +76,7 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
             return strpos($exception, '*') !== false;
         });
         foreach ($wildcardExceptions as $wildcardException) {
-            $wildcardException = str_replace('*', '.*', $wildcardException);
-            $wildcardException = str_replace('\\', '\\\\', $wildcardException);
+            $wildcardException = str_replace(array('*', '\\'), array('.*', '\\\\'), $wildcardException);
             if (preg_match('/' . $wildcardException . '/', $className)) {
                 return true;
             }

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -66,7 +66,21 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
 
     protected function isExcludedFromAnalysis($className, $exceptions)
     {
-        return in_array(trim($className, " \t\n\r\0\x0B\\"), $exceptions);
+        $className = trim($className, " \t\n\r\0\x0B\\");
+
+        if (in_array($className, $exceptions)) {
+            return true;
+        }
+
+        $wildcardExceptions = array_filter($exceptions, fn ($exception) => strpos($exception, '*') !== false);
+        foreach ($wildcardExceptions as $wildcardException) {
+            $wildcardException = str_replace(['*', '\\'], ['.*', '\\\\'], $wildcardException);
+            if (preg_match('/' . $wildcardException . '/', $className)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     protected function isStaticMethodCall(AbstractNode $methodCall)

--- a/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/StaticAccess.php
@@ -72,9 +72,12 @@ class StaticAccess extends AbstractRule implements MethodAware, FunctionAware
             return true;
         }
 
-        $wildcardExceptions = array_filter($exceptions, fn ($exception) => strpos($exception, '*') !== false);
+        $wildcardExceptions = array_filter($exceptions, function ($exception) {
+            return strpos($exception, '*') !== false;
+        });
         foreach ($wildcardExceptions as $wildcardException) {
-            $wildcardException = str_replace(['*', '\\'], ['.*', '\\\\'], $wildcardException);
+            $wildcardException = str_replace('*', '.*', $wildcardException);
+            $wildcardException = str_replace('\\', '\\\\', $wildcardException);
             if (preg_match('/' . $wildcardException . '/', $className)) {
                 return true;
             }

--- a/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
+++ b/src/test/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
@@ -53,6 +53,30 @@ class StaticAccessTest extends AbstractTest
         $rule->apply($this->getMethod());
     }
 
+    public function testRuleNotAppliesToStaticMethodAccessWhenExcludedViaWildCard1()
+    {
+        $rule = new StaticAccess();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->addProperty('exceptions', 'Illuminate\Support\*');
+        $rule->apply($this->getMethod());
+    }
+
+    public function testRuleNotAppliesToStaticMethodAccessWhenExcludedViaWildCard2()
+    {
+        $rule = new StaticAccess();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->addProperty('exceptions', '*\Support\*');
+        $rule->apply($this->getMethod());
+    }
+
+    public function testRuleNotAppliesToStaticMethodAccessWhenExcludedViaWildCard3()
+    {
+        $rule = new StaticAccess();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->addProperty('exceptions', 'Illuminate\*');
+        $rule->apply($this->getMethod());
+    }
+
     public function testRuleAppliesToStaticMethodAccess()
     {
         $rule = new StaticAccess();

--- a/src/test/resources/files/Rule/CleanCode/StaticAccess/testRuleNotAppliesToStaticMethodAccessWhenExcludedViaWildCard1.php
+++ b/src/test/resources/files/Rule/CleanCode/StaticAccess/testRuleNotAppliesToStaticMethodAccessWhenExcludedViaWildCard1.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace Illuminate\Support;
+
+class Foo
+{
+    public function testRuleNotAppliesToStaticMethodAccessWhenExcludedViaWildCard1()
+    {
+        Excluded::foo();
+    }
+}

--- a/src/test/resources/files/Rule/CleanCode/StaticAccess/testRuleNotAppliesToStaticMethodAccessWhenExcludedViaWildCard2.php
+++ b/src/test/resources/files/Rule/CleanCode/StaticAccess/testRuleNotAppliesToStaticMethodAccessWhenExcludedViaWildCard2.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace Illuminate\Support;
+
+class Foo
+{
+    public function testRuleNotAppliesToStaticMethodAccessWhenExcludedViaWildCard2()
+    {
+        Excluded::foo();
+    }
+}

--- a/src/test/resources/files/Rule/CleanCode/StaticAccess/testRuleNotAppliesToStaticMethodAccessWhenExcludedViaWildCard3.php
+++ b/src/test/resources/files/Rule/CleanCode/StaticAccess/testRuleNotAppliesToStaticMethodAccessWhenExcludedViaWildCard3.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace Illuminate\Support;
+
+class Foo
+{
+    public function testRuleNotAppliesToStaticMethodAccessWhenExcludedViaWildCard3()
+    {
+        Excluded::foo();
+    }
+}


### PR DESCRIPTION
The title is the description.

Example 1:
```xml
    <rule ref="rulesets/cleancode.xml/StaticAccess">
        <properties>
            <property name="exceptions">
                <value>
                    \Illuminate\Support\*,
                </value>
            </property>
        </properties>
    </rule>
```

Example 2:

```xml
   <rule ref="rulesets/cleancode.xml/StaticAccess">
        <properties>
            <property name="exceptions">
                <value>
                    *\Support\*,
                </value>
            </property>
        </properties>
    </rule>
```

Example 3:

```xml
    <rule ref="rulesets/cleancode.xml/StaticAccess">
        <properties>
            <property name="exceptions">
                <value>
                    \Illuminate\*,
                </value>
            </property>
        </properties>
    </rule>
```