### PR TITLE
Update tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "php": "^8.1",
     "ext-xml": "*",
     "composer/xdebug-handler": "^3.0",
-    "pdepend/pdepend": "3.x-dev#625560a5915047e6b2a1047579eb1505709ababc"
+    "pdepend/pdepend": "3.x-dev#c21f168eccda0175040c9425b9b7c330176d60c4"
   },
   "require-dev": {
     "ext-json": "*",
@@ -49,8 +49,8 @@
     "friendsofphp/php-cs-fixer": "^3.57",
     "gregwar/rst": "^1.0",
     "mikey179/vfsstream": "^1.6.8",
-    "phpstan/phpstan": "~1.11.0",
-    "phpunit/phpunit": "^10.5.20",
+    "phpstan/phpstan": "~1.12.0",
+    "phpunit/phpunit": "^10.5.20,<10.5.32",
     "squizlabs/php_codesniffer": "^3.8.0"
   },
   "autoload": {

--- a/src/main/php/PHPMD/AbstractNode.php
+++ b/src/main/php/PHPMD/AbstractNode.php
@@ -309,8 +309,6 @@ abstract class AbstractNode
     /**
      * Returns the full qualified name of a class, an interface, a method or
      * a function.
-     *
-     * @return ?string
      */
     abstract public function getFullQualifiedName(): ?string;
 

--- a/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
+++ b/src/main/php/PHPMD/Cache/Model/ResultCacheState.php
@@ -12,7 +12,18 @@ use PHPMD\Utility\Paths;
 class ResultCacheState
 {
     /**
-     * @param array{files?: array<string, array{hash: string, violations?: list<array{metric: mixed, namespaceName: ?string, className: ?string, methodName: ?string, functionName: ?string, description: string, beginLine: int, endLine: int, rule: string, args: ?array<int, string>}>}>} $state
+     * @param array{files?: array<string, array{hash: string, violations?: list<array{
+     *  metric: mixed,
+     *  namespaceName: ?string,
+     *  className: ?string,
+     *  methodName: ?string,
+     *  functionName: ?string,
+     *  description: string,
+     *  beginLine: int,
+     *  endLine: int,
+     *  rule: string,
+     *  args: ?array<int, string>
+     * }>}>} $state
      */
     public function __construct(
         private readonly ResultCacheKey $cacheKey,
@@ -26,7 +37,18 @@ class ResultCacheState
     }
 
     /**
-     * @return list<array{metric: mixed, namespaceName: ?string, className: ?string, methodName: ?string, functionName: ?string, description: string, beginLine: int, endLine: int, rule: string, args: ?array<int, string>}>
+     * @return list<array{
+     *  metric: mixed,
+     *  namespaceName: ?string,
+     *  className: ?string,
+     *  methodName: ?string,
+     *  functionName: ?string,
+     *  description: string,
+     *  beginLine: int,
+     *  endLine: int,
+     *  rule: string,
+     *  args: ?array<int, string>
+     * }>
      */
     public function getViolations(string $filePath): array
     {
@@ -38,7 +60,18 @@ class ResultCacheState
     }
 
     /**
-     * @param list<array{metric: mixed, namespaceName: ?string, className: ?string, methodName: ?string, functionName: ?string, description: string, beginLine: int, endLine: int, rule: string, args: ?array<int, string>}> $violations
+     * @param list<array{
+     *  metric: mixed,
+     *  namespaceName: ?string,
+     *  className: ?string,
+     *  methodName: ?string,
+     *  functionName: ?string,
+     *  description: string,
+     *  beginLine: int,
+     *  endLine: int,
+     *  rule: string,
+     *  args: ?array<int, string>
+     * }> $violations
      */
     public function setViolations(string $filePath, array $violations): void
     {

--- a/src/main/php/PHPMD/Node/ASTNode.php
+++ b/src/main/php/PHPMD/Node/ASTNode.php
@@ -101,8 +101,6 @@ final class ASTNode extends AbstractNode
     /**
      * Returns the full qualified name of a class, an interface, a method or
      * a function.
-     *
-     * @return ?string
      */
     public function getFullQualifiedName(): ?string
     {

--- a/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
+++ b/src/main/php/PHPMD/Rule/AbstractLocalVariable.php
@@ -187,7 +187,6 @@ abstract class AbstractLocalVariable extends AbstractRule
     }
 
     /**
-     * @return ?string
      * @throws OutOfBoundsException
      */
     private function getParentMemberPrimaryPrefixImage(string $image, ASTPropertyPostfix $postfix): ?string

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -346,7 +346,9 @@ class CommandLineOptions
                 case '--reportfile-text':
                 case '--reportfile-xml':
                     preg_match('(^\-\-reportfile\-(checkstyle|github|gitlab|html|json|sarif|text|xml)$)', $arg, $match);
-                    $this->reportFiles[$match[1]] = (string) $this->readValue($equalChunk, $args);
+                    if (isset($match[1])) {
+                        $this->reportFiles[$match[1]] = (string) $this->readValue($equalChunk, $args);
+                    }
 
                     break;
 

--- a/src/main/php/PHPMD/Writer/StreamWriter.php
+++ b/src/main/php/PHPMD/Writer/StreamWriter.php
@@ -41,7 +41,7 @@ final class StreamWriter extends AbstractWriter
      */
     public function __construct($streamResourceOrUri)
     {
-        if (is_resource($streamResourceOrUri)) {
+        if (!is_string($streamResourceOrUri)) {
             $this->stream = $streamResourceOrUri;
 
             return;

--- a/src/test/php/PHPMD/AbstractStaticTestCase.php
+++ b/src/test/php/PHPMD/AbstractStaticTestCase.php
@@ -186,8 +186,11 @@ abstract class AbstractStaticTestCase extends TestCase
      *                                          if set to a closure, the closure is applied on the actual output array.
      * @throws Throwable
      */
-    public static function assertJsonEquals(string $actualOutput, string $expectedFileName, bool $removeDynamicValues = true): void
-    {
+    public static function assertJsonEquals(
+        string $actualOutput,
+        string $expectedFileName,
+        bool $removeDynamicValues = true
+    ): void {
         $actual = json_decode($actualOutput, true);
         static::assertIsArray($actual);
         // Remove dynamic timestamp and duration attribute

--- a/src/test/php/PHPMD/AbstractTestCase.php
+++ b/src/test/php/PHPMD/AbstractTestCase.php
@@ -254,8 +254,12 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      *
      * @param iterable<RuleViolation> $violations
      */
-    protected function getViolationFailureMessage(string $file, int $expectedInvokes, int $actualInvokes, iterable $violations): string
-    {
+    protected function getViolationFailureMessage(
+        string $file,
+        int $expectedInvokes,
+        int $actualInvokes,
+        iterable $violations
+    ): string {
         return basename($file) . " failed:\n" .
             "Expected $expectedInvokes violation" . ($expectedInvokes !== 1 ? 's' : '') . "\n" .
             "But $actualInvokes violation" . ($actualInvokes !== 1 ? 's' : '') . ' raised' .

--- a/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -191,8 +191,11 @@ class TooManyPublicMethodsTest extends AbstractTestCase
      * @param array<string> $privateMethods
      * @throws Throwable
      */
-    private function createClassMock(int $numberOfMethods, array $publicMethods = [], array $privateMethods = []): ClassNode
-    {
+    private function createClassMock(
+        int $numberOfMethods,
+        array $publicMethods = [],
+        array $privateMethods = []
+    ): ClassNode {
         $class = $this->getClassMock('npm', $numberOfMethods);
 
         $class->expects(static::any())


### PR DESCRIPTION
Type: refactoring
Breaking change: no

PHP-cs-fixer: Now detects a few more redundant return types.
phpstan: needed a negation and a check for successful preg_match.
phpcs: finds some more long lines to complain about
phpunit: 10.5.32 has breaking changes that makes in incompatible with paratest on PHP 8.1 see https://github.com/paratestphp/paratest/pull/883#issuecomment-2337988045 for details