### PR TITLE
fix: add missing space in CLI `--help`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [ 8.1, 8.2, 8.3, 8.4 ]
+        php: [ 8.1, 8.2, 8.3, 8.4, 8.5 ]
         setup: [ lowest, stable ]
 
     name: PHP ${{ matrix.php }} - prefer-${{ matrix.setup }}
@@ -43,17 +43,17 @@ jobs:
           key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.json') }}
 
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php != '8.4'
+        if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php != '8.5'
         run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
 
-      # For now we need to overwrite the PHP version check on the 8.4 beta as paratest has not been releasd for it yet
-      - name: Install dependencies (PHP 8.4 beta)
-        if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php == '8.4'
+      # For now we need to overwrite the PHP version check on the 8.5 beta as paratest has not been releasd for it yet
+      - name: Install dependencies (PHP 8.5 beta)
+        if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php == '8.5'
         run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }} --ignore-platform-req=php
 
       - name: Execute Unit Tests
         run: composer test
 
       - name: Run PHPStan
-        if: matrix.php != '8.4'
+        if: matrix.php != '8.5'
         run: vendor/bin/phpstan

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "php": "^8.1",
     "ext-xml": "*",
     "composer/xdebug-handler": "^3.0",
-    "pdepend/pdepend": "3.x-dev#5fddc0476146acf1455bd4cccf83f20439a0335b"
+    "pdepend/pdepend": "3.x-dev#b4646098599162a3c171c7e0b544c8fa86a87638"
   },
   "require-dev": {
     "ext-json": "*",
@@ -49,8 +49,8 @@
     "friendsofphp/php-cs-fixer": "^3.57",
     "gregwar/rst": "^1.0",
     "mikey179/vfsstream": "^1.6.8",
-    "phpstan/phpstan": "~2.1.0",
-    "phpunit/phpunit": "^10.5.20,<10.5.32",
+    "phpstan/phpstan": "~2.1.31",
+    "phpunit/phpunit": "^10.5.20,<10.5.32|^11.0.0",
     "squizlabs/php_codesniffer": "^3.8.0"
   },
   "autoload": {

--- a/src/TextUI/CommandLineOptions.php
+++ b/src/TextUI/CommandLineOptions.php
@@ -676,7 +676,7 @@ class CommandLineOptions
             '--color: enable color in output' . \PHP_EOL .
             '--extra-line-in-excerpt: Specify how many extra lines are added ' .
             'to a code snippet in html format' . \PHP_EOL .
-            '--: Explicit argument separator: Anything after "--" will be read as an argument even if' .
+            '--: Explicit argument separator: Anything after "--" will be read as an argument even if ' .
             'it starts with "-" or matches the name of an option' . \PHP_EOL;
     }
 

--- a/src/Utility/ExceptionsList.php
+++ b/src/Utility/ExceptionsList.php
@@ -78,6 +78,7 @@ final class ExceptionsList implements ArrayAccess, IteratorAggregate
                 $this->trim
             );
 
+            // @phpstan-ignore-next-line
             $this->exceptions = array_combine($values, $values);
         }
 

--- a/tests/php/PHPMD/TextUI/StreamFilter.php
+++ b/tests/php/PHPMD/TextUI/StreamFilter.php
@@ -35,10 +35,13 @@ class StreamFilter extends php_user_filter
         self::$streamHandle = '';
 
         while ($bucket = stream_bucket_make_writeable($in)) {
-            assert(is_string($bucket->data));
-            self::$streamHandle .= $bucket->data;
-            assert(is_int($bucket->datalen));
-            $consumed += $bucket->datalen;
+            /** @var string */
+            $data = $bucket->data;
+            self::$streamHandle .= $data;
+
+            /** @var int */
+            $datalen = $bucket->datalen;
+            $consumed += $datalen;
         }
 
         return PSFS_PASS_ON;


### PR DESCRIPTION
Type: bugfix
Issue: .
Breaking change: no

Current display is:

> `as an argument even ifit starts with`

This PR will add the missing space:

> `as an argument even if it starts with`