### PR TITLE
Fix legacy CLI shim only handles xml, breaking GrumPHP

### DIFF
--- a/bin/phpmd
+++ b/bin/phpmd
@@ -17,6 +17,7 @@
  */
 
 use PHPMD\TextUI\Command;
+use PHPMD\TextUI\LegacyArguments;
 use PHPMD\TextUI\XdebugOptionHandler;
 use PHPMD\TextUI\PdependWorkerCommand;
 use Symfony\Component\Console\Application;
@@ -47,21 +48,11 @@ if (!ini_get('date.timezone')) {
 
 ini_set('memory_limit', -1);
 
-// Compatibility shim for PhpStorm and other tools that use the old CLI interface:
-// phpmd <file> xml <ruleset>
-if (
-    isset($argv[1], $argv[2], $argv[3])
-    && $argv[2] === 'xml'
-    && $argv[1] !== 'analyze'
-    && !str_starts_with($argv[1], '-')
-) {
-    fwrite(STDERR, 'Deprecated: positional arguments are deprecated, use "phpmd analyze <file> --format xml --ruleset <ruleset>" instead.' . PHP_EOL);
-    $rulesets = [];
-    foreach (explode(',', $argv[3]) as $ruleset) {
-        $rulesets[] = '--ruleset';
-        $rulesets[] = $ruleset;
-    }
-    $argv = [$argv[0], 'analyze', $argv[1], '--format', 'xml', '--no-progress', ...$rulesets];
+// Compatibility shim for GrumPHP, PhpStorm and other tools that use the old CLI interface:
+// phpmd <file>,... <format> <ruleset>,... [--exclude <patterns>] [--suffixes <suffixes>] [...]
+if (LegacyArguments::isLegacyInvocation($argv)) {
+    fwrite(STDERR, LegacyArguments::deprecationMessage($argv));
+    $argv = LegacyArguments::transform($argv);
     $_SERVER['argv'] = $argv;
 }
 $application = new Application('PHPMD', Command::getVersion());

--- a/src/TextUI/LegacyArguments.php
+++ b/src/TextUI/LegacyArguments.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\TextUI;
+
+/**
+ * Compatibility shim for GrumPHP, PhpStorm and other tools that still call PHPMD
+ * with the pre-3.x positional command line:
+ *
+ * phpmd <file>,... <format> <ruleset>,... [--exclude <patterns>] [--suffixes <suffixes>] [...]
+ *
+ * The arguments are rewritten into the current "analyze" sub-command invocation.
+ */
+final class LegacyArguments
+{
+    /**
+     * Renderer formats accepted in the second positional argument.
+     *
+     * @var list<string>
+     */
+    private const FORMATS = [
+        'ansi',
+        'checkstyle',
+        'github',
+        'githubcheckruns',
+        'gitlab',
+        'html',
+        'json',
+        'sarif',
+        'text',
+        'xml',
+    ];
+
+    /**
+     * Options whose comma-separated value is expanded into repeated options.
+     *
+     * @var list<string>
+     */
+    private const REPEATABLE_OPTIONS = ['--exclude', '--suffixes'];
+
+    /**
+     * Tells whether the given arguments use the legacy positional command line.
+     *
+     * @param list<string> $argv
+     */
+    public static function isLegacyInvocation(array $argv): bool
+    {
+        return isset($argv[1], $argv[2], $argv[3])
+            && in_array($argv[2], self::FORMATS, true)
+            && $argv[1] !== 'analyze'
+            && !str_starts_with($argv[1], '-')
+            && !str_starts_with($argv[3], '-');
+    }
+
+    /**
+     * Rewrites legacy positional arguments into an "analyze" sub-command invocation.
+     *
+     * The comma-separated file list becomes separate path arguments, each ruleset
+     * becomes a repeated "--ruleset" option, and the comma-separated values of any
+     * trailing "--exclude" / "--suffixes" option are expanded into repeated options.
+     * Every other trailing argument is passed through unchanged.
+     *
+     * @param list<string> $argv
+     * @return list<string>
+     */
+    public static function transform(array $argv): array
+    {
+        $newArgv = [$argv[0], 'analyze', ...explode(',', $argv[1]), '--format', $argv[2], '--no-progress'];
+
+        foreach (explode(',', $argv[3]) as $ruleset) {
+            $newArgv[] = '--ruleset';
+            $newArgv[] = $ruleset;
+        }
+
+        for ($i = 4, $argc = count($argv); $i < $argc; $i++) {
+            if (in_array($argv[$i], self::REPEATABLE_OPTIONS, true) && isset($argv[$i + 1])) {
+                foreach (explode(',', $argv[$i + 1]) as $value) {
+                    $newArgv[] = $argv[$i];
+                    $newArgv[] = $value;
+                }
+                $i++;
+
+                continue;
+            }
+            $newArgv[] = $argv[$i];
+        }
+
+        return $newArgv;
+    }
+
+    /**
+     * Builds the deprecation notice printed for a legacy invocation.
+     *
+     * @param list<string> $argv
+     */
+    public static function deprecationMessage(array $argv): string
+    {
+        return 'Deprecated: positional arguments are deprecated, use "phpmd analyze <file> --format '
+            . $argv[2] . ' --ruleset <ruleset>" instead.' . PHP_EOL;
+    }
+}

--- a/tests/php/PHPMD/TextUI/LegacyArgumentsTest.php
+++ b/tests/php/PHPMD/TextUI/LegacyArgumentsTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace PHPMD\TextUI;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \PHPMD\TextUI\LegacyArguments
+ */
+class LegacyArgumentsTest extends TestCase
+{
+    /**
+     * @covers ::isLegacyInvocation
+     */
+    public function testIsLegacyInvocationAcceptsEveryRendererFormat(): void
+    {
+        $formats = [
+            'ansi', 'checkstyle', 'github', 'githubcheckruns', 'gitlab',
+            'html', 'json', 'sarif', 'text', 'xml',
+        ];
+
+        foreach ($formats as $format) {
+            static::assertTrue(
+                LegacyArguments::isLegacyInvocation(['phpmd', 'src/', $format, 'cleancode']),
+                sprintf('Format "%s" should be recognized as a legacy invocation', $format)
+            );
+        }
+    }
+
+    /**
+     * @covers ::isLegacyInvocation
+     */
+    public function testIsLegacyInvocationRejectsUnknownFormat(): void
+    {
+        static::assertFalse(LegacyArguments::isLegacyInvocation(['phpmd', 'src/', 'yaml', 'cleancode']));
+    }
+
+    /**
+     * @covers ::isLegacyInvocation
+     */
+    public function testIsLegacyInvocationRejectsAnalyzeSubCommand(): void
+    {
+        static::assertFalse(LegacyArguments::isLegacyInvocation(['phpmd', 'analyze', 'text', 'cleancode']));
+    }
+
+    /**
+     * @covers ::isLegacyInvocation
+     */
+    public function testIsLegacyInvocationRejectsOptionAsFirstArgument(): void
+    {
+        static::assertFalse(LegacyArguments::isLegacyInvocation(['phpmd', '--version', 'text', 'cleancode']));
+    }
+
+    /**
+     * @covers ::isLegacyInvocation
+     */
+    public function testIsLegacyInvocationRejectsOptionAsRulesetArgument(): void
+    {
+        static::assertFalse(LegacyArguments::isLegacyInvocation(['phpmd', 'src/', 'text', '--help']));
+    }
+
+    /**
+     * @covers ::isLegacyInvocation
+     */
+    public function testIsLegacyInvocationRejectsTooFewArguments(): void
+    {
+        static::assertFalse(LegacyArguments::isLegacyInvocation(['phpmd', 'src/', 'text']));
+    }
+
+    /**
+     * @covers ::transform
+     */
+    public function testTransformBuildsAnalyzeInvocation(): void
+    {
+        $result = LegacyArguments::transform(['phpmd', 'src/', 'text', 'cleancode']);
+
+        static::assertSame(
+            ['phpmd', 'analyze', 'src/', '--format', 'text', '--no-progress', '--ruleset', 'cleancode'],
+            $result
+        );
+    }
+
+    /**
+     * @covers ::transform
+     */
+    public function testTransformSplitsCommaSeparatedFileList(): void
+    {
+        $result = LegacyArguments::transform(['phpmd', 'src/File.php,src/Other.php', 'text', 'cleancode']);
+
+        static::assertSame(
+            [
+                'phpmd', 'analyze', 'src/File.php', 'src/Other.php', '--format', 'text', '--no-progress',
+                '--ruleset', 'cleancode',
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @covers ::transform
+     */
+    public function testTransformExpandsEveryRulesetIntoRepeatedOption(): void
+    {
+        $result = LegacyArguments::transform(['phpmd', 'src/', 'text', 'cleancode,codesize,naming']);
+
+        static::assertSame(
+            [
+                'phpmd', 'analyze', 'src/', '--format', 'text', '--no-progress',
+                '--ruleset', 'cleancode',
+                '--ruleset', 'codesize',
+                '--ruleset', 'naming',
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @covers ::transform
+     */
+    public function testTransformExpandsCommaSeparatedExcludeAndSuffixes(): void
+    {
+        $result = LegacyArguments::transform(
+            ['phpmd', 'src/', 'text', 'cleancode', '--exclude', 'vendor,tests', '--suffixes', 'php,phtml']
+        );
+
+        static::assertSame(
+            [
+                'phpmd', 'analyze', 'src/', '--format', 'text', '--no-progress', '--ruleset', 'cleancode',
+                '--exclude', 'vendor',
+                '--exclude', 'tests',
+                '--suffixes', 'php',
+                '--suffixes', 'phtml',
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @covers ::transform
+     */
+    public function testTransformPassesUnknownTrailingArgumentsThrough(): void
+    {
+        $result = LegacyArguments::transform(
+            ['phpmd', 'src/', 'text', 'cleancode', '--strict', '--reportfile', 'out.txt']
+        );
+
+        static::assertSame(
+            [
+                'phpmd', 'analyze', 'src/', '--format', 'text', '--no-progress', '--ruleset', 'cleancode',
+                '--strict',
+                '--reportfile', 'out.txt',
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @covers ::transform
+     */
+    public function testTransformKeepsExcludeWithoutValueUnchanged(): void
+    {
+        $result = LegacyArguments::transform(['phpmd', 'src/', 'text', 'cleancode', '--exclude']);
+
+        static::assertSame(
+            ['phpmd', 'analyze', 'src/', '--format', 'text', '--no-progress', '--ruleset', 'cleancode', '--exclude'],
+            $result
+        );
+    }
+
+    /**
+     * @covers ::transform
+     */
+    public function testTransformReproducesGrumphpCommandLine(): void
+    {
+        $result = LegacyArguments::transform(
+            [
+                'phpmd', 'src/File.php,src/Other.php', 'text', 'phpmd.xml',
+                '--exclude', 'vendor,tests', '--suffixes', 'php',
+            ]
+        );
+
+        static::assertSame(
+            [
+                'phpmd', 'analyze', 'src/File.php', 'src/Other.php', '--format', 'text', '--no-progress',
+                '--ruleset', 'phpmd.xml',
+                '--exclude', 'vendor',
+                '--exclude', 'tests',
+                '--suffixes', 'php',
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @covers ::deprecationMessage
+     */
+    public function testDeprecationMessageNamesTheRequestedFormat(): void
+    {
+        $message = LegacyArguments::deprecationMessage(['phpmd', 'src/', 'checkstyle', 'cleancode']);
+
+        static::assertStringContainsString('positional arguments are deprecated', $message);
+        static::assertStringContainsString('--format checkstyle', $message);
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: Resolves #1313
Breaking change: no

## What and why

The legacy CLI shim added in #1300 only activates when the format argument is exactly `xml`. Tools that still emit the 2.x positional command line but request a different renderer never reach the shim and fail with `Command "<file list>" is not defined`.

GrumPHP's `PhpMd` task is the concrete case. It builds:

    phpmd <files> <format> <rulesets> --exclude <list> --suffixes <list>

where `<files>` and the `--exclude` / `--suffixes` values are comma-separated and `<format>` is frequently not `xml`.

This change makes the shim:

- trigger for every renderer format (`ansi`, `checkstyle`, `github`, `githubcheckruns`, `gitlab`, `html`, `json`, `sarif`, `text`, `xml`);
- split the comma-separated file list into separate path arguments;
- expand trailing `--exclude` / `--suffixes` value lists into repeated options;
- pass any other trailing arguments through unchanged.

The `xml`-only path (PhpStorm and others) behaves exactly as before, and the deprecation notice on stderr now names the actual requested format.

## Tests

The shim is extracted from `bin/phpmd` into `PHPMD\TextUI\LegacyArguments` and covered by `LegacyArgumentsTest`: the format allow-list, the comma-separated file-list split, ruleset expansion, `--exclude` / `--suffixes` expansion, passthrough of other trailing arguments, and the deprecation notice.
`bin/phpmd` now just delegates to that class.