### PR TITLE
[3.x] Add exceptions parameter support to UnusedFormalParameter

### DIFF
--- a/public/rst/rules/unusedcode.rst
+++ b/public/rst/rules/unusedcode.rst
@@ -81,10 +81,17 @@ Example: ::
       }
   }
 
+This rule has the following properties:
+
++-----------------------------------+---------------+---------------------------------------+
+| Name                              | Default Value | Description                           |
++===================================+===============+=======================================+
+| exceptions                        |               | Comma-separated list of exceptions    |
++-----------------------------------+---------------+---------------------------------------+
+
 Remark
 ======
 
   This document is based on a ruleset xml-file, that was taken from the original source of the `PMD`__ project. This means that most parts of the content on this page are the intellectual work of the PMD community and its contributors and not of the PHPMD project.
 
 __ http://pmd.sourceforge.net/
-        

--- a/rulesets/unusedcode.xml
+++ b/rulesets/unusedcode.xml
@@ -90,6 +90,9 @@ class Something
 Avoid passing parameters to methods or constructors and then not using those parameters.
         </description>
         <priority>3</priority>
+        <properties>
+            <property name="exceptions" description="Comma-separated list of exceptions" value=""/>
+        </properties>
         <example>
 <![CDATA[
 class Foo

--- a/src/Baseline/BaselineMode.php
+++ b/src/Baseline/BaselineMode.php
@@ -4,12 +4,18 @@ namespace PHPMD\Baseline;
 
 enum BaselineMode
 {
-    /** Do not generate or update any baseline file */
+    /**
+     * Do not generate or update any baseline file
+     */
     case None;
 
-    /** Generate a baseline file for _all_ current violations */
+    /**
+     * Generate a baseline file for _all_ current violations
+     */
     case Generate;
 
-    /** Remove any non existing violations from the baseline file. Do not baseline any new violations. */
+    /**
+     * Remove any non existing violations from the baseline file. Do not baseline any new violations.
+     */
     case Update;
 }

--- a/src/Cache/Model/ResultCacheStrategy.php
+++ b/src/Cache/Model/ResultCacheStrategy.php
@@ -4,9 +4,13 @@ namespace PHPMD\Cache\Model;
 
 enum ResultCacheStrategy: string
 {
-    /** Determine the file cache freshness based on sha hash of the contents of the file */
+    /**
+     * Determine the file cache freshness based on sha hash of the contents of the file
+     */
     case Content = 'content';
 
-    /** Determine the file cache freshness based on the file modified timestamp */
+    /**
+     * Determine the file cache freshness based on the file modified timestamp
+     */
     case Timestamp = 'timestamp';
 }

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -20,6 +20,7 @@ namespace PHPMD\Rule;
 
 use OutOfBoundsException;
 use Override;
+use InvalidArgumentException;
 use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\ASTAllocationExpression;
 use PDepend\Source\AST\ASTAttribute;
@@ -63,6 +64,7 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
      * used at least one time within the artifacts body.
      *
      * @throws RuntimeException
+     * @throws InvalidArgumentException
      */
     public function apply(AbstractNode $node): void
     {

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -18,9 +18,9 @@
 
 namespace PHPMD\Rule;
 
+use InvalidArgumentException;
 use OutOfBoundsException;
 use Override;
-use InvalidArgumentException;
 use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\ASTAllocationExpression;
 use PDepend\Source\AST\ASTAttribute;

--- a/src/Rule/UnusedFormalParameter.php
+++ b/src/Rule/UnusedFormalParameter.php
@@ -38,6 +38,7 @@ use PHPMD\Node\AbstractCallableNode;
 use PHPMD\Node\MethodNode;
 use PHPMD\Rule;
 use PHPMD\Rule\Design\CouplingBetweenObjects;
+use PHPMD\Utility\ExceptionsList;
 use RuntimeException;
 
 /**
@@ -53,6 +54,9 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
      * @var array<string, AbstractNode<ASTVariableDeclarator>>
      */
     private array $nodes = [];
+
+    /** Temporary cache of configured exceptions. */
+    private ExceptionsList $exceptions;
 
     /**
      * This method checks that all parameters of a given function or method are
@@ -89,7 +93,10 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
         $this->removeUsedParameters($node);
 
         foreach ($this->nodes as $node) {
-            $this->addViolation($node, [$node->getImage()]);
+            $parameterName = $node->getImage();
+            if (!$this->getExceptionsList()->contains($parameterName)) {
+                $this->addViolation($node, [$parameterName]);
+            }
         }
     }
 
@@ -342,5 +349,15 @@ final class UnusedFormalParameter extends AbstractLocalVariable implements Funct
                 }
             }
         }
+    }
+
+    /**
+     * Gets array of exceptions from property
+     */
+    private function getExceptionsList(): ExceptionsList
+    {
+        $this->exceptions ??= new ExceptionsList($this, '$');
+
+        return $this->exceptions;
     }
 }

--- a/tests/php/PHPMD/Rule/UnusedFormalParameterTest.php
+++ b/tests/php/PHPMD/Rule/UnusedFormalParameterTest.php
@@ -495,4 +495,20 @@ class UnusedFormalParameterTest extends AbstractTestCase
         $rule->setReport($this->getReportWithOneViolation());
         $rule->apply($this->getMethod());
     }
+
+    public function testRuleDoesNotApplyToExceptionParameter(): void
+    {
+        $rule = new UnusedFormalParameter();
+        $rule->addProperty('exceptions', '$unused');
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getFunction());
+    }
+
+    public function testRuleAppliesToParameterNotInExceptionsList(): void
+    {
+        $rule = new UnusedFormalParameter();
+        $rule->addProperty('exceptions', '$other');
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getFunction());
+    }
 }

--- a/tests/resources/files/Rule/UnusedFormalParameter/testRuleAppliesToParameterNotInExceptionsList.php
+++ b/tests/resources/files/Rule/UnusedFormalParameter/testRuleAppliesToParameterNotInExceptionsList.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+function testRuleAppliesToParameterNotInExceptionsList($unused)
+{
+    // $unused is not used and not in the exceptions list
+}

--- a/tests/resources/files/Rule/UnusedFormalParameter/testRuleDoesNotApplyToExceptionParameter.php
+++ b/tests/resources/files/Rule/UnusedFormalParameter/testRuleDoesNotApplyToExceptionParameter.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+function testRuleDoesNotApplyToExceptionParameter($unused)
+{
+    // $unused is not used, but it's in the exceptions list
+}


### PR DESCRIPTION
Type: feature
Issue: Support for the exceptions parameter for the UnusedFormalParameter rule in https://github.com/phpmd/phpmd/issues/440
Breaking change: no

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
  
 ## Adding a New Rule

- Add the new rule to the matching rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new rule, e.g. ``src/site/rst/rules/naming.rst``
- Implement the new rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new rule in the rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new rule *should* apply
-- Cover the case when the new rule *should not* apply
-- Cover edge cases of the new rule

## Adding a New Rule Property

- Add the new property to rule set XML, e.g. ``src/main/resources/rulesets/naming.xml``
- Add documentation for the new property, e.g. ``src/site/rst/rules/naming.rst``
- Implement new property in rule, e.g. ``src/main/php/PHPMD/Rule/Naming/LongVariable.php``
- Cover cases for the new property in rule test, e.g. ``src/test/php/PHPMD/Rule/Naming/LongVariableTest.php``
-- Cover the case when the new property is not set and the rule *should not* apply
-- Cover the case when the new property is not set and the rule *should* apply
-- Cover case when the new property is set and the rule *should not* apply
-- Cover case when the new property is set and the rule *should* apply
-- Cover edge cases of the new property, if any
-->
