### PR TITLE
Ignore "StaticAccess" rule on predefined enum static methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,9 +60,9 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "PHPMD\\": "tests/php/PHPMD/"
-    },
-    "classmap": ["tests/resources/"]
+      "PHPMD\\": "tests/php/PHPMD/",
+      "": "tests/resources/"
+    }
   },
   "bin": [
     "bin/phpmd"

--- a/src/Rule/CleanCode/StaticAccess.php
+++ b/src/Rule/CleanCode/StaticAccess.php
@@ -77,7 +77,8 @@ final class StaticAccess extends AbstractRule implements FunctionAware, MethodAw
         return $methodCall->getChild(0)->getNode() instanceof ASTClassOrInterfaceReference &&
             $methodCall->getChild(1)->getNode() instanceof ASTMethodPostfix &&
             !$this->isCallingParent($methodCall) &&
-            !$this->isCallingSelf($methodCall);
+            !$this->isCallingSelf($methodCall) &&
+            !$this->isCallingEnumTranslator($methodCall);
     }
 
     /**
@@ -96,6 +97,23 @@ final class StaticAccess extends AbstractRule implements FunctionAware, MethodAw
     private function isCallingSelf(AbstractNode $methodCall): bool
     {
         return $methodCall->getChild(0)->getNode() instanceof ASTSelfReference;
+    }
+
+    /**
+     * @param AbstractNode<ASTMemberPrimaryPrefix> $methodCall
+     * @throws OutOfBoundsException
+     */
+    private function isCallingEnumTranslator(AbstractNode $methodCall): bool
+    {
+        $enumName = $methodCall->getChild(0)->getName();
+
+        if (!enum_exists($enumName)) {
+            return false;
+        }
+
+        $methodName = $methodCall->getChild(1)->getName();
+
+        return in_array($methodName, ['cases', 'from', 'tryFrom'], true);
     }
 
     /**

--- a/tests/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
+++ b/tests/php/PHPMD/Rule/CleanCode/StaticAccessTest.php
@@ -99,4 +99,25 @@ class StaticAccessTest extends AbstractTestCase
         $rule->addProperty('ignorepattern', '/^foobar/');
         $rule->apply($this->getMethod());
     }
+
+    public function testRuleNotAppliesToEnumTranslationStaticCall(): void
+    {
+        $rule = new StaticAccess();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getMethod());
+    }
+
+    public function testRuleAppliesToEnumMethodsFromOtherClasses(): void
+    {
+        $rule = new StaticAccess();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getMethod());
+    }
+
+    public function testRuleAppliesToEnumStaticCall(): void
+    {
+        $rule = new StaticAccess();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getMethod());
+    }
 }

--- a/tests/resources/files/Rule/CleanCode/StaticAccess/testRuleAppliesToEnumMethodsFromOtherClasses.php
+++ b/tests/resources/files/Rule/CleanCode/StaticAccess/testRuleAppliesToEnumMethodsFromOtherClasses.php
@@ -15,12 +15,12 @@
  * @link http://phpmd.org/
  */
 
-namespace tests\resources\files\Rule\CleanCode\StaticAccess;
+namespace test\resources\files\Rule\CleanCode\StaticAccess;
 
-class Foo
+final class Foo
 {
-    static public function testRuleNotAppliesToSelfStaticCall()
+    static public function testRuleAppliesToEnumMethodsFromOtherClasses(): void
     {
-        self::bar();
+        self::from();
     }
 }

--- a/tests/resources/files/Rule/CleanCode/StaticAccess/testRuleAppliesToEnumStaticCall.php
+++ b/tests/resources/files/Rule/CleanCode/StaticAccess/testRuleAppliesToEnumStaticCall.php
@@ -15,12 +15,14 @@
  * @link http://phpmd.org/
  */
 
-namespace tests\resources\files\Rule\CleanCode\StaticAccess;
+namespace test\resources\files\Rule\CleanCode\StaticAccess;
 
-class Foo
+use files\classes\SuitEnum;
+
+final class Foo
 {
-    static public function testRuleNotAppliesToSelfStaticCall()
+    static public function testRuleAppliesToEnumStaticCall(): void
     {
-        self::bar();
+        SuitEnum::bar();
     }
 }

--- a/tests/resources/files/Rule/CleanCode/StaticAccess/testRuleNotAppliesToEnumTranslationStaticCall.php
+++ b/tests/resources/files/Rule/CleanCode/StaticAccess/testRuleNotAppliesToEnumTranslationStaticCall.php
@@ -17,10 +17,12 @@
 
 namespace tests\resources\files\Rule\CleanCode\StaticAccess;
 
-class Foo
+use files\classes\SuitEnum;
+
+final class Foo
 {
-    static public function testRuleNotAppliesToSelfStaticCall()
+    static public function testRuleNotAppliesToEnumTranslationStaticCall(): void
     {
-        self::bar();
+        SuitEnum::cases();
     }
 }

--- a/tests/resources/files/classes/SuitEnum.php
+++ b/tests/resources/files/classes/SuitEnum.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHP Mess Detector.
  *
@@ -15,12 +16,12 @@
  * @link http://phpmd.org/
  */
 
-namespace tests\resources\files\Rule\CleanCode\StaticAccess;
+namespace files\classes;
 
-class Foo
+enum SuitEnum: string
 {
-    static public function testRuleNotAppliesToSelfStaticCall()
-    {
-        self::bar();
-    }
+    case Clubs = 'Clubs';
+    case Diamonds = 'Diamonds';
+    case Hearts = 'Hearts';
+    case Spades = 'Spades';
 }


### PR DESCRIPTION
Type: feature
Issue: Resolves #1073
Breaking change: no

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
  
 ## Adding a New Rule

- Add the new rule to the matching rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new rule, e.g. ``src/site/rst/rules/naming.rst``
- Implement the new rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new rule in the rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new rule *should* apply
-- Cover the case when the new rule *should not* apply
-- Cover edge cases of the new rule

## Adding a New Rule Property

- Add the new property to rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new property, e.g. ``src/site/rst/rules/naming.rst``
- Implement new property in rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new property in rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new property is not set and the rule *should not* apply
-- Cover the case when the new property is not set and the rule *should* apply
-- Cover case when the new property is set and the rule *should not* apply
-- Cover case when the new property is set and the rule *should* apply
-- Cover edge cases of the new property, if any
-->

### To Do

- [x] Confirm if there is a way to obtain the enum node reference without using `require_once` in tests;
- [x] Wait for #1224.
