### PR TITLE
Update pdepend/pdepend

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "php": "^8.1",
     "ext-xml": "*",
     "composer/xdebug-handler": "^3.0",
-    "pdepend/pdepend": "3.x-dev#d62d223699942d090469d567aff589f4ce321983"
+    "pdepend/pdepend": "3.x-dev#5fddc0476146acf1455bd4cccf83f20439a0335b"
   },
   "require-dev": {
     "ext-json": "*",

--- a/tests/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
+++ b/tests/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
@@ -122,8 +122,6 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToReturnDeclarationBool
-     *
-     * @throws Throwable
      */
     public function testRuleAppliesToReturnDeclarationBool(): void
     {
@@ -137,7 +135,6 @@ class BooleanGetMethodNameTest extends AbstractTestCase
      * testRuleAppliesToReturnDeclarationTrue
      *
      * @requires PHP 8.2.0
-     * @throws Throwable
      */
     public function testRuleAppliesToReturnDeclarationTrue(): void
     {
@@ -151,7 +148,6 @@ class BooleanGetMethodNameTest extends AbstractTestCase
      * testRuleAppliesToReturnDeclarationFalse
      *
      * @requires PHP 8.2.0
-     * @throws Throwable
      */
     public function testRuleAppliesToReturnDeclarationFalse(): void
     {


### PR DESCRIPTION
Type: refactoring
Breaking change: no

We started utilizing phpmd where I work and are using the 3.x branch so that it can be properly tested before a release.
So fare the only issue we hit was a conflict with an unnecessary polyfile. This has been fixed in pdepend and so this PR is simply to update to the fixed version, allowing us to install it in general and get feedback from more of the development team.