### PR TITLE
Update codesize ruleset to ignore 'test' methods and add test

### DIFF
--- a/rulesets/codesize.xml
+++ b/rulesets/codesize.xml
@@ -340,7 +340,7 @@ public class Foo extends Bar {
 A class with too many methods is probably a good suspect for refactoring, in
 order to reduce its complexity and find a way to have more fine grained objects.
 
-By default it ignores methods starting with 'get' or 'set'.
+By default it ignores methods starting with 'get', 'set', 'is', 'has', 'with', or 'test'.
 
 The default was changed from 10 to 25 in PHPMD 2.3.
             ]]>
@@ -348,7 +348,7 @@ The default was changed from 10 to 25 in PHPMD 2.3.
         <priority>3</priority>
         <properties>
             <property name="maxmethods" description="The method count reporting threshold" value="25"/>
-            <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get|is|has|with))i"/>
+            <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get|is|has|with|test))i"/>
         </properties>
     </rule>
 
@@ -362,13 +362,13 @@ The default was changed from 10 to 25 in PHPMD 2.3.
 A class with too many public methods is probably a good suspect for refactoring, in
 order to reduce its complexity and find a way to have more fine grained objects.
 
-By default it ignores methods starting with 'get' or 'set'.
+By default it ignores methods starting with 'get', 'set', 'is', 'has', 'with', or 'test'.
             ]]>
         </description>
         <priority>3</priority>
         <properties>
             <property name="maxmethods" description="The method count reporting threshold" value="10"/>
-            <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get|is|has|with))i"/>
+            <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get|is|has|with|test))i"/>
         </properties>
     </rule>
 

--- a/tests/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -131,6 +131,15 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(2, ['invoke', 'withClass']));
     }
 
+    public function testRuleIgnoresTestMethodsInTestClasses(): void
+    {
+        $rule = new TooManyPublicMethods();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('ignorepattern', '(^(set|get|is|has|with|test))i');
+        $rule->apply($this->createClassMock(2, ['invoke', 'testMyFeature']));
+    }
+
     public function testRuleApplyToBasicClass(): void
     {
         $class = $this->getClass();


### PR DESCRIPTION
Type: feature / documentation update
Issue: Resolves https://github.com/phpmd/phpmd/issues/503
Breaking change: yes

This simply adds test as a pattern that the rule ignores, the argument for having this as the default behavior is reasonable but changing it at a random update would probably be seen as disruptive to users so 3.x seems the right time mand place.