### PR TITLE
[3.x] Add exceptions parameter support to UnusedPrivateField

### DIFF
--- a/public/rst/rules/unusedcode.rst
+++ b/public/rst/rules/unusedcode.rst
@@ -24,6 +24,14 @@ Example: ::
       }
   }
 
+This rule has the following properties:
+
++-----------------------------------+---------------+--------------------------------------------------------+
+| Name                              | Default Value | Description                                            |
++===================================+===============+========================================================+
+| exceptions                        |               | Comma-separated list of exceptions                     |
++-----------------------------------+---------------+--------------------------------------------------------+
+
 UnusedLocalVariable
 ===================
 
@@ -87,4 +95,3 @@ Remark
   This document is based on a ruleset xml-file, that was taken from the original source of the `PMD`__ project. This means that most parts of the content on this page are the intellectual work of the PMD community and its contributors and not of the PHPMD project.
 
 __ http://pmd.sourceforge.net/
-        

--- a/rulesets/unusedcode.xml
+++ b/rulesets/unusedcode.xml
@@ -18,6 +18,12 @@ The Unused Code Ruleset contains a collection of rules that find unused code.
 Detects when a private field is declared and/or assigned a value, but not used.
         </description>
         <priority>3</priority>
+        <properties>
+            <property
+                    name="exceptions"
+                    description="Comma-separated list of field names that are allowed to be unused."
+                    value="" />
+        </properties>
         <example>
 <![CDATA[
 class Something

--- a/src/Baseline/BaselineMode.php
+++ b/src/Baseline/BaselineMode.php
@@ -4,12 +4,18 @@ namespace PHPMD\Baseline;
 
 enum BaselineMode
 {
-    /** Do not generate or update any baseline file */
+    /**
+     * Do not generate or update any baseline file
+     */
     case None;
 
-    /** Generate a baseline file for _all_ current violations */
+    /**
+     * Generate a baseline file for _all_ current violations
+     */
     case Generate;
 
-    /** Remove any non existing violations from the baseline file. Do not baseline any new violations. */
+    /**
+     * Remove any non existing violations from the baseline file. Do not baseline any new violations.
+     */
     case Update;
 }

--- a/src/Cache/Model/ResultCacheStrategy.php
+++ b/src/Cache/Model/ResultCacheStrategy.php
@@ -4,9 +4,13 @@ namespace PHPMD\Cache\Model;
 
 enum ResultCacheStrategy: string
 {
-    /** Determine the file cache freshness based on sha hash of the contents of the file */
+    /**
+     * Determine the file cache freshness based on sha hash of the contents of the file
+     */
     case Content = 'content';
 
-    /** Determine the file cache freshness based on the file modified timestamp */
+    /**
+     * Determine the file cache freshness based on the file modified timestamp
+     */
     case Timestamp = 'timestamp';
 }

--- a/src/Rule/UnusedPrivateField.php
+++ b/src/Rule/UnusedPrivateField.php
@@ -35,6 +35,7 @@ use PHPMD\AbstractRule;
 use PHPMD\Attribute\SuppressWarnings;
 use PHPMD\Node\ClassNode;
 use PHPMD\Rule\Design\CouplingBetweenObjects;
+use PHPMD\Utility\ExceptionsList;
 
 /**
  * This rule collects all private fields in a class that aren't used in any
@@ -51,6 +52,9 @@ final class UnusedPrivateField extends AbstractRule implements ClassAware
      */
     private array $fields = [];
 
+    /** Temporary cache of configured exceptions. */
+    private ExceptionsList $exceptions;
+
     /**
      * This method checks that all private class properties are at least accessed
      * by one method.
@@ -62,7 +66,14 @@ final class UnusedPrivateField extends AbstractRule implements ClassAware
         }
 
         foreach ($this->collectUnusedPrivateFields($node) as $field) {
-            $this->addViolation($field, [$field->getImage()]);
+            $fieldName = $field->getImage();
+
+            // Check if field name is in the exceptions list (without the $ prefix)
+            if ($this->getExceptionsList()->contains(ltrim($fieldName, '$'))) {
+                continue;
+            }
+
+            $this->addViolation($field, [$fieldName]);
         }
     }
 
@@ -212,5 +223,15 @@ final class UnusedPrivateField extends AbstractRule implements ClassAware
         }
 
         return $owner;
+    }
+
+    /**
+     * Gets exceptions from property
+     */
+    private function getExceptionsList(): ExceptionsList
+    {
+        $this->exceptions ??= new ExceptionsList($this);
+
+        return $this->exceptions;
     }
 }

--- a/tests/php/PHPMD/Rule/UnusedPrivateFieldTest.php
+++ b/tests/php/PHPMD/Rule/UnusedPrivateFieldTest.php
@@ -246,4 +246,26 @@ class UnusedPrivateFieldTest extends AbstractTestCase
         $rule->setReport($this->getReportWithNoViolation());
         $rule->apply($this->getClass());
     }
+
+    /**
+     * testRuleDoesNotApplyToWhitelistedPrivateField
+     */
+    public function testRuleDoesNotApplyToWhitelistedPrivateField(): void
+    {
+        $rule = new UnusedPrivateField();
+        $rule->addProperty('exceptions', 'unused');
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getClass());
+    }
+
+    /**
+     * testRuleAppliesToNonWhitelistedPrivateField
+     */
+    public function testRuleAppliesToNonWhitelistedPrivateField(): void
+    {
+        $rule = new UnusedPrivateField();
+        $rule->addProperty('exceptions', 'someOtherField');
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getClass());
+    }
 }

--- a/tests/resources/files/Rule/UnusedPrivateField/testRuleAppliesToNonWhitelistedPrivateField.php
+++ b/tests/resources/files/Rule/UnusedPrivateField/testRuleAppliesToNonWhitelistedPrivateField.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleAppliesToNonWhitelistedPrivateField
+{
+    private $notInExceptionsList = 42; // This should trigger a violation
+}

--- a/tests/resources/files/Rule/UnusedPrivateField/testRuleDoesNotApplyToWhitelistedPrivateField.php
+++ b/tests/resources/files/Rule/UnusedPrivateField/testRuleDoesNotApplyToWhitelistedPrivateField.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyToWhitelistedPrivateField
+{
+    private $unused = 42; // This should not trigger a violation because 'unused' is in the exceptions list
+}


### PR DESCRIPTION
Type: feature
Issue: Support for the exceptions parameter for the UnusedPrivateField rule in https://github.com/phpmd/phpmd/issues/440
Breaking change: no

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
  
 ## Adding a New Rule

- Add the new rule to the matching rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new rule, e.g. ``src/site/rst/rules/naming.rst``
- Implement the new rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new rule in the rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new rule *should* apply
-- Cover the case when the new rule *should not* apply
-- Cover edge cases of the new rule

## Adding a New Rule Property

- Add the new property to rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new property, e.g. ``src/site/rst/rules/naming.rst``
- Implement new property in rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new property in rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new property is not set and the rule *should not* apply
-- Cover the case when the new property is not set and the rule *should* apply
-- Cover case when the new property is set and the rule *should not* apply
-- Cover case when the new property is set and the rule *should* apply
-- Cover edge cases of the new property, if any
-->
