### PR TITLE
Fix notice NullableParamType in php8.4

### DIFF
--- a/src/main/php/PHPMD/Report.php
+++ b/src/main/php/PHPMD/Report.php
@@ -58,7 +58,7 @@ class Report
     /** @var BaselineValidator|null */
     private $baselineValidator;
 
-    public function __construct(BaselineValidator $baselineValidator = null)
+    public function __construct(?BaselineValidator $baselineValidator = null)
     {
         $this->baselineValidator = $baselineValidator;
     }

--- a/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
+++ b/src/main/php/PHPMD/Rule/CleanCode/BooleanArgumentFlag.php
@@ -74,7 +74,7 @@ class BooleanArgumentFlag extends AbstractRule implements MethodAware, FunctionA
         $this->scanFormalParameters($node);
     }
 
-    protected function isBooleanValue(ASTValue $value = null)
+    protected function isBooleanValue(?ASTValue $value = null)
     {
         return $value && $value->isValueAvailable() && ($value->getValue() === true || $value->getValue() === false);
     }

--- a/src/main/php/PHPMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateField.php
@@ -147,7 +147,7 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
      * @return boolean
      * @since 0.2.6
      */
-    protected function isValidPropertyNode(ASTNode $node = null)
+    protected function isValidPropertyNode(?ASTNode $node = null)
     {
         if ($node === null) {
             return false;


### PR DESCRIPTION
Type: bugfix  

Fix notice in php8.4 

PHPMD\Rule\CleanCode\BooleanArgumentFlag::isBooleanValue(): Implicitly marking parameter $value as nullable is deprecated, the explicit nullable type must be used instead
