### PR TITLE
[3.x] Option typo fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ composer.lock
 vendor
 dist
 .php-cs-fixer.cache
+.phpunit.cache

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -133,10 +133,10 @@ final class Command extends SymfonyCommand
             Rule::HIGHEST_PRIORITY
         );
         $this->addOption(
-            'suffixe',
+            'suffixes',
             null,
             InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-            'Ssource code filename extension',
+            'Source code filename extensions',
             ['php', 'php3', 'php4', 'php5', 'inc']
         );
         $this->addOption(

--- a/src/TextUI/CommandLineOptions.php
+++ b/src/TextUI/CommandLineOptions.php
@@ -151,7 +151,7 @@ class CommandLineOptions
         $this->coverageReport = $this->readString($input, 'coverage');
 
         /** @var list<string> */
-        $extensions = $input->getOption('suffixe');
+        $extensions = $input->getOption('suffixes');
         $this->extensions = $extensions;
 
         /** @var list<string> */

--- a/tests/php/PHPMD/TextUI/CommandTest.php
+++ b/tests/php/PHPMD/TextUI/CommandTest.php
@@ -198,7 +198,7 @@ class CommandTest extends AbstractTestCase
     public static function dataProviderWithFilter(): array
     {
         return [
-            ['--suffixe', ['.class.php']],
+            ['--suffixes', ['.class.php']],
             ['--exclude', ['ccn_', '*npath_', '*parse_error']],
         ];
     }


### PR DESCRIPTION
Type: bugfix
Issue: Resolves
Breaking change: kinda, in a way it's breaking change but because 3.0 is not released yet, it is not

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 
F
Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
  
 ## Adding a New Rule

- Add the new rule to the matching rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new rule, e.g. ``src/site/rst/rules/naming.rst``
- Implement the new rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new rule in the rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new rule *should* apply
-- Cover the case when the new rule *should not* apply
-- Cover edge cases of the new rule

## Adding a New Rule Property

- Add the new property to rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new property, e.g. ``src/site/rst/rules/naming.rst``
- Implement new property in rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new property in rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new property is not set and the rule *should not* apply
-- Cover the case when the new property is not set and the rule *should* apply
-- Cover case when the new property is set and the rule *should not* apply
-- Cover case when the new property is set and the rule *should* apply
-- Cover edge cases of the new property, if any
-->
This PR fixes name of option for analyze command `suffixe` -> `suffixes`.
I've also added .phpunit.cache folder to .gitignore