### PR TITLE
Fix errors for file aren't detected if they arise without touching the file with cache enabled

### DIFF
--- a/src/Cache/Model/ResultCacheState.php
+++ b/src/Cache/Model/ResultCacheState.php
@@ -4,6 +4,7 @@ namespace PHPMD\Cache\Model;
 
 use OutOfBoundsException;
 use PHPMD\Node\NodeInfo;
+use PHPMD\ProcessingError;
 use PHPMD\Rule;
 use PHPMD\RuleSet;
 use PHPMD\RuleViolation;
@@ -12,7 +13,7 @@ use PHPMD\Utility\Paths;
 class ResultCacheState
 {
     /**
-     * @param array{files?: array<string, array{hash: string, violations?: list<array{
+     * @param array{files?: array<string, array{hash: string, errors?: list<string>, violations?: list<array{
      *  metric: mixed,
      *  namespaceName: ?string,
      *  className: ?string,
@@ -76,6 +77,47 @@ class ResultCacheState
     public function setViolations(string $filePath, array $violations): void
     {
         $this->state['files'][$filePath]['violations'] = $violations;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getErrors(string $filePath): array
+    {
+        return $this->state['files'][$filePath]['errors'] ?? [];
+    }
+
+    /**
+     * @param list<string> $errors
+     */
+    public function setErrors(string $filePath, array $errors): void
+    {
+        if ($errors === []) {
+            return;
+        }
+
+        $this->state['files'][$filePath]['errors'] = $errors;
+    }
+
+    public function addError(string $filePath, ProcessingError $error): void
+    {
+        $this->state['files'][$filePath]['errors'][] = $error->getMessage();
+    }
+
+    /**
+     * @return list<ProcessingError>
+     */
+    public function getProcessingErrors(): array
+    {
+        $errors = [];
+
+        foreach ($this->state['files'] ?? [] as $file) {
+            foreach ($file['errors'] ?? [] as $message) {
+                $errors[] = new ProcessingError($message);
+            }
+        }
+
+        return $errors;
     }
 
     public function addRuleViolation(string $filePath, RuleViolation $violation): void

--- a/src/Cache/ResultCacheFileFilter.php
+++ b/src/Cache/ResultCacheFileFilter.php
@@ -53,8 +53,9 @@ class ResultCacheFileFilter implements Filter
             $this->newState->setFileState($filePath, $hash);
         }
         if (!$isModified && $this->state) {
-            // File was not modified, transfer previous violations
+            // File was not modified, transfer previous violations and processing errors
             $this->newState->setViolations($filePath, $this->state->getViolations($filePath));
+            $this->newState->setErrors($filePath, $this->state->getErrors($filePath));
         }
 
         if ($isModified) {

--- a/src/Cache/ResultCacheStateFactory.php
+++ b/src/Cache/ResultCacheStateFactory.php
@@ -30,7 +30,7 @@ class ResultCacheStateFactory
             return null;
         }
 
-        /** @var array{files?: array<string, array{hash: string, violations?: list<array{metric: mixed, namespaceName: ?string, className: ?string, methodName: ?string, functionName: ?string, description: string, beginLine: int, endLine: int, rule: string, args: ?array<int, string>}>}>} */
+        /** @var array{files?: array<string, array{hash: string, errors?: list<string>, violations?: list<array{metric: mixed, namespaceName: ?string, className: ?string, methodName: ?string, functionName: ?string, description: string, beginLine: int, endLine: int, rule: string, args: ?array<int, string>}>}>} */
         $state = $resultCache['state'];
 
         return new ResultCacheState($cacheKey, $state);

--- a/src/Cache/ResultCacheUpdater.php
+++ b/src/Cache/ResultCacheUpdater.php
@@ -23,8 +23,9 @@ class ResultCacheUpdater
      */
     public function update(array $ruleSetList, ResultCacheState $state, Report $report): ResultCacheState
     {
-        // grab a copy of the new violations
+        // grab a copy of the new violations and processing errors
         $newViolations = $report->getRuleViolations();
+        $newErrors = $report->getErrors();
 
         // add RuleViolations from the result cache to the report
         $violationsFromCache = 0;
@@ -34,18 +35,38 @@ class ResultCacheUpdater
             ++$violationsFromCache;
         }
 
+        // add ProcessingErrors from the result cache to the report
+        $errorsFromCache = 0;
+
+        foreach ($state->getProcessingErrors() as $error) {
+            $report->addError($error);
+            ++$errorsFromCache;
+        }
+
         // add violations from the report to the result cache
         foreach ($newViolations as $violation) {
             $filePath = Paths::getRelativePath($this->basePath, (string) $violation->getFileName());
             $state->addRuleViolation($filePath, $violation);
         }
 
+        // add processing errors from the report to the result cache
+        foreach ($newErrors as $error) {
+            // errors that cannot be attributed to a file cannot be restored from cache and are not stored
+            if ($error->getFile() === '') {
+                continue;
+            }
+            $filePath = Paths::getRelativePath($this->basePath, $error->getFile());
+            $state->addError($filePath, $error);
+        }
+
         $this->output->writeln(
-            'Cache: added ' . count($newViolations) . ' violations to the result cache.',
+            'Cache: added ' . count($newViolations) . ' violations and ' . count($newErrors)
+            . ' errors to the result cache.',
             OutputInterface::VERBOSITY_VERY_VERBOSE
         );
         $this->output->writeln(
-            'Cache: added ' . $violationsFromCache . ' violations from the result cache to the report.',
+            'Cache: added ' . $violationsFromCache . ' violations and ' . $errorsFromCache
+            . ' errors from the result cache to the report.',
             OutputInterface::VERBOSITY_VERY_VERBOSE
         );
 

--- a/tests/php/PHPMD/Cache/Model/ResultCacheStateTest.php
+++ b/tests/php/PHPMD/Cache/Model/ResultCacheStateTest.php
@@ -2,7 +2,9 @@
 
 namespace PHPMD\Cache\Model;
 
+use OutOfBoundsException;
 use PHPMD\Node\NodeInfo;
+use PHPMD\ProcessingError;
 use PHPMD\Rule\CleanCode\BooleanArgumentFlag;
 use PHPMD\RuleSet;
 use PHPMD\RuleViolation;
@@ -56,6 +58,74 @@ class ResultCacheStateTest extends TestCase
 
         $this->state->setViolations('/file/path', $violations);
         static::assertSame($violations, $this->state->getViolations('/file/path'));
+    }
+
+    /**
+     * @covers ::getErrors
+     * @covers ::setErrors
+     */
+    public function testGetSetErrors(): void
+    {
+        $errors = ['Unexpected end of token stream in file: /file/path.'];
+
+        static::assertCount(0, $this->state->getErrors('/file/path'));
+
+        $this->state->setErrors('/file/path', $errors);
+        static::assertSame($errors, $this->state->getErrors('/file/path'));
+    }
+
+    /**
+     * @covers ::addError
+     * @covers ::getErrors
+     * @covers ::getProcessingErrors
+     */
+    public function testAddErrorAndGetProcessingErrors(): void
+    {
+        $error = new ProcessingError('Unexpected end of token stream in file: /file/path.');
+
+        static::assertCount(0, $this->state->getProcessingErrors());
+
+        $this->state->addError('/file/path', $error);
+        static::assertSame([$error->getMessage()], $this->state->getErrors('/file/path'));
+
+        $errors = $this->state->getProcessingErrors();
+        static::assertCount(1, $errors);
+        static::assertSame($error->getMessage(), $errors[0]->getMessage());
+        static::assertSame('/file/path', $errors[0]->getFile());
+    }
+
+    /**
+     * @covers ::addError
+     * @covers ::toArray
+     */
+    public function testToArrayWithErrors(): void
+    {
+        $error = new ProcessingError('Unexpected end of token stream in file: /file/path.');
+
+        $this->state->setFileState('/file/path', 'hash');
+        $this->state->addError('/file/path', $error);
+
+        $expected = [
+            'key' => [
+                'strict' => true,
+                'baselineHash' => 'baseline',
+                'rules' => [],
+                'composer' => [],
+                'phpVersion' => 123,
+            ],
+            'state' => [
+                'files' => [
+                    '/file/path' => [
+                        'hash' => 'hash',
+                        'errors' => [
+                            'Unexpected end of token stream in file: /file/path.',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        static::assertSame($expected, $this->state->toArray());
     }
 
     /**
@@ -180,6 +250,50 @@ class ResultCacheStateTest extends TestCase
         $violations = $this->state->getRuleViolations('', [$ruleSet]);
         static::assertCount(1, $violations);
         static::assertEquals($ruleViolation, $violations[0]);
+    }
+
+    /**
+     * @covers ::getRuleViolations
+     */
+    public function testGetRuleViolationsWithEmptyState(): void
+    {
+        static::assertSame([], $this->state->getRuleViolations('', []));
+    }
+
+    /**
+     * @covers ::getRuleViolations
+     */
+    public function testGetRuleViolationsSkipsFilesWithoutViolations(): void
+    {
+        $this->state->setFileState('/file/path', 'hash');
+        $this->state->addError('/file/path', new ProcessingError('Failure in file: /file/path.'));
+
+        static::assertSame([], $this->state->getRuleViolations('', []));
+    }
+
+    /**
+     * @covers ::findRuleIn
+     * @covers ::getRuleViolations
+     */
+    public function testGetRuleViolationsWithUnknownRuleThrowsException(): void
+    {
+        $rule = new BooleanArgumentFlag();
+        $nodeInfo = new NodeInfo(
+            '/file/path',
+            'namespace',
+            'className',
+            'methodName',
+            'functionName',
+            123,
+            456
+        );
+
+        $ruleViolation = new RuleViolation($rule, $nodeInfo, 'violation', 100);
+        $this->state->addRuleViolation('/file/path', $ruleViolation);
+
+        self::expectException(OutOfBoundsException::class);
+
+        $this->state->getRuleViolations('', [new RuleSet()]);
     }
 
     /**

--- a/tests/php/PHPMD/Cache/ResultCacheFileFilterTest.php
+++ b/tests/php/PHPMD/Cache/ResultCacheFileFilterTest.php
@@ -56,6 +56,7 @@ class ResultCacheFileFilterTest extends AbstractTestCase
 
         $this->state->expects(static::once())->method('isFileModified')->willReturn(false);
         $this->state->expects(static::once())->method('getViolations')->willReturn(['violations']);
+        $this->state->expects(static::once())->method('getErrors')->willReturn(['error message']);
 
         static::assertFalse($filter->accept('ResultCacheFileFilterTest.php', __FILE__));
         $state = $filter->getState()->toArray();
@@ -63,6 +64,10 @@ class ResultCacheFileFilterTest extends AbstractTestCase
         static::assertIsArray($state['state']['files']['ResultCacheFileFilterTest.php']);
         static::assertIsArray($state['state']['files']['ResultCacheFileFilterTest.php']['violations']);
         static::assertCount(1, $state['state']['files']['ResultCacheFileFilterTest.php']['violations']);
+        static::assertSame(
+            ['error message'],
+            $state['state']['files']['ResultCacheFileFilterTest.php']['errors']
+        );
     }
 
     /**

--- a/tests/php/PHPMD/Cache/ResultCacheUpdaterTest.php
+++ b/tests/php/PHPMD/Cache/ResultCacheUpdaterTest.php
@@ -5,6 +5,7 @@ namespace PHPMD\Cache;
 use ArrayIterator;
 use PHPMD\AbstractTestCase;
 use PHPMD\Cache\Model\ResultCacheState;
+use PHPMD\ProcessingError;
 use PHPMD\RuleSet;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Output\NullOutput;
@@ -36,20 +37,52 @@ class ResultCacheUpdaterTest extends AbstractTestCase
         $report = $this->getReportMock();
         $violationA = $this->getRuleViolationMock('/base/path/violation/a');
         $violationB = $this->getRuleViolationMock('/base/path/violation/b');
+        $errorA = new ProcessingError('Error in file "/base/path/error/a"');
+        $errorB = new ProcessingError('Error in file "/base/path/error/b"');
 
         $report->expects(static::once())->method('getRuleViolations')->willReturn(new ArrayIterator([$violationA]));
+        $report->expects(static::once())->method('getErrors')->willReturn(new ArrayIterator([$errorA]));
         $this->state->expects(static::once())
             ->method('getRuleViolations')
             ->with('/base/path/', [$ruleSet])
             ->willReturn([$violationB]);
+        $this->state->expects(static::once())
+            ->method('getProcessingErrors')
+            ->willReturn([$errorB]);
 
         // expect ViolationB be added to the report
         $report->expects(static::once())->method('addRuleViolation')->with($violationB);
 
+        // expect ErrorB be added to the report
+        $report->expects(static::once())->method('addError')->with($errorB);
+
         // expect ViolationA be added to the state
         $this->state->expects(static::once())->method('addRuleViolation')->with('violation/a', $violationA);
 
+        // expect ErrorA be added to the state
+        $this->state->expects(static::once())->method('addError')->with('error/a', $errorA);
+
         $state = $this->updater->update([$ruleSet], $this->state, $report);
         static::assertSame($this->state, $state);
+    }
+
+    /**
+     * @covers ::update
+     */
+    public function testUpdateShouldNotCacheErrorsWithoutFile(): void
+    {
+        $ruleSet = new RuleSet();
+        $report = $this->getReportWithNoViolation();
+        $error = new ProcessingError('Error without any file reference');
+
+        $report->expects(static::once())->method('getRuleViolations')->willReturn(new ArrayIterator([]));
+        $report->expects(static::once())->method('getErrors')->willReturn(new ArrayIterator([$error]));
+        $this->state->expects(static::once())->method('getRuleViolations')->willReturn([]);
+        $this->state->expects(static::once())->method('getProcessingErrors')->willReturn([]);
+
+        // expect the error not to be added to the state, as it cannot be attributed to a file
+        $this->state->expects(static::never())->method('addError');
+
+        $this->updater->update([$ruleSet], $this->state, $report);
     }
 }


### PR DESCRIPTION
Type: bugfix
Issue: https://github.com/phpmd/phpmd/issues/1198
Breaking change: no

This PR fixes the result cache dropping processing errors (PDepend parse errors, for example "Unexpected end of token stream") on cached runs.

Before this change, a file that produced a processing error and was not modified between two runs was skipped by the cache on the second run, and the error silently disappeared from the report. Only rule violations were persisted and restored.

Why this happened:
- `ResultCacheState` only stored the violations of each file, so processing errors had no representation in the cache file.
- `ResultCacheFileFilter` transferred only the cached violations for unmodified files.
- `ResultCacheUpdater` only exchanged violations between the report and the cache state.

What changed:

- `ResultCacheState` gains an optional errors key (a list of error messages) in the per-file state, with `getErrors()`, `setErrors()`, `addError()` and `getProcessingErrors()`. The `ProcessingError` objects are rebuilt from the stored messages; the file path is re-extracted by the existing `ProcessingError::extractFile()`. `setErrors()` writes nothing for an empty list, so cache files without errors keep the exact same format.
- `ResultCacheFileFilter` transfers the cached errors of unmodified files to the new state, next to the violations.
- `ResultCacheUpdater` restores cached errors into the report and stores the report's new errors into the cache, symmetrically to violations. Errors that cannot be attributed to a file (`getFile()` returns an empty string) are reported normally in the current run but are not cached, because they cannot be keyed to a cache entry. The very-verbose cache messages now include the error counts.
- `ResultCacheStateFactory` updates the PHPDoc array shape with the optional errors key. Existing cache files stay valid, no cache version bump is needed.

Tests added:

- `ResultCacheStateTest`: get/set/add of errors, rebuilding `ProcessingError` objects from the state, and the `toArray()` serialization with errors.
- `ResultCacheFileFilterTest`: cached errors are transferred for unmodified files.
- `ResultCacheUpdaterTest`: errors round-trip between report and cache, and errors without a file reference are never cached.

Validation:

- New tests fail without the fix (6 errors), pass with the fix.
- Full suite passes (858 tests, 2518 assertions).