### PR TITLE
Add exceptions parameter support to UnusedPrivateField

### DIFF
--- a/src/main/php/PHPMD/Rule/UnusedPrivateField.php
+++ b/src/main/php/PHPMD/Rule/UnusedPrivateField.php
@@ -47,6 +47,9 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
     {
         /** @var ClassNode $field */
         foreach ($this->collectUnusedPrivateFields($node) as $field) {
+            if ($this->isExcepted($field)) {
+                continue;
+            }
             $this->addViolation($field, array($field->getImage()));
         }
     }
@@ -205,5 +208,26 @@ class UnusedPrivateField extends AbstractRule implements ClassAware
         }
 
         return $owner;
+    }
+
+    /**
+     * Checks if the given field is in the exceptions list.
+     *
+     * @param \PHPMD\Node\ASTNode $field
+     * @return boolean
+     */
+    protected function isExcepted(ASTNode $field)
+    {
+        return in_array(trim($field->getImage(), '$'), $this->getExceptionsList());
+    }
+
+    /**
+     * Gets array of exceptions from property
+     *
+     * @return array
+     */
+    protected function getExceptionsList()
+    {
+        return explode(',', $this->getStringProperty('exceptions', ''));
     }
 }

--- a/src/main/resources/rulesets/unusedcode.xml
+++ b/src/main/resources/rulesets/unusedcode.xml
@@ -18,6 +18,9 @@ The Unused Code Ruleset contains a collection of rules that find unused code.
 Detects when a private field is declared and/or assigned a value, but not used.
         </description>
         <priority>3</priority>
+        <properties>
+            <property name="exceptions" description="Comma-separated list of exceptions" value=""/>
+        </properties>
         <example>
 <![CDATA[
 class Something

--- a/src/site/rst/rules/unusedcode.rst
+++ b/src/site/rst/rules/unusedcode.rst
@@ -24,6 +24,14 @@ Example: ::
       }
   }
 
+This rule has the following properties:
+
++-----------------------------------+---------------+--------------------------------------------------------+
+| Name                              | Default Value | Description                                            |
++===================================+===============+========================================================+
+| exceptions                        |               | Comma-separated list of exceptions                     |
++-----------------------------------+---------------+--------------------------------------------------------+
+
 UnusedLocalVariable
 ===================
 
@@ -87,4 +95,3 @@ Remark
   This document is based on a ruleset xml-file, that was taken from the original source of the `PMD`__ project. This means that most parts of the content on this page are the intellectual work of the PMD community and its contributors and not of the PHPMD project.
 
 __ http://pmd.sourceforge.net/
-        

--- a/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
+++ b/src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php
@@ -279,4 +279,43 @@ class UnusedPrivateFieldTest extends AbstractTest
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
+
+    /**
+     * testRuleDoesNotApplyToUnusedPrivateFieldWithExceptionInExceptionsProperty
+     *
+     * @return void
+     */
+    public function testRuleDoesNotApplyToUnusedPrivateFieldWithExceptionInExceptionsProperty()
+    {
+        $rule = new UnusedPrivateField();
+        $rule->addProperty('exceptions', 'foo');
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getClass());
+    }
+
+    /**
+     * testRuleAppliesWhenFieldIsNotInExceptionsProperty
+     *
+     * @return void
+     */
+    public function testRuleAppliesWhenFieldIsNotInExceptionsProperty()
+    {
+        $rule = new UnusedPrivateField();
+        $rule->addProperty('exceptions', 'bar');
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getClass());
+    }
+
+    /**
+     * testRuleDoesNotApplyToMultipleUnusedPrivateFieldsWithExceptionsInExceptionsProperty
+     *
+     * @return void
+     */
+    public function testRuleDoesNotApplyToMultipleUnusedPrivateFieldsWithExceptionsInExceptionsProperty()
+    {
+        $rule = new UnusedPrivateField();
+        $rule->addProperty('exceptions', 'foo,bar');
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getClass());
+    }
 }

--- a/src/test/resources/files/Rule/UnusedPrivateField/testRuleAppliesWhenFieldIsNotInExceptionsProperty.php
+++ b/src/test/resources/files/Rule/UnusedPrivateField/testRuleAppliesWhenFieldIsNotInExceptionsProperty.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleAppliesWhenFieldIsNotInExceptionsProperty
+{
+    private $foo = 0;
+}

--- a/src/test/resources/files/Rule/UnusedPrivateField/testRuleDoesNotApplyToMultipleUnusedPrivateFieldsWithExceptionsInExceptionsProperty.php
+++ b/src/test/resources/files/Rule/UnusedPrivateField/testRuleDoesNotApplyToMultipleUnusedPrivateFieldsWithExceptionsInExceptionsProperty.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyToMultipleUnusedPrivateFieldsWithExceptionsInExceptionsProperty
+{
+    private $foo = 0;
+    private $bar = 1;
+}

--- a/src/test/resources/files/Rule/UnusedPrivateField/testRuleDoesNotApplyToUnusedPrivateFieldWithExceptionInExceptionsProperty.php
+++ b/src/test/resources/files/Rule/UnusedPrivateField/testRuleDoesNotApplyToUnusedPrivateFieldWithExceptionInExceptionsProperty.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyToUnusedPrivateFieldWithExceptionInExceptionsProperty
+{
+    private $foo = 0;
+}


### PR DESCRIPTION
### Summary
This pull request adds support for the `exceptions` parameter to the `UnusedPrivateField` rule, allowing users to whitelist specific private fields that should not be flagged as violations. This resolves issue #440, which requested that all rules support exception whitelists rather than requiring users to add `@SuppressWarnings` annotations throughout their code.

### Related Issues
- Closes #440: Feature req: add exception white-lists to all rules

### Changes Made
1. **Modified `src/main/php/PHPMD/Rule/UnusedPrivateField.php`**
   - Added `isExcepted()` method to check if a field is in the exceptions list
   - Added `getExceptionsList()` method to parse the exceptions property
   - Modified the `apply()` method to skip fields that are in the exceptions list

2. **Updated `src/main/resources/rulesets/unusedcode.xml`**
   - Added the `exceptions` property to the UnusedPrivateField rule definition with default value ""
   - Added documentation for the property

3. **Enhanced `src/test/php/PHPMD/Rule/UnusedPrivateFieldTest.php`**
   - Added `testRuleDoesNotApplyToUnusedPrivateFieldWithExceptionInExceptionsProperty()` test
   - Added `testRuleAppliesWhenFieldIsNotInExceptionsProperty()` test
   - Added `testRuleDoesNotApplyToMultipleUnusedPrivateFieldsWithExceptionsInExceptionsProperty()` test

4. **Added test resources**
   - `src/test/resources/files/Rule/UnusedPrivateField/testRuleDoesNotApplyToUnusedPrivateFieldWithExceptionInExceptionsProperty.php`
   - `src/test/resources/files/Rule/UnusedPrivateField/testRuleAppliesWhenFieldIsNotInExceptionsProperty.php`
   - `src/test/resources/files/Rule/UnusedPrivateField/testRuleDoesNotApplyToMultipleUnusedPrivateFieldsWithExceptionsInExceptionsProperty.php`

### Usage Example
```php
<!-- In phpmd.xml or ruleset configuration -->
<rule ref="rulesets/unusedcode.xml/UnusedPrivateField">
    <properties>
        <property name="exceptions" value="serialVersionUID,serialPersistentFields"/>
    </properties>
</rule>
```

In this example, private fields named `serialVersionUID` and `serialPersistentFields` would be excluded from violations.

### Testing
- All existing tests pass
- New tests verify that:
  - Fields in the exceptions list are not flagged
  - Fields not in the exceptions list are still flagged
  - Multiple exceptions can be specified with comma-separated values

### Code Standards
The code follows the [PSR-2 coding standard](http://www.php-fig.org/psr/psr-2/) as required by the project's [phpcs.xml.dist](https://github.com/phpmd/phpmd/blob/master/phpcs.xml.dist).

### Implementation Notes
This implementation follows the same pattern as the `UnusedLocalVariable` rule's exceptions feature (PR #329), ensuring consistency across the codebase.
