### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Coding Standard
 ---------------
 
 Make sure your code changes comply with the [coding standard](https://github.com/phpmd/phpmd/blob/master/phpcs.xml.dist) by
-using [PHP Codesniffer](https://github.com/squizlabs/PHP_CodeSniffer)
+using [PHP Codesniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer)
 from within your PHPMD folder:
 
     vendor/bin/phpcs -p --extensions=php src > phpcs.txt

--- a/composer.json
+++ b/composer.json
@@ -46,13 +46,13 @@
   "require-dev": {
     "ext-json": "*",
     "ext-simplexml": "*",
-    "brianium/paratest": "^7.3",
+    "brianium/paratest": "~7.3.2|^7.8.5",
     "easy-doc/easy-doc": "^1.3.2",
     "friendsofphp/php-cs-fixer": "^3.57",
     "gregwar/rst": "^1.0",
     "mikey179/vfsstream": "^1.6.8",
-    "phpstan/phpstan": "~2.1.38",
-    "phpunit/phpunit": "^10.5.20,<10.5.32|^11.0.0",
+    "phpstan/phpstan": "~2.1.44",
+    "phpunit/phpunit": "^10.5.62|^11.5.50",
     "squizlabs/php_codesniffer": "^3.8.0"
   },
   "autoload": {
@@ -78,11 +78,6 @@
     "build-website": "easy-doc build src/site/config.php --verbose"
   },
   "config": {
-    "sort-packages": true,
-    "audit": {
-      "ignore": [
-        "PKSA-z3gr-8qht-p93v"
-      ]
-    }
+    "sort-packages": true
   }
 }

--- a/src/Utility/ExceptionsList.php
+++ b/src/Utility/ExceptionsList.php
@@ -78,7 +78,6 @@ final class ExceptionsList implements ArrayAccess, IteratorAggregate
                 $this->trim
             );
 
-            // @phpstan-ignore-next-line
             $this->exceptions = array_combine($values, $values);
         }
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932