### PR TITLE
Allow `BooleanGetMethodName` rule to infer the return type from type declaration

### DIFF
--- a/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
+++ b/src/main/php/PHPMD/Rule/Naming/BooleanGetMethodName.php
@@ -17,6 +17,8 @@
 
 namespace PHPMD\Rule\Naming;
 
+use PDepend\Source\AST\ASTCallable;
+use PDepend\Source\AST\ASTScalarType;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\MethodNode;
@@ -77,6 +79,16 @@ class BooleanGetMethodName extends AbstractRule implements MethodAware
      */
     protected function isReturnTypeBoolean(MethodNode $node)
     {
+        $wrappedNode = $node->getNode();
+        if ($wrappedNode instanceof ASTCallable) {
+            $returnType = $wrappedNode->getReturnType();
+            if ($returnType instanceof ASTScalarType
+                && in_array($returnType->getImage(), array('bool', 'true', 'false'), true)
+            ) {
+                return true;
+            }
+        }
+
         $comment = $node->getDocComment();
         if ($comment === null) {
             return false;

--- a/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
+++ b/src/test/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
@@ -135,6 +135,51 @@ class BooleanGetMethodNameTest extends AbstractTest
     }
 
     /**
+     * testRuleAppliesToReturnDeclarationBool
+     *
+     * @requires PHP 7.0.0
+     *
+     * @return void
+     */
+    public function testRuleAppliesToReturnDeclarationBool()
+    {
+        $rule = new BooleanGetMethodName();
+        $rule->addProperty('checkParameterizedMethods', 'false');
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getMethod());
+    }
+
+    /**
+     * testRuleAppliesToReturnDeclarationTrue
+     *
+     * @requires PHP 8.2.0
+     *
+     * @return void
+     */
+    public function testRuleAppliesToReturnDeclarationTrue()
+    {
+        $rule = new BooleanGetMethodName();
+        $rule->addProperty('checkParameterizedMethods', 'false');
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getMethod());
+    }
+
+    /**
+     * testRuleAppliesToReturnDeclarationFalse
+     *
+     * @requires PHP 8.2.0
+     *
+     * @return void
+     */
+    public function testRuleAppliesToReturnDeclarationFalse()
+    {
+        $rule = new BooleanGetMethodName();
+        $rule->addProperty('checkParameterizedMethods', 'false');
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getMethod());
+    }
+
+    /**
      * Returns the first method found in a source file related to the calling
      * test method.
      *

--- a/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleAppliesToReturnDeclarationBool.php
+++ b/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleAppliesToReturnDeclarationBool.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleAppliesToReturnDeclarationBool
+{
+    public function getBaz(): bool
+    {
+        return true;
+    }
+}

--- a/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleAppliesToReturnDeclarationFalse.php
+++ b/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleAppliesToReturnDeclarationFalse.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleAppliesToReturnDeclarationFalse
+{
+    public function getBaz(): false
+    {
+        return false;
+    }
+}

--- a/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleAppliesToReturnDeclarationTrue.php
+++ b/src/test/resources/files/Rule/Naming/BooleanGetMethodName/testRuleAppliesToReturnDeclarationTrue.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleAppliesToReturnDeclarationTrue
+{
+    public function getBaz(): true
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Type: feature
Issue: n/a
Breaking change: kinda, for users who already are using the `BooleanGetMethodName` rule together with methods that use `bool`, `true` or `false` return type declarations but do not respect the rule.

`bool` return type was introduced in PHP 7.0.0.
`true` and `false` return types were introduced in PHP 8.2.0.

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
  
 ## Adding a New Rule

- Add the new rule to the matching rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new rule, e.g. ``src/site/rst/rules/naming.rst``
- Implement the new rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new rule in the rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new rule *should* apply
-- Cover the case when the new rule *should not* apply
-- Cover edge cases of the new rule

## Adding a New Rule Property

- Add the new property to rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new property, e.g. ``src/site/rst/rules/naming.rst``
- Implement new property in rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new property in rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new property is not set and the rule *should not* apply
-- Cover the case when the new property is not set and the rule *should* apply
-- Cover case when the new property is set and the rule *should not* apply
-- Cover case when the new property is set and the rule *should* apply
-- Cover edge cases of the new property, if any
-->
