### PR TITLE
Allow null metric in ResultCacheState rule violations

### DIFF
--- a/src/Cache/Model/ResultCacheState.php
+++ b/src/Cache/Model/ResultCacheState.php
@@ -128,7 +128,7 @@ class ResultCacheState
                 } else {
                     $violationMessage = ['args' => $violation['args'], 'message' => $violation['description']];
                 }
-                assert(is_numeric($violation['metric']));
+                assert($violation['metric'] === null || is_numeric($violation['metric']));
                 $ruleViolations[] = new RuleViolation($rule, $nodeInfo, $violationMessage, $violation['metric']);
             }
         }

--- a/tests/php/PHPMD/Cache/Model/ResultCacheStateTest.php
+++ b/tests/php/PHPMD/Cache/Model/ResultCacheStateTest.php
@@ -156,6 +156,33 @@ class ResultCacheStateTest extends TestCase
     }
 
     /**
+     * @covers ::findRuleIn
+     * @covers ::getRuleViolations
+     */
+    public function testGetRuleViolationsWithNullMetric(): void
+    {
+        $ruleSet = new RuleSet();
+        $ruleSet->addRule(new BooleanArgumentFlag());
+        $rule = new BooleanArgumentFlag();
+        $nodeInfo = new NodeInfo(
+            '/file/path',
+            'namespace',
+            'className',
+            'methodName',
+            'functionName',
+            123,
+            456
+        );
+
+        $ruleViolation = new RuleViolation($rule, $nodeInfo, 'violation', null);
+
+        $this->state->addRuleViolation('/file/path', $ruleViolation);
+        $violations = $this->state->getRuleViolations('', [$ruleSet]);
+        static::assertCount(1, $violations);
+        static::assertEquals($ruleViolation, $violations[0]);
+    }
+
+    /**
      * @covers ::isFileModified
      * @covers ::setFileState
      */


### PR DESCRIPTION
Type: bugfix
Issue: Resolves https://github.com/phpmd/phpmd/issues/1279
Breaking change: no

Simply allow `$violation['metric']` to be `null`.