### PR TITLE
fixes a bug where the regex for checking the method names for tests does not pass if the method name contains a number following an underscore #1

### DIFF
--- a/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
+++ b/src/main/php/PHPMD/Rule/Controversial/CamelCaseMethodName.php
@@ -80,7 +80,7 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
         }
 
         if ($this->getBooleanProperty('allow-underscore-test') && strpos($methodName, 'test') === 0) {
-            return preg_match('/^test[a-zA-Z0-9]*(_[a-z][a-zA-Z0-9]*)*$/', $methodName);
+            return preg_match('/^test[a-zA-Z0-9]*(_[a-z0-9][a-zA-Z0-9]*)*$/', $methodName);
         }
 
         if ($this->getBooleanProperty('allow-underscore')) {


### PR DESCRIPTION
fix(https://github.com/phpmd/phpmd/issues/851) : fixes a bug that the camel case method regex does not passes for method names where an underscore is followed by a number

Type: bugfix
Issue: Resolves https://github.com/phpmd/phpmd/issues/851
Breaking change: no (if yes explain why)

The regex for checking the method names for tests does not pass if the method name contains a number following an underscore, such as `test_it_throws_if_more_5`:
```
> preg_match('/^test[a-zA-Z0-9]*(_[a-z][a-zA-Z0-9]*)*$/', 'test_it_throws_if_more_5') 
= 0

> preg_match('/^test[a-zA-Z0-9]*(_[a-z][a-zA-Z0-9]*)*$/', 'test_it_throws_if_more_f5')
= 1
```
This PR allows numbers:
```
> preg_match('/^test[a-zA-Z0-9]*(_[a-z0-9][a-zA-Z0-9]*)*$/', 'test_it_throws_if_more_5')                  
= 1
```
