### PR TITLE
Update pdepend/pdepend version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "php": "^8.1",
     "ext-xml": "*",
     "composer/xdebug-handler": "^3.0",
-    "pdepend/pdepend": "3.x-dev#a348a12d483e221f8e0e027953f3b5437d700f41"
+    "pdepend/pdepend": "3.x-dev#66b533ed8dfb92242a1cceef4d963836e8bab792"
   },
   "require-dev": {
     "ext-json": "*",


### PR DESCRIPTION
Type: bugfix / feature
Breaking change: no

Simply update pdepend to the latest development verison, which is hopefully the final update for the 3.0 release.

This sets the base for working on the 3 remaning features for PHPMD 3.0.0:
- yml config
- Symfony console app (including progressbar, think phpstan)
- Ignore via PHP attributes
