### PR TITLE
Rename ignorePatterns to excludePatterns throughout codebase

### DIFF
--- a/src/PHPMD.php
+++ b/src/PHPMD.php
@@ -50,7 +50,7 @@ class PHPMD
      *
      * @var list<string>
      */
-    private array $ignorePatterns = [];
+    private array $excludePatterns = [];
 
     /**
      * The input source file or directory.
@@ -139,23 +139,23 @@ class PHPMD
      * @return string[]
      * @since 2.9.0
      */
-    public function getIgnorePatterns(): array
+    public function getExcludePatterns(): array
     {
-        return $this->ignorePatterns;
+        return $this->excludePatterns;
     }
 
     /**
-     * Add a list of ignore patterns which is used to exclude directories from
+     * Add a list of exclude patterns which is used to exclude directories from
      * the source analysis.
      *
-     * @param list<string> $ignorePatterns List of ignore patterns.
+     * @param list<string> $excludePatterns List of exclude patterns.
      * @since 2.9.0
      */
-    public function addIgnorePatterns(array $ignorePatterns): void
+    public function addExcludePatterns(array $excludePatterns): void
     {
-        $this->ignorePatterns = [
-            ...$this->ignorePatterns,
-            ...$ignorePatterns,
+        $this->excludePatterns = [
+            ...$this->excludePatterns,
+            ...$excludePatterns,
         ];
     }
 
@@ -205,21 +205,21 @@ class PHPMD
      * argument. The result will be passed to all given renderer instances.
      *
      * @param list<string>        $inputPath
-     * @param list<string>        $ignorePattern
+     * @param list<string>        $excludePatterns
      * @param RendererInterface[] $renderers
      * @param list<RuleSet>       $ruleSetList
      * @throws Exception
      */
     public function processFiles(
         array $inputPath,
-        array $ignorePattern,
+        array $excludePatterns,
         array $renderers,
         array $ruleSetList,
         Report $report,
         ?ProgressListener $progressListener = null
     ): void {
         // Merge parsed excludes
-        $this->addIgnorePatterns($ignorePattern);
+        $this->addExcludePatterns($excludePatterns);
 
         $this->input = $inputPath;
 

--- a/src/ParserFactory.php
+++ b/src/ParserFactory.php
@@ -118,9 +118,9 @@ final class ParserFactory
      */
     private function initIgnores(Engine $pdepend, PHPMD $phpmd): void
     {
-        if (count($phpmd->getIgnorePatterns()) > 0) {
+        if (count($phpmd->getExcludePatterns()) > 0) {
             $pdepend->addFileFilter(
-                new ExcludePathFilter($phpmd->getIgnorePatterns())
+                new ExcludePathFilter($phpmd->getExcludePatterns())
             );
         }
     }

--- a/src/RuleSetFactory.php
+++ b/src/RuleSetFactory.php
@@ -562,7 +562,7 @@ class RuleSetFactory
      * @return list<string>
      * @throws RuntimeException Thrown if file is not proper xml
      */
-    public function getIgnorePattern(array $fileName): array
+    public function getExcludePatterns(array $fileName): array
     {
         $excludes = [];
         $files = array_map(trim(...), $fileName);

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -342,10 +342,10 @@ final class Command extends SymfonyCommand
         );
 
         $phpmd->setFileExtensions($options->getExtensions());
-        $phpmd->addIgnorePatterns($options->getIgnore());
+        $phpmd->addExcludePatterns($options->getExcludePatterns());
         $phpmd->setThreads($options->getThreads());
 
-        $ignorePattern = $ruleSetFactory->getIgnorePattern($options->getRuleSets());
+        $excludePatterns = $ruleSetFactory->getExcludePatterns($options->getRuleSets());
         $ruleSetList = $ruleSetFactory->createRuleSets($options->getRuleSets());
 
         $cwd = getcwd() ?: '';
@@ -370,7 +370,7 @@ final class Command extends SymfonyCommand
 
         $phpmd->processFiles(
             $options->getInputPaths(),
-            $ignorePattern,
+            $excludePatterns,
             $renderers,
             $ruleSetList,
             $report ?? new Report(),

--- a/src/TextUI/CommandLineOptions.php
+++ b/src/TextUI/CommandLineOptions.php
@@ -95,7 +95,7 @@ class CommandLineOptions
      *
      * @var list<string>
      */
-    private array $ignore = [];
+    private array $excludePatterns = [];
 
     /**
      * Should PHPMD run in strict mode?
@@ -159,7 +159,7 @@ class CommandLineOptions
 
         /** @var list<string> */
         $ignore = $input->getOption('exclude');
-        $this->ignore = $ignore;
+        $this->excludePatterns = $ignore;
         $this->strict = (bool) $input->getOption('strict');
         $this->generateBaseline = $input->getOption('update-baseline') ? BaselineMode::Update : BaselineMode::None;
         if ($input->getOption('generate-baseline')) {
@@ -292,9 +292,9 @@ class CommandLineOptions
      *
      * @return list<string>
      */
-    public function getIgnore(): array
+    public function getExcludePatterns(): array
     {
-        return $this->ignore;
+        return $this->excludePatterns;
     }
 
     public function getThreads(): ?int

--- a/tests/php/PHPMD/PHPMDTest.php
+++ b/tests/php/PHPMD/PHPMDTest.php
@@ -55,7 +55,7 @@ class PHPMDTest extends AbstractTestCase
 
         $phpmd->processFiles(
             [self::createFileUri('source/ccn_function.php')],
-            $this->ruleSetFactory->getIgnorePattern(['pmd-refset1']),
+            $this->ruleSetFactory->getExcludePatterns(['pmd-refset1']),
             [$renderer],
             $this->ruleSetFactory->createRuleSets(['pmd-refset1']),
             new Report()
@@ -79,7 +79,7 @@ class PHPMDTest extends AbstractTestCase
         $phpmd = new PHPMD();
         $phpmd->processFiles(
             [self::createFileUri('source')],
-            $this->ruleSetFactory->getIgnorePattern(['pmd-refset1']),
+            $this->ruleSetFactory->getExcludePatterns(['pmd-refset1']),
             [$renderer],
             $this->ruleSetFactory->createRuleSets(['pmd-refset1']),
             new Report()
@@ -103,7 +103,7 @@ class PHPMDTest extends AbstractTestCase
         $phpmd = new PHPMD();
         $phpmd->processFiles(
             [self::createFileUri('source/ccn_function.php')],
-            $this->ruleSetFactory->getIgnorePattern(['pmd-refset1']),
+            $this->ruleSetFactory->getExcludePatterns(['pmd-refset1']),
             [$renderer],
             $this->ruleSetFactory->createRuleSets(['pmd-refset1']),
             new Report()
@@ -143,7 +143,7 @@ class PHPMDTest extends AbstractTestCase
         $phpmd = new PHPMD();
         $phpmd->processFiles(
             [self::createFileUri('source/source_without_violations.php')],
-            $this->ruleSetFactory->getIgnorePattern(['pmd-refset1']),
+            $this->ruleSetFactory->getExcludePatterns(['pmd-refset1']),
             [$renderer],
             $this->ruleSetFactory->createRuleSets(['pmd-refset1']),
             new Report()
@@ -166,7 +166,7 @@ class PHPMDTest extends AbstractTestCase
         $phpmd = new PHPMD();
         $phpmd->processFiles(
             [self::createFileUri('source/source_with_npath_violation.php')],
-            $this->ruleSetFactory->getIgnorePattern(['pmd-refset1']),
+            $this->ruleSetFactory->getExcludePatterns(['pmd-refset1']),
             [$renderer],
             $this->ruleSetFactory->createRuleSets(['pmd-refset1']),
             new Report()
@@ -189,7 +189,7 @@ class PHPMDTest extends AbstractTestCase
         $phpmd = new PHPMD();
         $phpmd->processFiles(
             [self::createFileUri('source/source_with_npath_violation.php')],
-            $this->ruleSetFactory->getIgnorePattern(['pmd-refset1']),
+            $this->ruleSetFactory->getExcludePatterns(['pmd-refset1']),
             [$renderer],
             $this->ruleSetFactory->createRuleSets(['pmd-refset1']),
             new Report(new BaselineValidator($baselineSet, BaselineMode::None))
@@ -211,7 +211,7 @@ class PHPMDTest extends AbstractTestCase
         $phpmd = new PHPMD();
         $phpmd->processFiles(
             [self::createFileUri('source/source_with_parse_error.php')],
-            $this->ruleSetFactory->getIgnorePattern(['pmd-refset1']),
+            $this->ruleSetFactory->getExcludePatterns(['pmd-refset1']),
             [$renderer],
             $this->ruleSetFactory->createRuleSets(['pmd-refset1']),
             new Report()
@@ -233,7 +233,7 @@ class PHPMDTest extends AbstractTestCase
         // Process without exclusions, should result in violations.
         $phpmd->processFiles(
             [self::createFileUri('sourceExcluded/')],
-            $this->ruleSetFactory->getIgnorePattern(['pmd-refset1']),
+            $this->ruleSetFactory->getExcludePatterns(['pmd-refset1']),
             [],
             $this->ruleSetFactory->createRuleSets(['pmd-refset1']),
             new Report()
@@ -245,7 +245,7 @@ class PHPMDTest extends AbstractTestCase
         // Process with exclusions, should result in no violations.
         $phpmd->processFiles(
             [self::createFileUri('sourceExcluded/')],
-            $this->ruleSetFactory->getIgnorePattern(['exclude-pattern']),
+            $this->ruleSetFactory->getExcludePatterns(['exclude-pattern']),
             [],
             $this->ruleSetFactory->createRuleSets(['exclude-pattern']),
             new Report()

--- a/tests/php/PHPMD/ParserFactoryTest.php
+++ b/tests/php/PHPMD/ParserFactoryTest.php
@@ -122,9 +122,9 @@ class ParserFactoryTest extends AbstractTestCase
 
         $uri = $this->createFileUri('ParserFactory/File/Test.php');
 
-        $phpmd = $this->getMockBuilder(PHPMD::class)->onlyMethods(['getIgnorePatterns', 'getInput'])->getMock();
+        $phpmd = $this->getMockBuilder(PHPMD::class)->onlyMethods(['getExcludePatterns', 'getInput'])->getMock();
         $phpmd->expects(static::exactly(2))
-            ->method('getIgnorePatterns')
+            ->method('getExcludePatterns')
             ->willReturn(['Test']);
         $phpmd->expects(static::once())
             ->method('getInput')

--- a/tests/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
+++ b/tests/php/PHPMD/Regression/AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest.php
@@ -45,7 +45,7 @@ class AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest extends AbstractR
         $inputPath = self::createFileUri('001/source');
         $phpmd->processFiles(
             [$inputPath],
-            $ruleSetFactory->getIgnorePattern(['pmd-refset1']),
+            $ruleSetFactory->getExcludePatterns(['pmd-refset1']),
             [$renderer],
             $ruleSetFactory->createRuleSets(['pmd-refset1']),
             new Report()
@@ -70,7 +70,7 @@ class AcceptsFilesAndDirectoriesAsInputTicket001RegressionTest extends AbstractR
         $inputPath = self::createFileUri('001/source/FooBar.php');
         $phpmd->processFiles(
             [$inputPath],
-            $ruleSetFactory->getIgnorePattern(['pmd-refset1']),
+            $ruleSetFactory->getExcludePatterns(['pmd-refset1']),
             [$renderer],
             $ruleSetFactory->createRuleSets(['pmd-refset1']),
             new Report()

--- a/tests/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
+++ b/tests/php/PHPMD/Regression/ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest.php
@@ -83,7 +83,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
 
         $phpmd->processFiles(
             [__DIR__ . '/Sources/ExcessivePublicCountWorksForPublicStaticMethods.php'],
-            $ruleSetFactory->getIgnorePattern(['codesize']),
+            $ruleSetFactory->getExcludePatterns(['codesize']),
             [$this->renderer],
             $ruleSetFactory->createRuleSets(['codesize']),
             new Report()
@@ -123,7 +123,7 @@ class ExcessivePublicCountWorksCorrectlyWithStaticMethodsRegressionTest extends 
             );
         $phpmd->processFiles(
             [__DIR__ . '/Sources/ExcessivePublicCountSuppressionWorksForPublicStaticMethods.php'],
-            $ruleSetFactory->getIgnorePattern(['codesize']),
+            $ruleSetFactory->getExcludePatterns(['codesize']),
             [$this->renderer],
             $ruleSetFactory->createRuleSets(['codesize']),
             new Report()

--- a/tests/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
+++ b/tests/php/PHPMD/Regression/MaximumNestingLevelTicket24975295RegressionTest.php
@@ -50,7 +50,7 @@ class MaximumNestingLevelTicket24975295RegressionTest extends AbstractRegression
         $phpmd = new PHPMD();
         $phpmd->processFiles(
             [$inputs],
-            $factory->getIgnorePattern($rules),
+            $factory->getExcludePatterns($rules),
             $renderers,
             $factory->createRuleSets($rules),
             new Report()

--- a/tests/php/PHPMD/RuleSetFactoryTest.php
+++ b/tests/php/PHPMD/RuleSetFactoryTest.php
@@ -307,7 +307,7 @@ class RuleSetFactoryTest extends AbstractTestCase
         self::changeWorkingDirectory();
 
         $factory = new RuleSetFactory();
-        $excludes = $factory->getIgnorePattern(['exclude-pattern']);
+        $excludes = $factory->getExcludePatterns(['exclude-pattern']);
 
         $expected = [
             '*sourceExcluded/*.php',
@@ -622,7 +622,7 @@ class RuleSetFactoryTest extends AbstractTestCase
                         '*sourceExcluded/*.php',
                         '*sourceExcluded\*.php',
                     ],
-                    $factory->getIgnorePattern([$path . self::DIR_UNDER_TESTS])
+                    $factory->getExcludePatterns([$path . self::DIR_UNDER_TESTS])
                 );
             } catch (RuleSetNotFoundException) {
                 $ruleSetNotFoundExceptionCount++;

--- a/tests/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/tests/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -433,7 +433,7 @@ class CommandLineOptionsTest extends AbstractTestCase
         $args = $this->createInput(['paths' => [__FILE__], '--format' => 'text', '--ruleset' => ['codesize'], '--exclude' => ['bar/biz']]);
         $opts = new CommandLineOptions($args);
 
-        static::assertSame(['bar/biz'], $opts->getIgnore());
+        static::assertSame(['bar/biz'], $opts->getExcludePatterns());
     }
 
     /**


### PR DESCRIPTION
Type: refactoring
Issue: Resolves https://github.com/phpmd/phpmd/issues/746
Breaking change: yes

A few trivial renames to match arguments and documentation rather then the deprecated names.
