### PR TITLE
Update to PHPStan 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     "friendsofphp/php-cs-fixer": "^3.57",
     "gregwar/rst": "^1.0",
     "mikey179/vfsstream": "^1.6.8",
-    "phpstan/phpstan": "~1.12.0",
+    "phpstan/phpstan": "~2.1.0",
     "phpunit/phpunit": "^10.5.20,<10.5.32",
     "squizlabs/php_codesniffer": "^3.8.0"
   },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ parameters:
         - src/
         - tests/php/
     rememberPossiblyImpureFunctionValues: false
-    level: max
+    level: 9
     exceptions:
         reportUncheckedExceptionDeadCatch: true
         implicitThrows: false

--- a/src/Cache/ResultCacheStateFactory.php
+++ b/src/Cache/ResultCacheStateFactory.php
@@ -44,14 +44,20 @@ class ResultCacheStateFactory
         assert(is_bool($data['strict']));
         assert(is_string($data['baselineHash']) || $data['baselineHash'] === null);
         assert(is_array($data['rules']));
+
+        /** @var array<string, string> */
+        $rules = $data['rules'];
         assert(is_array($data['composer']));
+
+        /** @var array<string, string> */
+        $composer = $data['composer'];
         assert(is_int($data['phpVersion']));
 
         return new ResultCacheKey(
             $data['strict'],
             $data['baselineHash'],
-            $data['rules'],
-            $data['composer'],
+            $rules,
+            $composer,
             $data['phpVersion']
         );
     }

--- a/src/Cache/ResultCacheUpdater.php
+++ b/src/Cache/ResultCacheUpdater.php
@@ -18,7 +18,7 @@ class ResultCacheUpdater
     }
 
     /**
-     * @param RuleSet[] $ruleSetList
+     * @param list<RuleSet> $ruleSetList
      * @throws OutOfBoundsException
      */
     public function update(array $ruleSetList, ResultCacheState $state, Report $report): ResultCacheState

--- a/src/PHPMD.php
+++ b/src/PHPMD.php
@@ -117,7 +117,7 @@ class PHPMD
     /**
      * Sets a list of filename extensions for valid php source code files.
      *
-     * @param array<string> $fileExtensions Extensions without leading dot.
+     * @param list<string> $fileExtensions Extensions without leading dot.
      */
     public function setFileExtensions(array $fileExtensions): void
     {
@@ -139,7 +139,7 @@ class PHPMD
      * Add a list of ignore patterns which is used to exclude directories from
      * the source analysis.
      *
-     * @param array<string> $ignorePatterns List of ignore patterns.
+     * @param list<string> $ignorePatterns List of ignore patterns.
      * @return $this
      * @since 2.9.0
      */
@@ -159,7 +159,7 @@ class PHPMD
     }
 
     /**
-     * @return $this;
+     * @return $this
      */
     public function setResultCache(ResultCacheEngine $resultCache)
     {
@@ -193,9 +193,9 @@ class PHPMD
      * path. It will apply rules defined in the comma-separated <b>$ruleSets</b>
      * argument. The result will be passed to all given renderer instances.
      *
-     * @param string[]      $ignorePattern
+     * @param list<string>        $ignorePattern
      * @param RendererInterface[] $renderers
-     * @param RuleSet[]          $ruleSetList
+     * @param list<RuleSet>       $ruleSetList
      * @throws Exception
      */
     public function processFiles(

--- a/src/Renderer/HTMLRenderer.php
+++ b/src/Renderer/HTMLRenderer.php
@@ -81,7 +81,7 @@ final class HTMLRenderer extends AbstractRenderer
 
     public function __construct(?int $extraLineInExcerpt = null)
     {
-        if ($extraLineInExcerpt && is_int($extraLineInExcerpt)) {
+        if ($extraLineInExcerpt) {
             $this->extraLineInExcerpt = $extraLineInExcerpt;
         }
     }

--- a/src/Rule/AbstractLocalVariable.php
+++ b/src/Rule/AbstractLocalVariable.php
@@ -91,8 +91,8 @@ abstract class AbstractLocalVariable extends AbstractRule
 
         if ($parent?->isInstanceOf(ASTPropertyPostfix::class)) {
             $primaryPrefix = $parent->getParent();
-            $primaryPrefixParent = $primaryPrefix?->getParent();
-            if ($primaryPrefixParent?->isInstanceOf(ASTMemberPrimaryPrefix::class)) {
+            $primaryPrefixParent = $primaryPrefix?->getParent()?->getNode();
+            if ($primaryPrefixParent instanceof ASTMemberPrimaryPrefix) {
                 return !$primaryPrefixParent->isStatic();
             }
 
@@ -100,8 +100,10 @@ abstract class AbstractLocalVariable extends AbstractRule
                 return false;
             }
 
+            $primaryPrefix = $primaryPrefix->getNode();
+
             return ($parent->getChild(0)->getNode() !== $node->getNode()
-                || ($primaryPrefix->isInstanceOf(ASTMemberPrimaryPrefix::class) && !$primaryPrefix->isStatic())
+                || ($primaryPrefix instanceof ASTMemberPrimaryPrefix && !$primaryPrefix->isStatic())
             );
         }
 
@@ -210,7 +212,7 @@ abstract class AbstractLocalVariable extends AbstractRule
     /**
      * Reflect function trying as namespaced function first, then global function.
      *
-     * @SuppressWarnings(PHPMD.EmptyCatchBlock)
+     * @SuppressWarnings(EmptyCatchBlock)
      */
     private function getReflectionFunctionByName(string $functionName): ?ReflectionFunction
     {

--- a/src/Rule/Design/CountInLoopExpression.php
+++ b/src/Rule/Design/CountInLoopExpression.php
@@ -48,7 +48,7 @@ use RuntimeException;
  * - do-while() loops
  *
  * @author Kamil Szymanski <kamilszymanski@gmail.com>
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(CouplingBetweenObjects)
  */
 final class CountInLoopExpression extends AbstractRule implements ClassAware, EnumAware, TraitAware
 {

--- a/src/Rule/Naming/BooleanGetMethodName.php
+++ b/src/Rule/Naming/BooleanGetMethodName.php
@@ -19,7 +19,6 @@
 namespace PHPMD\Rule\Naming;
 
 use OutOfBoundsException;
-use PDepend\Source\AST\ASTCallable;
 use PDepend\Source\AST\ASTScalarType;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
@@ -75,14 +74,12 @@ final class BooleanGetMethodName extends AbstractRule implements MethodAware
     private function isReturnTypeBoolean(MethodNode $node): bool
     {
         $wrappedNode = $node->getNode();
-        if ($wrappedNode instanceof ASTCallable) {
-            $returnType = $wrappedNode->getReturnType();
-            if (
-                $returnType instanceof ASTScalarType
-                && in_array($returnType->getImage(), ['bool', 'true', 'false'], true)
-            ) {
-                return true;
-            }
+        $returnType = $wrappedNode->getReturnType();
+        if (
+            $returnType instanceof ASTScalarType
+            && in_array($returnType->getImage(), ['bool', 'true', 'false'], true)
+        ) {
+            return true;
         }
 
         $comment = $node->getComment();

--- a/src/Rule/Naming/LongVariable.php
+++ b/src/Rule/Naming/LongVariable.php
@@ -116,7 +116,7 @@ final class LongVariable extends AbstractRule implements ClassAware, FunctionAwa
      * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
-     * @SuppressWarnings(PHPMD.LongVariable)
+     * @SuppressWarnings(LongVariable)
      */
     private function checkMaximumLength(AbstractNode $node): void
     {

--- a/src/Rule/UnusedPrivateField.php
+++ b/src/Rule/UnusedPrivateField.php
@@ -136,8 +136,8 @@ final class UnusedPrivateField extends AbstractRule implements ClassAware
         $image = '$';
         $child = $postfix->getFirstChildOfType(ASTIdentifier::class);
 
-        $parent = $postfix->getParent();
-        if ($parent?->isInstanceOf(ASTMemberPrimaryPrefix::class) && $parent->isStatic()) {
+        $parent = $postfix->getParent()?->getNode();
+        if ($parent instanceof ASTMemberPrimaryPrefix && $parent->isStatic()) {
             $image = '';
             $child = $postfix->getFirstChildOfType(ASTVariable::class);
         }

--- a/src/TextUI/CommandLineOptions.php
+++ b/src/TextUI/CommandLineOptions.php
@@ -19,7 +19,6 @@
 namespace PHPMD\TextUI;
 
 use InvalidArgumentException;
-use PHPMD\AbstractRenderer;
 use PHPMD\Baseline\BaselineMode;
 use PHPMD\Cache\Model\ResultCacheStrategy;
 use PHPMD\Console\OutputInterface;
@@ -36,7 +35,7 @@ use ValueError;
  * This is a helper class that collects the specified cli arguments and puts them
  * into accessible properties.
  *
- * @SuppressWarnings(PHPMD.LongVariable)
+ * @SuppressWarnings(LongVariable)
  */
 class CommandLineOptions
 {
@@ -55,7 +54,7 @@ class CommandLineOptions
     /**
      * The specified report format.
      *
-     * @var ?class-string<AbstractRenderer>
+     * @var ?string
      */
     private $reportFormat;
 
@@ -375,7 +374,7 @@ class CommandLineOptions
         $validator->validate('ruleset', $this->ruleSets);
 
         $this->reportFormat = array_pop($arguments);
-        $validator->validate('report format', $this->reportFormat);
+        $validator->validate('report format', $this->reportFormat ?? '');
 
         $this->inputPath = implode(',', $arguments);
 
@@ -401,7 +400,7 @@ class CommandLineOptions
     /**
      * Returns the specified report format.
      *
-     * @return class-string<AbstractRenderer>|null
+     * @return ?string
      */
     public function getReportFormat()
     {

--- a/tests/php/PHPMD/AbstractStaticTestCase.php
+++ b/tests/php/PHPMD/AbstractStaticTestCase.php
@@ -134,10 +134,10 @@ abstract class AbstractStaticTestCase extends TestCase
      */
     protected static function createResourceUriForTest(string $localPath): string
     {
-        $frame = static::getCallingTestCase();
-        static::assertIsString($frame['class']);
+        $class = static::getCallingTestCase()['class'] ?? null;
+        static::assertIsString($class);
 
-        return static::getResourceFilePathFromClassName($frame['class'], $localPath);
+        return static::getResourceFilePathFromClassName($class, $localPath);
     }
 
     /**
@@ -254,7 +254,7 @@ abstract class AbstractStaticTestCase extends TestCase
     /**
      * Returns the trace frame of the calling test case.
      *
-     * @return array<string, mixed>
+     * @return array{function: string, class?: class-string}
      * @throws ErrorException
      */
     protected static function getCallingTestCase(): array

--- a/tests/php/PHPMD/AbstractTestCase.php
+++ b/tests/php/PHPMD/AbstractTestCase.php
@@ -38,7 +38,6 @@ use PHPMD\Node\NodeInfo;
 use PHPMD\Node\TraitNode;
 use PHPMD\Rule\Design\TooManyFields;
 use PHPMD\Stubs\RuleStub;
-use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionProperty;
 
@@ -204,13 +203,9 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     /**
      * Assert that a given file trigger N times the given rule.
      *
-     * Rethrows the PHPUnit ExpectationFailedException with the base name
-     * of the file for better readability.
-     *
      * @param Rule $rule Rule to test.
      * @param int $expectedInvokes Count of expected invocations.
      * @param string $file Test file containing a method with the same name to be tested.
-     * @throws ExpectationFailedException
      */
     protected function expectRuleHasViolationsForFile(Rule $rule, int $expectedInvokes, string $file): void
     {
@@ -223,13 +218,10 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
             ? $actualInvokes > 0
             : $actualInvokes === $expectedInvokes;
 
-        if (!$assertion) {
-            throw new ExpectationFailedException(
-                $this->getViolationFailureMessage($file, $expectedInvokes, $actualInvokes, $violations)
-            );
-        }
-
-        static::assertTrue($assertion);
+        static::assertTrue(
+            $assertion,
+            $assertion ? '' : $this->getViolationFailureMessage($file, $expectedInvokes, $actualInvokes, $violations)
+        );
     }
 
     /**
@@ -304,10 +296,10 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      */
     protected static function createResourceUriForTest(string $localPath): string
     {
-        $frame = static::getCallingTestCase();
-        static::assertIsString($frame['class']);
+        $class = static::getCallingTestCase()['class'] ?? null;
+        static::assertIsString($class);
 
-        return static::getResourceFilePathFromClassName($frame['class'], $localPath);
+        return static::getResourceFilePathFromClassName($class, $localPath);
     }
 
     /**
@@ -614,7 +606,6 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
     private function getNodeForCallingTestCase(Iterator $nodes): ASTNode
     {
         $frame = $this->getCallingTestCase();
-        static::assertIsString($frame['function']);
 
         return $this->getNodeByName($nodes, $frame['function']);
     }

--- a/tests/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
+++ b/tests/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
@@ -19,7 +19,7 @@
 namespace PHPMD\Regression\Sources;
 
 /**
- * @SuppressWarnings(PHPMD.ExcessivePublicCount)
+ * @SuppressWarnings(ExcessivePublicCount)
  */
 class ExcessivePublicCountSuppressionWorksForPublicStaticMethods
 {

--- a/tests/php/PHPMD/Renderer/AnsiRendererTest.php
+++ b/tests/php/PHPMD/Renderer/AnsiRendererTest.php
@@ -77,8 +77,7 @@ class AnsiRendererTest extends AbstractTestCase
             PHP_EOL . 'FILE: /foo.php' . PHP_EOL . '--------------' . PHP_EOL,
             " 2 | \e[31mVIOLATION\e[0m | Test description" . PHP_EOL,
             " 3 | \e[31mVIOLATION\e[0m | Test description" . PHP_EOL,
-            PHP_EOL . "\e[33mERROR\e[0m while parsing /foo/baz.php" . PHP_EOL . '--------------------------------' .
-            (version_compare(PHP_VERSION, '5.4.0-dev', '<') ? '--' : '') . PHP_EOL,
+            PHP_EOL . "\e[33mERROR\e[0m while parsing /foo/baz.php" . PHP_EOL . '--------------------------------' . PHP_EOL,
             'Error in file "/foo/baz.php"' . PHP_EOL,
             PHP_EOL . 'Found 3 violations and 1 error in 200ms' . PHP_EOL,
         ];

--- a/tests/php/PHPMD/RuleSetFactoryTest.php
+++ b/tests/php/PHPMD/RuleSetFactoryTest.php
@@ -68,8 +68,7 @@ class RuleSetFactoryTest extends AbstractTestCase
      */
     public function testCreateRuleSetsReturnsArray(): void
     {
-        $ruleSets = $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
-        static::assertIsArray($ruleSets);
+        $this->createRuleSetsFromAbsoluteFiles('rulesets/set1.xml');
     }
 
     /**
@@ -167,7 +166,6 @@ class RuleSetFactoryTest extends AbstractTestCase
         self::changeWorkingDirectory();
 
         $ruleSets = $this->createRuleSetsFromFiles('rulesets/set1.xml');
-        static::assertIsArray($ruleSets);
     }
 
     /**

--- a/tests/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/tests/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -762,13 +762,6 @@ class CommandLineOptionsTest extends AbstractTestCase
         static::assertEquals($expected, $opts->getReportFiles());
     }
 
-    public function testCliOptionExtraLineInExcerptShouldBeWithNumber(): void
-    {
-        $args = [__FILE__, __FILE__, 'text', 'codesize', '--extra-line-in-excerpt', '5'];
-        $opts = new CommandLineOptions($args);
-        static::assertSame(5, $opts->extraLineInExcerpt());
-    }
-
     /**
      * @return list<list<mixed>>
      */
@@ -817,5 +810,12 @@ class CommandLineOptionsTest extends AbstractTestCase
                 ],
             ],
         ];
+    }
+
+    public function testCliOptionExtraLineInExcerptShouldBeWithNumber(): void
+    {
+        $args = [__FILE__, __FILE__, 'text', 'codesize', '--extra-line-in-excerpt', '5'];
+        $opts = new CommandLineOptions($args);
+        static::assertSame(5, $opts->extraLineInExcerpt());
     }
 }

--- a/tests/php/PHPMD/TextUI/StreamFilter.php
+++ b/tests/php/PHPMD/TextUI/StreamFilter.php
@@ -36,7 +36,7 @@ class StreamFilter extends php_user_filter
 
         while ($bucket = stream_bucket_make_writeable($in)) {
             self::$streamHandle .= $bucket->data;
-            $consumed += $bucket->datalen;
+            $consumed += (int) $bucket->datalen;
         }
 
         return PSFS_PASS_ON;


### PR DESCRIPTION
Type: refactoring
Breaking change: no

- Set PHPStan level to 9 since 2.1 adds a new level (will be addressed in a follow up
- Fix one code style issue