### PR TITLE
Fix/1239 short variable

### DIFF
--- a/src/Rule/Naming/ShortVariable.php
+++ b/src/Rule/Naming/ShortVariable.php
@@ -19,6 +19,7 @@
 namespace PHPMD\Rule\Naming;
 
 use PDepend\Source\AST\ASTCatchStatement;
+use PDepend\Source\AST\ASTClosure;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTForeachStatement;
 use PDepend\Source\AST\ASTForInit;
@@ -174,7 +175,35 @@ final class ShortVariable extends AbstractRule implements ClassAware, FunctionAw
 
         return $this->isChildOf($node, ASTCatchStatement::class)
             || $this->isChildOf($node, ASTForInit::class)
-            || $this->isChildOf($node, ASTMemberPrimaryPrefix::class);
+            || $this->isPartOfMemberPrimaryPrefix($node);
+    }
+
+    /**
+     * Checks if the given node is part of a member access chain, like the
+     * property name in a static property access. Nodes inside a closure or
+     * arrow function that is itself passed as an argument within such a
+     * chain are not part of it, so their parameters and local variables
+     * are still checked.
+     *
+     * @param AbstractNode<ASTNode> $node
+     */
+    private function isPartOfMemberPrimaryPrefix(AbstractNode $node): bool
+    {
+        $parent = $node->getParent();
+
+        while ($parent) {
+            if ($parent->isInstanceOf(ASTMemberPrimaryPrefix::class)) {
+                return true;
+            }
+
+            if ($parent->isInstanceOf(ASTClosure::class)) {
+                return false;
+            }
+
+            $parent = $parent->getParent();
+        }
+
+        return false;
     }
 
     /**

--- a/tests/php/PHPMD/Rule/Naming/ShortVariableTest.php
+++ b/tests/php/PHPMD/Rule/Naming/ShortVariableTest.php
@@ -217,6 +217,33 @@ class ShortVariableTest extends AbstractTestCase
         $rule->apply($this->getMethod());
     }
 
+    public function testRuleAppliesToClosureParameterPassedAsMethodArgument(): void
+    {
+        $rule = new ShortVariable();
+        $rule->addProperty('minimum', '3');
+        $rule->addProperty('exceptions', '');
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getMethod());
+    }
+
+    public function testRuleAppliesToArrowFunctionParameterPassedAsMethodArgument(): void
+    {
+        $rule = new ShortVariable();
+        $rule->addProperty('minimum', '3');
+        $rule->addProperty('exceptions', '');
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getMethod());
+    }
+
+    public function testRuleNotAppliesToStaticMemberAccessedInClosurePassedAsMethodArgument(): void
+    {
+        $rule = new ShortVariable();
+        $rule->addProperty('minimum', '3');
+        $rule->addProperty('exceptions', '');
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getMethod());
+    }
+
     public function testRuleAppliesToIdenticalVariableOnlyOneTime(): void
     {
         $rule = new ShortVariable();

--- a/tests/resources/files/Rule/Naming/ShortVariable/testRuleAppliesToArrowFunctionParameterPassedAsMethodArgument.php
+++ b/tests/resources/files/Rule/Naming/ShortVariable/testRuleAppliesToArrowFunctionParameterPassedAsMethodArgument.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleAppliesToArrowFunctionParameterPassedAsMethodArgument
+{
+    public function acceptsCallback(callable $callback)
+    {
+        return $callback('hi');
+    }
+
+    public function testRuleAppliesToArrowFunctionParameterPassedAsMethodArgument()
+    {
+        return $this->acceptsCallback(fn ($fo) => $fo);
+    }
+}

--- a/tests/resources/files/Rule/Naming/ShortVariable/testRuleAppliesToClosureParameterPassedAsMethodArgument.php
+++ b/tests/resources/files/Rule/Naming/ShortVariable/testRuleAppliesToClosureParameterPassedAsMethodArgument.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleAppliesToClosureParameterPassedAsMethodArgument
+{
+    public function acceptsCallback(callable $callback)
+    {
+        return $callback('hi');
+    }
+
+    public function testRuleAppliesToClosureParameterPassedAsMethodArgument()
+    {
+        return $this->acceptsCallback(function ($fo) {
+            return $fo;
+        });
+    }
+}

--- a/tests/resources/files/Rule/Naming/ShortVariable/testRuleNotAppliesToStaticMemberAccessedInClosurePassedAsMethodArgument.php
+++ b/tests/resources/files/Rule/Naming/ShortVariable/testRuleNotAppliesToStaticMemberAccessedInClosurePassedAsMethodArgument.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleNotAppliesToStaticMemberAccessedInClosurePassedAsMethodArgument
+{
+    private static $fo = 42;
+
+    public function acceptsCallback(callable $callback)
+    {
+        return $callback();
+    }
+
+    public function testRuleNotAppliesToStaticMemberAccessedInClosurePassedAsMethodArgument()
+    {
+        return $this->acceptsCallback(function () {
+            return self::$fo;
+        });
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: https://github.com/phpmd/phpmd/issues/1239
Breaking change: no

This PR fixes the ShortVariable rule not detecting short variable names inside closures and arrow functions that are passed directly as arguments to a method call.

Before this change, a parameter like `$b` in `$this->acceptsCallback(function ($b) { return $b; })` was silently accepted, while the same closure assigned to a variable first was correctly flagged.

Why this happened:

- The rule exempts variables that are part of a member access chain (for example, the property name in `self::$fo`), so that such names are not treated as local variables.
- This exemption used `isChildOf($node, ASTMemberPrimaryPrefix::class)`, which walks up the ancestor chain without any boundary.
- A closure passed as an argument to `$this->acceptsCallback(...)` is nested inside the `ASTMemberPrimaryPrefix` node of that call, so every variable inside the closure body matched the exemption and was skipped.

What changed:

- `ShortVariable` gains a private `isPartOfMemberPrimaryPrefix()` method that replaces the unbounded `isChildOf()` check. It walks up the parents but stops at the first `ASTClosure` boundary: a variable that lives inside a closure body is not part of the enclosing member access chain, so it is still checked. Variables whose member access parent is found before any closure boundary (such as `self::$fo`, including inside a closure body) keep the existing exemption.

Tests added:

- `testRuleAppliesToClosureParameterPassedAsMethodArgument`: a short closure parameter passed directly as a method argument is now reported.
- `testRuleAppliesToArrowFunctionParameterPassedAsMethodArgument`: the same fix covers arrow functions, which PDepend also represents as `ASTClosure`.
- `testRuleNotAppliesToStaticMemberAccessedInClosurePassedAsMethodArgument`: a static property access like `self::$fo` inside such a closure is still exempted, preserving the original behavior the exemption exists for.

Validation:

- The two new applied tests fail without the fix, pass with it.
- Full suite passes (862 tests, 2531 assertions).