### PR TITLE
Resolve most PHPUnit 11 and PHP 8.5 deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,5 +55,4 @@ jobs:
         run: composer test
 
       - name: Run PHPStan
-        if: matrix.php != '8.5'
         run: vendor/bin/phpstan

--- a/src/Renderer/JSONRenderer.php
+++ b/src/Renderer/JSONRenderer.php
@@ -70,8 +70,8 @@ class JSONRenderer extends AbstractRenderer
         foreach ($report->getRuleViolations() as $violation) {
             $fileName = $violation->getFileName();
             $rule = $violation->getRule();
-            $filesList[$fileName]['file'] = $fileName;
-            $filesList[$fileName]['violations'][] = [
+            $filesList[$fileName ?? '']['file'] = $fileName;
+            $filesList[$fileName ?? '']['violations'][] = [
                 'beginLine' => $violation->getBeginLine(),
                 'endLine' => $violation->getEndLine(),
                 'package' => $violation->getNamespaceName(),

--- a/src/Report.php
+++ b/src/Report.php
@@ -62,7 +62,7 @@ class Report
             return;
         }
 
-        $fileName = $violation->getFileName();
+        $fileName = $violation->getFileName() ?? '';
         if (!isset($this->ruleViolations[$fileName])) {
             $this->ruleViolations[$fileName] = [];
         }

--- a/tests/php/PHPMD/AbstractTestCase.php
+++ b/tests/php/PHPMD/AbstractTestCase.php
@@ -431,7 +431,9 @@ abstract class AbstractTestCase extends AbstractStaticTestCase
      */
     protected function getRuleMock()
     {
-        return @$this->getMockForAbstractClass(AbstractRule::class);
+        return $this->getMockBuilder(AbstractRule::class)
+            ->onlyMethods(['apply'])
+            ->getMock();
     }
 
     /**

--- a/tests/php/PHPMD/Baseline/BaselineValidatorTest.php
+++ b/tests/php/PHPMD/Baseline/BaselineValidatorTest.php
@@ -5,6 +5,7 @@ namespace PHPMD\Baseline;
 use PHPMD\AbstractTestCase;
 use PHPMD\Rule;
 use PHPMD\RuleViolation;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -31,9 +32,9 @@ class BaselineValidatorTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider dataProvider
      * @covers ::isBaselined
      */
+    #[DataProvider('dataProvider')]
     public function testIsBaselined(bool $contains, BaselineMode $baselineMode, bool $isBaselined): void
     {
         $this->baselineSet->method('contains')->willReturn($contains);

--- a/tests/php/PHPMD/Console/OutputTest.php
+++ b/tests/php/PHPMD/Console/OutputTest.php
@@ -3,6 +3,7 @@
 namespace PHPMD\Console;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @coversDefaultClass  \PHPMD\Console\Output
@@ -56,9 +57,9 @@ class OutputTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider verbosityProvider
      * @covers ::write
      */
+    #[DataProvider('verbosityProvider')]
     public function testWriteWithVerbosityOption(int $verbosity, string $expected, string $msg): void
     {
         $this->output->setVerbosity($verbosity);

--- a/tests/php/PHPMD/Node/ASTNodeTest.php
+++ b/tests/php/PHPMD/Node/ASTNodeTest.php
@@ -20,12 +20,12 @@ namespace PHPMD\Node;
 
 use PDepend\Source\AST\ASTNode as PDependNode;
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the {@link \PHPMD\Node\ASTNode} class.
- *
- * @covers \PHPMD\Node\ASTNode
  */
+#[CoversClass(ASTNode::class)]
 class ASTNodeTest extends AbstractTestCase
 {
     /**
@@ -36,7 +36,7 @@ class ASTNodeTest extends AbstractTestCase
         $mock = $this->getMockBuilder(PDependNode::class)->getMock();
         $mock->expects(static::once())
             ->method('getImage')
-            ->will(static::returnValue(''));
+            ->willReturn('');
 
         $node = new ASTNode($mock, __FILE__);
         $node->getImage();
@@ -50,7 +50,7 @@ class ASTNodeTest extends AbstractTestCase
         $mock = $this->getMockBuilder(PDependNode::class)->getMock();
         $mock->expects(static::once())
             ->method('getImage')
-            ->will(static::returnValue(''));
+            ->willReturn('');
 
         $node = new ASTNode($mock, __FILE__);
         $node->getName();

--- a/tests/php/PHPMD/Node/AnnotationTest.php
+++ b/tests/php/PHPMD/Node/AnnotationTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Node;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the {@link \PHPMD\Node\Annotation} class.
- *
- * @covers \PHPMD\Node\Annotation
  */
+#[CoversClass(Annotation::class)]
 class AnnotationTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Node/AnnotationsTest.php
+++ b/tests/php/PHPMD/Node/AnnotationsTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Node;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the {@link \PHPMD\Node\Annotations} class.
- *
- * @covers \PHPMD\Node\Annotations
  */
+#[CoversClass(Annotations::class)]
 class AnnotationsTest extends AbstractTestCase
 {
     /**
@@ -45,14 +45,12 @@ class AnnotationsTest extends AbstractTestCase
         $class->expects(static::once())
             ->method('__call')
             ->with(static::equalTo('getComment'))
-            ->will(
-                static::returnValue(
-                    '/**
-                      * @SuppressWarnings("Foo")
-                      * @SuppressWarnings("Bar")
-                      * @SuppressWarnings("Baz")
-                      */'
-                )
+            ->willReturn(
+                '/**
+                  * @SuppressWarnings("Foo")
+                  * @SuppressWarnings("Bar")
+                  * @SuppressWarnings("Baz")
+                  */'
             );
 
         $annotations = new Annotations($class);
@@ -68,7 +66,7 @@ class AnnotationsTest extends AbstractTestCase
         $class->expects(static::once())
             ->method('__call')
             ->with(static::equalTo('getComment'))
-            ->will(static::returnValue('/** @SuppressWarnings("PMD") */'));
+            ->willReturn('/** @SuppressWarnings("PMD") */');
 
         $annotations = new Annotations($class);
         static::assertTrue($annotations->suppresses($this->getRuleMock()));
@@ -83,13 +81,11 @@ class AnnotationsTest extends AbstractTestCase
         $class->expects(static::once())
             ->method('__call')
             ->with(static::equalTo('getComment'))
-            ->will(
-                static::returnValue(
-                    '/**
-                      * @SuppressWarnings("FooBar")
-                      * @SuppressWarnings("PMD")
-                      */'
-                )
+            ->willReturn(
+                '/**
+                  * @SuppressWarnings("FooBar")
+                  * @SuppressWarnings("PMD")
+                  */'
             );
 
         $annotations = new Annotations($class);

--- a/tests/php/PHPMD/Node/ClassNodeTest.php
+++ b/tests/php/PHPMD/Node/ClassNodeTest.php
@@ -24,13 +24,13 @@ use PDepend\Source\AST\ASTNamespace;
 use PHPMD\AbstractRule;
 use PHPMD\AbstractTestCase;
 use PHPMD\Rule\Design\CouplingBetweenObjects;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the class node implementation.
- *
- * @covers \PHPMD\Node\AbstractTypeNode
- * @covers \PHPMD\Node\ClassNode
  */
+#[CoversClass(AbstractTypeNode::class)]
+#[CoversClass(ClassNode::class)]
 class ClassNodeTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Node/FunctionTest.php
+++ b/tests/php/PHPMD/Node/FunctionTest.php
@@ -20,13 +20,13 @@ namespace PHPMD\Node;
 
 use PDepend\Source\AST\ASTFunction;
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the function node implementation.
- *
- * @covers \PHPMD\Node\AbstractCallableNode
- * @covers \PHPMD\Node\FunctionNode
  */
+#[CoversClass(AbstractCallableNode::class)]
+#[CoversClass(FunctionNode::class)]
 class FunctionTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Node/InterfaceNodeTest.php
+++ b/tests/php/PHPMD/Node/InterfaceNodeTest.php
@@ -21,13 +21,13 @@ namespace PHPMD\Node;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTNamespace;
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the interface node implementation.
- *
- * @covers \PHPMD\Node\AbstractTypeNode
- * @covers \PHPMD\Node\InterfaceNode
  */
+#[CoversClass(AbstractTypeNode::class)]
+#[CoversClass(InterfaceNode::class)]
 class InterfaceNodeTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Node/MethodNodeTest.php
+++ b/tests/php/PHPMD/Node/MethodNodeTest.php
@@ -22,13 +22,13 @@ use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the method node implementation.
- *
- * @covers \PHPMD\Node\AbstractCallableNode
- * @covers \PHPMD\Node\MethodNode
  */
+#[CoversClass(AbstractCallableNode::class)]
+#[CoversClass(MethodNode::class)]
 class MethodNodeTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Node/TraitNodeTest.php
+++ b/tests/php/PHPMD/Node/TraitNodeTest.php
@@ -21,13 +21,13 @@ namespace PHPMD\Node;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTTrait;
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the trait node implementation.
- *
- * @covers \PHPMD\Node\AbstractTypeNode
- * @covers \PHPMD\Node\TraitNode
  */
+#[CoversClass(AbstractTypeNode::class)]
+#[CoversClass(TraitNode::class)]
 class TraitNodeTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/PHPMDTest.php
+++ b/tests/php/PHPMD/PHPMDTest.php
@@ -23,12 +23,12 @@ use PHPMD\Baseline\BaselineSet;
 use PHPMD\Baseline\BaselineValidator;
 use PHPMD\Renderer\XMLRenderer;
 use PHPMD\Stubs\WriterStub;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the main PHPMD class.
- *
- * @covers \PHPMD\PHPMD
  */
+#[CoversClass(PHPMD::class)]
 class PHPMDTest extends AbstractTestCase
 {
     private RuleSetFactory $ruleSetFactory;

--- a/tests/php/PHPMD/ParserFactoryTest.php
+++ b/tests/php/PHPMD/ParserFactoryTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD;
 
 use PHPMD\Node\ClassNode;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the parser factory class.
- *
- * @covers \PHPMD\ParserFactory
  */
+#[CoversClass(ParserFactory::class)]
 class ParserFactoryTest extends AbstractTestCase
 {
     /**
@@ -60,7 +60,7 @@ class ParserFactoryTest extends AbstractTestCase
         $phpmd = $this->getMockBuilder(PHPMD::class)->onlyMethods(['getInput'])->getMock();
         $phpmd->expects(static::once())
             ->method('getInput')
-            ->will(static::returnValue($uri));
+            ->willReturn($uri);
 
         $ruleSet = $this->getRuleSetMock(ClassNode::class);
 
@@ -82,7 +82,7 @@ class ParserFactoryTest extends AbstractTestCase
         $phpmd = $this->getMockBuilder(PHPMD::class)->onlyMethods(['getInput'])->getMock();
         $phpmd->expects(static::once())
             ->method('getInput')
-            ->will(static::returnValue($uri1 . ',' . $uri2));
+            ->willReturn($uri1 . ',' . $uri2);
 
         $ruleSet = $this->getRuleSetMock(ClassNode::class, 2);
 
@@ -104,7 +104,7 @@ class ParserFactoryTest extends AbstractTestCase
         $phpmd = $this->getMockBuilder(PHPMD::class)->onlyMethods(['getInput'])->getMock();
         $phpmd->expects(static::once())
             ->method('getInput')
-            ->will(static::returnValue($uri1 . ',' . $uri2));
+            ->willReturn($uri1 . ',' . $uri2);
 
         $ruleSet = $this->getRuleSetMock(ClassNode::class, 2);
 

--- a/tests/php/PHPMD/ParserTest.php
+++ b/tests/php/PHPMD/ParserTest.php
@@ -31,14 +31,14 @@ use PDepend\Util\Configuration;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\FunctionNode;
 use PHPMD\Node\MethodNode;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\Container;
 
 /**
  * Test case for the PHP_Depend backend adapter class.
- *
- * @covers \PHPMD\Parser
  */
+#[CoversClass(Parser::class)]
 class ParserTest extends AbstractTestCase
 {
     /**
@@ -49,7 +49,7 @@ class ParserTest extends AbstractTestCase
         $mock = $this->getPHPDependClassMock();
         $mock->expects(static::once())
             ->method('isUserDefined')
-            ->will(static::returnValue(true));
+            ->willReturn(true);
 
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock(ClassNode::class));
@@ -66,7 +66,7 @@ class ParserTest extends AbstractTestCase
         $mock = $this->getPHPDependClassMock();
         $mock->expects(static::once())
             ->method('isUserDefined')
-            ->will(static::returnValue(false));
+            ->willReturn(false);
 
         $adapter = new Parser($this->getPHPDependMock());
         $adapter->addRuleSet($this->getRuleSetMock());
@@ -134,9 +134,9 @@ class ParserTest extends AbstractTestCase
         $pdepend = $this->getPHPDependMock();
         $pdepend->expects(static::once())
             ->method('getExceptions')
-            ->will(static::returnValue([
+            ->willReturn([
                 new InvalidStateException(42, __FILE__, 'foo'),
-            ]));
+            ]);
 
         $parser = new Parser($pdepend);
         $parser->parse($report);
@@ -172,16 +172,16 @@ class ParserTest extends AbstractTestCase
             ->getMock();
         $class->expects(static::any())
             ->method('getCompilationUnit')
-            ->will(static::returnValue($this->getPHPDependFileMock('foo.php')));
+            ->willReturn($this->getPHPDependFileMock('foo.php'));
         $class->expects(static::any())
             ->method('getConstants')
-            ->will(static::returnValue([]));
+            ->willReturn([]);
         $class->expects(static::any())
             ->method('getProperties')
-            ->will(static::returnValue(new ASTArtifactList([])));
+            ->willReturn(new ASTArtifactList([]));
         $class->expects(static::any())
             ->method('getMethods')
-            ->will(static::returnValue(new ASTArtifactList([])));
+            ->willReturn(new ASTArtifactList([]));
 
         return $class;
     }
@@ -198,7 +198,7 @@ class ParserTest extends AbstractTestCase
             ->getMock();
         $function->expects(static::atLeastOnce())
             ->method('getCompilationUnit')
-            ->will(static::returnValue($this->getPHPDependFileMock($fileName)));
+            ->willReturn($this->getPHPDependFileMock($fileName));
 
         return $function;
     }
@@ -215,7 +215,7 @@ class ParserTest extends AbstractTestCase
             ->getMock();
         $method->expects(static::atLeastOnce())
             ->method('getCompilationUnit')
-            ->will(static::returnValue($this->getPHPDependFileMock($fileName)));
+            ->willReturn($this->getPHPDependFileMock($fileName));
 
         return $method;
     }
@@ -232,7 +232,7 @@ class ParserTest extends AbstractTestCase
             ->getMock();
         $file->expects(static::any())
             ->method('getFileName')
-            ->will(static::returnValue($fileName));
+            ->willReturn($fileName);
 
         return $file;
     }

--- a/tests/php/PHPMD/ProcessingErrorTest.php
+++ b/tests/php/PHPMD/ProcessingErrorTest.php
@@ -18,12 +18,15 @@
 
 namespace PHPMD;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
 /**
  * Test case for the processing error class.
  *
- * @covers \PHPMD\ProcessingError
  * @since 1.2.1
  */
+#[CoversClass(ProcessingError::class)]
 class ProcessingErrorTest extends AbstractTestCase
 {
     /**
@@ -40,9 +43,8 @@ class ProcessingErrorTest extends AbstractTestCase
      * a given exception message,
      *
      * @param string $message The original exception message
-     *
-     * @dataProvider getParserExceptionMessages
      */
+    #[DataProvider('getParserExceptionMessages')]
     public function testGetFileReturnsExpectedFileName(string $message): void
     {
         $processingError = new ProcessingError($message);

--- a/tests/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
+++ b/tests/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
@@ -66,21 +66,19 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
 
         $this->renderer->expects(static::once())
             ->method('renderReport')
-            ->will(
-                static::returnCallback(
-                    function (Report $report) use ($self): void {
-                        $isViolating = false;
-                        foreach ($report->getRuleViolations() as $ruleViolation) {
-                            if (str_starts_with($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE)) {
-                                $isViolating = true;
+            ->willReturnCallback(
+                function (Report $report) use ($self): void {
+                    $isViolating = false;
+                    foreach ($report->getRuleViolations() as $ruleViolation) {
+                        if (str_starts_with($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE)) {
+                            $isViolating = true;
 
-                                break;
-                            }
+                            break;
                         }
-                        $self->assertTrue($isViolating);
-                        $self->assertEquals(4, count($report->getRuleViolations()));
                     }
-                )
+                    $self->assertTrue($isViolating);
+                    $self->assertEquals(4, count($report->getRuleViolations()));
+                }
             );
 
         $phpmd->processFiles(
@@ -109,21 +107,19 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
 
         $this->renderer->expects(static::once())
             ->method('renderReport')
-            ->will(
-                static::returnCallback(
-                    function (Report $report) use ($self): void {
-                        $isViolating = false;
-                        foreach ($report->getRuleViolations() as $ruleViolation) {
-                            if (str_starts_with($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE)) {
-                                $isViolating = true;
+            ->willReturnCallback(
+                function (Report $report) use ($self): void {
+                    $isViolating = false;
+                    foreach ($report->getRuleViolations() as $ruleViolation) {
+                        if (str_starts_with($ruleViolation->getDescription(), $self::VIOLATION_MESSAGE)) {
+                            $isViolating = true;
 
-                                break;
-                            }
+                            break;
                         }
-                        $self->assertFalse($isViolating);
-                        $self->assertEquals(3, count($report->getRuleViolations()));
                     }
-                )
+                    $self->assertFalse($isViolating);
+                    $self->assertEquals(3, count($report->getRuleViolations()));
+                }
             );
         $phpmd->processFiles(
             __DIR__ . '/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php',

--- a/tests/php/PHPMD/Renderer/AnsiRendererTest.php
+++ b/tests/php/PHPMD/Renderer/AnsiRendererTest.php
@@ -21,12 +21,12 @@ namespace PHPMD\Renderer;
 use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\Stubs\WriterStub;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the ansi renderer implementation.
- *
- * @covers \PHPMD\Renderer\AnsiRendererTest
  */
+#[CoversClass(AnsiRendererTest::class)]
 class AnsiRendererTest extends AbstractTestCase
 {
     /**
@@ -49,19 +49,19 @@ class AnsiRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::atLeastOnce())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator($violations)));
+            ->willReturn(new ArrayIterator($violations));
         $report->expects(static::atLeastOnce())
             ->method('isEmpty')
-            ->will(static::returnValue(false));
+            ->willReturn(false);
         $report->expects(static::atLeastOnce())
             ->method('hasErrors')
-            ->will(static::returnValue(true));
+            ->willReturn(true);
         $report->expects(static::atLeastOnce())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator($errors)));
+            ->willReturn(new ArrayIterator($errors));
         $report->expects(static::once())
             ->method('getElapsedTimeInMillis')
-            ->will(static::returnValue(200));
+            ->willReturn(200.0);
 
         $renderer = new AnsiRenderer();
         $renderer->setWriter($writer);
@@ -101,19 +101,19 @@ class AnsiRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::atLeastOnce())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
         $report->expects(static::atLeastOnce())
             ->method('isEmpty')
-            ->will(static::returnValue(true));
+            ->willReturn(true);
         $report->expects(static::atLeastOnce())
             ->method('hasErrors')
-            ->will(static::returnValue(false));
+            ->willReturn(false);
         $report->expects(static::atLeastOnce())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
         $report->expects(static::once())
             ->method('getElapsedTimeInMillis')
-            ->will(static::returnValue(200));
+            ->willReturn(200.0);
 
         $renderer = new AnsiRenderer();
         $renderer->setWriter($writer);

--- a/tests/php/PHPMD/Renderer/CheckStyleRendererTest.php
+++ b/tests/php/PHPMD/Renderer/CheckStyleRendererTest.php
@@ -22,12 +22,12 @@ use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the xml renderer implementation.
- *
- * @covers \PHPMD\Renderer\XMLRenderer
  */
+#[CoversClass(XMLRenderer::class)]
 class CheckStyleRendererTest extends AbstractTestCase
 {
     /**
@@ -47,10 +47,10 @@ class CheckStyleRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator($violations)));
+            ->willReturn(new ArrayIterator($violations));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
 
         $renderer = new XMLRenderer();
         $renderer->setWriter($writer);
@@ -84,10 +84,10 @@ class CheckStyleRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator($processingErrors)));
+            ->willReturn(new ArrayIterator($processingErrors));
 
         $renderer = new XMLRenderer();
         $renderer->setWriter($writer);

--- a/tests/php/PHPMD/Renderer/GitHubRendererTest.php
+++ b/tests/php/PHPMD/Renderer/GitHubRendererTest.php
@@ -22,12 +22,12 @@ use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the GitHub renderer implementation.
- *
- * @covers \PHPMD\Renderer\GitHubRenderer
  */
+#[CoversClass(GitHubRenderer::class)]
 class GitHubRendererTest extends AbstractTestCase
 {
     /**
@@ -47,10 +47,10 @@ class GitHubRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator($violations)));
+            ->willReturn(new ArrayIterator($violations));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
 
         $renderer = new GitHubRenderer();
         $renderer->setWriter($writer);
@@ -84,10 +84,10 @@ class GitHubRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator($errors)));
+            ->willReturn(new ArrayIterator($errors));
 
         $renderer = new GitHubRenderer();
         $renderer->setWriter($writer);

--- a/tests/php/PHPMD/Renderer/GitLabRendererTest.php
+++ b/tests/php/PHPMD/Renderer/GitLabRendererTest.php
@@ -22,12 +22,12 @@ use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the JSON renderer implementation.
- *
- * @covers \PHPMD\Renderer\GitLabRenderer
  */
+#[CoversClass(GitLabRenderer::class)]
 class GitLabRendererTest extends AbstractTestCase
 {
     /**
@@ -46,10 +46,10 @@ class GitLabRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator($violations)));
+            ->willReturn(new ArrayIterator($violations));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
 
         $renderer = new GitLabRenderer();
         $renderer->setWriter($writer);
@@ -81,10 +81,10 @@ class GitLabRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator($processingErrors)));
+            ->willReturn(new ArrayIterator($processingErrors));
 
         $renderer = new GitLabRenderer();
         $renderer->setWriter($writer);

--- a/tests/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/tests/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -21,12 +21,12 @@ namespace PHPMD\Renderer;
 use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\Stubs\WriterStub;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the html renderer implementation.
- *
- * @covers \PHPMD\Renderer\HTMLRenderer
  */
+#[CoversClass(HTMLRenderer::class)]
 class HTMLRendererTest extends AbstractTestCase
 {
     /**
@@ -46,7 +46,7 @@ class HTMLRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator($violations)));
+            ->willReturn(new ArrayIterator($violations));
 
         $extraLineInExcerpt = 2;
         $renderer = new HTMLRenderer($extraLineInExcerpt);

--- a/tests/php/PHPMD/Renderer/JSONRendererTest.php
+++ b/tests/php/PHPMD/Renderer/JSONRendererTest.php
@@ -22,12 +22,12 @@ use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the JSON renderer implementation.
- *
- * @covers \PHPMD\Renderer\JSONRenderer
  */
+#[CoversClass(JSONRenderer::class)]
 class JSONRendererTest extends AbstractTestCase
 {
     /**
@@ -46,10 +46,10 @@ class JSONRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator($violations)));
+            ->willReturn(new ArrayIterator($violations));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
 
         $renderer = new JSONRenderer();
         $renderer->setWriter($writer);
@@ -81,10 +81,10 @@ class JSONRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator($processingErrors)));
+            ->willReturn(new ArrayIterator($processingErrors));
 
         $renderer = new JSONRenderer();
         $renderer->setWriter($writer);

--- a/tests/php/PHPMD/Renderer/SARIFRendererTest.php
+++ b/tests/php/PHPMD/Renderer/SARIFRendererTest.php
@@ -23,12 +23,12 @@ use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\RuleStub;
 use PHPMD\Stubs\WriterStub;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the SARIF renderer implementation.
- *
- * @covers \PHPMD\Renderer\SARIFRenderer
  */
+#[CoversClass(SARIFRenderer::class)]
 class SARIFRendererTest extends AbstractTestCase
 {
     /**
@@ -57,10 +57,10 @@ class SARIFRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator($violations)));
+            ->willReturn(new ArrayIterator($violations));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
 
         $renderer = new SARIFRenderer();
         $renderer->setWriter($writer);
@@ -105,10 +105,10 @@ class SARIFRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator($processingErrors)));
+            ->willReturn(new ArrayIterator($processingErrors));
 
         $renderer = new SARIFRenderer();
         $renderer->setWriter($writer);

--- a/tests/php/PHPMD/Renderer/TextRendererTest.php
+++ b/tests/php/PHPMD/Renderer/TextRendererTest.php
@@ -24,12 +24,12 @@ use PHPMD\Console\OutputInterface;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\RuleStub;
 use PHPMD\Stubs\WriterStub;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the text renderer implementation.
- *
- * @covers \PHPMD\Renderer\TextRenderer
  */
+#[CoversClass(TextRenderer::class)]
 class TextRendererTest extends AbstractTestCase
 {
     /**
@@ -52,10 +52,10 @@ class TextRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator($violations)));
+            ->willReturn(new ArrayIterator($violations));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
 
         $renderer = new TextRenderer();
         $renderer->setWriter($writer);
@@ -91,10 +91,10 @@ class TextRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator($violations)));
+            ->willReturn(new ArrayIterator($violations));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
 
         $renderer->start();
         $renderer->renderReport($report);
@@ -127,10 +127,10 @@ class TextRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator($violations)));
+            ->willReturn(new ArrayIterator($violations));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
 
         $renderer->start();
         $renderer->renderReport($report);
@@ -159,10 +159,10 @@ class TextRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator($errors)));
+            ->willReturn(new ArrayIterator($errors));
 
         $renderer = new TextRenderer();
         $renderer->setWriter($writer);

--- a/tests/php/PHPMD/Renderer/XMLRendererTest.php
+++ b/tests/php/PHPMD/Renderer/XMLRendererTest.php
@@ -22,12 +22,12 @@ use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\ProcessingError;
 use PHPMD\Stubs\WriterStub;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the xml renderer implementation.
- *
- * @covers \PHPMD\Renderer\XMLRenderer
  */
+#[CoversClass(XMLRenderer::class)]
 class XMLRendererTest extends AbstractTestCase
 {
     /**
@@ -47,10 +47,10 @@ class XMLRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator($violations)));
+            ->willReturn(new ArrayIterator($violations));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
 
         $renderer = new XMLRenderer();
         $renderer->setWriter($writer);
@@ -84,10 +84,10 @@ class XMLRendererTest extends AbstractTestCase
         $report = $this->getReportWithNoViolation();
         $report->expects(static::once())
             ->method('getRuleViolations')
-            ->will(static::returnValue(new ArrayIterator([])));
+            ->willReturn(new ArrayIterator([]));
         $report->expects(static::once())
             ->method('getErrors')
-            ->will(static::returnValue(new ArrayIterator($processingErrors)));
+            ->willReturn(new ArrayIterator($processingErrors));
 
         $renderer = new XMLRenderer();
         $renderer->setWriter($writer);

--- a/tests/php/PHPMD/ReportTest.php
+++ b/tests/php/PHPMD/ReportTest.php
@@ -22,12 +22,12 @@ use PHPMD\Baseline\BaselineMode;
 use PHPMD\Baseline\BaselineSet;
 use PHPMD\Baseline\BaselineValidator;
 use PHPMD\Baseline\ViolationBaseline;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the report class.
- *
- * @covers \PHPMD\Report
  */
+#[CoversClass(Report::class)]
 class ReportTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/CleanCode/BooleanArgumentFlagTest.php
+++ b/tests/php/PHPMD/Rule/CleanCode/BooleanArgumentFlagTest.php
@@ -19,6 +19,7 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @coversDefaultClass \PHPMD\Rule\CleanCode\BooleanArgumentFlag
@@ -42,9 +43,8 @@ class BooleanArgumentFlagTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     *
-     * @dataProvider getApplyingCases
      */
+    #[DataProvider('getApplyingCases')]
     public function testRuleAppliesTo(string $file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::ONE_VIOLATION, $file);
@@ -54,9 +54,8 @@ class BooleanArgumentFlagTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     *
-     * @dataProvider getNotApplyingCases
      */
+    #[DataProvider('getNotApplyingCases')]
     public function testRuleDoesNotApplyTo(string $file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::NO_VIOLATION, $file);

--- a/tests/php/PHPMD/Rule/CleanCode/MissingImportTest.php
+++ b/tests/php/PHPMD/Rule/CleanCode/MissingImportTest.php
@@ -19,6 +19,7 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * MissingImport Tests
@@ -42,9 +43,8 @@ class MissingImportTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     *
-     * @dataProvider getApplyingCases
      */
+    #[DataProvider('getApplyingCases')]
     public function testRuleAppliesTo(string $file): void
     {
         $expectedInvokes = str_contains($file, 'testRuleAppliesTwice')
@@ -57,9 +57,8 @@ class MissingImportTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     *
-     * @dataProvider getNotApplyingCases
      */
+    #[DataProvider('getNotApplyingCases')]
     public function testRuleDoesNotApplyTo(string $file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::NO_VIOLATION, $file);

--- a/tests/php/PHPMD/Rule/CleanCode/UndefinedVariableTest.php
+++ b/tests/php/PHPMD/Rule/CleanCode/UndefinedVariableTest.php
@@ -19,6 +19,7 @@
 namespace PHPMD\Rule\CleanCode;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test case for the undefined variable rule.
@@ -39,9 +40,8 @@ class UndefinedVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     *
-     * @dataProvider getApplyingCases
      */
+    #[DataProvider('getApplyingCases')]
     public function testRuleAppliesTo(string $file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::ONE_VIOLATION, $file);
@@ -51,9 +51,8 @@ class UndefinedVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     *
-     * @dataProvider getNotApplyingCases
      */
+    #[DataProvider('getNotApplyingCases')]
     public function testRuleDoesNotApplyTo(string $file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule(), static::NO_VIOLATION, $file);

--- a/tests/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
+++ b/tests/php/PHPMD/Rule/Controversial/CamelCaseClassNameTest.php
@@ -19,11 +19,12 @@ use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTNamespace;
 use PHPMD\AbstractTestCase;
 use PHPMD\Node\ClassNode;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the camel case class name rule.
- * @covers \PHPMD\Rule\Controversial\CamelCaseClassName
  */
+#[CoversClass(CamelCaseClassName::class)]
 class CamelCaseClassNameTest extends AbstractTestCase
 {
     public function testRuleDoesNotApplyForValidClassName(): void

--- a/tests/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
+++ b/tests/php/PHPMD/Rule/Controversial/CamelCaseMethodNameTest.php
@@ -20,12 +20,12 @@ namespace PHPMD\Rule\Controversial;
 
 use PHPMD\AbstractTestCase;
 use PHPMD\Node\MethodNode;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the camel case method name rule.
- *
- * @covers \PHPMD\Rule\Controversial\CamelCaseMethodName
  */
+#[CoversClass(CamelCaseMethodName::class)]
 class CamelCaseMethodNameTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
+++ b/tests/php/PHPMD/Rule/Controversial/CamelCaseNamespaceTest.php
@@ -19,11 +19,12 @@
 namespace PHPMD\Rule\Controversial;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the camel case namespace rule.
- * @covers \PHPMD\Rule\Controversial\CamelCaseNamespace
  */
+#[CoversClass(CamelCaseNamespace::class)]
 class CamelCaseNamespaceTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
+++ b/tests/php/PHPMD/Rule/Controversial/CamelCaseParameterNameTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Controversial;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the camel case parameter name rule.
- *
- * @covers \PHPMD\Rule\Controversial\CamelCaseParameterName
  */
+#[CoversClass(CamelCaseParameterName::class)]
 class CamelCaseParameterNameTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
+++ b/tests/php/PHPMD/Rule/Controversial/CamelCasePropertyNameTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Controversial;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the camel case property name rule.
- *
- * @covers \PHPMD\Rule\Controversial\CamelCasePropertyName
  */
+#[CoversClass(CamelCasePropertyName::class)]
 class CamelCasePropertyNameTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
+++ b/tests/php/PHPMD/Rule/Controversial/CamelCaseVariableNameTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Controversial;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the camel case variable name rule.
- *
- * @covers \PHPMD\Rule\Controversial\CamelCaseVariableName
  */
+#[CoversClass(CamelCaseVariableName::class)]
 class CamelCaseVariableNameTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/CyclomaticComplexityTest.php
+++ b/tests/php/PHPMD/Rule/CyclomaticComplexityTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the cyclomatic complexity violation rule.
- *
- * @covers \PHPMD\Rule\CyclomaticComplexity
  */
+#[CoversClass(CyclomaticComplexity::class)]
 class CyclomaticComplexityTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
+++ b/tests/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
@@ -19,13 +19,14 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\CouplingBetweenObjects} class.
  *
- * @covers \PHPMD\Rule\Design\CouplingBetweenObjects
  * @link https://www.pivotaltracker.com/story/show/10474987
  */
+#[CoversClass(CouplingBetweenObjects::class)]
 class CouplingBetweenObjectsTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
+++ b/tests/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\DepthOfInheritance} class.
- *
- * @covers \PHPMD\Rule\Design\DepthOfInheritance
  */
+#[CoversClass(DepthOfInheritance::class)]
 class DepthOfInheritanceTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
+++ b/tests/php/PHPMD/Rule/Design/DevelopmentCodeFragmentTest.php
@@ -19,14 +19,15 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\DevelopmentCodeFragment} class.
  *
- * @covers \PHPMD\Rule\Design\DevelopmentCodeFragment
  * @link https://github.com/phpmd/phpmd/issues/265
  * @since 2.3.0
  */
+#[CoversClass(DevelopmentCodeFragment::class)]
 class DevelopmentCodeFragmentTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Design/EvalExpressionTest.php
+++ b/tests/php/PHPMD/Rule/Design/EvalExpressionTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\EvalExpression} class.
- *
- * @covers \PHPMD\Rule\Design\EvalExpression
  */
+#[CoversClass(EvalExpression::class)]
 class EvalExpressionTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Design/ExitExpressionTest.php
+++ b/tests/php/PHPMD/Rule/Design/ExitExpressionTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\ExitExpression} class.
- *
- * @covers \PHPMD\Rule\Design\ExitExpression
  */
+#[CoversClass(ExitExpression::class)]
 class ExitExpressionTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Design/GotoStatementTest.php
+++ b/tests/php/PHPMD/Rule/Design/GotoStatementTest.php
@@ -19,13 +19,14 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\GotoStatement} class.
  *
- * @covers \PHPMD\Rule\Design\GotoStatement
  * @link https://www.pivotaltracker.com/story/show/10474873
  */
+#[CoversClass(GotoStatement::class)]
 class GotoStatementTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Design/LongClassTest.php
+++ b/tests/php/PHPMD/Rule/Design/LongClassTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the excessive long class rule.
- *
- * @covers \PHPMD\Rule\Design\LongClass
  */
+#[CoversClass(LongClass::class)]
 class LongClassTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Design/LongMethodTest.php
+++ b/tests/php/PHPMD/Rule/Design/LongMethodTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the excessive long method rule.
- *
- * @covers \PHPMD\Rule\Design\LongMethod
  */
+#[CoversClass(LongMethod::class)]
 class LongMethodTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Design/LongParameterListTest.php
+++ b/tests/php/PHPMD/Rule/Design/LongParameterListTest.php
@@ -21,13 +21,13 @@ namespace PHPMD\Rule\Design;
 use PHPMD\AbstractTestCase;
 use PHPMD\Node\FunctionNode;
 use PHPMD\Node\MethodNode;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Test case for the excessive long parameter list rule.
- *
- * @covers \PHPMD\Rule\Design\LongParameterList
  */
+#[CoversClass(LongParameterList::class)]
 class LongParameterListTest extends AbstractTestCase
 {
     /**
@@ -129,7 +129,7 @@ class LongParameterListTest extends AbstractTestCase
     {
         $mock->expects(static::once())
             ->method('getParameterCount')
-            ->will(static::returnValue($parameterCount));
+            ->willReturn($parameterCount);
 
         return $mock;
     }

--- a/tests/php/PHPMD/Rule/Design/NpathComplexityTest.php
+++ b/tests/php/PHPMD/Rule/Design/NpathComplexityTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * This is a test case for the NPath complexity rule.
- *
- * @covers \PHPMD\Rule\Design\NpathComplexity
  */
+#[CoversClass(NpathComplexity::class)]
 class NpathComplexityTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
+++ b/tests/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Design\NumberOfChildren} class.
- *
- * @covers \PHPMD\Rule\Design\NumberOfChildren
  */
+#[CoversClass(NumberOfChildren::class)]
 class NumberOfChildrenTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Design/TooManyFieldsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyFieldsTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the too many methods rule.
- *
- * @covers \PHPMD\Rule\Design\TooManyFields
  */
+#[CoversClass(TooManyFields::class)]
 class TooManyFieldsTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -20,12 +20,12 @@ namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
 use PHPMD\Node\ClassNode;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the too many methods rule.
- *
- * @covers \PHPMD\Rule\Design\TooManyMethods
  */
+#[CoversClass(TooManyMethods::class)]
 class TooManyMethodsTest extends AbstractTestCase
 {
     /**
@@ -151,7 +151,7 @@ class TooManyMethodsTest extends AbstractTestCase
         if (is_array($methodNames)) {
             $class->expects(static::once())
                 ->method('getMethodNames')
-                ->will(static::returnValue($methodNames));
+                ->willReturn($methodNames);
         }
 
         return $class;

--- a/tests/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -24,12 +24,12 @@ use PHPMD\AbstractTestCase;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\MethodNode;
 use PHPMD\Report;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the too many public methods rule.
- *
- * @covers \PHPMD\Rule\Design\TooManyPublicMethods
  */
+#[CoversClass(TooManyPublicMethods::class)]
 class TooManyPublicMethodsTest extends AbstractTestCase
 {
     public function testRuleDoesNotApplyToClassesWithLessMethodsThanThreshold(): void
@@ -162,10 +162,10 @@ class TooManyPublicMethodsTest extends AbstractTestCase
 
         $class->expects(static::any())
             ->method('getMethods')
-            ->will(static::returnValue([
+            ->willReturn([
                 ...array_map($this->createPublicMethod(...), $publicMethods),
                 ...array_map($this->createPrivateMethod(...), $privateMethods),
-            ]));
+            ]);
 
         return $class;
     }

--- a/tests/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
+++ b/tests/php/PHPMD/Rule/Design/WeightedMethodCountTest.php
@@ -19,13 +19,14 @@
 namespace PHPMD\Rule\Design;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the weighted method count rule.
  *
- * @covers \PHPMD\Rule\Design\WeightedMethodCount
  * @since 0.2.5
  */
+#[CoversClass(WeightedMethodCount::class)]
 class WeightedMethodCountTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/ExcessivePublicCountTest.php
+++ b/tests/php/PHPMD/Rule/ExcessivePublicCountTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the excessive use of public members rule.
- *
- * @covers \PHPMD\Rule\ExcessivePublicCount
  */
+#[CoversClass(ExcessivePublicCount::class)]
 class ExcessivePublicCountTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
+++ b/tests/php/PHPMD/Rule/Naming/BooleanGetMethodNameTest.php
@@ -20,12 +20,13 @@ namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
 use PHPMD\Node\MethodNode;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
  * Test case for the {@link \PHPMD\Rule\Naming\BooleanGetMethodName} rule class.
- *
- * @covers \PHPMD\Rule\Naming\BooleanGetMethodName
  */
+#[CoversClass(BooleanGetMethodName::class)]
 class BooleanGetMethodNameTest extends AbstractTestCase
 {
     /**
@@ -133,9 +134,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToReturnDeclarationTrue
-     *
-     * @requires PHP 8.2.0
      */
+    #[RequiresPhp('>= 8.2.0')]
     public function testRuleAppliesToReturnDeclarationTrue(): void
     {
         $rule = new BooleanGetMethodName();
@@ -146,9 +146,8 @@ class BooleanGetMethodNameTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToReturnDeclarationFalse
-     *
-     * @requires PHP 8.2.0
      */
+    #[RequiresPhp('>= 8.2.0')]
     public function testRuleAppliesToReturnDeclarationFalse(): void
     {
         $rule = new BooleanGetMethodName();

--- a/tests/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
+++ b/tests/php/PHPMD/Rule/Naming/ConstantNamingConventionsTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the constructor name rule.
- *
- * @covers \PHPMD\Rule\Naming\ConstantNamingConventions
  */
+#[CoversClass(ConstantNamingConventions::class)]
 class ConstantNamingConventionsTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
+++ b/tests/php/PHPMD/Rule/Naming/ConstructorWithNameAsEnclosingClassTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the constructor name rule.
- *
- * @covers \PHPMD\Rule\Naming\ConstructorWithNameAsEnclosingClass
  */
+#[CoversClass(ConstructorWithNameAsEnclosingClass::class)]
 class ConstructorWithNameAsEnclosingClassTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Naming/LongVariableTest.php
+++ b/tests/php/PHPMD/Rule/Naming/LongVariableTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the really long variable, parameter and property name rule.
- *
- * @covers \PHPMD\Rule\Naming\LongVariable
  */
+#[CoversClass(LongVariable::class)]
 class LongVariableTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
+++ b/tests/php/PHPMD/Rule/Naming/ShortMethodNameTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the very short method and function name rule.
- *
- * @covers \PHPMD\Rule\Naming\ShortMethodName
  */
+#[CoversClass(ShortMethodName::class)]
 class ShortMethodNameTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/tests/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -19,12 +19,13 @@
 namespace PHPMD\Rule\Naming;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test case for the really short variable, parameter and property name rule.
- *
- * @covers \PHPMD\Rule\Naming\ShortVariable
  */
+#[CoversClass(ShortVariable::class)]
 class ShortVariableTest extends AbstractTestCase
 {
     /**
@@ -318,9 +319,8 @@ class ShortVariableTest extends AbstractTestCase
 
     /**
      * testRuleAppliesToVariablesWithinForeach
-     *
-     * @dataProvider provideClassWithShortForeachVariables
      */
+    #[DataProvider('provideClassWithShortForeachVariables')]
     public function testRuleAppliesToVariablesWithinForeach(string $allowShortVarInLoop, int $expectedErrorsCount): void
     {
         $rule = new ShortVariable();

--- a/tests/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/tests/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -19,13 +19,14 @@
 namespace PHPMD\Rule;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
  * Test case for the unused formal parameter rule.
- *
- * @covers \PHPMD\Rule\AbstractLocalVariable
- * @covers \PHPMD\Rule\UnusedFormalParameter
  */
+#[CoversClass(AbstractLocalVariable::class)]
+#[CoversClass(UnusedFormalParameter::class)]
 class UnusedFormalParameterTest extends AbstractTestCase
 {
     /**
@@ -482,9 +483,7 @@ class UnusedFormalParameterTest extends AbstractTestCase
         $rule->apply($methods[0]);
     }
 
-    /**
-     * @requires PHP >= 8.3
-     */
+    #[RequiresPhp('>= 8.3')]
     public function testRuleDoesNotApplyToMethodWithOverrideAttribute(): void
     {
         if (\PHP_VERSION_ID < 80300) {
@@ -496,9 +495,7 @@ class UnusedFormalParameterTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @requires PHP >= 8.3
-     */
+    #[RequiresPhp('>= 8.3')]
     public function testRuleAppliesToMethodWithoutOverrideAttribute(): void
     {
         if (\PHP_VERSION_ID < 80300) {
@@ -510,9 +507,7 @@ class UnusedFormalParameterTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
-    /**
-     * @requires PHP < 8.3
-     */
+    #[RequiresPhp('< 8.3')]
     public function testRuleAppliesToMethodWithOverrideAttributeBeforePhp83(): void
     {
         if (\PHP_VERSION_ID >= 80300) {

--- a/tests/php/PHPMD/Rule/UnusedLocalVariableTest.php
+++ b/tests/php/PHPMD/Rule/UnusedLocalVariableTest.php
@@ -19,13 +19,14 @@
 namespace PHPMD\Rule;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test case for the unused local variable rule.
- *
- * @covers \PHPMD\Rule\AbstractLocalVariable
- * @covers \PHPMD\Rule\UnusedLocalVariable
  */
+#[CoversClass(AbstractLocalVariable::class)]
+#[CoversClass(UnusedLocalVariable::class)]
 class UnusedLocalVariableTest extends AbstractTestCase
 {
     /**
@@ -55,9 +56,8 @@ class UnusedLocalVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should apply.
      *
      * @param string $file The test file to test against.
-     *
-     * @dataProvider getApplyingCases
      */
+    #[DataProvider('getApplyingCases')]
     public function testRuleAppliesTo(string $file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule($file), static::ONE_VIOLATION, $file);
@@ -67,9 +67,8 @@ class UnusedLocalVariableTest extends AbstractTestCase
      * Tests the rule for cases where it should not apply.
      *
      * @param string $file The test file to test against.
-     *
-     * @dataProvider getNotApplyingCases
      */
+    #[DataProvider('getNotApplyingCases')]
     public function testRuleDoesNotApplyTo(string $file): void
     {
         $this->expectRuleHasViolationsForFile($this->getRule($file), static::NO_VIOLATION, $file);

--- a/tests/php/PHPMD/Rule/UnusedPrivateFieldTest.php
+++ b/tests/php/PHPMD/Rule/UnusedPrivateFieldTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the unused private field rule.
- *
- * @covers \PHPMD\Rule\UnusedPrivateField
  */
+#[CoversClass(UnusedPrivateField::class)]
 class UnusedPrivateFieldTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/Rule/UnusedPrivateMethodTest.php
+++ b/tests/php/PHPMD/Rule/UnusedPrivateMethodTest.php
@@ -19,12 +19,12 @@
 namespace PHPMD\Rule;
 
 use PHPMD\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the unused private method rule.
- *
- * @covers \PHPMD\Rule\UnusedPrivateMethod
  */
+#[CoversClass(UnusedPrivateMethod::class)]
 class UnusedPrivateMethodTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/RuleSetFactoryTest.php
+++ b/tests/php/PHPMD/RuleSetFactoryTest.php
@@ -23,13 +23,14 @@ use org\bovigo\vfs\vfsStream;
 use PHPMD\Exception\RuleClassFileNotFoundException;
 use PHPMD\Exception\RuleClassNotFoundException;
 use PHPMD\Exception\RuleSetNotFoundException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 
 /**
  * Test case for the rule set factory class.
- *
- * @covers \PHPMD\RuleSetFactory
  */
+#[CoversClass(RuleSetFactory::class)]
 class RuleSetFactoryTest extends AbstractTestCase
 {
     /**
@@ -637,9 +638,8 @@ class RuleSetFactoryTest extends AbstractTestCase
      * Checks the ruleset XML files provided with PHPMD all provide externalInfoUrls
      *
      * @param string $file The path to the ruleset xml to test
-     *
-     * @dataProvider getDefaultRuleSets
      */
+    #[DataProvider('getDefaultRuleSets')]
     public function testDefaultRuleSetsProvideExternalInfoUrls(string $file): void
     {
         $ruleSets = $this->createRuleSetsFromFiles($file);

--- a/tests/php/PHPMD/RuleSetTest.php
+++ b/tests/php/PHPMD/RuleSetTest.php
@@ -27,12 +27,12 @@ use PHPMD\Node\ClassNode;
 use PHPMD\Node\FunctionNode;
 use PHPMD\Rule\CleanCode\ElseExpression;
 use PHPMD\Stubs\RuleStub;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the {@link \PHPMD\RuleSet} class.
- *
- * @covers \PHPMD\RuleSet
  */
+#[CoversClass(RuleSet::class)]
 class RuleSetTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PHPMD/RuleTest.php
+++ b/tests/php/PHPMD/RuleTest.php
@@ -35,7 +35,9 @@ class RuleTest extends AbstractTestCase
      */
     public function testGetBooleanPropertyReturnsTrueForStringValue1(): void
     {
-        $rule = $this->getMockForAbstractClass(AbstractRule::class);
+        $rule = $this->getMockBuilder(AbstractRule::class)
+            ->onlyMethods(['apply'])
+            ->getMock();
         $rule->addProperty(__FUNCTION__, '1');
 
         static::assertTrue($rule->getBooleanProperty(__FUNCTION__));
@@ -49,7 +51,9 @@ class RuleTest extends AbstractTestCase
      */
     public function testGetBooleanPropertyReturnsTrueForStringValueOn(): void
     {
-        $rule = $this->getMockForAbstractClass(AbstractRule::class);
+        $rule = $this->getMockBuilder(AbstractRule::class)
+            ->onlyMethods(['apply'])
+            ->getMock();
         $rule->addProperty(__FUNCTION__, 'on');
 
         static::assertTrue($rule->getBooleanProperty(__FUNCTION__));
@@ -63,7 +67,9 @@ class RuleTest extends AbstractTestCase
      */
     public function testGetBooleanPropertyReturnsTrueForStringValueTrue(): void
     {
-        $rule = $this->getMockForAbstractClass(AbstractRule::class);
+        $rule = $this->getMockBuilder(AbstractRule::class)
+            ->onlyMethods(['apply'])
+            ->getMock();
         $rule->addProperty(__FUNCTION__, 'true');
 
         static::assertTrue($rule->getBooleanProperty(__FUNCTION__));
@@ -77,7 +83,9 @@ class RuleTest extends AbstractTestCase
      */
     public function testGetBooleanPropertyReturnsTrueForDifferentStringValue(): void
     {
-        $rule = $this->getMockForAbstractClass(AbstractRule::class);
+        $rule = $this->getMockBuilder(AbstractRule::class)
+            ->onlyMethods(['apply'])
+            ->getMock();
         $rule->addProperty(__FUNCTION__, 'True');
 
         static::assertFalse($rule->getBooleanProperty(__FUNCTION__));
@@ -91,7 +99,9 @@ class RuleTest extends AbstractTestCase
      */
     public function testGetBooleanPropertyReturnsFallbackString(): void
     {
-        $rule = $this->getMockForAbstractClass(AbstractRule::class);
+        $rule = $this->getMockBuilder(AbstractRule::class)
+            ->onlyMethods(['apply'])
+            ->getMock();
 
         static::assertTrue($rule->getBooleanProperty(__FUNCTION__, true));
     }
@@ -104,7 +114,9 @@ class RuleTest extends AbstractTestCase
      */
     public function testGetIntPropertyReturnsValueOfTypeInteger(): void
     {
-        $rule = $this->getMockForAbstractClass(AbstractRule::class);
+        $rule = $this->getMockBuilder(AbstractRule::class)
+            ->onlyMethods(['apply'])
+            ->getMock();
         $rule->addProperty(__FUNCTION__, '42.3');
 
         static::assertSame(42, $rule->getIntProperty(__FUNCTION__));
@@ -120,7 +132,9 @@ class RuleTest extends AbstractTestCase
     {
         self::expectException(OutOfBoundsException::class);
 
-        $rule = $this->getMockForAbstractClass(AbstractRule::class);
+        $rule = $this->getMockBuilder(AbstractRule::class)
+            ->onlyMethods(['apply'])
+            ->getMock();
         $rule->getIntProperty(__FUNCTION__);
     }
 
@@ -132,7 +146,9 @@ class RuleTest extends AbstractTestCase
      */
     public function testGetIntPropertyReturnsFallbackString(): void
     {
-        $rule = $this->getMockForAbstractClass(AbstractRule::class);
+        $rule = $this->getMockBuilder(AbstractRule::class)
+            ->onlyMethods(['apply'])
+            ->getMock();
 
         static::assertSame(123, $rule->getIntProperty(__FUNCTION__, 123));
     }
@@ -147,7 +163,9 @@ class RuleTest extends AbstractTestCase
     {
         self::expectException(OutOfBoundsException::class);
 
-        $rule = $this->getMockForAbstractClass(AbstractRule::class);
+        $rule = $this->getMockBuilder(AbstractRule::class)
+            ->onlyMethods(['apply'])
+            ->getMock();
         $rule->getBooleanProperty(__FUNCTION__);
     }
 
@@ -161,7 +179,9 @@ class RuleTest extends AbstractTestCase
     {
         self::expectException(OutOfBoundsException::class);
 
-        $rule = $this->getMockForAbstractClass(AbstractRule::class);
+        $rule = $this->getMockBuilder(AbstractRule::class)
+            ->onlyMethods(['apply'])
+            ->getMock();
         $rule->getStringProperty(__FUNCTION__);
     }
 
@@ -173,7 +193,9 @@ class RuleTest extends AbstractTestCase
      */
     public function testGetStringPropertyReturnsString(): void
     {
-        $rule = $this->getMockForAbstractClass(AbstractRule::class);
+        $rule = $this->getMockBuilder(AbstractRule::class)
+            ->onlyMethods(['apply'])
+            ->getMock();
         $rule->addProperty(__FUNCTION__, 'Forty Two');
 
         static::assertSame('Forty Two', $rule->getStringProperty(__FUNCTION__));
@@ -187,7 +209,9 @@ class RuleTest extends AbstractTestCase
      */
     public function testGetStringPropertyReturnsFallbackString(): void
     {
-        $rule = $this->getMockForAbstractClass(AbstractRule::class);
+        $rule = $this->getMockBuilder(AbstractRule::class)
+            ->onlyMethods(['apply'])
+            ->getMock();
 
         static::assertSame('fallback', $rule->getStringProperty(__FUNCTION__, 'fallback'));
     }

--- a/tests/php/PHPMD/RuleViolationTest.php
+++ b/tests/php/PHPMD/RuleViolationTest.php
@@ -19,13 +19,14 @@
 namespace PHPMD;
 
 use PHPMD\Node\NodeInfo;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Test case for the {@link \PHPMD\RuleViolation} class.
  *
- * @covers \PHPMD\RuleViolation
  * @since 0.2.5
  */
+#[CoversClass(RuleViolation::class)]
 class RuleViolationTest extends AbstractTestCase
 {
     public function testNodeInfoGetters(): void

--- a/tests/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/tests/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -35,13 +35,14 @@ use PHPMD\Renderer\SARIFRenderer;
 use PHPMD\Renderer\TextRenderer;
 use PHPMD\Renderer\XMLRenderer;
 use PHPMD\Rule;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 
 /**
  * Test case for the {@link \PHPMD\TextUI\CommandLineOptions} class.
- *
- * @covers \PHPMD\TextUI\CommandLineOptions
  */
+#[CoversClass(CommandLineOptions::class)]
 class CommandLineOptionsTest extends AbstractTestCase
 {
     /**
@@ -624,9 +625,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @param class-string $expectedClass
      *
-     * @dataProvider dataProviderCreateRenderer
      * @covers \PHPMD\Renderer\RendererFactory::getRenderer
      */
+    #[DataProvider('dataProviderCreateRenderer')]
     public function testCreateRenderer(string $reportFormat, $expectedClass): void
     {
         require_once self::$filesDirectory . '/PHPMD/Test/Renderer/NamespaceRenderer.php';
@@ -662,9 +663,9 @@ class CommandLineOptionsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider dataProviderCreateRendererThrowsException
      * @covers \PHPMD\Renderer\RendererFactory::getCustomRenderer
      */
+    #[DataProvider('dataProviderCreateRendererThrowsException')]
     public function testCreateRendererThrowsException(string $reportFormat, string $expectedExceptionMessage): void
     {
         self::expectExceptionObject(new InvalidArgumentException(
@@ -703,9 +704,7 @@ class CommandLineOptionsTest extends AbstractTestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProviderDeprecatedCliOptions
-     */
+    #[DataProvider('dataProviderDeprecatedCliOptions')]
     public function testDeprecatedCliOptions(string $deprecatedName, string $newName, Closure $result): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', sprintf('--%s', $deprecatedName), '42'];
@@ -751,9 +750,8 @@ class CommandLineOptionsTest extends AbstractTestCase
     /**
      * @param list<string> $options
      * @param list<mixed> $expected
-     *
-     * @dataProvider dataProviderGetReportFiles
      */
+    #[DataProvider('dataProviderGetReportFiles')]
     public function testGetReportFiles(array $options, array $expected): void
     {
         $args = [__FILE__, __FILE__, 'text', 'codesize', ...$options];

--- a/tests/php/PHPMD/TextUI/CommandTest.php
+++ b/tests/php/PHPMD/TextUI/CommandTest.php
@@ -20,12 +20,13 @@ namespace PHPMD\TextUI;
 
 use PHPMD\AbstractTestCase;
 use PHPMD\Utility\Paths;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test case for the {@link \PHPMD\TextUI\Command} class.
- *
- * @covers \PHPMD\TextUI\Command
  */
+#[CoversClass(Command::class)]
 class CommandTest extends AbstractTestCase
 {
     /** @var ?resource */
@@ -43,9 +44,8 @@ class CommandTest extends AbstractTestCase
 
     /**
      * @param ?array<string> $options
-     *
-     * @dataProvider dataProviderTestMainWithOption
      */
+    #[DataProvider('dataProviderTestMainWithOption')]
     public function testMainStrictOptionIsOfByDefault(
         string $sourceFile,
         ExitCode $expectedExitCode,
@@ -191,9 +191,7 @@ class CommandTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @dataProvider dataProviderWithFilter
-     */
+    #[DataProvider('dataProviderWithFilter')]
     public function testWithFilter(string $option, string $value): void
     {
         $args = [


### PR DESCRIPTION
Type: refactoring
Issue: #1245
Breaking change: no

This addresses most of the deprecation warnings coming from PHPUnit 11. This should make it easier to eventually migrate to PHPUnit 12 and generate less noise in our test output.

Note that we are doing a lot of test method specific coverate, this isn't supported in PHPUnit Attributes, so I have left these unchanged. To resolve these we would need to either split tests up into multiple classes or accept that the other methods can also result in the same coverage.

Also enables PHPStan on PHP 8.5 and dealt with issues specific to it.