### PR TITLE
Use attributes for suppression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "php": "^8.1",
     "ext-xml": "*",
     "composer/xdebug-handler": "^3.0",
-    "pdepend/pdepend": "3.x-dev#a348a12d483e221f8e0e027953f3b5437d700f41"
+    "pdepend/pdepend": "3.x-dev#df5f2bfe5e392877bdcd6e894eefdc7e0df65f69"
   },
   "require-dev": {
     "ext-json": "*",

--- a/public/rst/documentation/suppress-warnings.rst
+++ b/public/rst/documentation/suppress-warnings.rst
@@ -8,9 +8,8 @@ from PHPMD or to suppress special rules for some software artifacts. ::
   /**
    * This will suppress all the PMD warnings in
    * this class.
-   *
-   * @SuppressWarnings(PHPMD)
    */
+  #[SuppressWarnings]
   class Bar {
       function  foo() {
           $baz = 23;
@@ -19,38 +18,14 @@ from PHPMD or to suppress special rules for some software artifacts. ::
 
 Or you can suppress one rule with an annotation like this: ::
 
-  /**
-   *
-   */
   class Bar {
       /**
        * This will suppress UnusedLocalVariable
        * warnings in this method
-       *
-       * @SuppressWarnings(PHPMD.UnusedLocalVariable)
        */
+      #[SuppressWarnings(UnusedLocalVariable::class)]
       public function foo() {
           $baz = 42;
-      }
-  }
-
-The ``@SuppressWarnings`` annotation of PHPMD also supports some
-wildcard exclusion, so that you can suppress several warnings with
-a single annotation. ::
-
-  /**
-   * Suppress all rules containing "unused" in this
-   * class
-   *
-   * @SuppressWarnings("unused")
-   */
-  class Bar {
-      private $unusedPrivateField = 42;
-      public function foo($unusedFormalParameter = 23)
-      {
-          $unusedLocalVariable = 17;
-      }
-      private function unusedPrivateMethod() {
       }
   }
 
@@ -59,10 +34,9 @@ so that you can exclude multiple rules by name. ::
 
   /**
    * Suppress all warnings from these two rules.
-   *
-   * @SuppressWarnings(PHPMD.LongVariable)
-   * @SuppressWarnings(PHPMD.UnusedLocalVariable)
    */
+  #[SuppressWarnings(LongVariable::class)]
+  #[SuppressWarnings(UnusedLocalVariable::class)]
   class Bar {
       public function foo($thisIsALongAndUnusedVariable)
       {

--- a/src/AbstractNode.php
+++ b/src/AbstractNode.php
@@ -301,10 +301,10 @@ abstract class AbstractNode
     }
 
     /**
-     * Checks if this node has a suppressed annotation for the given rule
+     * Checks if this node has suppressed warninngs for the given rule
      * instance.
      */
-    abstract public function hasSuppressWarningsAnnotationFor(Rule $rule): bool;
+    abstract public function hasSuppressWarningsFor(Rule $rule): bool;
 
     /**
      * Returns the full qualified name of a class, an interface, a method or

--- a/src/AbstractRule.php
+++ b/src/AbstractRule.php
@@ -22,6 +22,7 @@ use InvalidArgumentException;
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PDepend\Source\AST\ASTNode;
+use PHPMD\Attribute\SuppressWarnings;
 use PHPMD\Node\AbstractTypeNode;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\EnumNode;
@@ -32,9 +33,8 @@ use RuntimeException;
 
 /**
  * This is the abstract base class for PHPMD rules.
- *
- * @SuppressWarnings(PHPMD)
  */
+#[SuppressWarnings]
 abstract class AbstractRule implements Rule
 {
     /** The name for this rule instance. */
@@ -362,7 +362,7 @@ abstract class AbstractRule implements Rule
     protected function applyOnClassMethods(AbstractTypeNode $node): void
     {
         foreach ($node->getMethods() as $method) {
-            if (!$this->strict && $method->hasSuppressWarningsAnnotationFor($this)) {
+            if (!$this->strict && $method->hasSuppressWarningsFor($this)) {
                 continue;
             }
 

--- a/src/Attribute/SuppressWarnings.php
+++ b/src/Attribute/SuppressWarnings.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Attribute;
+
+use Attribute;
+use PHPMD\Rule;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::TARGET_FUNCTION | Attribute::IS_REPEATABLE)]
+final class SuppressWarnings
+{
+    public function __construct(
+        /** @var ?class-string<Rule> $rule */
+        public ?string $rule = null,
+    ) {
+    }
+}

--- a/src/Node/ASTNode.php
+++ b/src/Node/ASTNode.php
@@ -20,7 +20,9 @@ namespace PHPMD\Node;
 
 use PDepend\Source\AST\ASTNode as PDependNode;
 use PHPMD\AbstractNode;
+use PHPMD\Attribute\SuppressWarnings;
 use PHPMD\Rule;
+use PHPMD\Rule\UnusedFormalParameter;
 
 /**
  * Wrapper around a PHP_Depend ast node.
@@ -48,10 +50,10 @@ final class ASTNode extends AbstractNode
      * Checks if this node has a suppressed annotation for the given rule
      * instance.
      *
-     * @SuppressWarnings("PMD.UnusedFormalParameter")
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
      */
-    public function hasSuppressWarningsAnnotationFor(Rule $rule): bool
+    #[SuppressWarnings(UnusedFormalParameter::class)]
+    public function hasSuppressWarningsFor(Rule $rule): bool
     {
         return false;
     }

--- a/src/Node/AbstractNode.php
+++ b/src/Node/AbstractNode.php
@@ -33,13 +33,20 @@ abstract class AbstractNode extends BaseNode
 {
     /** Annotations associated with node instance. */
     private Annotations $annotations;
+    private Attributes $attributes;
 
     /**
      * Checks if this node has a suppressed annotation for the given rule
      * instance.
      */
-    public function hasSuppressWarningsAnnotationFor(Rule $rule): bool
+    public function hasSuppressWarningsFor(Rule $rule): bool
     {
+        $this->attributes ??= new Attributes($this);
+
+        if ($this->attributes->suppresses($rule)) {
+            return true;
+        }
+
         $this->annotations ??= new Annotations($this);
 
         return $this->annotations->suppresses($rule);

--- a/src/Node/Attributes.php
+++ b/src/Node/Attributes.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Node;
+
+use PDepend\Source\AST\AbstractASTArtifact;
+use PDepend\Source\AST\ASTAllocationExpression;
+use PDepend\Source\AST\ASTAttribute;
+use PDepend\Source\AST\ASTClassFqnPostfix;
+use PDepend\Source\AST\ASTLiteral;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PHPMD\AbstractNode;
+use PHPMD\Attribute\SuppressWarnings;
+use PHPMD\Rule;
+
+final class Attributes
+{
+    /** @var array<string, true> */
+    private array $suppressed = [];
+
+    /**
+     * @param AbstractNode<AbstractASTArtifact> $node
+     */
+    public function __construct(AbstractNode $node)
+    {
+        foreach ($node->getChildren() as $attributes) {
+            if (!$attributes instanceof ASTAttribute) {
+                continue;
+            }
+            foreach ($attributes->getChildren() as $attribute) {
+                if (!$attribute instanceof ASTAllocationExpression) {
+                    continue;
+                }
+                $allocation = $attribute->getChildren();
+                $class = $allocation[0] ?? null;
+                if (!$class || trim($class->getImage(), '\\') !== SuppressWarnings::class) {
+                    continue;
+                }
+                $arguments = $allocation[1] ?? null;
+                if ($arguments) {
+                    // #[SuppressWarnings()]
+                    $arguments = $arguments->getChildren();
+                }
+                if (!$arguments) {
+                    // #[SuppressWarnings]
+                    $this->suppressed['+all'] = true;
+
+                    continue;
+                }
+                $argument = $arguments[0];
+
+                if ($argument instanceof ASTLiteral) {
+                    // #[SuppressWarnings('\PHPMD\Rules\UnusedLocalVariable')]
+                    $this->suppressed[trim($argument->getImage(), '\\\'""')] = true;
+
+                    continue;
+                }
+                if (!$argument instanceof ASTMemberPrimaryPrefix || !$argument->isStatic()) {
+                    continue;
+                }
+                $children = $argument->getChildren();
+                if (!$children[1] instanceof ASTClassFqnPostfix) {
+                    continue;
+                }
+                $rule = $children[0];
+                // #[SuppressWarnings(UnusedLocalVariable::class)]
+                $this->suppressed[trim($rule->getImage(), '\\')] = true;
+            }
+        }
+    }
+
+    /**
+     * Checks if one of the attributes suppresses the given rule.
+     */
+    public function suppresses(Rule $rule): bool
+    {
+        return $this->suppressed['+all'] ?? $this->suppressed[$rule::class] ?? false;
+    }
+}

--- a/src/Node/MethodNode.php
+++ b/src/Node/MethodNode.php
@@ -85,13 +85,13 @@ class MethodNode extends AbstractCallableNode
      *
      * @throws RuntimeException
      */
-    public function hasSuppressWarningsAnnotationFor(Rule $rule): bool
+    public function hasSuppressWarningsFor(Rule $rule): bool
     {
-        if (parent::hasSuppressWarningsAnnotationFor($rule)) {
+        if (parent::hasSuppressWarningsFor($rule)) {
             return true;
         }
 
-        return $this->getParentType()->hasSuppressWarningsAnnotationFor($rule);
+        return $this->getParentType()->hasSuppressWarningsFor($rule);
     }
 
     /**

--- a/src/Rule/AbstractLocalVariable.php
+++ b/src/Rule/AbstractLocalVariable.php
@@ -29,6 +29,8 @@ use PDepend\Source\AST\ASTStringIndexExpression;
 use PDepend\Source\AST\ASTVariable;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
+use PHPMD\Attribute\SuppressWarnings;
+use PHPMD\Rule\Design\EmptyCatchBlock;
 use ReflectionException;
 use ReflectionFunction;
 
@@ -211,9 +213,8 @@ abstract class AbstractLocalVariable extends AbstractRule
 
     /**
      * Reflect function trying as namespaced function first, then global function.
-     *
-     * @SuppressWarnings(EmptyCatchBlock)
      */
+    #[SuppressWarnings(EmptyCatchBlock::class)]
     private function getReflectionFunctionByName(string $functionName): ?ReflectionFunction
     {
         try {
@@ -267,7 +268,7 @@ abstract class AbstractLocalVariable extends AbstractRule
 
         $parameters = $reflectionFunction->getParameters();
 
-        if (PHP_VERSION_ID < 50600 || $reflectionFunction->isVariadic()) {
+        if ($reflectionFunction->isVariadic()) {
             $argumentPosition = min($argumentPosition, count($parameters) - 1);
         }
 

--- a/src/Rule/CleanCode/UndefinedVariable.php
+++ b/src/Rule/CleanCode/UndefinedVariable.php
@@ -38,19 +38,21 @@ use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PDepend\Source\AST\State;
 use PHPMD\AbstractNode;
+use PHPMD\Attribute\SuppressWarnings;
 use PHPMD\Node\AbstractCallableNode;
 use PHPMD\Node\MethodNode;
 use PHPMD\Rule\AbstractLocalVariable;
+use PHPMD\Rule\CyclomaticComplexity;
+use PHPMD\Rule\Design\CouplingBetweenObjects;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
 
 /**
  * This rule collects all undefined variables within a given function or method
  * that are used by any code in the analyzed source artifact.
- *
- * @SuppressWarnings("PMD.CouplingBetweenObjects")
- * @SuppressWarnings("PMD.CyclomaticComplexity")
  */
+#[SuppressWarnings(CyclomaticComplexity::class)]
+#[SuppressWarnings(CouplingBetweenObjects::class)]
 final class UndefinedVariable extends AbstractLocalVariable implements FunctionAware, MethodAware
 {
     /**

--- a/src/Rule/Design/CountInLoopExpression.php
+++ b/src/Rule/Design/CountInLoopExpression.php
@@ -28,6 +28,7 @@ use PDepend\Source\AST\ASTStatement;
 use PDepend\Source\AST\ASTWhileStatement;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
+use PHPMD\Attribute\SuppressWarnings;
 use PHPMD\Node\ClassNode;
 use PHPMD\Node\EnumNode;
 use PHPMD\Node\TraitNode;
@@ -48,8 +49,8 @@ use RuntimeException;
  * - do-while() loops
  *
  * @author Kamil Szymanski <kamilszymanski@gmail.com>
- * @SuppressWarnings(CouplingBetweenObjects)
  */
+#[SuppressWarnings(CouplingBetweenObjects::class)]
 final class CountInLoopExpression extends AbstractRule implements ClassAware, EnumAware, TraitAware
 {
     /**

--- a/src/Rule/Naming/LongVariable.php
+++ b/src/Rule/Naming/LongVariable.php
@@ -26,6 +26,7 @@ use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
+use PHPMD\Attribute\SuppressWarnings;
 use PHPMD\Rule\ClassAware;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
@@ -116,8 +117,8 @@ final class LongVariable extends AbstractRule implements ClassAware, FunctionAwa
      * @param AbstractNode<ASTNode> $node
      * @throws InvalidArgumentException
      * @throws OutOfBoundsException
-     * @SuppressWarnings(LongVariable)
      */
+    #[SuppressWarnings(self::class)]
     private function checkMaximumLength(AbstractNode $node): void
     {
         $threshold = $this->getIntProperty('maximum');

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -31,17 +31,18 @@ use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
+use PHPMD\Attribute\SuppressWarnings;
 use PHPMD\Node\AbstractCallableNode;
 use PHPMD\Node\MethodNode;
+use PHPMD\Rule\Design\CouplingBetweenObjects;
 use ReflectionMethod;
 use RuntimeException;
 
 /**
  * This rule collects all formal parameters of a given function or method that
  * are not used in a statement of the artifact's body.
- *
- * @SuppressWarnings("PMD.CouplingBetweenObjects")
  */
+#[SuppressWarnings(CouplingBetweenObjects::class)]
 final class UnusedFormalParameter extends AbstractLocalVariable implements FunctionAware, MethodAware
 {
     /**

--- a/src/Rule/UnusedLocalVariable.php
+++ b/src/Rule/UnusedLocalVariable.php
@@ -35,15 +35,16 @@ use PDepend\Source\AST\ASTString;
 use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
+use PHPMD\Attribute\SuppressWarnings;
 use PHPMD\Node\AbstractCallableNode;
+use PHPMD\Rule\Design\CouplingBetweenObjects;
 use PHPMD\Utility\ExceptionsList;
 
 /**
  * This rule collects all local variables within a given function or method
  * that are not used by any code in the analyzed source artifact.
- *
- * @SuppressWarnings("PMD.CouplingBetweenObjects")
  */
+#[SuppressWarnings(CouplingBetweenObjects::class)]
 final class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware, MethodAware
 {
     /**

--- a/src/Rule/UnusedPrivateField.php
+++ b/src/Rule/UnusedPrivateField.php
@@ -32,14 +32,15 @@ use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
+use PHPMD\Attribute\SuppressWarnings;
 use PHPMD\Node\ClassNode;
+use PHPMD\Rule\Design\CouplingBetweenObjects;
 
 /**
  * This rule collects all private fields in a class that aren't used in any
  * method of the analyzed class.
- *
- * @SuppressWarnings("PMD.CouplingBetweenObjects")
  */
+#[SuppressWarnings(CouplingBetweenObjects::class)]
 final class UnusedPrivateField extends AbstractRule implements ClassAware
 {
     /**

--- a/src/Rule/UnusedPrivateMethod.php
+++ b/src/Rule/UnusedPrivateMethod.php
@@ -101,7 +101,7 @@ final class UnusedPrivateMethod extends AbstractRule implements ClassAware
     {
         return (
             $method->isPrivate() &&
-            !$method->hasSuppressWarningsAnnotationFor($this) &&
+            !$method->hasSuppressWarningsFor($this) &&
             strcasecmp($method->getImage(), $class->getImage()) !== 0 &&
             strcasecmp($method->getImage(), '__construct') !== 0 &&
             strcasecmp($method->getImage(), '__destruct') !== 0 &&

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -249,7 +249,7 @@ class RuleSet implements IteratorAggregate
 
         // Apply all rules to this node
         foreach ($this->rules[$className] as $rule) {
-            if ($node->hasSuppressWarningsAnnotationFor($rule) && !$this->strict) {
+            if ($node->hasSuppressWarningsFor($rule) && !$this->strict) {
                 continue;
             }
             $rule->setReport($this->report);

--- a/src/TextUI/CommandLineOptions.php
+++ b/src/TextUI/CommandLineOptions.php
@@ -19,6 +19,7 @@
 namespace PHPMD\TextUI;
 
 use InvalidArgumentException;
+use PHPMD\Attribute\SuppressWarnings;
 use PHPMD\Baseline\BaselineMode;
 use PHPMD\Cache\Model\ResultCacheStrategy;
 use PHPMD\Console\OutputInterface;
@@ -27,6 +28,7 @@ use PHPMD\Renderer\Option\Verbose;
 use PHPMD\Renderer\RendererFactory;
 use PHPMD\Renderer\RendererInterface;
 use PHPMD\Rule;
+use PHPMD\Rule\Naming\LongVariable;
 use PHPMD\Utility\ArgumentsValidator;
 use TypeError;
 use ValueError;
@@ -34,9 +36,8 @@ use ValueError;
 /**
  * This is a helper class that collects the specified cli arguments and puts them
  * into accessible properties.
- *
- * @SuppressWarnings(LongVariable)
  */
+#[SuppressWarnings(LongVariable::class)]
 class CommandLineOptions
 {
     /** Error code for invalid input */
@@ -656,8 +657,8 @@ class CommandLineOptions
             '--exclude: comma-separated string of patterns that are used to ' .
             'ignore directories. Use asterisks to exclude by pattern. ' .
             'For example *src/foo/*.php or *src/foo/*' . \PHP_EOL .
-            '--strict: also report those nodes with a @SuppressWarnings ' .
-            'annotation' . \PHP_EOL .
+            '--strict: also report those nodes with a SuppressWarnings ' .
+            'attribute' . \PHP_EOL .
             '--ignore-errors-on-exit: will exit with a zero code, ' .
             'even on error' . \PHP_EOL .
             '--ignore-violations-on-exit: will exit with a zero code, ' .

--- a/tests/php/PHPMD/Node/ASTNodeTest.php
+++ b/tests/php/PHPMD/Node/ASTNodeTest.php
@@ -66,7 +66,7 @@ class ASTNodeTest extends AbstractTestCase
         $node = new ASTNode($mock, __FILE__);
         $rule = $this->getRuleMock();
 
-        static::assertFalse($node->hasSuppressWarningsAnnotationFor($rule));
+        static::assertFalse($node->hasSuppressWarningsFor($rule));
     }
 
     /**

--- a/tests/php/PHPMD/Node/ClassNodeTest.php
+++ b/tests/php/PHPMD/Node/ClassNodeTest.php
@@ -58,7 +58,7 @@ class ClassNodeTest extends AbstractTestCase
 
         $node = new ClassNode($class);
 
-        static::assertTrue($node->hasSuppressWarningsAnnotationFor($rule));
+        static::assertTrue($node->hasSuppressWarningsFor($rule));
     }
 
     /**
@@ -74,7 +74,7 @@ class ClassNodeTest extends AbstractTestCase
 
         $node = new ClassNode($class);
 
-        static::assertTrue($node->hasSuppressWarningsAnnotationFor($rule));
+        static::assertTrue($node->hasSuppressWarningsFor($rule));
 
         $class = new ASTClass(null);
         $class->setComment('/** @SuppressWarnings(PMD.TooManyFields) */');
@@ -84,7 +84,7 @@ class ClassNodeTest extends AbstractTestCase
 
         $node = new ClassNode($class);
 
-        static::assertFalse($node->hasSuppressWarningsAnnotationFor($rule));
+        static::assertFalse($node->hasSuppressWarningsFor($rule));
     }
 
     /**

--- a/tests/php/PHPMD/Node/MethodNodeTest.php
+++ b/tests/php/PHPMD/Node/MethodNodeTest.php
@@ -83,7 +83,7 @@ class MethodNodeTest extends AbstractTestCase
         $rule->setName('FooBar');
 
         $method = $this->getMethod();
-        static::assertTrue($method->hasSuppressWarningsAnnotationFor($rule));
+        static::assertTrue($method->hasSuppressWarningsFor($rule));
     }
 
     /**
@@ -95,7 +95,7 @@ class MethodNodeTest extends AbstractTestCase
         $rule->setName('FooBar');
 
         $method = $this->getMethod();
-        static::assertTrue($method->hasSuppressWarningsAnnotationFor($rule));
+        static::assertTrue($method->hasSuppressWarningsFor($rule));
     }
 
     /**
@@ -107,7 +107,7 @@ class MethodNodeTest extends AbstractTestCase
         $rule->setName('FooBar');
 
         $method = $this->getMethod();
-        static::assertTrue($method->hasSuppressWarningsAnnotationFor($rule));
+        static::assertTrue($method->hasSuppressWarningsFor($rule));
     }
 
     /**
@@ -119,7 +119,7 @@ class MethodNodeTest extends AbstractTestCase
         $rule->setName('FooBar');
 
         $method = $this->getMethod();
-        static::assertTrue($method->hasSuppressWarningsAnnotationFor($rule));
+        static::assertTrue($method->hasSuppressWarningsFor($rule));
     }
 
     /**

--- a/tests/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
+++ b/tests/php/PHPMD/Regression/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php
@@ -18,9 +18,10 @@
 
 namespace PHPMD\Regression\Sources;
 
-/**
- * @SuppressWarnings(ExcessivePublicCount)
- */
+use PHPMD\Attribute\SuppressWarnings;
+use PHPMD\Rule\ExcessivePublicCount;
+
+#[SuppressWarnings(ExcessivePublicCount::class)]
 class ExcessivePublicCountSuppressionWorksForPublicStaticMethods
 {
     public static function aMethod(): void

--- a/tests/php/PHPMD/RuleSetTest.php
+++ b/tests/php/PHPMD/RuleSetTest.php
@@ -71,6 +71,17 @@ class RuleSetTest extends AbstractTestCase
         static::assertNull($rule->node);
     }
 
+    public function testApplyNotInvokesRuleWhenSuppressAttributeExists(): void
+    {
+        $ruleSet = $this->createRuleSetFixture(__FUNCTION__);
+        $ruleSet->setReport($this->getReportWithNoViolation());
+        $ruleSet->apply($this->getClass());
+        $rule = $ruleSet->getRuleByName(__FUNCTION__);
+
+        static::assertInstanceOf(RuleStub::class, $rule);
+        static::assertNull($rule->node);
+    }
+
     /**
      * testApplyInvokesRuleWhenStrictModeIsSet
      */

--- a/tests/resources/files/RuleSet/testApplyNotInvokesRuleWhenSuppressAttributeExists.php
+++ b/tests/resources/files/RuleSet/testApplyNotInvokesRuleWhenSuppressAttributeExists.php
@@ -1,0 +1,10 @@
+<?php
+
+use PHPMD\Attribute\SuppressWarnings;
+use PHPMD\Rule\ExcessivePublicCount;
+
+#[SuppressWarnings]
+class testApplyNotInvokesRuleWhenSuppressAttributeExists
+{
+
+}


### PR DESCRIPTION
Type: feature
fixes https://github.com/phpmd/phpmd/issues/1252
Breaking change: no

This allows for using attributes for rule suppression:
```php
#[SuppressWarnings(UnusedLocalVariable::class)]
class Bar {
    public function foo($thisIsALongAndUnusedVariable) {}
}
```

The benefit here is better validation and comparability with other tools (PHPStan can now spot incorrect usage).

## Limitations

This works for
```php
#[SuppressWarnings(PHPMD\Rules\UnusedLocalVariable::class)]
#[SuppressWarnings('\PHPMD\Rules\UnusedLocalVariable')]
#[SuppressWarnings]
#[SuppressWarnings()]
```
but not for this despite technically being valid:
```php
#[SuppressWarnings(null)]
```
it probably doesn't work for this case either:
```php
#[SuppressWarnings('\PHPMD\Rules\' . 'UnusedLocalVariable')]
```