### PR TITLE
Feature longparam exception

### DIFF
--- a/rulesets/codesize.xml
+++ b/rulesets/codesize.xml
@@ -165,6 +165,7 @@ wrap the numerous parameters.  Basically, try to group the parameters together.
         <priority>3</priority>
         <properties>
             <property name="minimum" description="The parameter count reporting threshold" value="10"/>
+            <property name="exceptions" description="Comma-separated list of method/function names to ignore" value=""/>
         </properties>
         <example>
             <![CDATA[

--- a/src/Rule/Design/ExcessiveParameterList.php
+++ b/src/Rule/Design/ExcessiveParameterList.php
@@ -45,6 +45,12 @@ final class ExcessiveParameterList extends AbstractRule implements FunctionAware
             return;
         }
 
+        $exceptions = $this->getExceptionsList();
+
+        if (in_array($node->getName(), $exceptions)) {
+            return;
+        }
+
         $this->addViolation(
             $node,
             [
@@ -54,5 +60,21 @@ final class ExcessiveParameterList extends AbstractRule implements FunctionAware
                 (string) $threshold,
             ]
         );
+    }
+
+    /**
+     * Gets array of exceptions from property
+     *
+     * @return array
+     */
+    private function getExceptionsList()
+    {
+        try {
+            $exceptions = $this->getStringProperty('exceptions');
+        } catch (\OutOfBoundsException $e) {
+            $exceptions = '';
+        }
+
+        return explode(',', $exceptions);
     }
 }

--- a/src/Rule/Design/ExcessiveParameterList.php
+++ b/src/Rule/Design/ExcessiveParameterList.php
@@ -18,6 +18,7 @@
 
 namespace PHPMD\Rule\Design;
 
+use OutOfBoundsException;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\AbstractCallableNode;
@@ -46,8 +47,7 @@ final class ExcessiveParameterList extends AbstractRule implements FunctionAware
         }
 
         $exceptions = $this->getExceptionsList();
-
-        if (in_array($node->getName(), $exceptions)) {
+        if (in_array($node->getName(), $exceptions, true)) {
             return;
         }
 
@@ -65,16 +65,13 @@ final class ExcessiveParameterList extends AbstractRule implements FunctionAware
     /**
      * Gets array of exceptions from property
      *
-     * @return array
+     * @return array<string>
+     * @throws OutOfBoundsException
      */
-    private function getExceptionsList()
+    private function getExceptionsList(): array
     {
-        try {
-            $exceptions = $this->getStringProperty('exceptions');
-        } catch (\OutOfBoundsException $e) {
-            $exceptions = '';
-        }
+        $exceptions = $this->getStringProperty('exceptions', '');
 
-        return explode(',', $exceptions);
+        return array_filter(array_map('trim', explode(',', $exceptions)));
     }
 }

--- a/tests/php/PHPMD/Rule/Design/ExcessiveParameterListTest.php
+++ b/tests/php/PHPMD/Rule/Design/ExcessiveParameterListTest.php
@@ -79,6 +79,65 @@ class ExcessiveParameterListTest extends AbstractTestCase
     }
 
     /**
+     * testApplyIgnoresMethodInExceptionsList
+     */
+    public function testApplyIgnoresMethodInExceptionsList(): void
+    {
+        $method = $this->getMethodMock();
+        $method->method('getParameterCount')->willReturn(3);
+        $method->method('getName')->willReturn('fooBar');
+
+        $rule = new ExcessiveParameterList();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->addProperty('minimum', '3');
+        $rule->addProperty('exceptions', 'fooBar');
+        $rule->apply($method);
+    }
+
+    /**
+     * testApplyReportsMethodNotInExceptionsList
+     */
+    public function testApplyReportsMethodNotInExceptionsList(): void
+    {
+        $method = $this->getMethodMock();
+        $method->method('getParameterCount')->willReturn(3);
+        $method->method('getName')->willReturn('fooBar');
+
+        $rule = new ExcessiveParameterList();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('minimum', '3');
+        $rule->addProperty('exceptions', 'otherMethod');
+        $rule->apply($method);
+    }
+
+    /**
+     * testApplyIgnoresFunctionInExceptionsList
+     */
+    public function testApplyIgnoresFunctionInExceptionsList(): void
+    {
+        $function = $this->createFunctionMock();
+        $function->method('getParameterCount')->willReturn(3);
+        $function->method('getName')->willReturn('fooBar');
+
+        $rule = new ExcessiveParameterList();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->addProperty('minimum', '3');
+        $rule->addProperty('exceptions', 'fooBar');
+        $rule->apply($function);
+    }
+
+    /**
+     * testApplyReportsMethodWhenExceptionsPropertyNotSet
+     */
+    public function testApplyReportsMethodWhenExceptionsPropertyNotSet(): void
+    {
+        $rule = new ExcessiveParameterList();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('minimum', '3');
+        $rule->apply($this->createMethod(3));
+    }
+
+    /**
      * Returns a mocked method instance.
      */
     private function createMethod(int $parameterCount): MethodNode


### PR DESCRIPTION
Type: feature
Breaking change: no

Rebase of: https://github.com/phpmd/phpmd/pull/559

> I took inspiration/code from the [ShortVariable](https://github.com/phpmd/phpmd/blob/master/src/main/php/PHPMD/Rule/Naming/ShortVariable.php#L122) rule which already had an exception list property and added it to the LongParameterList rule.
