### PR TITLE
Execute `composer dump-autoload` in CI jobs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,6 +46,10 @@ jobs:
           composer require scrutinizer/ocular --no-update --no-interaction
           composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
 
+      - name: Dump Composer autoload
+        if: steps.composer-cache.outputs.cache-hit == 'true'
+        run: composer dump-autoload
+
       - name: Execute Unit Tests
         run: vendor/bin/paratest --coverage-text --coverage-clover=coverage.xml
         env:

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -55,5 +55,9 @@ jobs:
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer update --prefer-dist --no-progress --prefer-stable
 
+      - name: Dump Composer autoload
+        if: steps.composer-cache.outputs.cache-hit == 'true'
+        run: composer dump-autoload
+
       - name: Run test suite
         run: vendor/bin/paratest --display-deprecations

--- a/.github/workflows/tests-with-composer.yml
+++ b/.github/workflows/tests-with-composer.yml
@@ -47,6 +47,10 @@ jobs:
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer up
 
+      - name: Dump Composer autoload
+        if: steps.composer-cache.outputs.cache-hit == 'true'
+        run: composer dump-autoload
+
       - name: Run `composer test` twice
         run: |
           composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,10 @@ jobs:
         if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php == '8.4'
         run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }} --ignore-platform-req=php
 
+      - name: Dump Composer autoload
+        if: steps.composer-cache.outputs.cache-hit == 'true'
+        run: composer dump-autoload
+
       - name: Execute Unit Tests
         run: composer test
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,5 +39,9 @@ jobs:
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer update --no-progress --prefer-${{ matrix.setup }} --prefer-dist
 
+      - name: Dump Composer autoload
+        if: steps.composer-cache.outputs.cache-hit == 'true'
+        run: composer dump-autoload
+
       - name: Execute Unit Tests
         run: composer test


### PR DESCRIPTION
Type: CI
Issue: n/a
Breaking change: no

This change is required to allow the CI jobs to update the cached contents from `vendor/composer/autoload_classmap.php`, even when the contents at `composer.json` remains the same.

For evidence regarding the fixed cases, see the CI jobs from #1221.

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
  
 ## Adding a New Rule

- Add the new rule to the matching rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new rule, e.g. ``src/site/rst/rules/naming.rst``
- Implement the new rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new rule in the rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new rule *should* apply
-- Cover the case when the new rule *should not* apply
-- Cover edge cases of the new rule

## Adding a New Rule Property

- Add the new property to rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new property, e.g. ``src/site/rst/rules/naming.rst``
- Implement new property in rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new property in rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new property is not set and the rule *should not* apply
-- Cover the case when the new property is not set and the rule *should* apply
-- Cover case when the new property is set and the rule *should not* apply
-- Cover case when the new property is set and the rule *should* apply
-- Cover edge cases of the new property, if any
-->
