### PR TITLE
Php84 deprecation fix

### DIFF
--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -58,7 +58,7 @@ class Report
     /** @var BaselineValidator|null */
     private $baselineValidator;
 
-    public function __construct(BaselineValidator $baselineValidator = null)
+    public function __construct(?BaselineValidator $baselineValidator = null)
     {
         $this->baselineValidator = $baselineValidator;
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -74,7 +74,7 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
         $this->scanFormalParameters($node);
     }
 
-    protected function isBooleanValue(ASTValue $value = null)
+    protected function isBooleanValue(?ASTValue $value = null)
     {
         return $value && $value->isValueAvailable() && ($value->getValue() === true || $value->getValue() === false);
     }

--- a/src/main/php/PHPMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateField.php
@@ -147,7 +147,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * @return boolean
      * @since 0.2.6
      */
-    protected function isValidPropertyNode(ASTNode $node = null)
+    protected function isValidPropertyNode(?ASTNode $node = null)
     {
         if ($node === null) {
             return false;

--- a/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/src/test/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -167,7 +167,7 @@ class TooManyMethodsTest extends AbstractTest
      * @param string[] $methodNames
      * @return \PHPMD\Node\ClassNode
      */
-    private function createClassMock($numberOfMethods, array $methodNames = null)
+    private function createClassMock($numberOfMethods, ?array $methodNames = null)
     {
         $class = $this->getClassMock('nom', $numberOfMethods);
 

--- a/src/test/php/PHPMD/TextUI/CommandTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandTest.php
@@ -52,7 +52,7 @@ class CommandTest extends AbstractTest
      * @return void
      * @dataProvider dataProviderTestMainWithOption
      */
-    public function testMainStrictOptionIsOfByDefault($sourceFile, $expectedExitCode, array $options = null)
+    public function testMainStrictOptionIsOfByDefault($sourceFile, $expectedExitCode, ?array $options = null)
     {
         $args = array_filter(
             array_merge(

--- a/src/test/resources/files/Integration/CouplingBetweenObjectsIntegration/testReportContainsCouplingBetweenObjectsWarning.php
+++ b/src/test/resources/files/Integration/CouplingBetweenObjectsIntegration/testReportContainsCouplingBetweenObjectsWarning.php
@@ -72,7 +72,7 @@ class testReportContainsCouplingBetweenObjectsWarning
      * @return void
      * @throws \InvalidArgumentException
      */
-    public function traverse(\DOMNode $node = null)
+    public function traverse(?\DOMNode $node = null)
     {
 
     }

--- a/src/test/resources/files/source/source_with_parse_error.php
+++ b/src/test/resources/files/source/source_with_parse_error.php
@@ -1,4 +1,3 @@
 <?php
 
 function test () {
-}

--- a/src/test/resources/files/source/source_with_parse_error.php
+++ b/src/test/resources/files/source/source_with_parse_error.php
@@ -1,3 +1,4 @@
 <?php
 
 function test () {
+}


### PR DESCRIPTION
Type: bugfix
Issue: Related to the prominent deprecation in PHP 8.4 (Change the implicit nullable type declaration to a nullable type declaration)
Breaking change: no 

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
  
 ## Adding a New Rule

- Add the new rule to the matching rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new rule, e.g. ``src/site/rst/rules/naming.rst``
- Implement the new rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new rule in the rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new rule *should* apply
-- Cover the case when the new rule *should not* apply
-- Cover edge cases of the new rule

## Adding a New Rule Property

- Add the new property to rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new property, e.g. ``src/site/rst/rules/naming.rst``
- Implement new property in rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new property in rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new property is not set and the rule *should not* apply
-- Cover the case when the new property is not set and the rule *should* apply
-- Cover case when the new property is set and the rule *should not* apply
-- Cover case when the new property is set and the rule *should* apply
-- Cover edge cases of the new property, if any
-->
