### PR TITLE
Get version from changelog

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,0 @@
-project.version   = 2.15.0

--- a/scripts/build.php
+++ b/scripts/build.php
@@ -3,7 +3,8 @@
 $root = realpath(__DIR__ . '/../') . '/';
 
 $archiveName = 'phpmd.phar';
-$version = parse_ini_file($root . 'build.properties')['project.version'] ?? '@package_version@';
+$changelog = file_get_contents($root . 'CHANGELOG', false, null, 0, 1024);
+$version = preg_match('/phpmd-([\S]+)/', $changelog, $match) ? $match[1] : '@package_version@';
 
 echo 'PHPMD ', $version, PHP_EOL, PHP_EOL;
 

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -183,12 +183,12 @@ final class Command
      */
     private function getVersion(): string
     {
-        $build = __DIR__ . '/../../build.properties';
+        $build = __DIR__ . '/../../CHANGELOG';
 
         $version = '@package_version@';
         if (file_exists($build)) {
-            $data = @parse_ini_file($build);
-            $version = $data['project.version'] ?? $version;
+            $changelog = file_get_contents($build, false, null, 0, 1024) ?: '';
+            $version = preg_match('/phpmd-([\S]+)/', $changelog, $match) ? $match[1] : $version;
         }
 
         return $version;

--- a/tests/php/PHPMD/TextUI/CommandTest.php
+++ b/tests/php/PHPMD/TextUI/CommandTest.php
@@ -439,9 +439,8 @@ class CommandTest extends AbstractTestCase
             ]
         );
 
-        $data = @parse_ini_file(__DIR__ . '/../../../../build.properties');
-        static::assertIsArray($data);
-        $version = $data['project.version'];
+        $changelog = file_get_contents(__DIR__ . '/../../../../CHANGELOG', false, null, 0, 1024) ?: '';
+        $version = preg_match('/phpmd-([\S]+)/', $changelog, $match) ? $match[1] : '@package_version@';
 
         static::assertEquals('PHPMD ' . $version, trim(StreamFilter::$streamHandle));
     }


### PR DESCRIPTION
Type: documentation update
Breaking change: no

This is based on a proposal from @kylekatarnls the benefit is that we only have to write the version in one place, the downside is that we have to be more strict about how we write the change log and cant change the version independently.