### PR TITLE
Add CLI shim for legacy positional arguments

### DIFF
--- a/bin/phpmd
+++ b/bin/phpmd
@@ -46,6 +46,23 @@ if (!ini_get('date.timezone')) {
 
 ini_set('memory_limit', -1);
 
+// Compatibility shim for PhpStorm and other tools that use the old CLI interface:
+// phpmd <file> xml <ruleset>
+if (
+    isset($argv[1], $argv[2], $argv[3])
+    && $argv[2] === 'xml'
+    && $argv[1] !== 'analyze'
+    && !str_starts_with($argv[1], '-')
+) {
+    fwrite(STDERR, 'Deprecated: positional arguments are deprecated, use "phpmd analyze <file> --format xml --ruleset <ruleset>" instead.' . PHP_EOL);
+    $rulesets = [];
+    foreach (explode(',', $argv[3]) as $ruleset) {
+        $rulesets[] = '--ruleset';
+        $rulesets[] = $ruleset;
+    }
+    $argv = [$argv[0], 'analyze', $argv[1], '--format', 'xml', '--no-progress', ...$rulesets];
+    $_SERVER['argv'] = $argv;
+}
 $application = new Application('PHPMD', Command::getVersion());
 $command = new Command();
 if (method_exists($application, 'addCommand')) {


### PR DESCRIPTION
Type: bugfix / feature / refactoring
Breaking change: no

> If the mountain will not come to Muhammad, then Muhammad must go to the mountain

This lets us stay compatible with the positional arguments as used by PhpStorm meaning that intergration won't break even if they do not adapt to the 3.x Symfony style CLI.

The adapter is narrow in scope only triggering for `xml` output when the `analyzer` command isn't used and 3 arguments are given.

It also emits a warning that CLI format is deprecated to cokes people to update things.

Since JetBrain was nice enough to leave me with a licens for testing I was able to see what they actually call and test that this works in reality.