### PR TITLE
Include full vendor folder in phar

### DIFF
--- a/scripts/build.php
+++ b/scripts/build.php
@@ -11,11 +11,7 @@ echo 'PHPMD ', $version, PHP_EOL, PHP_EOL;
 $phar = new Phar($archiveName);
 $phar->buildFromDirectory($root, '/^'.preg_quote($root, '/').'src/');
 $phar->buildFromDirectory($root, '/^'.preg_quote($root, '/').'rulesets/');
-$phar->buildFromDirectory($root, '/^'.preg_quote($root, '/').'vendor\/autoload\.php/');
-$phar->buildFromDirectory($root, '/^'.preg_quote($root, '/').'vendor\/composer/');
-$phar->buildFromDirectory($root, '/^'.preg_quote($root, '/').'vendor\/pdepend/');
-$phar->buildFromDirectory($root, '/^'.preg_quote($root, '/').'vendor\/psr/');
-$phar->buildFromDirectory($root, '/^'.preg_quote($root, '/').'vendor\/symfony(?!.*\/.*\/Test\/).*$/');
+$phar->buildFromDirectory($root, '/^'.preg_quote($root, '/').'vendor/');
 
 $patchList = [
     'src/PHPMD.php',


### PR DESCRIPTION
Type: refactoring
Breaking change: no

The amount of space saved by this is so small it doesn't show up in a 0.0MB comparison. It makes the more sensitive to changes in dependencies (`psr` is new in 3.x since it's pulled in by the newer symfony) so including the full vendor folder will simplify maintenance and hidden issues, I think symfony just have one minor class in the test folder that is excluded.