### PR TITLE
Allow the insecure packages to work with prefer lowest.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,11 @@
       "PHPMD\\": "src/main/php"
     }
   },
+  "config": {
+    "audit": {
+      "block-insecure": false
+    }
+  },
   "bin": [
     "src/bin/phpmd"
   ],


### PR DESCRIPTION
Type: bugfix / feature
Issue: -
Breaking change: no

The actions now fail on a security issue while in running composer install because of older packages with security issues.
