### PR TITLE
Allow throwing exceptions unchecked in tests

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,3 +10,7 @@ parameters:
         check:
             missingCheckedExceptionInThrows: true
             tooWideThrowType: true
+    ignoreErrors:
+        -
+            identifier: missingType.checkedException
+            path: tests/*

--- a/tests/php/PHPMD/AbstractStaticTestCase.php
+++ b/tests/php/PHPMD/AbstractStaticTestCase.php
@@ -21,7 +21,6 @@ namespace PHPMD;
 use Closure;
 use ErrorException;
 use PHPUnit\Framework\TestCase;
-use Throwable;
 
 /**
  * Abstract base class for PHPMD test cases.
@@ -48,8 +47,6 @@ abstract class AbstractStaticTestCase extends TestCase
     /**
      * This method initializes the test environment, it configures the files
      * directory and sets the include_path for svn versions.
-     *
-     * @throws Throwable
      */
     public static function setUpBeforeClass(): void
     {
@@ -103,7 +100,6 @@ abstract class AbstractStaticTestCase extends TestCase
     /**
      * Returns the absolute path for a test resource for the current test.
      *
-     * @throws Throwable
      * @since 1.1.0
      */
     protected static function createCodeResourceUriForTest(): string
@@ -133,7 +129,7 @@ abstract class AbstractStaticTestCase extends TestCase
      * Returns the absolute path for a test resource for the current test.
      *
      * @param string $localPath The local/relative file location
-     * @throws Throwable
+     *
      * @since 1.1.0
      */
     protected static function createResourceUriForTest(string $localPath): string
@@ -149,7 +145,6 @@ abstract class AbstractStaticTestCase extends TestCase
      *
      * @param string $actualOutput Generated xml output.
      * @param string $expectedFileName File with expected xml result.
-     * @throws Throwable
      */
     public static function assertXmlEquals(string $actualOutput, string $expectedFileName): void
     {
@@ -184,7 +179,6 @@ abstract class AbstractStaticTestCase extends TestCase
      * @param string $expectedFileName File with expected JSON result.
      * @param bool $removeDynamicValues If set to `false`, the actual output is not normalized,
      *                                          if set to a closure, the closure is applied on the actual output array.
-     * @throws Throwable
      */
     public static function assertJsonEquals(
         string $actualOutput,
@@ -244,8 +238,6 @@ abstract class AbstractStaticTestCase extends TestCase
 
     /**
      * Creates a file uri for a temporary test file.
-     *
-     * @throws Throwable
      */
     protected static function createTempFileUri(?string $fileName = null): string
     {

--- a/tests/php/PHPMD/AbstractTestCase.php
+++ b/tests/php/PHPMD/AbstractTestCase.php
@@ -41,7 +41,6 @@ use PHPMD\Stubs\RuleStub;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionProperty;
-use Throwable;
 
 /**
  * Abstract base class for PHPMD test cases.
@@ -115,8 +114,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Returns the first class found in a source file related to the calling
      * test method.
-     *
-     * @throws Throwable
      */
     protected function getClass(): ClassNode
     {
@@ -130,8 +127,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Returns the first interface found in a source file related to the calling
      * test method.
-     *
-     * @throws Throwable
      */
     protected function getInterface(): InterfaceNode
     {
@@ -142,9 +137,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
         );
     }
 
-    /**
-     * @throws Throwable
-     */
     protected function getTrait(): TraitNode
     {
         return new TraitNode(
@@ -154,9 +146,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
         );
     }
 
-    /**
-     * @throws Throwable
-     */
     protected function getEnum(): EnumNode
     {
         return new EnumNode(
@@ -169,8 +158,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Returns the first method found in a source file related to the calling
      * test method.
-     *
-     * @throws Throwable
      */
     protected function getMethod(): MethodNode
     {
@@ -183,8 +170,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Returns the first function found in a source files related to the calling
      * test method.
-     *
-     * @throws Throwable
      */
     protected function getFunction(): FunctionNode
     {
@@ -198,7 +183,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Returns the first method or function node for a given test file.
      *
-     * @throws Throwable
      * @since 2.8.3
      */
     protected function getNodeForTestFile(string $file): FunctionNode|MethodNode
@@ -227,7 +211,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * @param int $expectedInvokes Count of expected invocations.
      * @param string $file Test file containing a method with the same name to be tested.
      * @throws ExpectationFailedException
-     * @throws Throwable
      */
     protected function expectRuleHasViolationsForFile(Rule $rule, int $expectedInvokes, string $file): void
     {
@@ -274,7 +257,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Return a human-friendly summary for a list of violations.
      *
      * @param iterable<RuleViolation> $violations
-     * @throws Throwable
      */
     protected function getViolationsSummary(iterable $violations): string
     {
@@ -304,7 +286,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Returns the absolute path for a test resource for the current test.
      *
-     * @throws Throwable
      * @since 1.1.0
      */
     protected static function createCodeResourceUriForTest(): string
@@ -318,7 +299,7 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Returns the absolute path for a test resource for the current test.
      *
      * @param string $localPath The local/relative file location
-     * @throws Throwable
+     *
      * @since 1.1.0
      */
     protected static function createResourceUriForTest(string $localPath): string
@@ -351,7 +332,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Creates a mocked class node instance.
      *
      * @return ClassNode&MockObject
-     * @throws Throwable
      */
     protected function getClassMock(?string $metric = null, ?int $value = null)
     {
@@ -373,7 +353,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Creates a mocked method node instance.
      *
      * @return MethodNode&MockObject
-     * @throws Throwable
      */
     protected function getMethodMock(?string $metric = null, ?int $value = null)
     {
@@ -388,7 +367,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      *
      * @param ?string $metric The metric acronym used by PHP_Depend.
      * @param ?numeric $value The expected metric return value.
-     * @throws Throwable
      */
     protected function createFunctionMock(?string $metric = null, mixed $value = null): FunctionNode&MockObject
     {
@@ -408,7 +386,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      *
      * @param int $expectedInvokes Number of expected invokes.
      * @return MockObject&Report
-     * @throws Throwable
      */
     protected function getReportMock(int $expectedInvokes = -1)
     {
@@ -431,8 +408,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
 
     /**
      * Get a mocked report with one violation
-     *
-     * @throws Throwable
      */
     public function getReportWithOneViolation(): Report
     {
@@ -443,7 +418,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Get a mocked report with no violation
      *
      * @return MockObject&Report
-     * @throws Throwable
      */
     public function getReportWithNoViolation()
     {
@@ -452,8 +426,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
 
     /**
      * Get a mocked report with at least one violation
-     *
-     * @throws Throwable
      */
     public function getReportWithAtLeastOneViolation(): Report
     {
@@ -464,7 +436,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Creates a mocked {@link \PHPMD\AbstractRule} instance.
      *
      * @return AbstractRule&MockObject
-     * @throws Throwable
      */
     protected function getRuleMock()
     {
@@ -478,7 +449,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      *                                                            once.
      * @param int|string $count How often should apply() be called?
      * @return MockObject&RuleSet
-     * @throws Throwable
      */
     protected function getRuleSetMock($expectedClass = null, int|string $count = '*')
     {
@@ -512,7 +482,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * @param object|null $rule The rule object to use.
      * @param string|null $description The violation description to use.
      * @return MockObject&RuleViolation
-     * @throws Throwable
      */
     protected function getRuleViolationMock(
         string $fileName = '/foo/bar.php',
@@ -560,7 +529,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * Creates a mocked rule violation instance.
      *
      * @return MockObject&ProcessingError
-     * @throws Throwable
      */
     protected function getErrorMock(
         string $file = '/foo/baz.php',
@@ -595,7 +563,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * @param ?string $metric The metric acronym used by PHP_Depend.
      * @param ?numeric $value The expected metric return value.
      * @return (FunctionNode|MethodNode)&MockObject
-     * @throws Throwable
      */
     private function createFunctionOrMethodMock(
         string $mockBuilder,
@@ -643,7 +610,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * @param Iterator<T> $nodes
      * @return T
      * @throws ErrorException
-     * @throws Throwable
      */
     private function getNodeForCallingTestCase(Iterator $nodes): ASTNode
     {
@@ -658,7 +624,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      * in that file.
      *
      * @throws ErrorException
-     * @throws Throwable
      */
     private function parseSource(string $sourceFile): ASTNamespace
     {

--- a/tests/php/PHPMD/Baseline/BaselineFileFinderTest.php
+++ b/tests/php/PHPMD/Baseline/BaselineFileFinderTest.php
@@ -5,7 +5,6 @@ namespace PHPMD\Baseline;
 use PHPMD\AbstractTestCase;
 use PHPMD\TextUI\CommandLineOptions;
 use RuntimeException;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Baseline\BaselineFileFinder
@@ -14,7 +13,6 @@ use Throwable;
 class BaselineFileFinderTest extends AbstractTestCase
 {
     /**
-     * @throws Throwable
      * @covers ::find
      */
     public function testShouldFindFileFromCLI(): void
@@ -25,7 +23,6 @@ class BaselineFileFinderTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::existingFile
      * @covers ::find
      */
@@ -44,7 +41,6 @@ class BaselineFileFinderTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::find
      * @covers ::nullOrThrow
      */
@@ -60,7 +56,6 @@ class BaselineFileFinderTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::find
      * @covers ::nullOrThrow
      */
@@ -72,7 +67,6 @@ class BaselineFileFinderTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::existingFile
      * @covers ::find
      * @covers ::nullOrThrow
@@ -85,7 +79,6 @@ class BaselineFileFinderTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::find
      * @covers ::notNull
      * @covers ::nullOrThrow

--- a/tests/php/PHPMD/Baseline/BaselineSetFactoryTest.php
+++ b/tests/php/PHPMD/Baseline/BaselineSetFactoryTest.php
@@ -6,7 +6,6 @@ use PHPMD\AbstractTestCase;
 use PHPMD\Rule\CleanCode\MissingImport;
 use PHPMD\Rule\CleanCode\UndefinedVariable;
 use RuntimeException;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Baseline\BaselineSetFactory
@@ -14,7 +13,6 @@ use Throwable;
 class BaselineSetFactoryTest extends AbstractTestCase
 {
     /**
-     * @throws Throwable
      * @covers ::fromFile
      */
     public function testFromFileShouldSucceed(): void
@@ -30,7 +28,6 @@ class BaselineSetFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::fromFile
      */
     public function testFromFileShouldSucceedWithBackAndForwardSlashes(): void
@@ -46,7 +43,6 @@ class BaselineSetFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::fromFile
      */
     public function testFromFileShouldThrowExceptionForMissingFile(): void
@@ -59,7 +55,6 @@ class BaselineSetFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::fromFile
      */
     public function testFromFileShouldThrowExceptionForOnInvalidXML(): void
@@ -72,7 +67,6 @@ class BaselineSetFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::fromFile
      */
     public function testFromFileViolationMissingRuleShouldThrowException(): void
@@ -85,7 +79,6 @@ class BaselineSetFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::fromFile
      */
     public function testFromFileViolationMissingFileShouldThrowException(): void

--- a/tests/php/PHPMD/Baseline/BaselineSetTest.php
+++ b/tests/php/PHPMD/Baseline/BaselineSetTest.php
@@ -3,7 +3,6 @@
 namespace PHPMD\Baseline;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Baseline\BaselineSet
@@ -11,7 +10,6 @@ use Throwable;
 class BaselineSetTest extends AbstractTestCase
 {
     /**
-     * @throws Throwable
      * @covers ::addEntry
      * @covers ::contains
      */
@@ -24,7 +22,6 @@ class BaselineSetTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::addEntry
      * @covers ::contains
      */
@@ -37,7 +34,6 @@ class BaselineSetTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::addEntry
      * @covers ::contains
      */
@@ -55,7 +51,6 @@ class BaselineSetTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::addEntry
      * @covers ::contains
      */
@@ -68,7 +63,6 @@ class BaselineSetTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::addEntry
      * @covers ::contains
      */

--- a/tests/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/tests/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -6,7 +6,6 @@ use PHPMD\AbstractTestCase;
 use PHPMD\Rule;
 use PHPMD\RuleViolation;
 use PHPUnit\Framework\MockObject\MockObject;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Baseline\BaselineValidator
@@ -20,9 +19,6 @@ class BaselineValidatorTest extends AbstractTestCase
     /** @var MockObject&RuleViolation */
     private $violation;
 
-    /**
-     * @throws Throwable
-     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -35,7 +31,6 @@ class BaselineValidatorTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @dataProvider dataProvider
      * @covers ::isBaselined
      */

--- a/tests/php/PHPMD/Baseline/ViolationBaselineTest.php
+++ b/tests/php/PHPMD/Baseline/ViolationBaselineTest.php
@@ -3,7 +3,6 @@
 namespace PHPMD\Baseline;
 
 use PHPUnit\Framework\TestCase;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Baseline\ViolationBaseline
@@ -11,7 +10,6 @@ use Throwable;
 class ViolationBaselineTest extends TestCase
 {
     /**
-     * @throws Throwable
      * @covers ::__construct
      * @covers ::getRuleName
      */
@@ -24,7 +22,6 @@ class ViolationBaselineTest extends TestCase
     /**
      * Test the give file matches the baseline correctly
      *
-     * @throws Throwable
      * @covers ::__construct
      * @covers ::matches
      */
@@ -40,7 +37,6 @@ class ViolationBaselineTest extends TestCase
     /**
      * Test the give file matches the baseline correctly
      *
-     * @throws Throwable
      * @covers ::__construct
      * @covers ::matches
      */

--- a/tests/php/PHPMD/Cache/Model/ResultCacheKeyTest.php
+++ b/tests/php/PHPMD/Cache/Model/ResultCacheKeyTest.php
@@ -3,7 +3,6 @@
 namespace PHPMD\Cache\Model;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\Model\ResultCacheKey
@@ -12,7 +11,6 @@ use Throwable;
 class ResultCacheKeyTest extends AbstractTestCase
 {
     /**
-     * @throws Throwable
      * @covers ::toArray
      */
     public function testToArray(): void
@@ -36,7 +34,6 @@ class ResultCacheKeyTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::isEqualTo
      */
     public function testIsEqualTo(): void
@@ -61,7 +58,6 @@ class ResultCacheKeyTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::isEqualTo
      */
     public function testIsEqualToDiffStrict(): void
@@ -86,7 +82,6 @@ class ResultCacheKeyTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::isEqualTo
      */
     public function testIsEqualToDiffRules(): void
@@ -111,7 +106,6 @@ class ResultCacheKeyTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::isEqualTo
      */
     public function testIsEqualToDiffComposer(): void
@@ -136,7 +130,6 @@ class ResultCacheKeyTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::isEqualTo
      */
     public function testIsEqualToDiffPhpVersion(): void
@@ -161,7 +154,6 @@ class ResultCacheKeyTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::isEqualTo
      */
     public function testIsEqualToDiffBaselineHash(): void

--- a/tests/php/PHPMD/Cache/Model/ResultCacheStateTest.php
+++ b/tests/php/PHPMD/Cache/Model/ResultCacheStateTest.php
@@ -7,7 +7,6 @@ use PHPMD\Rule\CleanCode\BooleanArgumentFlag;
 use PHPMD\RuleSet;
 use PHPMD\RuleViolation;
 use PHPUnit\Framework\TestCase;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\Model\ResultCacheState
@@ -26,7 +25,6 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::getCacheKey
      */
     public function testGetCacheKey(): void
@@ -35,7 +33,6 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::getViolations
      * @covers ::setViolations
      */
@@ -62,7 +59,6 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::addRuleViolation
      */
     public function testAddRuleViolation(): void
@@ -101,7 +97,6 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::findRuleIn
      * @covers ::getRuleViolations
      */
@@ -129,7 +124,6 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::findRuleIn
      * @covers ::getRuleViolations
      */
@@ -162,7 +156,6 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::isFileModified
      * @covers ::setFileState
      */
@@ -176,7 +169,6 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::toArray
      */
     public function testToArray(): void

--- a/tests/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
+++ b/tests/php/PHPMD/Cache/ResultCacheEngineFactoryTest.php
@@ -11,7 +11,6 @@ use PHPMD\RuleSet;
 use PHPMD\TextUI\CommandLineOptions;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionProperty;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheEngineFactory
@@ -30,9 +29,6 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
 
     private ResultCacheEngineFactory $engineFactory;
 
-    /**
-     * @throws Throwable
-     */
     protected function setUp(): void
     {
         $this->options = $this->getMockBuilder(CommandLineOptions::class)
@@ -49,7 +45,6 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::create
      */
     public function testCreateNotEnabledShouldReturnNull(): void
@@ -61,7 +56,6 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::create
      */
     public function testCreateCacheMissShouldHaveNoOriginalState(): void
@@ -85,7 +79,6 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::create
      */
     public function testCreateCacheHitShouldHaveOriginalState(): void
@@ -107,9 +100,6 @@ class ResultCacheEngineFactoryTest extends AbstractTestCase
         static::assertNotNull($this->getFileFilterState($engine->getFileFilter()));
     }
 
-    /**
-     * @throws Throwable
-     */
     private function getFileFilterState(ResultCacheFileFilter $filter): ?ResultCacheState
     {
         $property = new ReflectionProperty($filter, 'state');

--- a/tests/php/PHPMD/Cache/ResultCacheEngineTest.php
+++ b/tests/php/PHPMD/Cache/ResultCacheEngineTest.php
@@ -3,7 +3,6 @@
 namespace PHPMD\Cache;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheEngine
@@ -12,7 +11,6 @@ use Throwable;
 class ResultCacheEngineTest extends AbstractTestCase
 {
     /**
-     * @throws Throwable
      * @covers ::getFileFilter
      * @covers ::getUpdater
      * @covers ::getWriter

--- a/tests/php/PHPMD/Cache/ResultCacheFileFilterTest.php
+++ b/tests/php/PHPMD/Cache/ResultCacheFileFilterTest.php
@@ -8,7 +8,6 @@ use PHPMD\Cache\Model\ResultCacheState;
 use PHPMD\Cache\Model\ResultCacheStrategy as Strategy;
 use PHPMD\Console\NullOutput;
 use PHPUnit\Framework\MockObject\MockObject;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheFileFilter
@@ -24,9 +23,6 @@ class ResultCacheFileFilterTest extends AbstractTestCase
     /** @var MockObject&ResultCacheState */
     private $state;
 
-    /**
-     * @throws Throwable
-     */
     protected function setUp(): void
     {
         $this->output = new NullOutput();
@@ -35,7 +31,6 @@ class ResultCacheFileFilterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::accept
      * @covers ::getState
      */
@@ -52,7 +47,6 @@ class ResultCacheFileFilterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::accept
      * @covers ::getState
      */
@@ -70,7 +64,6 @@ class ResultCacheFileFilterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::accept
      * @covers ::getState
      */
@@ -88,7 +81,6 @@ class ResultCacheFileFilterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::accept
      * @covers ::getState
      */
@@ -106,7 +98,6 @@ class ResultCacheFileFilterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::accept
      */
     public function testAcceptShouldCacheResults(): void

--- a/tests/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
+++ b/tests/php/PHPMD/Cache/ResultCacheKeyFactoryTest.php
@@ -6,7 +6,6 @@ use org\bovigo\vfs\vfsStream;
 use PHPMD\AbstractTestCase;
 use PHPMD\Rule\CleanCode\DuplicatedArrayKey;
 use PHPMD\RuleSet;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheKeyFactory
@@ -26,7 +25,6 @@ class ResultCacheKeyFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::create
      * @covers ::createRuleHashes
      * @covers ::getBaselineHash

--- a/tests/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
+++ b/tests/php/PHPMD/Cache/ResultCacheStateFactoryTest.php
@@ -4,7 +4,6 @@ namespace PHPMD\Cache;
 
 use PHPMD\AbstractTestCase;
 use PHPMD\Cache\Model\ResultCacheKey;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheStateFactory
@@ -19,7 +18,6 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::fromFile
      */
     public function testFromFileNonExisting(): void
@@ -29,7 +27,6 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::createCacheKey
      * @covers ::fromFile
      */
@@ -40,7 +37,6 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::createCacheKey
      * @covers ::fromFile
      */
@@ -51,7 +47,6 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::createCacheKey
      * @covers ::fromFile
      */
@@ -77,7 +72,6 @@ class ResultCacheStateFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::createCacheKey
      * @covers ::fromFile
      */

--- a/tests/php/PHPMD/Cache/ResultCacheUpdaterTest.php
+++ b/tests/php/PHPMD/Cache/ResultCacheUpdaterTest.php
@@ -8,7 +8,6 @@ use PHPMD\Cache\Model\ResultCacheState;
 use PHPMD\Console\NullOutput;
 use PHPMD\RuleSet;
 use PHPUnit\Framework\MockObject\MockObject;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheUpdater
@@ -21,9 +20,6 @@ class ResultCacheUpdaterTest extends AbstractTestCase
 
     private ResultCacheUpdater $updater;
 
-    /**
-     * @throws Throwable
-     */
     protected function setUp(): void
     {
         $this->state = $this->getMockBuilder(ResultCacheState::class)->disableOriginalConstructor()->getMock();
@@ -32,7 +28,6 @@ class ResultCacheUpdaterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::update
      */
     public function testUpdate(): void

--- a/tests/php/PHPMD/Cache/ResultCacheWriterTest.php
+++ b/tests/php/PHPMD/Cache/ResultCacheWriterTest.php
@@ -6,7 +6,6 @@ use org\bovigo\vfs\vfsStream;
 use PHPMD\AbstractTestCase;
 use PHPMD\Cache\Model\ResultCacheKey;
 use PHPMD\Cache\Model\ResultCacheState;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Cache\ResultCacheWriter
@@ -25,7 +24,6 @@ class ResultCacheWriterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::write
      */
     public function testWrite(): void

--- a/tests/php/PHPMD/Console/OutputTest.php
+++ b/tests/php/PHPMD/Console/OutputTest.php
@@ -3,7 +3,6 @@
 namespace PHPMD\Console;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * @coversDefaultClass  \PHPMD\Console\Output
@@ -13,9 +12,6 @@ class OutputTest extends AbstractTestCase
 {
     private TestOutput $output;
 
-    /**
-     * @throws Throwable
-     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -25,7 +21,6 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::getVerbosity
      * @covers ::setVerbosity
      */
@@ -39,7 +34,6 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::write
      */
     public function testWriteSingleMessage(): void
@@ -51,7 +45,6 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::write
      */
     public function testWriteMultiMessageWithNewline(): void
@@ -63,7 +56,6 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @dataProvider verbosityProvider
      * @covers ::write
      */
@@ -114,7 +106,6 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::writeln
      */
     public function testWritelnMessage(): void

--- a/tests/php/PHPMD/Console/StreamOutputTest.php
+++ b/tests/php/PHPMD/Console/StreamOutputTest.php
@@ -3,7 +3,6 @@
 namespace PHPMD\Console;
 
 use PHPUnit\Framework\TestCase;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Console\StreamOutput
@@ -11,7 +10,6 @@ use Throwable;
 class StreamOutputTest extends TestCase
 {
     /**
-     * @throws Throwable
      * @covers ::__construct
      * @covers ::doWrite
      */

--- a/tests/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
+++ b/tests/php/PHPMD/Integration/CommandLineInputFileOptionTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\Integration;
 
 use PHPMD\AbstractTestCase;
 use PHPMD\TextUI\Command;
-use Throwable;
 
 /**
  * Integration tests for the command line option <em>--inputfile</em>.
@@ -33,7 +32,6 @@ class CommandLineInputFileOptionTest extends AbstractTestCase
      * testReportContainsExpectedRuleViolationWarning
      *
      * @outputBuffering enabled
-     * @throws Throwable
      */
     public function testReportContainsExpectedRuleViolationWarning(): void
     {
@@ -47,7 +45,6 @@ class CommandLineInputFileOptionTest extends AbstractTestCase
      * testReportNotContainsRuleViolationWarningForFileNotInList
      *
      * @outputBuffering enabled
-     * @throws Throwable
      */
     public function testReportNotContainsRuleViolationWarningForFileNotInList(): void
     {
@@ -59,8 +56,6 @@ class CommandLineInputFileOptionTest extends AbstractTestCase
 
     /**
      * Runs the PHPMD command line interface and returns the report content.
-     *
-     * @throws Throwable
      */
     protected static function runCommandLine(): string
     {

--- a/tests/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
+++ b/tests/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\Integration;
 
 use PHPMD\AbstractTestCase;
 use PHPMD\TextUI\Command;
-use Throwable;
 
 /**
  * Integration tests for the coupling between objects rule class.
@@ -33,7 +32,6 @@ class CouplingBetweenObjectsIntegrationTest extends AbstractTestCase
      * testReportContainsCouplingBetweenObjectsWarning
      *
      * @outputBuffering enabled
-     * @throws Throwable
      */
     public function testReportContainsCouplingBetweenObjectsWarning(): void
     {

--- a/tests/php/PHPMD/Integration/GotoStatementIntegrationTest.php
+++ b/tests/php/PHPMD/Integration/GotoStatementIntegrationTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\Integration;
 
 use PHPMD\AbstractTestCase;
 use PHPMD\TextUI\Command;
-use Throwable;
 
 /**
  * Test case for the goto statement GotoStatementIntegrationTest.
@@ -33,7 +32,6 @@ class GotoStatementIntegrationTest extends AbstractTestCase
      * testReportContainsGotoStatementWarning
      *
      * @outputBuffering enabled
-     * @throws Throwable
      */
     public function testReportContainsGotoStatementWarning(): void
     {

--- a/tests/php/PHPMD/Node/ASTNodeTest.php
+++ b/tests/php/PHPMD/Node/ASTNodeTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\Node;
 
 use PDepend\Source\AST\ASTNode as PDependNode;
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\Node\ASTNode} class.
@@ -31,7 +30,6 @@ class ASTNodeTest extends AbstractTestCase
 {
     /**
      * testGetImageDelegatesToGetImageMethodOfWrappedNode
-     * @throws Throwable
      */
     public function testGetImageDelegatesToGetImageMethodOfWrappedNode(): void
     {
@@ -46,7 +44,6 @@ class ASTNodeTest extends AbstractTestCase
 
     /**
      * testGetNameDelegatesToGetImageMethodOfWrappedNode
-     * @throws Throwable
      */
     public function testGetNameDelegatesToGetImageMethodOfWrappedNode(): void
     {
@@ -61,7 +58,6 @@ class ASTNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsAnnotationForAlwaysReturnsFalse
-     * @throws Throwable
      */
     public function testHasSuppressWarningsAnnotationForAlwaysReturnsFalse(): void
     {
@@ -75,7 +71,6 @@ class ASTNodeTest extends AbstractTestCase
 
     /**
      * testGetParentNameReturnsNull
-     * @throws Throwable
      */
     public function testGetParentNameReturnsNull(): void
     {
@@ -87,7 +82,6 @@ class ASTNodeTest extends AbstractTestCase
 
     /**
      * testGetNamespaceNameReturnsNull
-     * @throws Throwable
      */
     public function testGetNamespaceNameReturnsNull(): void
     {
@@ -99,7 +93,6 @@ class ASTNodeTest extends AbstractTestCase
 
     /**
      * testGetFullQualifiedNameReturnsNull
-     * @throws Throwable
      */
     public function testGetFullQualifiedNameReturnsNull(): void
     {

--- a/tests/php/PHPMD/Node/AnnotationTest.php
+++ b/tests/php/PHPMD/Node/AnnotationTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Node;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\Node\Annotation} class.
@@ -30,7 +29,6 @@ class AnnotationTest extends AbstractTestCase
 {
     /**
      * testAnnotationReturnsFalseWhenNoSuppressWarningAnnotationExists
-     * @throws Throwable
      */
     public function testAnnotationReturnsFalseWhenNoSuppressWarningAnnotationExists(): void
     {
@@ -40,7 +38,6 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsFalseWhenSuppressWarningContainsInvalidValue
-     * @throws Throwable
      */
     public function testAnnotationReturnsFalseWhenSuppressWarningContainsInvalidValue(): void
     {
@@ -50,7 +47,6 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsWithPMD
-     * @throws Throwable
      */
     public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPMD(): void
     {
@@ -60,7 +56,6 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMD
-     * @throws Throwable
      */
     public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMD(): void
     {
@@ -70,7 +65,6 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMDLCFirst
-     * @throws Throwable
      */
     public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMDLCFirst(): void
     {
@@ -80,7 +74,6 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsPMDPlusRuleName
-     * @throws Throwable
      */
     public function testAnnotationReturnsTrueWhenSuppressWarningContainsPMDPlusRuleName(): void
     {
@@ -93,7 +86,6 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsPHPMDPlusRuleName
-     * @throws Throwable
      */
     public function testAnnotationReturnsTrueWhenSuppressWarningContainsPHPMDPlusRuleName(): void
     {
@@ -106,7 +98,6 @@ class AnnotationTest extends AbstractTestCase
 
     /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsPartialRuleName
-     * @throws Throwable
      */
     public function testAnnotationReturnsTrueWhenSuppressWarningContainsPartialRuleName(): void
     {

--- a/tests/php/PHPMD/Node/AnnotationsTest.php
+++ b/tests/php/PHPMD/Node/AnnotationsTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Node;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\Node\Annotations} class.
@@ -30,7 +29,6 @@ class AnnotationsTest extends AbstractTestCase
 {
     /**
      * testCollectionReturnsFalseWhenNoAnnotationExists
-     * @throws Throwable
      */
     public function testCollectionReturnsFalseWhenNoAnnotationExists(): void
     {
@@ -40,7 +38,6 @@ class AnnotationsTest extends AbstractTestCase
 
     /**
      * testCollectionReturnsFalseWhenNoMatchingAnnotationExists
-     * @throws Throwable
      */
     public function testCollectionReturnsFalseWhenNoMatchingAnnotationExists(): void
     {
@@ -64,7 +61,6 @@ class AnnotationsTest extends AbstractTestCase
 
     /**
      * testCollectionReturnsTrueWhenMatchingAnnotationExists
-     * @throws Throwable
      */
     public function testCollectionReturnsTrueWhenMatchingAnnotationExists(): void
     {
@@ -80,7 +76,6 @@ class AnnotationsTest extends AbstractTestCase
 
     /**
      * testCollectionReturnsTrueWhenOneMatchingAnnotationExists
-     * @throws Throwable
      */
     public function testCollectionReturnsTrueWhenOneMatchingAnnotationExists(): void
     {

--- a/tests/php/PHPMD/Node/ClassNodeTest.php
+++ b/tests/php/PHPMD/Node/ClassNodeTest.php
@@ -24,7 +24,6 @@ use PDepend\Source\AST\ASTNamespace;
 use PHPMD\AbstractRule;
 use PHPMD\AbstractTestCase;
 use PHPMD\Rule\Design\CouplingBetweenObjects;
-use Throwable;
 
 /**
  * Test case for the class node implementation.
@@ -36,7 +35,6 @@ class ClassNodeTest extends AbstractTestCase
 {
     /**
      * testGetMethodNamesReturnsExpectedResult
-     * @throws Throwable
      */
     public function testGetMethodNamesReturnsExpectedResult(): void
     {
@@ -50,7 +48,6 @@ class ClassNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsAnnotationForReturnsTrue
-     * @throws Throwable
      */
     public function testHasSuppressWarningsAnnotationForReturnsTrue(): void
     {
@@ -66,7 +63,6 @@ class ClassNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsWithRuleNameContainingSlashes
-     * @throws Throwable
      */
     public function testHasSuppressWarningsWithRuleNameContainingSlashes(): void
     {
@@ -93,7 +89,6 @@ class ClassNodeTest extends AbstractTestCase
 
     /**
      * testGetFullQualifiedNameReturnsExpectedValue
-     * @throws Throwable
      */
     public function testGetFullQualifiedNameReturnsExpectedValue(): void
     {
@@ -105,27 +100,18 @@ class ClassNodeTest extends AbstractTestCase
         static::assertSame('Sindelfingen\\MyClass', $node->getFullQualifiedName());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testGetConstantCountReturnsZeroByDefault(): void
     {
         $class = new ClassNode(new ASTClass('MyClass'));
         static::assertSame(0, $class->getConstantCount());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testGetConstantCount(): void
     {
         $class = $this->getClass();
         static::assertSame(3, $class->getConstantCount());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testGetParentNameReturnsNull(): void
     {
         $class = new ClassNode(new ASTClass('MyClass'));

--- a/tests/php/PHPMD/Node/FunctionTest.php
+++ b/tests/php/PHPMD/Node/FunctionTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\Node;
 
 use PDepend\Source\AST\ASTFunction;
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the function node implementation.
@@ -32,7 +31,6 @@ class FunctionTest extends AbstractTestCase
 {
     /**
      * testMagicCallDelegatesToWrappedPHPDependFunction
-     * @throws Throwable
      */
     public function testMagicCallDelegatesToWrappedPHPDependFunction(): void
     {

--- a/tests/php/PHPMD/Node/InterfaceNodeTest.php
+++ b/tests/php/PHPMD/Node/InterfaceNodeTest.php
@@ -21,7 +21,6 @@ namespace PHPMD\Node;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTNamespace;
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the interface node implementation.
@@ -33,7 +32,6 @@ class InterfaceNodeTest extends AbstractTestCase
 {
     /**
      * testGetFullQualifiedNameReturnsExpectedValue
-     * @throws Throwable
      */
     public function testGetFullQualifiedNameReturnsExpectedValue(): void
     {
@@ -45,27 +43,18 @@ class InterfaceNodeTest extends AbstractTestCase
         static::assertSame('Sindelfingen\\MyInterface', $node->getFullQualifiedName());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testGetConstantCountReturnsZeroByDefault(): void
     {
         $interface = new InterfaceNode(new ASTInterface('MyInterface'));
         static::assertSame(0, $interface->getConstantCount());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testGetConstantCount(): void
     {
         $class = $this->getInterface();
         static::assertSame(3, $class->getConstantCount());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testGetParentNameReturnsNull(): void
     {
         $interface = new InterfaceNode(new ASTInterface('MyInterface'));

--- a/tests/php/PHPMD/Node/MethodNodeTest.php
+++ b/tests/php/PHPMD/Node/MethodNodeTest.php
@@ -22,7 +22,6 @@ use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the method node implementation.
@@ -34,7 +33,6 @@ class MethodNodeTest extends AbstractTestCase
 {
     /**
      * testMagicCallDelegatesToWrappedPHPDependMethod
-     * @throws Throwable
      */
     public function testMagicCallDelegatesToWrappedPHPDependMethod(): void
     {
@@ -48,7 +46,6 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testGetParentTypeReturnsInterfaceForInterfaceMethod
-     * @throws Throwable
      */
     public function testGetParentTypeReturnsInterfaceForInterfaceMethod(): void
     {
@@ -60,7 +57,6 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testGetParentTypeReturnsClassForClassMethod
-     * @throws Throwable
      */
     public function testGetParentTypeReturnsClassForClassMethod(): void
     {
@@ -70,9 +66,6 @@ class MethodNodeTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testGetParentTypeReturnsTrait(): void
     {
         static::assertInstanceOf(
@@ -83,7 +76,6 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsExecutesDefaultImplementation
-     * @throws Throwable
      */
     public function testHasSuppressWarningsExecutesDefaultImplementation(): void
     {
@@ -96,7 +88,6 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsDelegatesToParentClassMethod
-     * @throws Throwable
      */
     public function testHasSuppressWarningsDelegatesToParentClassMethod(): void
     {
@@ -109,7 +100,6 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsDelegatesToParentInterfaceMethod
-     * @throws Throwable
      */
     public function testHasSuppressWarningsDelegatesToParentInterfaceMethod(): void
     {
@@ -122,7 +112,6 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testHasSuppressWarningsIgnoresCaseFirstLetter
-     * @throws Throwable
      */
     public function testHasSuppressWarningsIgnoresCaseFirstLetter(): void
     {
@@ -136,7 +125,6 @@ class MethodNodeTest extends AbstractTestCase
     /**
      * testIsDeclarationReturnsTrueForMethodDeclaration
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testIsDeclarationReturnsTrueForMethodDeclaration(): void
@@ -148,7 +136,6 @@ class MethodNodeTest extends AbstractTestCase
     /**
      * testIsDeclarationReturnsTrueForMethodDeclarationWithParent
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testIsDeclarationReturnsTrueForMethodDeclarationWithParent(): void
@@ -160,7 +147,6 @@ class MethodNodeTest extends AbstractTestCase
     /**
      * testIsDeclarationReturnsFalseForInheritMethodDeclaration
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testIsDeclarationReturnsFalseForInheritMethodDeclaration(): void
@@ -172,7 +158,6 @@ class MethodNodeTest extends AbstractTestCase
     /**
      * testIsDeclarationReturnsFalseForImplementedAbstractMethod
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testIsDeclarationReturnsFalseForImplementedAbstractMethod(): void
@@ -184,7 +169,6 @@ class MethodNodeTest extends AbstractTestCase
     /**
      * testIsDeclarationReturnsFalseForImplementedInterfaceMethod
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testIsDeclarationReturnsFalseForImplementedInterfaceMethod(): void
@@ -193,9 +177,6 @@ class MethodNodeTest extends AbstractTestCase
         static::assertFalse($method->isDeclaration());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testIsDeclarationReturnsTrueForPrivateMethod(): void
     {
         $method = $this->getMethod();
@@ -204,7 +185,6 @@ class MethodNodeTest extends AbstractTestCase
 
     /**
      * testGetFullQualifiedNameReturnsExpectedValue
-     * @throws Throwable
      */
     public function testGetFullQualifiedNameReturnsExpectedValue(): void
     {

--- a/tests/php/PHPMD/Node/NodeInfoFactoryTest.php
+++ b/tests/php/PHPMD/Node/NodeInfoFactoryTest.php
@@ -3,7 +3,6 @@
 namespace PHPMD\Node;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Node\NodeInfoFactory
@@ -11,7 +10,6 @@ use Throwable;
 class NodeInfoFactoryTest extends AbstractTestCase
 {
     /**
-     * @throws Throwable
      * @covers ::fromNode
      */
     public function testFromNodeForAbstractTypeNode(): void
@@ -34,7 +32,6 @@ class NodeInfoFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::fromNode
      */
     public function testFromNodeForMethodNode(): void
@@ -58,7 +55,6 @@ class NodeInfoFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::fromNode
      */
     public function testFromNodeForFunctionNode(): void

--- a/tests/php/PHPMD/Node/NodeInfoTest.php
+++ b/tests/php/PHPMD/Node/NodeInfoTest.php
@@ -3,7 +3,6 @@
 namespace PHPMD\Node;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Node\NodeInfo
@@ -11,7 +10,6 @@ use Throwable;
 class NodeInfoTest extends AbstractTestCase
 {
     /**
-     * @throws Throwable
      * @covers ::__construct
      */
     public function testConstruct(): void

--- a/tests/php/PHPMD/Node/TraitNodeTest.php
+++ b/tests/php/PHPMD/Node/TraitNodeTest.php
@@ -21,7 +21,6 @@ namespace PHPMD\Node;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTTrait;
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the trait node implementation.
@@ -33,7 +32,6 @@ class TraitNodeTest extends AbstractTestCase
 {
     /**
      * testGetFullQualifiedNameReturnsExpectedValue
-     * @throws Throwable
      */
     public function testGetFullQualifiedNameReturnsExpectedValue(): void
     {
@@ -45,18 +43,12 @@ class TraitNodeTest extends AbstractTestCase
         static::assertSame('Sindelfingen\\MyTrait', $node->getFullQualifiedName());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testGetConstantCountReturnsZeroByDefault(): void
     {
         $trait = new TraitNode(new ASTTrait('MyTrait'));
         static::assertSame(0, $trait->getConstantCount());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testGetParentNameReturnsNull(): void
     {
         $trait = new TraitNode(new ASTTrait('MyTrait'));

--- a/tests/php/PHPMD/PHPMDTest.php
+++ b/tests/php/PHPMD/PHPMDTest.php
@@ -23,7 +23,6 @@ use PHPMD\Baseline\BaselineSet;
 use PHPMD\Baseline\BaselineValidator;
 use PHPMD\Renderer\XMLRenderer;
 use PHPMD\Stubs\WriterStub;
-use Throwable;
 
 /**
  * Test case for the main PHPMD class.
@@ -41,7 +40,6 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * Tests the main PHPMD interface with default settings an a xml-renderer.
-     * @throws Throwable
      */
     public function testRunWithDefaultSettingsAndXmlRenderer(): void
     {
@@ -67,7 +65,6 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testRunWithDefaultSettingsAndXmlRendererAgainstSingleFile
-     * @throws Throwable
      */
     public function testRunWithDefaultSettingsAndXmlRendererAgainstDirectory(): void
     {
@@ -92,7 +89,6 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testRunWithDefaultSettingsAndXmlRendererAgainstSingleFile
-     * @throws Throwable
      */
     public function testRunWithDefaultSettingsAndXmlRendererAgainstSingleFile(): void
     {
@@ -117,7 +113,6 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testHasErrorsReturnsFalseByDefault
-     * @throws Throwable
      */
     public function testHasErrorsReturnsFalseByDefault(): void
     {
@@ -127,7 +122,6 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testHasViolationsReturnsFalseByDefault
-     * @throws Throwable
      */
     public function testHasViolationsReturnsFalseByDefault(): void
     {
@@ -137,7 +131,6 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testHasViolationsReturnsFalseForSourceWithoutViolations
-     * @throws Throwable
      */
     public function testHasViolationsReturnsFalseForSourceWithoutViolations(): void
     {
@@ -161,7 +154,6 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testHasViolationsReturnsTrueForSourceWithViolation
-     * @throws Throwable
      */
     public function testHasViolationsReturnsTrueForSourceWithViolation(): void
     {
@@ -183,9 +175,6 @@ class PHPMDTest extends AbstractTestCase
         static::assertTrue($phpmd->hasViolations());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testHasViolationsReturnsFalseWhenViolationIsBaselined(): void
     {
         self::changeWorkingDirectory();
@@ -210,7 +199,6 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testHasErrorsReturnsTrueForSourceWithError
-     * @throws Throwable
      */
     public function testHasErrorsReturnsTrueForSourceWithError(): void
     {
@@ -234,7 +222,6 @@ class PHPMDTest extends AbstractTestCase
 
     /**
      * testIgnorePattern
-     * @throws Throwable
      */
     public function testIgnorePattern(): void
     {

--- a/tests/php/PHPMD/ParserFactoryTest.php
+++ b/tests/php/PHPMD/ParserFactoryTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD;
 
 use PHPMD\Node\ClassNode;
-use Throwable;
 
 /**
  * Test case for the parser factory class.
@@ -30,7 +29,6 @@ class ParserFactoryTest extends AbstractTestCase
 {
     /**
      * testFactoryConfiguresInputDirectory
-     * @throws Throwable
      */
     public function testFactoryConfiguresInputDirectory(): void
     {
@@ -52,7 +50,6 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresInputFile
-     * @throws Throwable
      */
     public function testFactoryConfiguresInputFile(): void
     {
@@ -74,7 +71,6 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresMultipleInputDirectories
-     * @throws Throwable
      */
     public function testFactoryConfiguresMultipleInputDirectories(): void
     {
@@ -97,7 +93,6 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresMultipleInputFilesAndDirectories
-     * @throws Throwable
      */
     public function testFactoryConfiguresMultipleInputFilesAndDirectories(): void
     {
@@ -120,7 +115,6 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresIgnorePattern
-     * @throws Throwable
      */
     public function testFactoryConfiguresIgnorePattern(): void
     {
@@ -141,7 +135,6 @@ class ParserFactoryTest extends AbstractTestCase
 
     /**
      * testFactoryConfiguresFileExtensions
-     * @throws Throwable
      */
     public function testFactoryConfiguresFileExtensions(): void
     {

--- a/tests/php/PHPMD/ParserTest.php
+++ b/tests/php/PHPMD/ParserTest.php
@@ -33,7 +33,6 @@ use PHPMD\Node\FunctionNode;
 use PHPMD\Node\MethodNode;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\Container;
-use Throwable;
 
 /**
  * Test case for the PHP_Depend backend adapter class.
@@ -44,7 +43,6 @@ class ParserTest extends AbstractTestCase
 {
     /**
      * Tests that the metrics adapter delegates a node to a registered rule-set.
-     * @throws Throwable
      */
     public function testAdapterDelegatesClassNodeToRuleSet(): void
     {
@@ -62,7 +60,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the metrics adapter does not delegate a node without source
      * code file to a registered rule-set.
-     * @throws Throwable
      */
     public function testAdapterDoesNotDelegateNonSourceClassNodeToRuleSet(): void
     {
@@ -79,7 +76,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the metrics adapter delegates a node to a registered rule-set.
-     * @throws Throwable
      */
     public function testAdapterDelegatesMethodNodeToRuleSet(): void
     {
@@ -92,7 +88,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the metrics adapter does not delegate a node without source
      * code file to a registered rule-set.
-     * @throws Throwable
      */
     public function testAdapterDoesNotDelegateNonSourceMethodNodeToRuleSet(): void
     {
@@ -104,7 +99,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the metrics adapter delegates a node to a registered rule-set.
-     * @throws Throwable
      */
     public function testAdapterDelegatesFunctionNodeToRuleSet(): void
     {
@@ -117,7 +111,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the metrics adapter does not delegate a node without source
      * code file to a registered rule-set.
-     * @throws Throwable
      */
     public function testAdapterDoesNotDelegateNonSourceFunctionNodeToRuleSet(): void
     {
@@ -130,7 +123,6 @@ class ParserTest extends AbstractTestCase
     /**
      * testParserStoreParsingExceptionsInReport
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testParserStoreParsingExceptionsInReport(): void
@@ -154,7 +146,6 @@ class ParserTest extends AbstractTestCase
      * Creates a mocked PDepend instance.
      *
      * @return Engine&MockObject
-     * @throws Throwable
      */
     private function getPHPDependMock()
     {
@@ -173,7 +164,6 @@ class ParserTest extends AbstractTestCase
      * Creates a mocked PDepend class instance.
      *
      * @return ASTClass&MockObject
-     * @throws Throwable
      */
     protected function getPHPDependClassMock()
     {
@@ -200,7 +190,6 @@ class ParserTest extends AbstractTestCase
      * Creates a mocked PHP_Depend function instance.
      *
      * @param ?string $fileName Optional file name for the source file.
-     * @throws Throwable
      */
     protected function getPHPDependFunctionMock(?string $fileName = '/foo/bar.php'): ASTFunction&MockObject
     {
@@ -218,7 +207,6 @@ class ParserTest extends AbstractTestCase
      * Creates a mocked PHP_Depend method instance.
      *
      * @param ?string $fileName Optional file name for the source file.
-     * @throws Throwable
      */
     protected function getPHPDependMethodMock(?string $fileName = '/foo/bar.php'): ASTMethod&MockObject
     {
@@ -236,7 +224,6 @@ class ParserTest extends AbstractTestCase
      * Creates a mocked PHP_Depend file instance.
      *
      * @param ?string $fileName The temporary file name.
-     * @throws Throwable
      */
     protected function getPHPDependFileMock(?string $fileName): ASTCompilationUnit&MockObject
     {

--- a/tests/php/PHPMD/ProcessingErrorTest.php
+++ b/tests/php/PHPMD/ProcessingErrorTest.php
@@ -18,8 +18,6 @@
 
 namespace PHPMD;
 
-use Throwable;
-
 /**
  * Test case for the processing error class.
  *
@@ -30,7 +28,6 @@ class ProcessingErrorTest extends AbstractTestCase
 {
     /**
      * testGetMessageReturnsTheExpectedValue
-     * @throws Throwable
      */
     public function testGetMessageReturnsTheExpectedValue(): void
     {
@@ -43,7 +40,7 @@ class ProcessingErrorTest extends AbstractTestCase
      * a given exception message,
      *
      * @param string $message The original exception message
-     * @throws Throwable
+     *
      * @dataProvider getParserExceptionMessages
      */
     public function testGetFileReturnsExpectedFileName(string $message): void

--- a/tests/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
+++ b/tests/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
@@ -23,7 +23,6 @@ use PHPMD\Renderer\XMLRenderer;
 use PHPMD\Report;
 use PHPMD\RuleSetFactory;
 use PHPMD\Stubs\WriterStub;
-use Throwable;
 
 /**
  * Regression test for issue 001.
@@ -32,7 +31,6 @@ class AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest extends AbstractR
 {
     /**
      * testCliAcceptsDirectoryAsInput
-     * @throws Throwable
      */
     public function testCliAcceptsDirectoryAsInput(): void
     {
@@ -58,7 +56,6 @@ class AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest extends AbstractR
 
     /**
      * testCliAcceptsSingleFileAsInput
-     * @throws Throwable
      */
     public function testCliAcceptsSingleFileAsInput(): void
     {

--- a/tests/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest.php
+++ b/tests/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\Regression;
 
 use PHPMD\Rule\ExcessivePublicCount;
 use PHPMD\RuleSet;
-use Throwable;
 
 /**
  * Regression test for issue 015.
@@ -29,7 +28,6 @@ class ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest extends Abstr
 {
     /**
      * testRuleSetInvokesRuleForClassInstance
-     * @throws Throwable
      */
     public function testRuleSetInvokesRuleForClassInstance(): void
     {

--- a/tests/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
+++ b/tests/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
@@ -23,7 +23,6 @@ use PHPMD\Renderer\TextRenderer;
 use PHPMD\Report;
 use PHPMD\RuleSetFactory;
 use PHPUnit\Framework\MockObject\MockObject;
-use Throwable;
 
 /**
  * Regression test for issue 409.
@@ -40,8 +39,6 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
 
     /**
      * Sets up the renderer mock
-     *
-     * @throws Throwable
      */
     protected function setUp(): void
     {
@@ -59,7 +56,6 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
      * - TooManyMethods
      * - TooManyPublicMethods
      * - ExcessiveClassComplexity
-     * @throws Throwable
      */
     public function testReportIsGeneratedIWithNoSuppression(): void
     {
@@ -103,7 +99,6 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
      * - TooManyMethods
      * - TooManyPublicMethods
      * - ExcessiveClassComplexity
-     * @throws Throwable
      */
     public function testReportIsNotGeneratedIWithSuppression(): void
     {

--- a/tests/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest.php
+++ b/tests/php/PHPMD/Regression/InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\Regression;
 
 use PHPMD\Rule\UnusedFormalParameter;
 use PHPMD\Rule\UnusedLocalVariable;
-use Throwable;
 
 /**
  * Regression test for issue 007.
@@ -29,7 +28,6 @@ class InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest extend
 {
     /**
      * testLocalVariableUsedInDoubleQuoteStringGetsNotReported
-     * @throws Throwable
      */
     public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported(): void
     {
@@ -40,7 +38,6 @@ class InvalidUnusedLocalVariableAndFormalParameterTicket007RegressionTest extend
 
     /**
      * testFormalParameterUsedInDoubleQuoteStringGetsNotReported
-     * @throws Throwable
      */
     public function testFormalParameterUsedInDoubleQuoteStringGetsNotReported(): void
     {

--- a/tests/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
+++ b/tests/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
@@ -23,7 +23,6 @@ use PHPMD\Renderer\TextRenderer;
 use PHPMD\Report;
 use PHPMD\RuleSetFactory;
 use PHPMD\Writer\StreamWriter;
-use Throwable;
 
 /**
  * Regression test for issue 14990109.
@@ -37,7 +36,6 @@ class MaximumNestingLevelTicket24975295RegressionTest extends AbstractRegression
      * testLocalVariableUsedInDoubleQuoteStringGetsNotReported
      *
      * @outputBuffering enabled
-     * @throws Throwable
      */
     public function testLocalVariableUsedInDoubleQuoteStringGetsNotReported(): void
     {

--- a/tests/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020RegressionTest.php
+++ b/tests/php/PHPMD/Regression/StaticVariablesFlaggedAsUnusedTicket020RegressionTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Regression;
 
 use PHPMD\Rule\UnusedLocalVariable;
-use Throwable;
 
 /**
  * Regression test for issue 020.
@@ -28,7 +27,6 @@ class StaticVariablesFlaggedAsUnusedTicket020RegressionTest extends AbstractRegr
 {
     /**
      * testRuleDoesNotApplyToAnySuperGlobalVariable
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToAnyStaticLocalVariable(): void
     {

--- a/tests/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019RegressionTest.php
+++ b/tests/php/PHPMD/Regression/SuperGlobalsFlaggedAsUnusedTicket019RegressionTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Regression;
 
 use PHPMD\Rule\UnusedLocalVariable;
-use Throwable;
 
 /**
  * Regression test for issue 019.
@@ -28,7 +27,6 @@ class SuperGlobalsFlaggedAsUnusedTicket019RegressionTest extends AbstractRegress
 {
     /**
      * testRuleDoesNotApplyToAnySuperGlobalVariable
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToAnySuperGlobalVariable(): void
     {

--- a/tests/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036RegressionTest.php
+++ b/tests/php/PHPMD/Regression/SuppressWarningsNotAppliesToUnusedPrivateMethod036RegressionTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\Regression;
 
 use PHPMD\Rule\UnusedPrivateMethod;
 use PHPMD\RuleSet;
-use Throwable;
 
 /**
  * Regression test for issue 036.
@@ -29,7 +28,6 @@ class SuppressWarningsNotAppliesToUnusedPrivateMethod036RegressionTest extends A
 {
     /**
      * testRuleDoesNotApplyToPrivateMethodWithSuppressWarningsAnnotation
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToPrivateMethodWithSuppressWarningsAnnotation(): void
     {

--- a/tests/php/PHPMD/Regression/UnusedParameterArgvTicket14990109RegressionTest.php
+++ b/tests/php/PHPMD/Regression/UnusedParameterArgvTicket14990109RegressionTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\Regression;
 
 use PHPMD\Rule\UnusedFormalParameter;
 use PHPMD\RuleSet;
-use Throwable;
 
 /**
  * Regression test for issue 14990109.
@@ -32,7 +31,6 @@ class UnusedParameterArgvTicket14990109RegressionTest extends AbstractRegression
 {
     /**
      * testRuleDoesNotApplyToFunctionParameterNamedArgv
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToFunctionParameterNamedArgv(): void
     {
@@ -45,7 +43,6 @@ class UnusedParameterArgvTicket14990109RegressionTest extends AbstractRegression
 
     /**
      * testRuleDoesNotApplyToMethodParameterNamedArgv
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToMethodParameterNamedArgv(): void
     {

--- a/tests/php/PHPMD/Renderer/AnsiRendererTest.php
+++ b/tests/php/PHPMD/Renderer/AnsiRendererTest.php
@@ -21,7 +21,6 @@ namespace PHPMD\Renderer;
 use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\Stubs\WriterStub;
-use Throwable;
 
 /**
  * Test case for the ansi renderer implementation.
@@ -32,7 +31,6 @@ class AnsiRendererTest extends AbstractTestCase
 {
     /**
      * testRendererOutputsForReportWithContents
-     * @throws Throwable
      */
     public function testRendererOutputsForReportWithContents(): void
     {
@@ -96,7 +94,6 @@ class AnsiRendererTest extends AbstractTestCase
 
     /**
      * testRendererOutputsForReportWithoutContents
-     * @throws Throwable
      */
     public function testRendererOutputsForReportWithoutContents(): void
     {

--- a/tests/php/PHPMD/Renderer/BaselineRendererTest.php
+++ b/tests/php/PHPMD/Renderer/BaselineRendererTest.php
@@ -5,7 +5,6 @@ namespace PHPMD\Renderer;
 use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\Stubs\WriterStub;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Renderer\BaselineRenderer
@@ -14,7 +13,6 @@ use Throwable;
 class BaselineRendererTest extends AbstractTestCase
 {
     /**
-     * @throws Throwable
      * @covers ::renderReport
      */
     public function testRenderReport(): void
@@ -43,7 +41,6 @@ class BaselineRendererTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::renderReport
      */
     public function testRenderReportShouldWriteMethodName(): void
@@ -70,7 +67,6 @@ class BaselineRendererTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::renderReport
      */
     public function testRenderReportShouldDeduplicateSimilarViolations(): void
@@ -98,7 +94,6 @@ class BaselineRendererTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::renderReport
      */
     public function testRenderEmptyReport(): void

--- a/tests/php/PHPMD/Renderer/CheckStyleRendererTest.php
+++ b/tests/php/PHPMD/Renderer/CheckStyleRendererTest.php
@@ -22,7 +22,6 @@ use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
-use Throwable;
 
 /**
  * Test case for the xml renderer implementation.
@@ -33,7 +32,6 @@ class CheckStyleRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfXmlElements
-     * @throws Throwable
      */
     public function testRendererCreatesExpectedNumberOfXmlElements(): void
     {
@@ -70,7 +68,6 @@ class CheckStyleRendererTest extends AbstractTestCase
     /**
      * testRendererAddsProcessingErrorsToXmlReport
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testRendererAddsProcessingErrorsToXmlReport(): void

--- a/tests/php/PHPMD/Renderer/GitHubRendererTest.php
+++ b/tests/php/PHPMD/Renderer/GitHubRendererTest.php
@@ -22,7 +22,6 @@ use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
-use Throwable;
 
 /**
  * Test case for the GitHub renderer implementation.
@@ -33,7 +32,6 @@ class GitHubRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfTextEntries
-     * @throws Throwable
      */
     public function testRendererCreatesExpectedNumberOfTextEntries(): void
     {
@@ -71,7 +69,6 @@ class GitHubRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToTextReport
-     * @throws Throwable
      */
     public function testRendererAddsProcessingErrorsToTextReport(): void
     {

--- a/tests/php/PHPMD/Renderer/GitLabRendererTest.php
+++ b/tests/php/PHPMD/Renderer/GitLabRendererTest.php
@@ -22,7 +22,6 @@ use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
-use Throwable;
 
 /**
  * Test case for the JSON renderer implementation.
@@ -33,7 +32,6 @@ class GitLabRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfGitLabElements
-     * @throws Throwable
      */
     public function testRendererCreatesExpectedNumberOfGitLabElements(): void
     {
@@ -68,7 +66,6 @@ class GitLabRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToGitLabReport
-     * @throws Throwable
      */
     public function testRendererAddsProcessingErrorsToGitLabReport(): void
     {

--- a/tests/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/tests/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -21,7 +21,6 @@ namespace PHPMD\Renderer;
 use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\Stubs\WriterStub;
-use Throwable;
 
 /**
  * Test case for the html renderer implementation.
@@ -32,7 +31,6 @@ class HTMLRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfTextEntries
-     * @throws Throwable
      */
     public function testRendererCreatesExpectedHtmlTableRow(): void
     {

--- a/tests/php/PHPMD/Renderer/JSONRendererTest.php
+++ b/tests/php/PHPMD/Renderer/JSONRendererTest.php
@@ -22,7 +22,6 @@ use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
-use Throwable;
 
 /**
  * Test case for the JSON renderer implementation.
@@ -33,7 +32,6 @@ class JSONRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfJsonElements
-     * @throws Throwable
      */
     public function testRendererCreatesExpectedNumberOfJsonElements(): void
     {
@@ -68,7 +66,6 @@ class JSONRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToJsonReport
-     * @throws Throwable
      */
     public function testRendererAddsProcessingErrorsToJsonReport(): void
     {

--- a/tests/php/PHPMD/Renderer/RendererFactoryTest.php
+++ b/tests/php/PHPMD/Renderer/RendererFactoryTest.php
@@ -4,7 +4,6 @@ namespace PHPMD\Renderer;
 
 use PHPMD\AbstractTestCase;
 use PHPMD\Writer\StreamWriter;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Renderer\RendererFactory
@@ -12,7 +11,6 @@ use Throwable;
 class RendererFactoryTest extends AbstractTestCase
 {
     /**
-     * @throws Throwable
      * @covers ::createBaselineRenderer
      */
     public function testCreateBaselineRendererSuccessfully(): void

--- a/tests/php/PHPMD/Renderer/SARIFRendererTest.php
+++ b/tests/php/PHPMD/Renderer/SARIFRendererTest.php
@@ -23,7 +23,6 @@ use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\RuleStub;
 use PHPMD\Stubs\WriterStub;
-use Throwable;
 
 /**
  * Test case for the SARIF renderer implementation.
@@ -34,7 +33,6 @@ class SARIFRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfJsonElements
-     * @throws Throwable
      */
     public function testRendererCreatesExpectedNumberOfJsonElements(): void
     {
@@ -86,7 +84,6 @@ class SARIFRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToJsonReport
-     * @throws Throwable
      */
     public function testRendererAddsProcessingErrorsToJsonReport(): void
     {

--- a/tests/php/PHPMD/Renderer/TextRendererTest.php
+++ b/tests/php/PHPMD/Renderer/TextRendererTest.php
@@ -24,7 +24,6 @@ use PHPMD\Console\OutputInterface;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\RuleStub;
 use PHPMD\Stubs\WriterStub;
-use Throwable;
 
 /**
  * Test case for the text renderer implementation.
@@ -35,7 +34,6 @@ class TextRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfTextEntries
-     * @throws Throwable
      */
     public function testRendererCreatesExpectedNumberOfTextEntries(): void
     {
@@ -74,9 +72,6 @@ class TextRendererTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRendererSupportVerbose(): void
     {
         // Create a writer instance.
@@ -113,9 +108,6 @@ class TextRendererTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRendererSupportColor(): void
     {
         // Create a writer instance.
@@ -152,7 +144,6 @@ class TextRendererTest extends AbstractTestCase
 
     /**
      * testRendererAddsProcessingErrorsToTextReport
-     * @throws Throwable
      */
     public function testRendererAddsProcessingErrorsToTextReport(): void
     {

--- a/tests/php/PHPMD/Renderer/XMLRendererTest.php
+++ b/tests/php/PHPMD/Renderer/XMLRendererTest.php
@@ -22,7 +22,6 @@ use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
-use Throwable;
 
 /**
  * Test case for the xml renderer implementation.
@@ -33,7 +32,6 @@ class XMLRendererTest extends AbstractTestCase
 {
     /**
      * testRendererCreatesExpectedNumberOfXmlElements
-     * @throws Throwable
      */
     public function testRendererCreatesExpectedNumberOfXmlElements(): void
     {
@@ -70,7 +68,6 @@ class XMLRendererTest extends AbstractTestCase
     /**
      * testRendererAddsProcessingErrorsToXmlReport
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testRendererAddsProcessingErrorsToXmlReport(): void

--- a/tests/php/PHPMD/ReportTest.php
+++ b/tests/php/PHPMD/ReportTest.php
@@ -22,7 +22,6 @@ use PHPMD\Baseline\BaselineMode;
 use PHPMD\Baseline\BaselineSet;
 use PHPMD\Baseline\BaselineValidator;
 use PHPMD\Baseline\ViolationBaseline;
-use Throwable;
 
 /**
  * Test case for the report class.
@@ -34,7 +33,6 @@ class ReportTest extends AbstractTestCase
     /**
      * Tests that the report returns a linear/sorted list of all rule violation
      * files.
-     * @throws Throwable
      */
     public function testReportReturnsAListWithAllRuleViolations(): void
     {
@@ -58,7 +56,6 @@ class ReportTest extends AbstractTestCase
 
     /**
      * Tests that the report returns the result by the violation line number.
-     * @throws Throwable
      */
     public function testReportSortsResultByLineNumber(): void
     {
@@ -94,7 +91,6 @@ class ReportTest extends AbstractTestCase
 
     /**
      * Tests that the timer method returns the expected result.
-     * @throws Throwable
      */
     public function testReportTimerReturnsMilliSeconds(): void
     {
@@ -116,7 +112,6 @@ class ReportTest extends AbstractTestCase
 
     /**
      * testIsEmptyReturnsTrueByDefault
-     * @throws Throwable
      */
     public function testIsEmptyReturnsTrueByDefault(): void
     {
@@ -126,7 +121,6 @@ class ReportTest extends AbstractTestCase
 
     /**
      * testIsEmptyReturnsFalseWhenAtLeastOneViolationExists
-     * @throws Throwable
      */
     public function testIsEmptyReturnsFalseWhenAtLeastOneViolationExists(): void
     {
@@ -139,7 +133,6 @@ class ReportTest extends AbstractTestCase
     /**
      * testHasErrorsReturnsFalseByDefault
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testHasErrorsReturnsFalseByDefault(): void
@@ -151,7 +144,6 @@ class ReportTest extends AbstractTestCase
     /**
      * testHasErrorsReturnsTrueWhenReportContainsAtLeastOneError
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testHasErrorsReturnsTrueWhenReportContainsAtLeastOneError(): void
@@ -165,7 +157,6 @@ class ReportTest extends AbstractTestCase
     /**
      * testGetErrorsReturnsEmptyIteratorByDefault
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testGetErrorsReturnsEmptyIteratorByDefault(): void
@@ -177,7 +168,6 @@ class ReportTest extends AbstractTestCase
     /**
      * testGetErrorsReturnsPreviousAddedProcessingError
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testGetErrorsReturnsPreviousAddedProcessingError(): void
@@ -188,9 +178,6 @@ class ReportTest extends AbstractTestCase
         static::assertSame(1, iterator_count($report->getErrors()));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testReportShouldIgnoreBaselineViolation(): void
     {
         $ruleA = $this->getRuleViolationMock('foo.txt');
@@ -213,9 +200,6 @@ class ReportTest extends AbstractTestCase
         static::assertSame($ruleB, $violations[0]);
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testReportShouldIgnoreNewViolationsOnBaselineUpdate(): void
     {
         $ruleA = $this->getRuleViolationMock('foo.txt');

--- a/tests/php/PHPMD/Rule/CleanCode/BooleanArgumentFlagTest.php
+++ b/tests/php/PHPMD/Rule/CleanCode/BooleanArgumentFlagTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Rule\CleanCode\BooleanArgumentFlag
@@ -43,7 +42,7 @@ class BooleanArgumentFlagTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     * @throws Throwable
+     *
      * @dataProvider getApplyingCases
      */
     public function testRuleAppliesTo(string $file): void
@@ -55,7 +54,7 @@ class BooleanArgumentFlagTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     * @throws Throwable
+     *
      * @dataProvider getNotApplyingCases
      */
     public function testRuleDoesNotApplyTo(string $file): void

--- a/tests/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
+++ b/tests/php/PHPMD/Rule/CleanCode/DuplicatedArrayKeyTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Duplicated Array Key Test.
@@ -31,7 +30,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutArrayDefinition
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodWithoutArrayDefinition(): void
     {
@@ -42,7 +40,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithNonAssotiativeArrayDefinition
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodWithNonAssotiativeArrayDefinition(): void
     {
@@ -53,7 +50,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithAssotiativeArrayDefinitionWithoutDuplicatedKeys
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodWithAssotiativeArrayDefinitionWithoutDuplicatedKeys(): void
     {
@@ -64,7 +60,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys(): void
     {
@@ -75,7 +70,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys(): void
     {
@@ -86,7 +80,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys(): void
     {
@@ -97,7 +90,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys
-     * @throws Throwable
      */
     public function testRuleAppliesMultipleTimesToMethodWithAssotiativeArrayDefinitionWithDuplicatedKeys(): void
     {
@@ -108,7 +100,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutArrayDefinition
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFunctionWithoutArrayDefinition(): void
     {
@@ -119,7 +110,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithNonAssotiativeArrayDefinition
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFunctionWithNonAssotiativeArrayDefinition(): void
     {
@@ -130,7 +120,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithAssotiativeArrayDefinitionWithoutDuplicatedKeys
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFunctionWithAssotiativeArrayDefinitionWithoutDuplicatedKeys(): void
     {
@@ -141,7 +130,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys(): void
     {
@@ -152,7 +140,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedTypeKeys(): void
     {
@@ -163,7 +150,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedMixedQuotedKeys(): void
     {
@@ -174,7 +160,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys
-     * @throws Throwable
      */
     public function testRuleAppliesMultipleTimesToFunctionWithAssotiativeArrayDefinitionWithDuplicatedKeys(): void
     {
@@ -185,7 +170,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenKeyIsDeclaredInNonStandardWay
-     * @throws Throwable
      */
     public function testRuleAppliesWhenKeyIsDeclaredInNonStandardWay(): void
     {
@@ -196,7 +180,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesCorrectlyWithNestedArrays
-     * @throws Throwable
      */
     public function testRuleAppliesCorrectlyWithNestedArrays(): void
     {
@@ -207,7 +190,6 @@ class DuplicatedArrayKeyTest extends AbstractTestCase
 
     /**
      * testRuleAppliesCorrectlyToMultipleArrays
-     * @throws Throwable
      */
     public function testRuleAppliesCorrectlyToMultipleArrays(): void
     {

--- a/tests/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
+++ b/tests/php/PHPMD/Rule/CleanCode/ElseExpressionTest.php
@@ -19,13 +19,9 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 class ElseExpressionTest extends AbstractTestCase
 {
-    /**
-     * @throws Throwable
-     */
     public function testRuleNotAppliesToMethodWithoutElseExpression(): void
     {
         $rule = new ElseExpression();
@@ -33,9 +29,6 @@ class ElseExpressionTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleAppliesToMethodWithElseExpression(): void
     {
         $rule = new ElseExpression();
@@ -43,9 +36,6 @@ class ElseExpressionTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleAppliesMultipleTimesToMethodWithMultipleElseExpressions(): void
     {
         $rule = new ElseExpression();

--- a/tests/php/PHPMD/Rule/CleanCode/ErrorControlOperatorTest.php
+++ b/tests/php/PHPMD/Rule/CleanCode/ErrorControlOperatorTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Error Control Operator Test
@@ -31,7 +30,6 @@ class ErrorControlOperatorTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply to unary operators in functions
      *
-     * @throws Throwable
      * @covers ::apply
      */
     public function testDoesNotApplyToOtherUnaryOperatorsInFunction(): void
@@ -44,7 +42,6 @@ class ErrorControlOperatorTest extends AbstractTestCase
     /**
      * Tests that the rule applies error control operators to functions
      *
-     * @throws Throwable
      * @covers ::apply
      */
     public function testAppliesToErrorControlOperatorInFunction(): void
@@ -57,7 +54,6 @@ class ErrorControlOperatorTest extends AbstractTestCase
     /**
      * Tests that the rule applies error control operators to classes and methods
      *
-     * @throws Throwable
      * @covers ::apply
      */
     public function testAppliedToClassesAndMethods(): void

--- a/tests/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
+++ b/tests/php/PHPMD/Rule/CleanCode/IfStatementAssignmentTest.php
@@ -19,13 +19,9 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 class IfStatementAssignmentTest extends AbstractTestCase
 {
-    /**
-     * @throws Throwable
-     */
     public function testRuleNotAppliesInsideClosure(): void
     {
         $rule = new IfStatementAssignment();
@@ -33,9 +29,6 @@ class IfStatementAssignmentTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleNotAppliesInsideClosureCallbacks(): void
     {
         $rule = new IfStatementAssignment();
@@ -43,9 +36,6 @@ class IfStatementAssignmentTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleNotAppliesToIfsWithoutAssignment(): void
     {
         $rule = new IfStatementAssignment();
@@ -53,9 +43,6 @@ class IfStatementAssignmentTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleNotAppliesToIfsWithConditionsOnly(): void
     {
         $rule = new IfStatementAssignment();
@@ -63,9 +50,6 @@ class IfStatementAssignmentTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleNotAppliesToLogicalOperators(): void
     {
         $rule = new IfStatementAssignment();
@@ -73,9 +57,6 @@ class IfStatementAssignmentTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleWorksCorrectlyWhenExpressionContainsMath(): void
     {
         $rule = new IfStatementAssignment();
@@ -83,9 +64,6 @@ class IfStatementAssignmentTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleAppliesToFunctions(): void
     {
         $rule = new IfStatementAssignment();
@@ -93,9 +71,6 @@ class IfStatementAssignmentTest extends AbstractTestCase
         $rule->apply($this->getFunction());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleAppliesMultipleIfConditions(): void
     {
         $rule = new IfStatementAssignment();
@@ -103,9 +78,6 @@ class IfStatementAssignmentTest extends AbstractTestCase
         $rule->apply($this->getFunction());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleAppliesToMultilevelIfConditions(): void
     {
         $rule = new IfStatementAssignment();
@@ -113,9 +85,6 @@ class IfStatementAssignmentTest extends AbstractTestCase
         $rule->apply($this->getFunction());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleAppliesMultipleTimesInOneIfCondition(): void
     {
         $rule = new IfStatementAssignment();

--- a/tests/php/PHPMD/Rule/CleanCode/MissingImportTest.php
+++ b/tests/php/PHPMD/Rule/CleanCode/MissingImportTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * MissingImport Tests
@@ -43,7 +42,7 @@ class MissingImportTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     * @throws Throwable
+     *
      * @dataProvider getApplyingCases
      */
     public function testRuleAppliesTo(string $file): void
@@ -58,7 +57,7 @@ class MissingImportTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     * @throws Throwable
+     *
      * @dataProvider getNotApplyingCases
      */
     public function testRuleDoesNotApplyTo(string $file): void
@@ -69,7 +68,6 @@ class MissingImportTest extends AbstractTestCase
     /**
      * Tests that it applies to a class that has fully qualified class names
      *
-     * @throws Throwable
      * @covers ::apply
      * @covers ::isSelfReference
      */
@@ -83,7 +81,6 @@ class MissingImportTest extends AbstractTestCase
     /**
      * Tests that it does not apply to a class in root namespace when configured.
      *
-     * @throws Throwable
      * @covers ::apply
      * @covers ::isGlobalNamespace
      */

--- a/tests/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
+++ b/tests/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
@@ -19,16 +19,12 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Rule\CleanCode\StaticAccess
  */
 class StaticAccessTest extends AbstractTestCase
 {
-    /**
-     * @throws Throwable
-     */
     public function testRuleNotAppliesToParentStaticCall(): void
     {
         $rule = new StaticAccess();
@@ -36,9 +32,6 @@ class StaticAccessTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleNotAppliesToSelfStaticCall(): void
     {
         $rule = new StaticAccess();
@@ -46,9 +39,6 @@ class StaticAccessTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleNotAppliesToDynamicMethodCall(): void
     {
         $rule = new StaticAccess();
@@ -56,9 +46,6 @@ class StaticAccessTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleNotAppliesToStaticMethodAccessWhenExcluded(): void
     {
         $rule = new StaticAccess();
@@ -67,9 +54,6 @@ class StaticAccessTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleAppliesToStaticMethodAccess(): void
     {
         $rule = new StaticAccess();
@@ -77,9 +61,6 @@ class StaticAccessTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleAppliesToStaticMethodAccessWhenNotAllExcluded(): void
     {
         $rule = new StaticAccess();
@@ -88,9 +69,6 @@ class StaticAccessTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleNotAppliesToConstantAccess(): void
     {
         $rule = new StaticAccess();
@@ -99,7 +77,6 @@ class StaticAccessTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::apply
      * @covers ::isMethodIgnored
      */
@@ -112,7 +89,6 @@ class StaticAccessTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::apply
      * @covers ::isMethodIgnored
      */

--- a/tests/php/PHPMD/Rule/CleanCode/UndefinedVariableTest.php
+++ b/tests/php/PHPMD/Rule/CleanCode/UndefinedVariableTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the undefined variable rule.
@@ -40,7 +39,7 @@ class UndefinedVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     * @throws Throwable
+     *
      * @dataProvider getApplyingCases
      */
     public function testRuleAppliesTo(string $file): void
@@ -52,7 +51,7 @@ class UndefinedVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     * @throws Throwable
+     *
      * @dataProvider getNotApplyingCases
      */
     public function testRuleDoesNotApplyTo(string $file): void

--- a/tests/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
+++ b/tests/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
@@ -19,7 +19,6 @@ use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTNamespace;
 use PHPMD\AbstractTestCase;
 use PHPMD\Node\ClassNode;
-use Throwable;
 
 /**
  * Test case for the camel case class name rule.
@@ -27,9 +26,6 @@ use Throwable;
  */
 class CamelCaseClassNameTest extends AbstractTestCase
 {
-    /**
-     * @throws Throwable
-     */
     public function testRuleDoesNotApplyForValidClassName(): void
     {
         $report = $this->getReportWithNoViolation();
@@ -40,9 +36,6 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('ValidClass'));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleDoesNotApplyForValidClassNameWithUppercaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
@@ -53,9 +46,6 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('ValidURLClass'));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleDoesApplyForClassNameWithUppercaseAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();
@@ -66,9 +56,6 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('ValidURLClass'));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleDoesNotApplyForClassNameWithCamelcaseAbbreviation(): void
     {
         $report = $this->getReportWithNoViolation();
@@ -79,9 +66,6 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('ValidUrlClass'));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleAppliesForClassNameWithLowerCase(): void
     {
         $report = $this->getReportWithOneViolation();
@@ -92,9 +76,6 @@ class CamelCaseClassNameTest extends AbstractTestCase
         $rule->apply($this->createClassNode('invalidClass'));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleAppliesForClassNameWithLowerCaseAndCamelcaseAbbreviation(): void
     {
         $report = $this->getReportWithOneViolation();

--- a/tests/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/tests/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\Rule\Controversial;
 
 use PHPMD\AbstractTestCase;
 use PHPMD\Node\MethodNode;
-use Throwable;
 
 /**
  * Test case for the camel case method name rule.
@@ -31,7 +30,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does not apply for a valid method name.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValidMethodName(): void
     {
@@ -48,7 +46,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for method name
      * with all caps abbreviation.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForMethodNameWithAllCapsAbbreviation(): void
     {
@@ -65,7 +62,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for method name
      * with camelcase abbreviation.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForMethodNameWithCamelcaseAbbreviation(): void
     {
@@ -82,7 +78,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for an method name
      * starting with a capital.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForMethodNameWithCapital(): void
     {
@@ -100,7 +95,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a method name
      * with underscores.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForMethodNameWithUnderscores(): void
     {
@@ -118,7 +112,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid method name
      * with an underscore at the beginning when it is allowed.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForValidMethodNameWithUnderscoreWhenNotAllowed(): void
     {
@@ -135,7 +128,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid method name
      * with an underscore at the beginning when it is not allowed.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValidMethodNameWithUnderscoreWhenAllowed(): void
     {
@@ -152,7 +144,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid method name
      * with an underscore at the beginning when it is not allowed.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForMagicMethods(): void
     {
@@ -172,7 +163,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid test method name
      * with an underscore.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForTestMethodWithUnderscoreWhenNotAllowed(): void
     {
@@ -189,7 +179,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid test method name
      * with an underscore when underscores are allowed.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForTestMethodWithUnderscoreWhenAllowed(): void
     {
@@ -206,7 +195,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid test method name
      * with multiple underscores in different positions when underscores are allowed.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForTestMethodWithMultipleUnderscoresWhenAllowed(): void
     {
@@ -223,7 +211,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a test method name
      * with consecutive underscores even when underscores are allowed.
-     * @throws Throwable
      */
     public function testRuleAppliesToTestMethodWithTwoConsecutiveUnderscoresWhenAllowed(): void
     {
@@ -240,8 +227,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply to for test method names that
      * have a capital after their single allowed underscore.
-     *
-     * @throws Throwable
      */
     public function testRuleAppliesToTestMethodWithUnderscoreFollowedByCapital(): void
     {
@@ -258,8 +243,6 @@ class CamelCaseMethodNameTest extends AbstractTestCase
     /**
      * Returns the first method found in a source file related to the calling
      * test method.
-     *
-     * @throws Throwable
      */
     protected function getMethod(): MethodNode
     {

--- a/tests/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
+++ b/tests/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Controversial;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the camel case namespace rule.
@@ -29,7 +28,6 @@ class CamelCaseNamespaceTest extends AbstractTestCase
 {
     /**
      * Rule does not apply for valid namespace.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValidNamespace(): void
     {
@@ -42,7 +40,6 @@ class CamelCaseNamespaceTest extends AbstractTestCase
 
     /**
      * Rule does apply for incorrect namespace.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForIncorrectNamespace(): void
     {
@@ -55,7 +52,6 @@ class CamelCaseNamespaceTest extends AbstractTestCase
 
     /**
      * Rule does not apply for namespace with uppercase abbreviation.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForNamespaceWithUppercaseAbbreviation(): void
     {
@@ -68,7 +64,6 @@ class CamelCaseNamespaceTest extends AbstractTestCase
 
     /**
      * Rule does apply for namespace with uppercase abbreviation.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForNamespaceWithUppercaseAbbreviation(): void
     {
@@ -82,7 +77,6 @@ class CamelCaseNamespaceTest extends AbstractTestCase
 
     /**
      * Rule does not apply for invalid namespace in exception list.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForNamespaceInException(): void
     {

--- a/tests/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
+++ b/tests/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Controversial;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the camel case parameter name rule.
@@ -30,7 +29,6 @@ class CamelCaseParameterNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does apply for an invalid parameter name
-     * @throws Throwable
      */
     public function testRuleDoesApplyForInParameterNameWithUnderscore(): void
     {
@@ -46,7 +44,6 @@ class CamelCaseParameterNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does apply for all caps abbreviation when not allowed
-     * @throws Throwable
      */
     public function testRuleDoesApplyForAllCapsAbbreviation(): void
     {
@@ -63,7 +60,6 @@ class CamelCaseParameterNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does not apply for camelcase abbreviation
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForCamelcaseAbbreviation(): void
     {
@@ -81,7 +77,6 @@ class CamelCaseParameterNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for an invalid parameter name
      * starting with a capital.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForParameterNameWithCapital(): void
     {
@@ -97,7 +92,6 @@ class CamelCaseParameterNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does NOT apply for a valid parameter name
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValidParameterName(): void
     {
@@ -114,7 +108,6 @@ class CamelCaseParameterNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid parameter name
      * with an underscore at the beginning when it is allowed.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValidParameterNameWithUnderscoreWhenAllowed(): void
     {

--- a/tests/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
+++ b/tests/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Controversial;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the camel case property name rule.
@@ -30,7 +29,6 @@ class CamelCasePropertyNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does not apply for a valid property name.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValidPropertyName(): void
     {
@@ -44,7 +42,6 @@ class CamelCasePropertyNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does apply for all caps abbreviation in property name.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForAllCapsAbbreviationInProperty(): void
     {
@@ -59,7 +56,6 @@ class CamelCasePropertyNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does not apply for a camelcase abbreviation in property name.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForCamelcaseAbbreviationInProperty(): void
     {
@@ -75,7 +71,6 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a property name
      * starting with a capital.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForPropertyNameWithCapital(): void
     {
@@ -91,7 +86,6 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a property name
      * with underscores.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForPropertyNameWithUnderscores(): void
     {
@@ -107,7 +101,6 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid property name
      * with an underscore at the beginning when it is allowed.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForValidPropertyNameWithUnderscoreWhenNotAllowed(): void
     {
@@ -122,7 +115,6 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid property name
      * with no underscore at the beginning when it is allowed.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValidPropertyNameWithNoUnderscoreWhenAllowed(): void
     {
@@ -137,7 +129,6 @@ class CamelCasePropertyNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for a valid property name
      * with an underscore at the beginning when it is allowed.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValidPropertyNameWithUnderscoreWhenAllowed(): void
     {

--- a/tests/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
+++ b/tests/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Controversial;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the camel case variable name rule.
@@ -30,7 +29,6 @@ class CamelCaseVariableNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does apply for an invalid variable name
-     * @throws Throwable
      */
     public function testRuleDoesApplyForInvariableNameWithUnderscore(): void
     {
@@ -45,7 +43,6 @@ class CamelCaseVariableNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for variable name
      * with all caps abbreviation.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForAllCapsAbbreviation(): void
     {
@@ -61,7 +58,6 @@ class CamelCaseVariableNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply for variable name
      * with camelcase abbreviation.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForCamelcaseAbbreviation(): void
     {
@@ -77,7 +73,6 @@ class CamelCaseVariableNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for an invalid variable name
      * starting with a capital.
-     * @throws Throwable
      */
     public function testRuleDoesApplyForVariableNameWithCapital(): void
     {
@@ -91,7 +86,6 @@ class CamelCaseVariableNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does NOT apply for a valid variable name
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValidVariableName(): void
     {
@@ -105,7 +99,6 @@ class CamelCaseVariableNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does NOT apply for a statically accessed variable
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForStaticVariableAccess(): void
     {
@@ -119,7 +112,6 @@ class CamelCaseVariableNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does NOT apply if name allowed by config
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyIfExcluded(): void
     {
@@ -134,7 +126,6 @@ class CamelCaseVariableNameTest extends AbstractTestCase
     /**
      * Tests that the rule does apply for a valid variable name
      * with an underscore at the beginning when it is allowed.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValidVariableNameWithUnderscoreWhenAllowed(): void
     {

--- a/tests/php/PHPMD/Rule/CyclomaticComplexityTest.php
+++ b/tests/php/PHPMD/Rule/CyclomaticComplexityTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the cyclomatic complexity violation rule.
@@ -31,7 +30,6 @@ class CyclomaticComplexityTest extends AbstractTestCase
     /**
      * Tests that the rule applies for a value greater than the configured
      * threshold.
-     * @throws Throwable
      */
     public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
@@ -47,7 +45,6 @@ class CyclomaticComplexityTest extends AbstractTestCase
     /**
      * Test that the rule applies for a value that is equal with the configured
      * threshold.
-     * @throws Throwable
      */
     public function testRuleAppliesForValueEqualToThreshold(): void
     {
@@ -63,7 +60,6 @@ class CyclomaticComplexityTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply when the value is at least one lower
      * than the threshold.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValueLowerThanThreshold(): void
     {

--- a/tests/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
+++ b/tests/php/PHPMD/Rule/Design/CountInLoopExpressionTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Count In Loop Expression Test
@@ -30,7 +29,6 @@ class CountInLoopExpressionTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToAllTypesOfLoops
-     * @throws Throwable
      */
     public function testRuleAppliesToAllTypesOfLoops(): void
     {
@@ -41,7 +39,6 @@ class CountInLoopExpressionTest extends AbstractTestCase
 
     /**
      * testRuleNotApplyToExpressionElsewhere
-     * @throws Throwable
      */
     public function testRuleNotApplyToExpressionElsewhere(): void
     {
@@ -52,7 +49,6 @@ class CountInLoopExpressionTest extends AbstractTestCase
 
     /**
      * testRuleApplyToNestedLoops
-     * @throws Throwable
      */
     public function testRuleApplyToNestedLoops(): void
     {
@@ -63,7 +59,6 @@ class CountInLoopExpressionTest extends AbstractTestCase
 
     /**
      * testMutedRuleAtClassLevel
-     * @throws Throwable
      */
     public function testMutedRuleAtClassLevel(): void
     {
@@ -74,7 +69,6 @@ class CountInLoopExpressionTest extends AbstractTestCase
 
     /**
      * testMutedRuleAtMethodLevel
-     * @throws Throwable
      */
     public function testMutedRuleAtMethodLevel(): void
     {

--- a/tests/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
+++ b/tests/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\CouplingBetweenObjects} class.
@@ -31,7 +30,6 @@ class CouplingBetweenObjectsTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToClassWithCboLessThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToClassWithCboLessThanThreshold(): void
     {
@@ -43,7 +41,6 @@ class CouplingBetweenObjectsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithCboEqualToThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToClassWithCboEqualToThreshold(): void
     {
@@ -55,7 +52,6 @@ class CouplingBetweenObjectsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithCboGreaterThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToClassWithCboGreaterThanThreshold(): void
     {

--- a/tests/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
+++ b/tests/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\DepthOfInheritance} class.
@@ -30,7 +29,6 @@ class DepthOfInheritanceTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToClassWithNumberOfParentLessThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToClassWithNumberOfParentLessThanThreshold(): void
     {
@@ -42,7 +40,6 @@ class DepthOfInheritanceTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithNumberOfParentIdenticalToThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToClassWithNumberOfParentIdenticalToThreshold(): void
     {
@@ -54,7 +51,6 @@ class DepthOfInheritanceTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithNumberOfParentGreaterThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToClassWithNumberOfParentGreaterThanThreshold(): void
     {

--- a/tests/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/tests/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\DevelopmentCodeFragment} class.
@@ -32,7 +31,6 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutSuspectFunctionCall
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodWithoutSuspectFunctionCall(): void
     {
@@ -43,7 +41,6 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithSuspectFunctionCall
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodWithSuspectFunctionCall(): void
     {
@@ -54,7 +51,6 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithMultipleSuspectFunctionCall
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodWithMultipleSuspectFunctionCall(): void
     {
@@ -65,7 +61,6 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodWithSuspectFullyQualifiedFunctionCall(): void
     {
@@ -76,7 +71,6 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodWithMultipleSuspectFullyQualifiedFunctionCall(): void
     {
@@ -87,7 +81,6 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutSuspectFunctionCall
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFunctionWithoutSuspectFunctionCall(): void
     {
@@ -98,7 +91,6 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithSuspectFunctionCall
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionWithSuspectFunctionCall(): void
     {
@@ -109,7 +101,6 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithMultipleSuspectFunctionCall
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionWithMultipleSuspectFunctionCall(): void
     {
@@ -120,7 +111,6 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithSuspectFullyQualifiedFunctionCall
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionWithSuspectFullyQualifiedFunctionCall(): void
     {
@@ -131,7 +121,6 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithMultipleSuspectFullyQualifiedFunctionCall
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionWithMultipleSuspectFullyQualifiedFunctionCall(): void
     {
@@ -142,7 +131,6 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithinNamespace
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodWithinNamespace(): void
     {
@@ -154,7 +142,6 @@ class DevelopmentCodeFragmentTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithinNamespaceByDefault
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodWithinNamespaceByDefault(): void
     {

--- a/tests/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
+++ b/tests/php/PHPMD/Rule/Design/EmptyCatchBlockTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Empty Catch Block Test
@@ -31,7 +30,6 @@ class EmptyCatchBlockTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutTryCatchBlock
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodWithoutTryCatchBlock(): void
     {
@@ -42,7 +40,6 @@ class EmptyCatchBlockTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithEmptyCatchBlock
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionWithEmptyCatchBlock(): void
     {
@@ -53,7 +50,6 @@ class EmptyCatchBlockTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithNonEmptyCatchBlock
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFunctionWithNonEmptyCatchBlock(): void
     {
@@ -64,7 +60,6 @@ class EmptyCatchBlockTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToCatchBlockWithComments
-     * @throws Throwable
      */
     public function testRuleNotAppliesToCatchBlockWithComments(): void
     {
@@ -75,7 +70,6 @@ class EmptyCatchBlockTest extends AbstractTestCase
 
     /**
      * testRuleWorksWithNestedTryCatchBlocksAndNonSPLExceptions
-     * @throws Throwable
      */
     public function testRuleWorksWithNestedTryCatchBlocksAndNonSPLExceptions(): void
     {

--- a/tests/php/PHPMD/Rule/Design/EvalExpressionTest.php
+++ b/tests/php/PHPMD/Rule/Design/EvalExpressionTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\EvalExpression} class.
@@ -30,7 +29,6 @@ class EvalExpressionTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutEvalExpression
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodWithoutEvalExpression(): void
     {
@@ -41,7 +39,6 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithEvalExpression
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodWithEvalExpression(): void
     {
@@ -52,7 +49,6 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToMethodWithEvalExpression
-     * @throws Throwable
      */
     public function testRuleAppliesMultipleTimesToMethodWithEvalExpression(): void
     {
@@ -63,7 +59,6 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutEvalExpression
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFunctionWithoutEvalExpression(): void
     {
@@ -74,7 +69,6 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithEvalExpression
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionWithEvalExpression(): void
     {
@@ -85,7 +79,6 @@ class EvalExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToFunctionWithEvalExpression
-     * @throws Throwable
      */
     public function testRuleAppliesMultipleTimesToFunctionWithEvalExpression(): void
     {

--- a/tests/php/PHPMD/Rule/Design/ExitExpressionTest.php
+++ b/tests/php/PHPMD/Rule/Design/ExitExpressionTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\ExitExpression} class.
@@ -30,7 +29,6 @@ class ExitExpressionTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutExitExpression
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodWithoutExitExpression(): void
     {
@@ -41,7 +39,6 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithExitExpression
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodWithExitExpression(): void
     {
@@ -52,7 +49,6 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToMethodWithExitExpression
-     * @throws Throwable
      */
     public function testRuleAppliesMultipleTimesToMethodWithExitExpression(): void
     {
@@ -63,7 +59,6 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutExitExpression
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFunctionWithoutExitExpression(): void
     {
@@ -74,7 +69,6 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithExitExpression
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionWithExitExpression(): void
     {
@@ -85,7 +79,6 @@ class ExitExpressionTest extends AbstractTestCase
 
     /**
      * testRuleAppliesMultipleTimesToFunctionWithExitExpression
-     * @throws Throwable
      */
     public function testRuleAppliesMultipleTimesToFunctionWithExitExpression(): void
     {

--- a/tests/php/PHPMD/Rule/Design/GotoStatementTest.php
+++ b/tests/php/PHPMD/Rule/Design/GotoStatementTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\GotoStatement} class.
@@ -31,7 +30,6 @@ class GotoStatementTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToMethodWithoutGotoStatement
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodWithoutGotoStatement(): void
     {
@@ -42,7 +40,6 @@ class GotoStatementTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodWithGotoStatement
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodWithGotoStatement(): void
     {
@@ -53,7 +50,6 @@ class GotoStatementTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithoutGotoStatement
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFunctionWithoutGotoStatement(): void
     {
@@ -64,7 +60,6 @@ class GotoStatementTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithGotoStatement
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionWithGotoStatement(): void
     {

--- a/tests/php/PHPMD/Rule/Design/LongClassTest.php
+++ b/tests/php/PHPMD/Rule/Design/LongClassTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the excessive long class rule.
@@ -31,7 +30,6 @@ class LongClassTest extends AbstractTestCase
     /**
      * Tests that the rule applies for a value greater than the configured
      * threshold.
-     * @throws Throwable
      */
     public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
@@ -48,7 +46,6 @@ class LongClassTest extends AbstractTestCase
     /**
      * Test that the rule applies for a value that is equal with the configured
      * threshold.
-     * @throws Throwable
      */
     public function testRuleAppliesForValueEqualToThreshold(): void
     {
@@ -65,7 +62,6 @@ class LongClassTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply when the value is at least one lower
      * than the threshold.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValueLowerThanThreshold(): void
     {
@@ -81,7 +77,6 @@ class LongClassTest extends AbstractTestCase
 
     /**
      * Tests that the rule uses eloc when ignore whitespace is set
-     * @throws Throwable
      */
     public function testRuleUsesElocWhenIgnoreWhitespaceSet(): void
     {

--- a/tests/php/PHPMD/Rule/Design/LongMethodTest.php
+++ b/tests/php/PHPMD/Rule/Design/LongMethodTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the excessive long method rule.
@@ -31,7 +30,6 @@ class LongMethodTest extends AbstractTestCase
     /**
      * Tests that the rule applies for a value greater than the configured
      * threshold.
-     * @throws Throwable
      */
     public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
@@ -48,7 +46,6 @@ class LongMethodTest extends AbstractTestCase
     /**
      * Test that the rule applies for a value that is equal with the configured
      * threshold.
-     * @throws Throwable
      */
     public function testRuleAppliesForValueEqualToThreshold(): void
     {
@@ -65,7 +62,6 @@ class LongMethodTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply when the value is at least one lower
      * than the threshold.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValueLowerThanThreshold(): void
     {
@@ -81,7 +77,6 @@ class LongMethodTest extends AbstractTestCase
 
     /**
      * Tests that the rule uses eloc when ignore whitespace is set
-     * @throws Throwable
      */
     public function testRuleUsesElocWhenIgnoreWhitespaceSet(): void
     {

--- a/tests/php/PHPMD/Rule/Design/LongParameterListTest.php
+++ b/tests/php/PHPMD/Rule/Design/LongParameterListTest.php
@@ -22,7 +22,6 @@ use PHPMD\AbstractTestCase;
 use PHPMD\Node\FunctionNode;
 use PHPMD\Node\MethodNode;
 use PHPUnit\Framework\MockObject\MockObject;
-use Throwable;
 
 /**
  * Test case for the excessive long parameter list rule.
@@ -33,7 +32,6 @@ class LongParameterListTest extends AbstractTestCase
 {
     /**
      * testApplyIgnoresMethodsWithLessParametersThanMinimum
-     * @throws Throwable
      */
     public function testApplyIgnoresMethodsWithLessParametersThanMinimum(): void
     {
@@ -45,7 +43,6 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyReportsMethodsWithIdenticalParametersAndMinimum
-     * @throws Throwable
      */
     public function testApplyReportsMethodsWithIdenticalParametersAndMinimum(): void
     {
@@ -57,7 +54,6 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyReportsMethodsWithMoreParametersThanMinimum
-     * @throws Throwable
      */
     public function testApplyReportsMethodsWithMoreParametersThanMinimum(): void
     {
@@ -69,7 +65,6 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyIgnoresFunctionsWithLessParametersThanMinimum
-     * @throws Throwable
      */
     public function testApplyIgnoresFunctionsWithLessParametersThanMinimum(): void
     {
@@ -81,7 +76,6 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyReportsFunctionsWithIdenticalParametersAndMinimum
-     * @throws Throwable
      */
     public function testApplyReportsFunctionsWithIdenticalParametersAndMinimum(): void
     {
@@ -93,7 +87,6 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * testApplyReportsFunctionsWithMoreParametersThanMinimum
-     * @throws Throwable
      */
     public function testApplyReportsFunctionsWithMoreParametersThanMinimum(): void
     {
@@ -105,8 +98,6 @@ class LongParameterListTest extends AbstractTestCase
 
     /**
      * Returns a mocked method instance.
-     *
-     * @throws Throwable
      */
     private function createMethod(int $parameterCount): MethodNode
     {
@@ -120,7 +111,6 @@ class LongParameterListTest extends AbstractTestCase
      * Creates a mocked function node instance.
      *
      * @param int $parameterCount Number of function parameters.
-     * @throws Throwable
      */
     private function createFunction(int $parameterCount): FunctionNode
     {
@@ -134,7 +124,6 @@ class LongParameterListTest extends AbstractTestCase
      * Initializes the getParameterCount() method of the given callable.
      *
      * @param (FunctionNode|MethodNode)&MockObject $mock
-     * @throws Throwable
      */
     private function initFunctionOrMethodMock($mock, int $parameterCount): FunctionNode|MethodNode
     {

--- a/tests/php/PHPMD/Rule/Design/NpathComplexityTest.php
+++ b/tests/php/PHPMD/Rule/Design/NpathComplexityTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * This is a test case for the NPath complexity rule.
@@ -31,7 +30,6 @@ class NpathComplexityTest extends AbstractTestCase
     /**
      * Tests that the rule applies for a value greater than the configured
      * threshold.
-     * @throws Throwable
      */
     public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
@@ -47,7 +45,6 @@ class NpathComplexityTest extends AbstractTestCase
     /**
      * Test that the rule applies for a value that is equal with the configured
      * threshold.
-     * @throws Throwable
      */
     public function testRuleAppliesForValueEqualToThreshold(): void
     {
@@ -63,7 +60,6 @@ class NpathComplexityTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply when the value is at least one lower
      * than the threshold.
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyForValueLowerThanThreshold(): void
     {

--- a/tests/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
+++ b/tests/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\NumberOfChildren} class.
@@ -30,7 +29,6 @@ class NumberOfChildrenTest extends AbstractTestCase
 {
     /**
      * testRuleNotAppliesToClassWithChildrenLessThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToClassWithChildrenLessThanThreshold(): void
     {
@@ -42,7 +40,6 @@ class NumberOfChildrenTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithChildrenIdenticalToThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToClassWithChildrenIdenticalToThreshold(): void
     {
@@ -54,7 +51,6 @@ class NumberOfChildrenTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassWithChildrenGreaterThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToClassWithChildrenGreaterThanThreshold(): void
     {

--- a/tests/php/PHPMD/Rule/Design/TooManyFieldsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyFieldsTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the too many methods rule.
@@ -30,7 +29,6 @@ class TooManyFieldsTest extends AbstractTestCase
 {
     /**
      * testRuleDoesNotApplyToClassesWithLessFieldsThanThreshold
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToClassesWithLessFieldsThanThreshold(): void
     {
@@ -42,7 +40,6 @@ class TooManyFieldsTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToClassesWithSameNumberOfFieldsAsThreshold
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToClassesWithSameNumberOfFieldsAsThreshold(): void
     {
@@ -54,7 +51,6 @@ class TooManyFieldsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassesWithMoreFieldsThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToClassesWithMoreFieldsThanThreshold(): void
     {

--- a/tests/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
 use PHPMD\Node\ClassNode;
-use Throwable;
 
 /**
  * Test case for the too many methods rule.
@@ -31,7 +30,6 @@ class TooManyMethodsTest extends AbstractTestCase
 {
     /**
      * testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold(): void
     {
@@ -44,7 +42,6 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold(): void
     {
@@ -57,7 +54,6 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassesWithMoreMethodsThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToClassesWithMoreMethodsThanThreshold(): void
     {
@@ -70,7 +66,6 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresGetterMethodsInTest
-     * @throws Throwable
      */
     public function testRuleIgnoresGetterMethodsInTest(): void
     {
@@ -83,7 +78,6 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresSetterMethodsInTest
-     * @throws Throwable
      */
     public function testRuleIgnoresSetterMethodsInTest(): void
     {
@@ -96,7 +90,6 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven
-     * @throws Throwable
      */
     public function testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven(): void
     {
@@ -109,7 +102,6 @@ class TooManyMethodsTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresGetterAndSetterMethodsInTest
-     * @throws Throwable
      */
     public function testRuleIgnoresGetterAndSetterMethodsInTest(): void
     {
@@ -120,9 +112,6 @@ class TooManyMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(3, ['invoke', 'getClass', 'setClass']));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleIgnoresHassers(): void
     {
         $rule = new TooManyMethods();
@@ -132,9 +121,6 @@ class TooManyMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'hasClass']));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleIgnoresIssers(): void
     {
         $rule = new TooManyMethods();
@@ -144,9 +130,6 @@ class TooManyMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'isClass']));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleIgnoresWithers(): void
     {
         $rule = new TooManyMethods();
@@ -160,7 +143,6 @@ class TooManyMethodsTest extends AbstractTestCase
      * Creates a prepared class node mock
      *
      * @param string[] $methodNames
-     * @throws Throwable
      */
     private function createClassMock(int $numberOfMethods, ?array $methodNames = null): ClassNode
     {

--- a/tests/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -24,7 +24,6 @@ use PHPMD\AbstractTestCase;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\MethodNode;
 use PHPMD\Report;
-use Throwable;
 
 /**
  * Test case for the too many public methods rule.
@@ -33,9 +32,6 @@ use Throwable;
  */
 class TooManyPublicMethodsTest extends AbstractTestCase
 {
-    /**
-     * @throws Throwable
-     */
     public function testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold(): void
     {
         $rule = new TooManyPublicMethods();
@@ -45,9 +41,6 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(23));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleDoesNotApplyToClassesWithSameNumberOfMethodsAsThreshold(): void
     {
         $rule = new TooManyPublicMethods();
@@ -57,9 +50,6 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(42));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleAppliesToClassesWithMoreMethodsThanThreshold(): void
     {
         $rule = new TooManyPublicMethods();
@@ -69,9 +59,6 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleIgnoresGetterMethodsInTest(): void
     {
         $rule = new TooManyPublicMethods();
@@ -81,9 +68,6 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'getClass']));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleIgnoresSetterMethodsInTest(): void
     {
         $rule = new TooManyPublicMethods();
@@ -93,9 +77,6 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'setClass']));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleIgnoresCustomMethodsWhenRegexPropertyIsGiven(): void
     {
         $rule = new TooManyPublicMethods();
@@ -105,9 +86,6 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'injectClass']));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleIgnoresGetterAndSetterMethodsInTest(): void
     {
         $rule = new TooManyPublicMethods();
@@ -117,9 +95,6 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(3, ['foo', 'bar'], ['baz', 'bah']));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleIgnoresPrivateMethods(): void
     {
         $rule = new TooManyPublicMethods();
@@ -129,9 +104,6 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'getClass', 'setClass']));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleIgnoresHassers(): void
     {
         $rule = new TooManyPublicMethods();
@@ -141,9 +113,6 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'hasClass']));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleIgnoresIssers(): void
     {
         $rule = new TooManyPublicMethods();
@@ -153,9 +122,6 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'isClass']));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleIgnoresWithers(): void
     {
         $rule = new TooManyPublicMethods();
@@ -165,9 +131,6 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'withClass']));
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleApplyToBasicClass(): void
     {
         $class = $this->getClass();
@@ -189,7 +152,6 @@ class TooManyPublicMethodsTest extends AbstractTestCase
      *
      * @param array<string> $publicMethods
      * @param array<string> $privateMethods
-     * @throws Throwable
      */
     private function createClassMock(
         int $numberOfMethods,
@@ -209,7 +171,6 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @phpcsSuppress SlevomatCodingStandard.Classes.UnusedPrivateElements
      */
     private function createPublicMethod(string $methodName): MethodNode

--- a/tests/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
+++ b/tests/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the weighted method count rule.
@@ -31,7 +30,6 @@ class WeightedMethodCountTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesForValueGreaterThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesForValueGreaterThanThreshold(): void
     {
@@ -46,7 +44,6 @@ class WeightedMethodCountTest extends AbstractTestCase
 
     /**
      * testRuleAppliesForValueEqualToThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesForValueEqualToThreshold(): void
     {
@@ -61,7 +58,6 @@ class WeightedMethodCountTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesForValueLowerThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesForValueLowerThanThreshold(): void
     {

--- a/tests/php/PHPMD/Rule/ExcessivePublicCountTest.php
+++ b/tests/php/PHPMD/Rule/ExcessivePublicCountTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the excessive use of public members rule.
@@ -30,7 +29,6 @@ class ExcessivePublicCountTest extends AbstractTestCase
 {
     /**
      * testRuleDoesNotApplyToClassesWithLessPublicMembersThanThreshold
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToClassesWithLessPublicMembersThanThreshold(): void
     {
@@ -42,7 +40,6 @@ class ExcessivePublicCountTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassesWithSameNumberOfPublicMembersAsThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToClassesWithSameNumberOfPublicMembersAsThreshold(): void
     {
@@ -54,7 +51,6 @@ class ExcessivePublicCountTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClassesWithMorePublicMembersThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToClassesWithMorePublicMembersThanThreshold(): void
     {

--- a/tests/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
+++ b/tests/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
 use PHPMD\Node\MethodNode;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Naming\BooleanGetMethodName} rule class.
@@ -31,7 +30,6 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToMethodStartingWithGetAndReturningBoolean
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodStartingWithGetAndReturningBoolean(): void
     {
@@ -43,7 +41,6 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodStartingWithGetAndReturningBool
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodStartingWithGetAndReturningBool(): void
     {
@@ -55,7 +52,6 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToPearPrivateMethodStartingWithGetAndReturningBoolean
-     * @throws Throwable
      */
     public function testRuleAppliesToPearPrivateMethodStartingWithGetAndReturningBoolean(): void
     {
@@ -67,7 +63,6 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleIgnoresParametersWhenNotExplicitConfigured
-     * @throws Throwable
      */
     public function testRuleIgnoresParametersWhenNotExplicitConfigured(): void
     {
@@ -79,7 +74,6 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesWhenParametersAreExplicitEnabled
-     * @throws Throwable
      */
     public function testRuleNotAppliesWhenParametersAreExplicitEnabled(): void
     {
@@ -92,7 +86,6 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodStartingWithIs
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodStartingWithIs(): void
     {
@@ -105,7 +98,6 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodStartingWithHas
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodStartingWithHas(): void
     {
@@ -118,7 +110,6 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithReturnTypeNotBoolean
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodWithReturnTypeNotBoolean(): void
     {
@@ -132,8 +123,6 @@ class BooleanGetMethodNameTest extends AbstractTestCase
     /**
      * Returns the first method found in a source file related to the calling
      * test method.
-     *
-     * @throws Throwable
      */
     protected function getMethod(): MethodNode
     {

--- a/tests/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
+++ b/tests/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the constructor name rule.
@@ -30,7 +29,6 @@ class ConstantNamingConventionsTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToClassConstantWithLowerCaseCharacters
-     * @throws Throwable
      */
     public function testRuleAppliesToClassConstantWithLowerCaseCharacters(): void
     {
@@ -41,7 +39,6 @@ class ConstantNamingConventionsTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToInterfaceConstantWithLowerCaseCharacters
-     * @throws Throwable
      */
     public function testRuleAppliesToInterfaceConstantWithLowerCaseCharacters(): void
     {
@@ -52,7 +49,6 @@ class ConstantNamingConventionsTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToClassConstantWithUpperCaseCharacters
-     * @throws Throwable
      */
     public function testRuleNotAppliesToClassConstantWithUpperCaseCharacters(): void
     {
@@ -63,7 +59,6 @@ class ConstantNamingConventionsTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToInterfaceConstantWithUpperCaseCharacters
-     * @throws Throwable
      */
     public function testRuleNotAppliesToInterfaceConstantWithUpperCaseCharacters(): void
     {

--- a/tests/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
+++ b/tests/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the constructor name rule.
@@ -30,7 +29,6 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToConstructorMethodNamedAsEnclosingClass
-     * @throws Throwable
      */
     public function testRuleAppliesToConstructorMethodNamedAsEnclosingClass(): void
     {
@@ -41,7 +39,6 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToConstructorMethodNamedAsEnclosingClassCaseInsensitive
-     * @throws Throwable
      */
     public function testRuleAppliesToConstructorMethodNamedAsEnclosingClassCaseInsensitive(): void
     {
@@ -52,7 +49,6 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodNamedSimilarToEnclosingClass
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodNamedSimilarToEnclosingClass(): void
     {
@@ -61,9 +57,6 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleNotAppliesToMethodNamedAsEnclosingInterface(): void
     {
         $rule = new ConstructorWithNameAsEnclosingClass();
@@ -71,9 +64,6 @@ class ConstructorWithNameAsEnclosingClassTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleNotAppliesToMethodInNamespaces(): void
     {
         $rule = new ConstructorWithNameAsEnclosingClass();

--- a/tests/php/PHPMD/Rule/Naming/LongClassNameTest.php
+++ b/tests/php/PHPMD/Rule/Naming/LongClassNameTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test cases for LongClassName.
@@ -30,7 +29,6 @@ class LongClassNameTest extends AbstractTestCase
 {
     /**
      * Tests that the rule does not apply to class name length (43) below threshold (44)
-     * @throws Throwable
      */
     public function testRuleNotAppliesToClassNameBelowThreshold(): void
     {
@@ -42,7 +40,6 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to class name length (40) below threshold (39)
-     * @throws Throwable
      */
     public function testRuleAppliesToClassNameAboveThreshold(): void
     {
@@ -54,7 +51,6 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule does not apply to interface name length (47) below threshold (47)
-     * @throws Throwable
      */
     public function testRuleNotAppliesToInterfaceNameBelowThreshold(): void
     {
@@ -66,7 +62,6 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to class name length (44) above threshold (43)
-     * @throws Throwable
      */
     public function testRuleAppliesToInterfaceNameAboveThreshold(): void
     {
@@ -78,7 +73,6 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to trait name length (40) above threshold (39)
-     * @throws Throwable
      */
     public function testRuleAppliesToTraitNameAboveThreshold(): void
     {
@@ -90,7 +84,6 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to enum name length (39) above threshold (38)
-     * @throws Throwable
      */
     public function testRuleAppliesToEnumNameAboveThreshold(): void
     {
@@ -103,7 +96,6 @@ class LongClassNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply to class name length (69) below threshold (60)
      * with configured suffix length (9)
-     * @throws Throwable
      */
     public function testRuleNotAppliesToClassNameLengthWithSuffixSubtractedBelowThreshold(): void
     {
@@ -116,7 +108,6 @@ class LongClassNameTest extends AbstractTestCase
 
     /**
      * Tests that the rule applies to class name length (66) above threshold (56) with configured suffix length (9)
-     * @throws Throwable
      */
     public function testRuleAppliesToClassNameLengthWithSuffixSubtractedAboveThreshold(): void
     {
@@ -130,7 +121,6 @@ class LongClassNameTest extends AbstractTestCase
     /**
      * Tests that the rule does not apply to class name length (55) below threshold (54)
      * not matching configured suffix length (9)
-     * @throws Throwable
      */
     public function testRuleAppliesToClassNameLengthWithoutSuffixSubtracted(): void
     {
@@ -144,7 +134,6 @@ class LongClassNameTest extends AbstractTestCase
     /**
      * Tests that the rule applies to class name length (43) below threshold (40)
      * not matching configured prefix length (15)
-     * @throws Throwable
      */
     public function testRuleAppliesToClassNameWithPrefixMatched(): void
     {

--- a/tests/php/PHPMD/Rule/Naming/LongVariableTest.php
+++ b/tests/php/PHPMD/Rule/Naming/LongVariableTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the really long variable, parameter and property name rule.
@@ -30,7 +29,6 @@ class LongVariableTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToLocalVariableInFunctionWithNameLongerThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToLocalVariableInFunctionWithNameLongerThanThreshold(): void
     {
@@ -42,7 +40,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInFunctionWithNameSmallerThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToLocalVariableInFunctionWithNameSmallerThanThreshold(): void
     {
@@ -54,7 +51,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold(): void
     {
@@ -66,7 +62,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionParameterWithNameLongerThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionParameterWithNameLongerThanThreshold(): void
     {
@@ -78,7 +73,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionParameterWithNameSmallerThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFunctionParameterWithNameSmallerThanThreshold(): void
     {
@@ -90,7 +84,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToLocalVariableInMethodWithNameLongerThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToLocalVariableInMethodWithNameLongerThanThreshold(): void
     {
@@ -108,7 +101,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold(): void
     {
@@ -120,7 +112,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInMethodWithNameShorterThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToLocalVariableInMethodWithNameShorterThanThreshold(): void
     {
@@ -132,7 +123,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodParameterWithNameLongerThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodParameterWithNameLongerThanThreshold(): void
     {
@@ -150,7 +140,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodParameterWithNameShorterThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodParameterWithNameShorterThanThreshold(): void
     {
@@ -162,7 +151,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFieldWithNameLongerThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToFieldWithNameLongerThanThreshold(): void
     {
@@ -174,7 +162,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFieldWithNameEqualToThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFieldWithNameEqualToThreshold(): void
     {
@@ -186,7 +173,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFieldWithNameShorterThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFieldWithNameShorterThanThreshold(): void
     {
@@ -198,7 +184,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFieldAndParameterWithNameLongerThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToFieldAndParameterWithNameLongerThanThreshold(): void
     {
@@ -216,7 +201,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToStaticMembersAccessedInMethod
-     * @throws Throwable
      */
     public function testRuleNotAppliesToStaticMembersAccessedInMethod(): void
     {
@@ -228,7 +212,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToIdenticalVariableOnlyOneTime
-     * @throws Throwable
      */
     public function testRuleAppliesToIdenticalVariableOnlyOneTime(): void
     {
@@ -240,7 +223,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes
-     * @throws Throwable
      */
     public function testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes(): void
     {
@@ -259,7 +241,6 @@ class LongVariableTest extends AbstractTestCase
     /**
      * testRuleAppliesForLongPrivateProperty
      *
-     * @throws Throwable
      * @since 1.1.0
      */
     public function testRuleAppliesForLongPrivateProperty(): void
@@ -273,7 +254,6 @@ class LongVariableTest extends AbstractTestCase
     /**
      * testRuleAppliesForLongPrivateStaticProperty
      *
-     * @throws Throwable
      * @since 1.1.0
      */
     public function testRuleAppliesForLongPrivateStaticProperty(): void
@@ -286,7 +266,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToVariableNameSmallerThanThresholdWithSuffixSubtracted
-     * @throws Throwable
      */
     public function testRuleNotAppliesToVariableNameSmallerThanThresholdWithSuffixSubtracted(): void
     {
@@ -299,7 +278,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameLongerThanThresholdWithSuffixSubtracted
-     * @throws Throwable
      */
     public function testRuleAppliesToVariableNameLongerThanThresholdWithSuffixSubtracted(): void
     {
@@ -312,7 +290,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameLongerThanThresholdWithMultipleSuffixesDefined
-     * @throws Throwable
      */
     public function testRuleAppliesToVariableNameLongerThanThresholdWithMultipleSuffixesDefined(): void
     {
@@ -325,7 +302,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameSuffixIsNotSubtractedWhenNotASuffix
-     * @throws Throwable
      */
     public function testRuleAppliesToVariableNameSuffixIsNotSubtractedWhenNotASuffix(): void
     {
@@ -338,7 +314,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameWithEmptySubtractSuffixes
-     * @throws Throwable
      */
     public function testRuleAppliesToVariableNameWithEmptySubtractSuffixes(): void
     {
@@ -351,7 +326,6 @@ class LongVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariableNameFollowingHungarianNotation
-     * @throws Throwable
      */
     public function testRuleAppliesToVariableNameFollowingHungarianNotation(): void
     {

--- a/tests/php/PHPMD/Rule/Naming/ShortClassNameTest.php
+++ b/tests/php/PHPMD/Rule/Naming/ShortClassNameTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test cases for ShortClassName rule
@@ -30,7 +29,6 @@ class ShortClassNameTest extends AbstractTestCase
 {
     /**
      * Tests that rule does not apply to class name length (43) above threshold (43)
-     * @throws Throwable
      */
     public function testRuleNotAppliesToClassNameAboveThreshold(): void
     {
@@ -42,7 +40,6 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule applies to class name length (40) below threshold (41)
-     * @throws Throwable
      */
     public function testRuleAppliesToClassNameBelowThreshold(): void
     {
@@ -54,7 +51,6 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule does not apply to interface name length (47) above threshold (47)
-     * @throws Throwable
      */
     public function testRuleNotAppliesToInterfaceNameAboveThreshold(): void
     {
@@ -66,7 +62,6 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule applies for interface name length (44) below threshold (45)
-     * @throws Throwable
      */
     public function testRuleAppliesToInterfaceNameBelowThreshold(): void
     {
@@ -78,7 +73,6 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule does not apply for class name length (55) below threshold (61) when set in exceptions
-     * @throws Throwable
      */
     public function testRuleNotAppliesToClassNameBelowThresholdInExceptions(): void
     {
@@ -91,7 +85,6 @@ class ShortClassNameTest extends AbstractTestCase
 
     /**
      * Tests that rule applies to class name length (55) below threshold (56) when not set in exceptions
-     * @throws Throwable
      */
     public function testRuleAppliesToClassNameBelowThresholdNotInExceptions(): void
     {

--- a/tests/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
+++ b/tests/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the very short method and function name rule.
@@ -30,7 +29,6 @@ class ShortMethodNameTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToFunctionWithNameShorterThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionWithNameShorterThanThreshold(): void
     {
@@ -43,7 +41,6 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithNameEqualToThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFunctionWithNameEqualToThreshold(): void
     {
@@ -56,7 +53,6 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionWithNameLongerThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFunctionWithNameLongerThanThreshold(): void
     {
@@ -69,7 +65,6 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionWithNameShorterThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodWithNameShorterThanThreshold(): void
     {
@@ -82,7 +77,6 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithNameEqualToThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodWithNameEqualToThreshold(): void
     {
@@ -95,7 +89,6 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithNameLongerThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodWithNameLongerThanThreshold(): void
     {
@@ -108,7 +101,6 @@ class ShortMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodWithNameLongerThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodWithShortNameWhenException(): void
     {
@@ -122,7 +114,6 @@ class ShortMethodNameTest extends AbstractTestCase
     /**
      * testRuleAlsoWorksWithoutExceptionListConfigured
      *
-     * @throws Throwable
      * @link https://github.com/phpmd/phpmd/issues/80
      * @link https://github.com/phpmd/phpmd/issues/270
      * @since 2.2.2
@@ -135,9 +126,6 @@ class ShortMethodNameTest extends AbstractTestCase
         $rule->apply($this->getMethodMock());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testRuleAppliesAlsoWithoutExceptionListConfigured(): void
     {
         $rule = new ShortMethodName();

--- a/tests/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/tests/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the really short variable, parameter and property name rule.
@@ -30,7 +29,6 @@ class ShortVariableTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToLocalVariableInFunctionWithNameShorterThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToLocalVariableInFunctionWithNameShorterThanThreshold(): void
     {
@@ -43,7 +41,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToTryCatchBlocks
-     * @throws Throwable
      */
     public function testRuleNotAppliesToTryCatchBlocksInsideForeach(): void
     {
@@ -56,7 +53,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInFunctionWithNameLongerThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToLocalVariableInFunctionWithNameLongerThanThreshold(): void
     {
@@ -69,7 +65,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToLocalVariableInFunctionWithNameEqualToThreshold(): void
     {
@@ -82,7 +77,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFunctionParameterWithNameShorterThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionParameterWithNameShorterThanThreshold(): void
     {
@@ -95,7 +89,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFunctionParameterWithNameLongerThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFunctionParameterWithNameLongerThanThreshold(): void
     {
@@ -108,7 +101,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToLocalVariableInMethodWithNameShorterThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToLocalVariableInMethodWithNameShorterThanThreshold(): void
     {
@@ -127,7 +119,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToLocalVariableInMethodWithNameEqualToThreshold(): void
     {
@@ -140,7 +131,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToLocalVariableInMethodWithNameLongerThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToLocalVariableInMethodWithNameLongerThanThreshold(): void
     {
@@ -153,7 +143,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodParameterWithNameShorterThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodParameterWithNameShorterThanThreshold(): void
     {
@@ -172,7 +161,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToMethodParameterWithNameLongerThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToMethodParameterWithNameLongerThanThreshold(): void
     {
@@ -185,7 +173,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFieldWithNameShorterThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToFieldWithNameShorterThanThreshold(): void
     {
@@ -198,7 +185,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFieldWithNameEqualToThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFieldWithNameEqualToThreshold(): void
     {
@@ -211,7 +197,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToFieldWithNameGreaterThanThreshold
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFieldWithNameGreaterThanThreshold(): void
     {
@@ -224,7 +209,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToFieldAndParameterWithNameShorterThanThreshold
-     * @throws Throwable
      */
     public function testRuleAppliesToFieldAndParameterWithNameShorterThanThreshold(): void
     {
@@ -243,7 +227,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToShortVariableNameAsForLoopIndex
-     * @throws Throwable
      */
     public function testRuleNotAppliesToShortVariableNameAsForLoopIndex(): void
     {
@@ -256,7 +239,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToShortVariableNameAsForeachLoopIndex
-     * @throws Throwable
      */
     public function testRuleNotAppliesToShortVariableNameAsForeachLoopIndex(): void
     {
@@ -269,7 +251,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToShortVariableNameInCatchStatement
-     * @throws Throwable
      */
     public function testRuleNotAppliesToShortVariableNameInCatchStatement(): void
     {
@@ -282,7 +263,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToStaticMembersAccessedInMethod
-     * @throws Throwable
      */
     public function testRuleNotAppliesToStaticMembersAccessedInMethod(): void
     {
@@ -295,7 +275,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToIdenticalVariableOnlyOneTime
-     * @throws Throwable
      */
     public function testRuleAppliesToIdenticalVariableOnlyOneTime(): void
     {
@@ -308,7 +287,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes
-     * @throws Throwable
      */
     public function testRuleAppliesToIdenticalVariablesInDifferentContextsSeveralTimes(): void
     {
@@ -327,7 +305,6 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleNotAppliesToVariablesFromExceptionsList
-     * @throws Throwable
      */
     public function testRuleNotAppliesToVariablesFromExceptionsList(): void
     {
@@ -342,7 +319,6 @@ class ShortVariableTest extends AbstractTestCase
     /**
      * testRuleAppliesToVariablesWithinForeach
      *
-     * @throws Throwable
      * @dataProvider provideClassWithShortForeachVariables
      */
     public function testRuleAppliesToVariablesWithinForeach(string $allowShortVarInLoop, int $expectedErrorsCount): void

--- a/tests/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/tests/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the unused formal parameter rule.
@@ -31,7 +30,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToFunctionUnusedFormalParameter
-     * @throws Throwable
      */
     public function testRuleAppliesToFunctionUnusedFormalParameter(): void
     {
@@ -42,7 +40,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMultipleFunctionUnusedFormalParameter
-     * @throws Throwable
      */
     public function testRuleAppliesToMultipleFunctionUnusedFormalParameter(): void
     {
@@ -53,7 +50,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMethodUnusedFormalParameter
-     * @throws Throwable
      */
     public function testRuleAppliesToMethodUnusedFormalParameter(): void
     {
@@ -64,7 +60,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToEnumMethodUnusedFormalParameter
-     * @throws Throwable
      */
     public function testRuleAppliesToEnumMethodUnusedFormalParameter(): void
     {
@@ -75,7 +70,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToClosureUnusedFormalParameter
-     * @throws Throwable
      */
     public function testRuleAppliesToClosureUnusedFormalParameter(): void
     {
@@ -86,7 +80,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToMultipleMethodUnusedFormalParameter
-     * @throws Throwable
      */
     public function testRuleAppliesToMultipleMethodUnusedFormalParameter(): void
     {
@@ -106,7 +99,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleAppliesToFormalParameterWhenSimilarStaticMemberIsAccessed(): void
     {
@@ -125,7 +117,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFormalParameterUsedInPropertyCompoundVariable(): void
     {
@@ -144,7 +135,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleNotAppliesToFormalParameterUsedInMethodCompoundVariable(): void
     {
@@ -155,7 +145,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToAbstractMethodFormalParameter
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToAbstractMethodFormalParameter(): void
     {
@@ -166,7 +155,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToInterfaceMethodFormalParameter
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToInterfaceMethodFormalParameter(): void
     {
@@ -177,7 +165,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToInnerFunctionDeclaration
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToInnerFunctionDeclaration(): void
     {
@@ -197,7 +184,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToFormalParameterUsedInCompoundExpression(): void
     {
@@ -216,7 +202,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToMethodArgument(): void
     {
@@ -227,7 +212,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToMethodArgumentUsedAsArrayIndex
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToMethodArgumentUsedAsArrayIndex(): void
     {
@@ -246,7 +230,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToParameterUsedAsArrayIndex(): void
     {
@@ -265,7 +248,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToParameterUsedAsStringIndex(): void
     {
@@ -288,7 +270,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToMethodWithFuncGetArgs(): void
     {
@@ -298,7 +279,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @since 2.0.0
      */
     public function testFuncGetArgsRuleWorksCaseInsensitive(): void
@@ -311,7 +291,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     /**
      * testRuleDoesNotApplyToInheritMethod
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testRuleDoesNotApplyToInheritMethod(): void
@@ -324,7 +303,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     /**
      * testRuleDoesNotApplyToImplementedAbstractMethod
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testRuleDoesNotApplyToImplementedAbstractMethod(): void
@@ -337,7 +315,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     /**
      * testRuleDoesNotApplyToImplementedInterfaceMethod
      *
-     * @throws Throwable
      * @since 1.2.1
      */
     public function testRuleDoesNotApplyToImplementedInterfaceMethod(): void
@@ -349,7 +326,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToMagicMethod
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToMagicMethod(): void
     {
@@ -367,7 +343,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToMethodWithInheritdocAnnotation
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToMethodWithInheritdocAnnotation(): void
     {
@@ -378,7 +353,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToMethodWithInheritdocAnnotationCamelCase(): void
     {
@@ -388,7 +362,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @since 2.0.0
      */
     public function testCompactFunctionRuleDoesNotApply(): void
@@ -399,7 +372,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @since 2.0.0
      */
     public function testCompactFunctionRuleOnlyAppliesToUsedParameters(): void
@@ -410,7 +382,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @since 2.0.0
      */
     public function testCompactFunctionRuleWorksCaseInsensitive(): void
@@ -421,7 +392,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @since 2.0.1
      */
     public function testNamespacedCompactFunctionRuleDoesNotApply(): void
@@ -432,7 +402,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @since 2.0.1
      */
     public function testNamespacedCompactFunctionRuleOnlyAppliesToUsedParameters(): void
@@ -443,7 +412,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @since 2.0.1
      */
     public function testNamespacedCompactFunctionRuleWorksCaseInsensitive(): void
@@ -463,7 +431,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToFormalParameterUsedInStringCompoundVariable(): void
     {
@@ -486,7 +453,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToFormalParameterUsedAsParameterInStringCompoundVariable(): void
     {
@@ -503,7 +469,6 @@ class UnusedFormalParameterTest extends AbstractTestCase
      *     public function __construct(private string $foo) {}
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToPropertyPromotionParameters(): void
     {

--- a/tests/php/PHPMD/Rule/UnusedLocalVariableTest.php
+++ b/tests/php/PHPMD/Rule/UnusedLocalVariableTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the unused local variable rule.
@@ -56,7 +55,7 @@ class UnusedLocalVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     * @throws Throwable
+     *
      * @dataProvider getApplyingCases
      */
     public function testRuleAppliesTo(string $file): void
@@ -68,7 +67,7 @@ class UnusedLocalVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     * @throws Throwable
+     *
      * @dataProvider getNotApplyingCases
      */
     public function testRuleDoesNotApplyTo(string $file): void

--- a/tests/php/PHPMD/Rule/UnusedPrivateFieldTest.php
+++ b/tests/php/PHPMD/Rule/UnusedPrivateFieldTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the unused private field rule.
@@ -30,7 +29,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToUnusedPrivateField
-     * @throws Throwable
      */
     public function testRuleAppliesToUnusedPrivateField(): void
     {
@@ -41,7 +39,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToUnusedPrivateStaticField
-     * @throws Throwable
      */
     public function testRuleAppliesWhenFieldWithSameNameIsAccessedOnDifferentObject(): void
     {
@@ -52,7 +49,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToUnusedPrivateStaticField
-     * @throws Throwable
      */
     public function testRuleAppliesToUnusedPrivateStaticField(): void
     {
@@ -63,7 +59,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnDifferentClass
-     * @throws Throwable
      */
     public function testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnDifferentClass(): void
     {
@@ -74,7 +69,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnParent
-     * @throws Throwable
      */
     public function testRuleAppliesWhenStaticFieldWithSameNameIsAccessedOnParent(): void
     {
@@ -95,7 +89,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleAppliesWhenLocalVariableIsUsedInStaticMemberPrefix(): void
     {
@@ -116,7 +109,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleDoesNotResultInFatalErrorByCallingNonObject(): void
     {
@@ -127,7 +119,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToUnusedPublicField
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToUnusedPublicField(): void
     {
@@ -138,7 +129,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToUnusedProtectedField
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToUnusedProtectedField(): void
     {
@@ -149,7 +139,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToThisAccessedPrivateField
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToThisAccessedPrivateField(): void
     {
@@ -160,7 +149,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToSelfAccessedPrivateField
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToSelfAccessedPrivateField(): void
     {
@@ -171,7 +159,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToStaticAccessedPrivateField
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToStaticAccessedPrivateField(): void
     {
@@ -182,7 +169,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToClassNameAccessedPrivateField
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToClassNameAccessedPrivateField(): void
     {
@@ -203,7 +189,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToPrivateFieldInChainedMethodCall(): void
     {
@@ -224,7 +209,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToPrivateArrayFieldAccess(): void
     {
@@ -245,7 +229,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToPrivateStringIndexFieldAccess(): void
     {
@@ -256,7 +239,6 @@ class UnusedPrivateFieldTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToFieldWithMethodsThatReturnArray
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToFieldWithMethodsThatReturnArray(): void
     {

--- a/tests/php/PHPMD/Rule/UnusedPrivateMethodTest.php
+++ b/tests/php/PHPMD/Rule/UnusedPrivateMethodTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule;
 
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test case for the unused private method rule.
@@ -30,7 +29,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 {
     /**
      * testRuleAppliesToUnusedPrivateMethod
-     * @throws Throwable
      */
     public function testRuleAppliesToUnusedPrivateMethod(): void
     {
@@ -41,7 +39,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToUnusedStaticPrivateMethod
-     * @throws Throwable
      */
     public function testRuleAppliesToUnusedStaticPrivateMethod(): void
     {
@@ -52,7 +49,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToParentReferencedUnusedPrivateMethod
-     * @throws Throwable
      */
     public function testRuleAppliesToParentReferencedUnusedPrivateMethod(): void
     {
@@ -63,7 +59,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenMethodIsReferencedOnDifferentObject
-     * @throws Throwable
      */
     public function testRuleAppliesWhenMethodIsReferencedOnDifferentObject(): void
     {
@@ -74,7 +69,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenMethodIsReferencedOnDifferentClass
-     * @throws Throwable
      */
     public function testRuleAppliesWhenMethodIsReferencedOnDifferentClass(): void
     {
@@ -85,7 +79,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleAppliesWhenPropertyWithSimilarNameIsReferenced
-     * @throws Throwable
      */
     public function testRuleAppliesWhenPropertyWithSimilarNameIsReferenced(): void
     {
@@ -106,7 +99,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleAppliesWhenMethodWithSimilarNameIsInInvocationChain(): void
     {
@@ -117,7 +109,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToMethodUsedViaCallable
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToMethodUsedViaCallable(): void
     {
@@ -128,7 +119,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToPrivateConstructor
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToPrivateConstructor(): void
     {
@@ -139,7 +129,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToPrivatePhp4Constructor
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToPrivatePhp4Constructor(): void
     {
@@ -150,7 +139,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToPrivateCloneMethod
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToPrivateCloneMethod(): void
     {
@@ -161,7 +149,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToThisReferencedMethod
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToThisReferencedMethod(): void
     {
@@ -172,7 +159,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToSelfReferencedMethod
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToSelfReferencedMethod(): void
     {
@@ -183,7 +169,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToStaticReferencedMethod
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToStaticReferencedMethod(): void
     {
@@ -194,7 +179,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToClassNameReferencedMethod
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToClassNameReferencedMethod(): void
     {
@@ -216,7 +200,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
      *     }
      * }
      * </code>
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToPrivateMethodInChainedMethodCall(): void
     {
@@ -227,7 +210,6 @@ class UnusedPrivateMethodTest extends AbstractTestCase
 
     /**
      * testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo
-     * @throws Throwable
      */
     public function testRuleDoesNotApplyToPrivateMethodInChainedMethodCallInNumberBiggerThanTwo(): void
     {

--- a/tests/php/PHPMD/RuleSetFactoryTest.php
+++ b/tests/php/PHPMD/RuleSetFactoryTest.php
@@ -24,7 +24,6 @@ use PHPMD\Exception\RuleClassFileNotFoundException;
 use PHPMD\Exception\RuleClassNotFoundException;
 use PHPMD\Exception\RuleSetNotFoundException;
 use RuntimeException;
-use Throwable;
 
 /**
  * Test case for the rule set factory class.
@@ -42,7 +41,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetFileNameFindsXmlFileInBundledRuleSets
-     * @throws Throwable
      */
     public function testCreateRuleSetFileNameFindsXmlFileInBundledRuleSets(): void
     {
@@ -54,7 +52,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetFileNameFindsXmlFileInCurrentWorkingDirectory
-     * @throws Throwable
      */
     public function testCreateRuleSetFileNameFindsXmlFileInCurrentWorkingDirectory(): void
     {
@@ -68,7 +65,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsReturnsArray
-     * @throws Throwable
      */
     public function testCreateRuleSetsReturnsArray(): void
     {
@@ -78,7 +74,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForSingleFileReturnsArrayWithOneElement
-     * @throws Throwable
      */
     public function testCreateRuleSetsForSingleFileReturnsArrayWithOneElement(): void
     {
@@ -88,7 +83,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForSingleFileReturnsOneRuleSetInstance
-     * @throws Throwable
      */
     public function testCreateRuleSetsForSingleFileReturnsOneRuleSetInstance(): void
     {
@@ -98,7 +92,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsConfiguresExpectedRuleSetName
-     * @throws Throwable
      */
     public function testCreateRuleSetsConfiguresExpectedRuleSetName(): void
     {
@@ -108,7 +101,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsConfiguresExpectedRuleSetName
-     * @throws Throwable
      */
     public function testCreateRuleSetsConfiguresExpectedRuleSetDescription(): void
     {
@@ -118,7 +110,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForTwoFilesReturnsArrayWithTwoElements
-     * @throws Throwable
      */
     public function testCreateRuleSetsForTwoFilesReturnsArrayWithTwoElements(): void
     {
@@ -131,7 +122,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForTwoFilesReturnsExpectedRuleSetInstances
-     * @throws Throwable
      */
     public function testCreateRuleSetsForTwoFilesReturnsExpectedRuleSetInstances(): void
     {
@@ -145,7 +135,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForTwoConfiguresExpectedRuleSetNames
-     * @throws Throwable
      */
     public function testCreateRuleSetsForTwoConfiguresExpectedRuleSetNames(): void
     {
@@ -159,7 +148,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForTwoConfiguresExpectedRuleSetDescriptions
-     * @throws Throwable
      */
     public function testCreateRuleSetsForTwoConfiguresExpectedRuleSetDescriptions(): void
     {
@@ -173,7 +161,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForSingleLocalFileNameReturnsArray
-     * @throws Throwable
      */
     public function testCreateRuleSetsForLocalFileNameReturnsArray(): void
     {
@@ -185,7 +172,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForSingleLocalFileNameReturnsArrayWithOneElement
-     * @throws Throwable
      */
     public function testCreateRuleSetsForLocalFileNameReturnsArrayWithOneElement(): void
     {
@@ -197,7 +183,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForSingleLocalFileNameConfiguresExpectedRuleSetName
-     * @throws Throwable
      */
     public function testCreateRuleSetsForLocalFileNameConfiguresExpectedRuleSetName(): void
     {
@@ -209,7 +194,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithReferenceContainsExpectedRuleSet
-     * @throws Throwable
      */
     public function testCreateRuleSetsWithReferenceContainsExpectedRuleSet(): void
     {
@@ -221,7 +205,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithReferenceContainsExpectedNumberOfRules
-     * @throws Throwable
      */
     public function testCreateRuleSetsWithReferenceContainsExpectedNumberOfRules(): void
     {
@@ -233,7 +216,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsForLocalFileWithRuleSetReferenceNodes
-     * @throws Throwable
      */
     public function testCreateRuleSetsWithReferenceContainsRuleInstances(): void
     {
@@ -245,7 +227,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithReferenceContainsExpectedRules
-     * @throws Throwable
      */
     public function testCreateRuleSetsWithReferenceContainsExpectedRules(): void
     {
@@ -265,7 +246,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateSingleRuleSetReturnsRuleSetInstance
-     * @throws Throwable
      */
     public function testCreateSingleRuleSetReturnsRuleSetInstance(): void
     {
@@ -279,7 +259,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * Tests that the rule-set factory applies a set minimum priority filter correct.
-     * @throws Throwable
      */
     public function testCreateRuleSetWithSpecifiedMinimumPriorityOnlyContainsMatchingRules(): void
     {
@@ -294,7 +273,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * Tests that the rule-set factory applies a set maximum priority filter correct.
-     * @throws Throwable
      */
     public function testCreateRuleSetWithSpecifiedMaximumPriorityOnlyContainsMatchingRules(): void
     {
@@ -309,7 +287,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * Tests that the rule-set factory applies a set maximum priority filter correct.
-     * @throws Throwable
      */
     public function testCreateRuleSetWithSpecifiedPrioritiesOnlyContainsMatchingRules(): void
     {
@@ -325,7 +302,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleWithExcludePattern
-     * @throws Throwable
      */
     public function testCreateRuleWithExcludePattern(): void
     {
@@ -344,7 +320,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesPrioritySetting
-     * @throws Throwable
      */
     public function testCreateRuleSetsWithRuleReferenceThatOverwritesPrioritySetting(): void
     {
@@ -359,7 +334,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleWithExpectedExample
-     * @throws Throwable
      */
     public function testCreateRuleWithExpectedExample(): void
     {
@@ -374,7 +348,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleWithExpectedMultipleExamples
-     * @throws Throwable
      */
     public function testCreateRuleWithExpectedMultipleExamples(): void
     {
@@ -389,7 +362,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesDescriptionSetting
-     * @throws Throwable
      */
     public function testCreateRuleSetsWithRuleReferenceThatOverwritesDescriptionSetting(): void
     {
@@ -404,7 +376,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesPropertySetting
-     * @throws Throwable
      */
     public function testCreateRuleSetsWithRuleReferenceThatOverwritesPropertySetting(): void
     {
@@ -419,7 +390,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testFactorySupportsAlternativeSyntaxForPropertyValue
-     * @throws Throwable
      */
     public function testFactorySupportsAlternativeSyntaxForPropertyValue(): void
     {
@@ -434,7 +404,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesExamplesSetting
-     * @throws Throwable
      */
     public function testCreateRuleSetsWithRuleReferenceThatOverwritesExamplesSetting(): void
     {
@@ -451,7 +420,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesExamplesSetting
-     * @throws Throwable
      */
     public function testCreateRuleSetsWithRuleReferenceThatOverwritesNameSetting(): void
     {
@@ -466,7 +434,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesMessageSetting
-     * @throws Throwable
      */
     public function testCreateRuleSetsWithRuleReferenceThatOverwritesMessageSetting(): void
     {
@@ -481,7 +448,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceThatOverwritesExtInfoUrlSetting
-     * @throws Throwable
      */
     public function testCreateRuleSetsWithRuleReferenceThatOverwritesExtInfoUrlSetting(): void
     {
@@ -496,7 +462,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceNotContainsExcludedRule
-     * @throws Throwable
      */
     public function testCreateRuleSetsWithRuleReferenceNotContainsExcludedRule(): void
     {
@@ -511,7 +476,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsWithRuleReferenceNotContainsExcludedRules
-     * @throws Throwable
      */
     public function testCreateRuleSetsWithRuleReferenceNotContainsExcludedRules(): void
     {
@@ -528,7 +492,6 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Tests that the factory throws the expected exception for an invalid ruleset
      * identifier.
      *
-     * @throws Throwable
      * @covers \PHPMD\Exception\RuleSetNotFoundException
      */
     public function testCreateRuleSetsThrowsExceptionForInvalidIdentifier(): void
@@ -544,7 +507,6 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Tests that the factory throws an exception when the source code filename
      * for the configured rule does not exist.
      *
-     * @throws Throwable
      * @covers \PHPMD\Exception\RuleClassFileNotFoundException
      */
     public function testCreateRuleSetsThrowsExceptionWhenClassFileNotInIncludePath(): void
@@ -563,7 +525,6 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Tests that the factory throws the expected exception when a rule class
      * cannot be found.
      *
-     * @throws Throwable
      * @covers \PHPMD\Exception\RuleClassNotFoundException
      */
     public function testCreateRuleSetThrowsExceptionWhenFileNotContainsClass(): void
@@ -581,7 +542,6 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Tests that the factory throws the expected exception when a rule class
      * cannot be found.
      *
-     * @throws Throwable
      * @covers \PHPMD\Exception\RuleClassNotFoundException
      */
     public function testCreateRuleSetsThrowsExpectedExceptionForInvalidXmlFile(): void
@@ -596,7 +556,6 @@ class RuleSetFactoryTest extends AbstractTestCase
 
     /**
      * testCreateRuleSetsActivatesStrictModeOnRuleSet
-     * @throws Throwable
      */
     public function testCreateRuleSetsActivatesStrictModeOnRuleSet(): void
     {
@@ -616,7 +575,6 @@ class RuleSetFactoryTest extends AbstractTestCase
      * reference-by-includepath and explicit-classfile-declaration works.
      *
      * @throws Exception
-     * @throws Throwable
      */
     public function testAddPHPIncludePath(): void
     {
@@ -649,7 +607,6 @@ class RuleSetFactoryTest extends AbstractTestCase
     /**
      * Checks if PHPMD doesn't treat directories named as code rule as files
      *
-     * @throws Throwable
      * @link https://github.com/phpmd/phpmd/issues/47
      */
     public function testIfGettingRuleFilePathExcludeUnreadablePaths(): void
@@ -682,7 +639,7 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Checks the ruleset XML files provided with PHPMD all provide externalInfoUrls
      *
      * @param string $file The path to the ruleset xml to test
-     * @throws Throwable
+     *
      * @dataProvider getDefaultRuleSets
      */
     public function testDefaultRuleSetsProvideExternalInfoUrls(string $file): void
@@ -733,7 +690,7 @@ class RuleSetFactoryTest extends AbstractTestCase
      * @param string $file At least one rule configuration file name. You can
      *        also pass multiple parameters with ruleset configuration files.
      * @return \PHPMD\RuleSet[]
-     * @throws Throwable
+     *
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
      */
     private function createRuleSetsFromFiles(string $file): array

--- a/tests/php/PHPMD/RuleSetTest.php
+++ b/tests/php/PHPMD/RuleSetTest.php
@@ -27,7 +27,6 @@ use PHPMD\Node\ClassNode;
 use PHPMD\Node\FunctionNode;
 use PHPMD\Rule\CleanCode\ElseExpression;
 use PHPMD\Stubs\RuleStub;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\RuleSet} class.
@@ -38,7 +37,6 @@ class RuleSetTest extends AbstractTestCase
 {
     /**
      * testGetRuleByNameReturnsNullWhenNoMatchingRuleExists
-     * @throws Throwable
      */
     public function testGetRuleByNameThrowsExceptionWhenNoMatchingRuleExists(): void
     {
@@ -50,7 +48,6 @@ class RuleSetTest extends AbstractTestCase
 
     /**
      * testGetRuleByNameReturnsMatchingRuleInstance
-     * @throws Throwable
      */
     public function testGetRuleByNameReturnsMatchingRuleInstance(): void
     {
@@ -62,7 +59,6 @@ class RuleSetTest extends AbstractTestCase
 
     /**
      * testApplyNotInvokesRuleWhenSuppressAnnotationExists
-     * @throws Throwable
      */
     public function testApplyNotInvokesRuleWhenSuppressAnnotationExists(): void
     {
@@ -77,7 +73,6 @@ class RuleSetTest extends AbstractTestCase
 
     /**
      * testApplyInvokesRuleWhenStrictModeIsSet
-     * @throws Throwable
      */
     public function testApplyInvokesRuleWhenStrictModeIsSet(): void
     {
@@ -93,9 +88,6 @@ class RuleSetTest extends AbstractTestCase
         static::assertSame($class, $rule->node);
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testDescriptionCanBeChanged(): void
     {
         $ruleSet = new RuleSet();
@@ -107,9 +99,6 @@ class RuleSetTest extends AbstractTestCase
         static::assertSame('foobar', $ruleSet->getDescription());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testStrictnessCanBeEnabled(): void
     {
         $ruleSet = new RuleSet();
@@ -121,9 +110,6 @@ class RuleSetTest extends AbstractTestCase
         static::assertTrue($ruleSet->isStrict());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testReport(): void
     {
         $ruleSet = new RuleSet();
@@ -155,8 +141,6 @@ class RuleSetTest extends AbstractTestCase
     /**
      * Creates a rule set instance with a variable amount of appended rule
      * objects.
-     *
-     * @throws Throwable
      */
     private function createRuleSetFixture(): RuleSet
     {

--- a/tests/php/PHPMD/RuleTest.php
+++ b/tests/php/PHPMD/RuleTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD;
 
 use OutOfBoundsException;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\AbstractRule} class.
@@ -31,7 +30,6 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetBooleanPropertyReturnsTrueForStringValue1
      *
-     * @throws Throwable
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
@@ -46,7 +44,6 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetBooleanPropertyReturnsTrueForStringValueOn
      *
-     * @throws Throwable
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
@@ -61,7 +58,6 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetBooleanPropertyReturnsTrueForStringValueTrue
      *
-     * @throws Throwable
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
@@ -76,7 +72,6 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetBooleanPropertyReturnsTrueForDifferentStringValue
      *
-     * @throws Throwable
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
@@ -91,7 +86,6 @@ class RuleTest extends AbstractTestCase
     /**
      * Tests the getBooleanProperty method with a fallback value
      *
-     * @throws Throwable
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
@@ -105,7 +99,6 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetIntPropertyReturnsValueOfTypeInteger
      *
-     * @throws Throwable
      * @covers ::getIntProperty
      * @covers ::getProperty
      */
@@ -120,7 +113,6 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetIntPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
-     * @throws Throwable
      * @covers ::getIntProperty
      * @covers ::getProperty
      */
@@ -135,7 +127,6 @@ class RuleTest extends AbstractTestCase
     /**
      * Tests the getIntProperty method with a fallback value
      *
-     * @throws Throwable
      * @covers ::getIntProperty
      * @covers ::getProperty
      */
@@ -149,7 +140,6 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetBooleanPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
-     * @throws Throwable
      * @covers ::getBooleanProperty
      * @covers ::getProperty
      */
@@ -164,7 +154,6 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetStringPropertyThrowsExceptionWhenNoPropertyForNameExists
      *
-     * @throws Throwable
      * @covers ::getProperty
      * @covers ::getStringProperty
      */
@@ -179,7 +168,6 @@ class RuleTest extends AbstractTestCase
     /**
      * testGetStringPropertyReturnsStringValue
      *
-     * @throws Throwable
      * @covers ::getProperty
      * @covers ::getStringProperty
      */
@@ -194,7 +182,6 @@ class RuleTest extends AbstractTestCase
     /**
      * Tests the getStringProperty method with a fallback value
      *
-     * @throws Throwable
      * @covers ::getProperty
      * @covers ::getStringProperty
      */

--- a/tests/php/PHPMD/RuleViolationTest.php
+++ b/tests/php/PHPMD/RuleViolationTest.php
@@ -19,7 +19,6 @@
 namespace PHPMD;
 
 use PHPMD\Node\NodeInfo;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\RuleViolation} class.
@@ -29,9 +28,6 @@ use Throwable;
  */
 class RuleViolationTest extends AbstractTestCase
 {
-    /**
-     * @throws Throwable
-     */
     public function testNodeInfoGetters(): void
     {
         $rule = $this->getRuleMock();

--- a/tests/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/tests/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -36,7 +36,6 @@ use PHPMD\Renderer\TextRenderer;
 use PHPMD\Renderer\XMLRenderer;
 use PHPMD\Rule;
 use ReflectionProperty;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\TextUI\CommandLineOptions} class.
@@ -48,7 +47,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testAssignsInputArgumentToInputProperty
      *
-     * @throws Throwable
      * @since 1.1.0
      */
     public function testAssignsInputArgumentToInputProperty(): void
@@ -60,7 +58,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @since 2.14.0
      */
     public function testVerbose(): void
@@ -78,7 +75,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @since 2.14.0
      */
     public function testColored(): void
@@ -96,7 +92,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @since 2.14.0
      */
     public function testStdInDashShortCut(): void
@@ -108,7 +103,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @since 2.14.0
      */
     public function testMultipleFiles(): void
@@ -125,7 +119,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testAssignsFormatArgumentToReportFormatProperty
      *
-     * @throws Throwable
      * @since 1.1.0
      */
     public function testAssignsFormatArgumentToReportFormatProperty(): void
@@ -139,7 +132,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testAssignsRuleSetsArgumentToRuleSetProperty
      *
-     * @throws Throwable
      * @since 1.1.0
      */
     public function testAssignsRuleSetsArgumentToRuleSetProperty(): void
@@ -153,7 +145,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testThrowsExpectedExceptionWhenRequiredArgumentsNotSet
      *
-     * @throws Throwable
      * @since 1.1.0
      */
     public function testThrowsExpectedExceptionWhenRequiredArgumentsNotSet(): void
@@ -165,7 +156,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
     public function testThrowsExpectedExceptionWhenOptionNotFound(): void
@@ -183,7 +173,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
     public function testThrowsExpectedExceptionWhenOptionNotFoundInFront(): void
@@ -201,7 +190,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
     public function testThrowsExpectedExceptionWhenOptionNotFoundUsingArgumentSeparator(): void
@@ -219,7 +207,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
     public function testThrowsExpectedExceptionWhenBooleanOptionReceiveValue(): void
@@ -233,7 +220,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
     public function testOptionEqualSyntax(): void
@@ -245,7 +231,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers \PHPMD\Utility\ArgumentsValidator
      */
     public function testArgumentSeparatorEnforced(): void
@@ -259,7 +244,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testAssignsInputFileOptionToInputPathProperty
      *
-     * @throws Throwable
      * @since 1.1.0
      */
     public function testAssignsInputFileOptionToInputPathProperty(): void
@@ -275,7 +259,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testAssignsFormatArgumentCorrectWhenCalledWithInputFile
      *
-     * @throws Throwable
      * @since 1.1.0
      */
     public function testAssignsFormatArgumentCorrectWhenCalledWithInputFile(): void
@@ -291,7 +274,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testAssignsRuleSetsArgumentCorrectWhenCalledWithInputFile
      *
-     * @throws Throwable
      * @since 1.1.0
      */
     public function testAssignsRuleSetsArgumentCorrectWhenCalledWithInputFile(): void
@@ -307,7 +289,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testThrowsExpectedExceptionWhenInputFileNotExists
      *
-     * @throws Throwable
      * @since 1.1.0
      */
     public function testThrowsExpectedExceptionWhenInputFileNotExists(): void
@@ -322,7 +303,6 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * testHasVersionReturnsFalseByDefault
-     * @throws Throwable
      */
     public function testHasVersionReturnsFalseByDefault(): void
     {
@@ -334,7 +314,6 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * testCliOptionsAcceptsVersionArgument
-     * @throws Throwable
      */
     public function testCliOptionsAcceptsVersionArgument(): void
     {
@@ -346,7 +325,6 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if ignoreErrorsOnExit returns false by default
-     * @throws Throwable
      */
     public function testIgnoreErrorsOnExitReturnsFalseByDefault(): void
     {
@@ -358,7 +336,6 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if CLI options accepts ignoreErrorsOnExit argument
-     * @throws Throwable
      */
     public function testCliOptionsAcceptsIgnoreErrorsOnExitArgument(): void
     {
@@ -370,7 +347,6 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if CLI usage contains ignoreErrorsOnExit option
-     * @throws Throwable
      */
     public function testCliUsageContainsIgnoreErrorsOnExitOption(): void
     {
@@ -382,7 +358,6 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if ignoreViolationsOnExit returns false by default
-     * @throws Throwable
      */
     public function testIgnoreViolationsOnExitReturnsFalseByDefault(): void
     {
@@ -394,7 +369,6 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if CLI options accepts ignoreViolationsOnExit argument
-     * @throws Throwable
      */
     public function testCliOptionsAcceptsIgnoreViolationsOnExitArgument(): void
     {
@@ -406,7 +380,6 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if CLI usage contains ignoreViolationsOnExit option
-     * @throws Throwable
      */
     public function testCliUsageContainsIgnoreViolationsOnExitOption(): void
     {
@@ -418,7 +391,6 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * Tests if CLI usage contains the auto-discovered renderers
-     * @throws Throwable
      */
     public function testCliUsageContainsAutoDiscoveredRenderers(): void
     {
@@ -433,7 +405,6 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * testCliUsageContainsStrictOption
-     * @throws Throwable
      */
     public function testCliUsageContainsStrictOption(): void
     {
@@ -446,7 +417,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testCliOptionsIsStrictReturnsFalseByDefault
      *
-     * @throws Throwable
      * @since 1.2.0
      */
     public function testCliOptionsIsStrictReturnsFalseByDefault(): void
@@ -460,7 +430,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * testCliOptionsAcceptsStrictArgument
      *
-     * @throws Throwable
      * @since 1.2.0
      */
     public function testCliOptionsAcceptsStrictArgument(): void
@@ -476,9 +445,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertFalse($opts->hasStrict());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testCliOptionsAcceptsMinimumpriorityArgument(): void
     {
         $args = [__FILE__, '--minimumpriority', '42', __FILE__, 'text', 'codesize'];
@@ -487,9 +453,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertSame(42, $opts->getMinimumPriority());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testCliOptionsAcceptsMaximumpriorityArgument(): void
     {
         $args = [__FILE__, '--maximumpriority', '42', __FILE__, 'text', 'codesize'];
@@ -498,9 +461,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertSame(42, $opts->getMaximumPriority());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testCliOptionGenerateBaselineFalseByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
@@ -508,9 +468,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertSame(BaselineMode::None, $opts->generateBaseline());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testCliOptionVerbosityNormal(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
@@ -518,9 +475,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertSame(OutputInterface::VERBOSITY_NORMAL, $opts->getVerbosity());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testCliOptionVerbosityVerbose(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '-v'];
@@ -528,9 +482,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertSame(OutputInterface::VERBOSITY_VERBOSE, $opts->getVerbosity());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testCliOptionVerbosityVeryVerbose(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '-vv'];
@@ -538,9 +489,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertSame(OutputInterface::VERBOSITY_VERY_VERBOSE, $opts->getVerbosity());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testCliOptionVerbosityDebug(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '-vvv'];
@@ -548,9 +496,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertSame(OutputInterface::VERBOSITY_DEBUG, $opts->getVerbosity());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testCliOptionGenerateBaselineShouldBeSet(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--generate-baseline'];
@@ -558,9 +503,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertSame(BaselineMode::Generate, $opts->generateBaseline());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testCliOptionUpdateBaselineShouldBeSet(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--update-baseline'];
@@ -568,9 +510,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertSame(BaselineMode::Update, $opts->generateBaseline());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testCliOptionBaselineFileShouldBeNullByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
@@ -578,9 +517,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertNull($opts->baselineFile());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testCliOptionBaselineFileShouldBeWithFilename(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--baseline-file', 'foobar.txt'];
@@ -588,9 +524,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertSame('foobar.txt', $opts->baselineFile());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testGetMinimumPriorityReturnsLowestValueByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
@@ -599,9 +532,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertSame(Rule::LOWEST_PRIORITY, $opts->getMinimumPriority());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testGetCoverageReportReturnsNullByDefault(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize'];
@@ -610,9 +540,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertNull($opts->getCoverageReport());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testGetCoverageReportWithCliOption(): void
     {
         $opts = new CommandLineOptions(
@@ -629,9 +556,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertSame(__METHOD__, $opts->getCoverageReport());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testGetCacheWithCliOption(): void
     {
         $opts = new CommandLineOptions(
@@ -680,9 +604,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertTrue($opts->isCacheEnabled());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testExcludeOption(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--ignore', 'foo/bar', '--error-file', 'abc'];
@@ -702,7 +623,7 @@ class CommandLineOptionsTest extends AbstractTestCase
 
     /**
      * @param class-string $expectedClass
-     * @throws Throwable
+     *
      * @dataProvider dataProviderCreateRenderer
      * @covers \PHPMD\Renderer\RendererFactory::getRenderer
      */
@@ -741,7 +662,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @dataProvider dataProviderCreateRendererThrowsException
      * @covers \PHPMD\Renderer\RendererFactory::getCustomRenderer
      */
@@ -784,8 +704,6 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
-     * @throws Throwable
      * @dataProvider dataProviderDeprecatedCliOptions
      */
     public function testDeprecatedCliOptions(string $deprecatedName, string $newName, Closure $result): void
@@ -833,8 +751,7 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @param list<string> $options
      * @param list<mixed> $expected
-     * @throws Throwable
-     * @throws Throwable
+     *
      * @dataProvider dataProviderGetReportFiles
      */
     public function testGetReportFiles(array $options, array $expected): void
@@ -845,9 +762,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertEquals($expected, $opts->getReportFiles());
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testCliOptionExtraLineInExcerptShouldBeWithNumber(): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', '--extra-line-in-excerpt', '5'];

--- a/tests/php/PHPMD/TextUI/CommandTest.php
+++ b/tests/php/PHPMD/TextUI/CommandTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\TextUI;
 
 use PHPMD\AbstractTestCase;
 use PHPMD\Utility\Paths;
-use Throwable;
 
 /**
  * Test case for the {@link \PHPMD\TextUI\Command} class.
@@ -44,7 +43,7 @@ class CommandTest extends AbstractTestCase
 
     /**
      * @param ?array<string> $options
-     * @throws Throwable
+     *
      * @dataProvider dataProviderTestMainWithOption
      */
     public function testMainStrictOptionIsOfByDefault(
@@ -137,9 +136,6 @@ class CommandTest extends AbstractTestCase
         ];
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testWithMultipleReportFiles(): void
     {
         $args = [
@@ -173,9 +169,6 @@ class CommandTest extends AbstractTestCase
         static::assertFileExists($sarif);
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testOutput(): void
     {
         $uri = realpath(self::createFileUri('source/source_with_anonymous_class.php'));
@@ -199,7 +192,6 @@ class CommandTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @dataProvider dataProviderWithFilter
      */
     public function testWithFilter(string $option, string $value): void
@@ -230,9 +222,6 @@ class CommandTest extends AbstractTestCase
         ];
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testMainGenerateBaseline(): void
     {
         $path = realpath(self::createFileUri('source/source_with_anonymous_class.php'));
@@ -266,8 +255,6 @@ class CommandTest extends AbstractTestCase
      * - LongClassName violation should be removed
      * - ShortVariable violation should still exist
      * - BooleanGetMethodName shouldn't be added
-     *
-     * @throws Throwable
      */
     public function testMainUpdateBaseline(): void
     {
@@ -297,9 +284,6 @@ class CommandTest extends AbstractTestCase
         static::assertXmlStringEqualsXmlString($expectedXml, $actualXml);
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testMainBaselineViolationShouldBeIgnored(): void
     {
         $sourceFile = realpath(static::createResourceUriForTest('Baseline/ClassWithShortVariable.php'));
@@ -318,9 +302,6 @@ class CommandTest extends AbstractTestCase
         static::assertSame(ExitCode::Success, $exitCode);
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testMainWritesExceptionMessageToStderr(): void
     {
         stream_filter_register('stderr_stream', StreamFilter::class);
@@ -345,9 +326,6 @@ class CommandTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testMainWritesExceptionMessageToErrorFileIfSpecified(): void
     {
         $file = tempnam(sys_get_temp_dir(), 'err');
@@ -391,9 +369,6 @@ class CommandTest extends AbstractTestCase
         static::assertStringStartsWith(sprintf('No renderer supports the format "%s"', $format), $errors);
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testOutputDeprecation(): void
     {
         $file = tempnam(sys_get_temp_dir(), 'err');
@@ -421,9 +396,6 @@ class CommandTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @throws Throwable
-     */
     public function testMainPrintsVersionToStdout(): void
     {
         stream_filter_register('stderr_stream', StreamFilter::class);

--- a/tests/php/PHPMD/Utility/PathsTest.php
+++ b/tests/php/PHPMD/Utility/PathsTest.php
@@ -4,7 +4,6 @@ namespace PHPMD\Utility;
 
 use PHPMD\AbstractTestCase;
 use RuntimeException;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Utility\Paths
@@ -12,7 +11,6 @@ use Throwable;
 class PathsTest extends AbstractTestCase
 {
     /**
-     * @throws Throwable
      * @covers ::getRelativePath
      */
     public function testGetRelativePathShouldSubtractBasePath(): void
@@ -21,7 +19,6 @@ class PathsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::getRelativePath
      */
     public function testGetRelativePathShouldTreatForwardAndBackwardSlashes(): void
@@ -30,7 +27,6 @@ class PathsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::getRelativePath
      */
     public function testGetRelativePathShouldNotSubtractOnInfixPath(): void
@@ -39,7 +35,6 @@ class PathsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::concat
      */
     public function testConcat(): void
@@ -51,7 +46,6 @@ class PathsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::getRealPath
      */
     public function testGetRealPathShouldReturnTheRealPath(): void
@@ -61,7 +55,6 @@ class PathsTest extends AbstractTestCase
     }
 
     /**
-     * @throws Throwable
      * @covers ::getRealPath
      */
     public function testGetRealPathShouldThrowExceptionOnFailure(): void

--- a/tests/php/PHPMD/Utility/StringsTest.php
+++ b/tests/php/PHPMD/Utility/StringsTest.php
@@ -20,7 +20,6 @@ namespace PHPMD\Utility;
 
 use InvalidArgumentException;
 use PHPMD\AbstractTestCase;
-use Throwable;
 
 /**
  * Test cases for the Strings utility class.
@@ -31,8 +30,6 @@ class StringsTest extends AbstractTestCase
 {
     /**
      * Tests the lengthWithoutSuffixes() method with an empty string
-     *
-     * @throws Throwable
      */
     public function testLengthWithoutSuffixesEmptyString(): void
     {
@@ -41,8 +38,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the lengthWithoutSuffixes() method with an empty string with list of suffixes
-     *
-     * @throws Throwable
      */
     public function testLengthWithoutSuffixesEmptyStringWithConfiguredSubtractSuffix(): void
     {
@@ -51,8 +46,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the lengthWithoutSuffixes() method with a string not in the list of suffixes
-     *
-     * @throws Throwable
      */
     public function testLengthWithoutSuffixesStringWithoutSubtractSuffixMatch(): void
     {
@@ -61,8 +54,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the lengthWithoutSuffixes() method with a string in the list of suffixes
-     *
-     * @throws Throwable
      */
     public function testLengthWithoutSuffixesStringWithSubtractSuffixMatch(): void
     {
@@ -71,8 +62,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the lengthWithoutSuffixes() method with a string that should match only once for two potential matches
-     *
-     * @throws Throwable
      */
     public function testLengthWithoutSuffixesStringWithDoubleSuffixMatchSubtractOnce(): void
     {
@@ -81,8 +70,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the lengthWithoutSuffixes() method that a Prefix should not be matched
-     *
-     * @throws Throwable
      */
     public function testLengthWithoutSuffixesStringWithPrefixMatchShouldNotSubtract(): void
     {
@@ -91,8 +78,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the lengthWithoutSuffixes() method that a Prefix should be matched
-     *
-     * @throws Throwable
      */
     public function testlengthWithPrefixesAndSuffixesStringWithPrefixMatchShouldSubtract(): void
     {
@@ -102,8 +87,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the lengthWithoutPrefixesAndSuffixes() method that a Prefix should not be matched in order
-     *
-     * @throws Throwable
      */
     public function testlengthWithPrefixesAndSuffixesStringWithPrefixesMatchShouldSubtractInOrder(): void
     {
@@ -115,8 +98,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the splitToList() method with an empty separator
-     *
-     * @throws Throwable
      */
     public function testSplitToListEmptySeparatorThrowsException(): void
     {
@@ -129,8 +110,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the splitToList() method with an empty string
-     *
-     * @throws Throwable
      */
     public function testSplitToListEmptyString(): void
     {
@@ -139,8 +118,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the splitToList() method with a non-matching separator
-     *
-     * @throws Throwable
      */
     public function testSplitToListStringWithoutMatchingSeparator(): void
     {
@@ -149,8 +126,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the splitToList() method with a matching separator
-     *
-     * @throws Throwable
      */
     public function testSplitToListStringWithMatchingSeparator(): void
     {
@@ -159,8 +134,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the splitToList() method with trailing whitespace
-     *
-     * @throws Throwable
      */
     public function testSplitToListStringTrimsLeadingAndTrailingWhitespace(): void
     {
@@ -169,8 +142,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the splitToList() method that it removes empty strings from list
-     *
-     * @throws Throwable
      */
     public function testSplitToListStringRemoveEmptyStringValues(): void
     {
@@ -179,8 +150,6 @@ class StringsTest extends AbstractTestCase
 
     /**
      * Tests the splitToList() method that it does not remove zero values from list
-     *
-     * @throws Throwable
      */
     public function testSplitToListStringShouldNotRemoveAZeroValue(): void
     {

--- a/tests/php/PHPMD/Writer/StreamWriterTest.php
+++ b/tests/php/PHPMD/Writer/StreamWriterTest.php
@@ -3,7 +3,6 @@
 namespace PHPMD\Writer;
 
 use PHPUnit\Framework\TestCase;
-use Throwable;
 
 /**
  * @coversDefaultClass \PHPMD\Writer\StreamWriter
@@ -12,7 +11,6 @@ use Throwable;
 class StreamWriterTest extends TestCase
 {
     /**
-     * @throws Throwable
      * @covers ::getStream
      */
     public function testGetStream(): void


### PR DESCRIPTION
Type: documentation update
Breaking change: no

Text often rely on exceptions as a way to determine if they failed and letting PHPUnit's exception handler deal with it, there for there isn't a point to documenting what exceptions can be thrown in tests. Previously we there for hinted all exceptions as `@throws Throwable`, this PR allows us to fully omit documenting exceptions in the test folder.