### PR TITLE
PHP8.4 fix: Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() 

### DIFF
--- a/phpstan-baseline-pre-8.3.neon
+++ b/phpstan-baseline-pre-8.3.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to an undefined static method ReflectionMethod\:\:createFromMethodName\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Rule/UnusedFormalParameter.php

--- a/phpstan-baseline.neon.php
+++ b/phpstan-baseline.neon.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+$includes = [];
+if (PHP_VERSION_ID < 80300) {
+	$includes[] = __DIR__ . '/phpstan-baseline-pre-8.3.neon';
+}
+
+$config = [];
+$config['includes'] = $includes;
+
+// overrides config.platform.php in composer.json
+$config['parameters']['phpVersion'] = PHP_VERSION_ID;
+
+return $config;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,4 @@
 parameters:
-    phpVersion:
-        min: 80100
-        max: 80499
     paths:
         - src/
         - tests/php/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 parameters:
     phpVersion:
         min: 80100
+        max: 80499
     paths:
         - src/
         - tests/php/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,6 @@
 parameters:
-	phpVersion:
-		min: 80100
+        phpVersion:
+            min: 80100
     paths:
         - src/
         - tests/php/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,6 @@
 parameters:
+	phpVersion:
+		min: 80100
     paths:
         - src/
         - tests/php/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,5 @@
+includes:
+	- phpstan-baseline.neon.php
 parameters:
     paths:
         - src/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,6 @@
 parameters:
-        phpVersion:
-            min: 80100
+    phpVersion:
+        min: 80100
     paths:
         - src/
         - tests/php/

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -143,7 +143,7 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
         $methodName = substr($node->getFullQualifiedName(), 0, -2);
         /**
          * @var ReflectionMethod
-         * @phpstan-ignore function.alreadyNarrowedType function.alreadyNarrowedType
+         * @phpstan-ignore function.alreadyNarrowedType, function.alreadyNarrowedType
          */
         $reflectionMethod = method_exists('ReflectionMethod', 'createFromMethodName')
             ? ReflectionMethod::createFromMethodName($methodName)

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -142,6 +142,7 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
         // Remove the "()" at the end of method's name.
         $methodName = substr($node->getFullQualifiedName(), 0, -2);
         /** @phpstan-ignore function.alreadyNarrowedType function.alreadyNarrowedType */
+        /** @var ReflectionMethod */
         $reflectionMethod = method_exists('ReflectionMethod', 'createFromMethodName')
             ? ReflectionMethod::createFromMethodName($methodName)
             : new ReflectionMethod($methodName); // @codeCoverageIgnore

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -143,7 +143,7 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
 
         /**
          * @var ReflectionMethod
-         * @phpstan-ignore function.alreadyNarrowedTyp, missingType.checkedException
+         * @phpstan-ignore function.alreadyNarrowedType, missingType.checkedException
          */
         $reflectionMethod = method_exists('ReflectionMethod', 'createFromMethodName')
             ? ReflectionMethod::createFromMethodName($methodName)

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -143,7 +143,7 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
 
         /**
          * @var ReflectionMethod
-         * @phpstan-ignore function.alreadyNarrowedTyp, emissingType.checkedException
+         * @phpstan-ignore function.alreadyNarrowedTyp, missingType.checkedException
          */
         $reflectionMethod = method_exists('ReflectionMethod', 'createFromMethodName')
             ? ReflectionMethod::createFromMethodName($methodName)

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -33,7 +33,6 @@ use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\Node\AbstractCallableNode;
 use PHPMD\Node\MethodNode;
-use ReflectionException;
 use ReflectionMethod;
 use RuntimeException;
 
@@ -141,9 +140,10 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
 
         // Remove the "()" at the end of method's name.
         $methodName = substr($node->getFullQualifiedName(), 0, -2);
+
         /**
          * @var ReflectionMethod
-         * @phpstan-ignore function.alreadyNarrowedType, function.alreadyNarrowedType
+         * @phpstan-ignore function.alreadyNarrowedTyp, emissingType.checkedException
          */
         $reflectionMethod = method_exists('ReflectionMethod', 'createFromMethodName')
             ? ReflectionMethod::createFromMethodName($methodName)

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -56,7 +56,6 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
      * This method checks that all parameters of a given function or method are
      * used at least one time within the artifacts body.
      *
-     * @throws ReflectionException
      * @throws RuntimeException
      */
     public function apply(AbstractNode $node): void
@@ -122,7 +121,6 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
      * \Override attribute or the {@inheritDoc} annotation.
      *
      * @param AbstractCallableNode<AbstractASTCallable> $node
-     * @throws ReflectionException
      * @throws RuntimeException
      */
     private function isInheritedSignature(AbstractCallableNode $node): bool
@@ -143,11 +141,7 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
 
         // Remove the "()" at the end of method's name.
         $methodName = substr($node->getFullQualifiedName(), 0, -2);
-        if (\PHP_VERSION_ID < 80300) {
-            $reflectionMethod = new ReflectionMethod($methodName);
-        } else {
-            $reflectionMethod = ReflectionMethod::createFromMethodName($methodName);
-        }
+        $reflectionMethod = ReflectionMethod::createFromMethodName($methodName);
 
         foreach ($reflectionMethod->getAttributes() as $reflectionAttribute) {
             if ($reflectionAttribute->getName() === Override::class) {

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -141,9 +141,10 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
 
         // Remove the "()" at the end of method's name.
         $methodName = substr($node->getFullQualifiedName(), 0, -2);
+        /** @phpstan-ignore function.alreadyNarrowedType function.alreadyNarrowedType */
         $reflectionMethod = method_exists('ReflectionMethod', 'createFromMethodName')
             ? ReflectionMethod::createFromMethodName($methodName)
-            : new ReflectionMethod($methodName);
+            : new ReflectionMethod($methodName); // @codeCoverageIgnore
 
         foreach ($reflectionMethod->getAttributes() as $reflectionAttribute) {
             if ($reflectionAttribute->getName() === Override::class) {

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -143,11 +143,8 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
 
         /**
          * @var ReflectionMethod
-         * @phpstan-ignore function.alreadyNarrowedType, missingType.checkedException
          */
-        $reflectionMethod = method_exists('ReflectionMethod', 'createFromMethodName')
-            ? ReflectionMethod::createFromMethodName($methodName)
-            : new ReflectionMethod($methodName); // @codeCoverageIgnore
+        $reflectionMethod = ReflectionMethod::createFromMethodName($methodName);
 
         foreach ($reflectionMethod->getAttributes() as $reflectionAttribute) {
             if ($reflectionAttribute->getName() === Override::class) {

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -141,8 +141,10 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
 
         // Remove the "()" at the end of method's name.
         $methodName = substr($node->getFullQualifiedName(), 0, -2);
-        /** @phpstan-ignore function.alreadyNarrowedType function.alreadyNarrowedType */
-        /** @var ReflectionMethod */
+        /**
+         * @var ReflectionMethod
+         * @phpstan-ignore function.alreadyNarrowedType function.alreadyNarrowedType
+         */
         $reflectionMethod = method_exists('ReflectionMethod', 'createFromMethodName')
             ? ReflectionMethod::createFromMethodName($methodName)
             : new ReflectionMethod($methodName); // @codeCoverageIgnore

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -141,7 +141,9 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
 
         // Remove the "()" at the end of method's name.
         $methodName = substr($node->getFullQualifiedName(), 0, -2);
-        $reflectionMethod = ReflectionMethod::createFromMethodName($methodName);
+        $reflectionMethod = method_exists('ReflectionMethod', 'createFromMethodName')
+            ? ReflectionMethod::createFromMethodName($methodName)
+            : new ReflectionMethod($methodName);
 
         foreach ($reflectionMethod->getAttributes() as $reflectionAttribute) {
             if ($reflectionAttribute->getName() === Override::class) {

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -143,7 +143,11 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
 
         // Remove the "()" at the end of method's name.
         $methodName = substr($node->getFullQualifiedName(), 0, -2);
-        $reflectionMethod = new ReflectionMethod($methodName);
+        if (\PHP_VERSION_ID < 80300) {
+            $reflectionMethod = new ReflectionMethod($methodName);
+        } else {
+            $reflectionMethod = ReflectionMethod::createFromMethodName($methodName);
+        }
 
         foreach ($reflectionMethod->getAttributes() as $reflectionAttribute) {
             if ($reflectionAttribute->getName() === Override::class) {


### PR DESCRIPTION
fix: Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in src/Rule/UnusedFormalParameter.php on line 146

Type: bugfix  
Breaking change: no

https://www.php.net/manual/en/reflectionmethod.construct.php#:~:text=The%20alternative%20signature%20is%20deprecated%20as%20of%20PHP%208.4.0

https://www.php.net/manual/en/reflectionmethod.createfrommethodname.php