### PR TITLE
Make common cli options configurable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@ New features:
 - Added YAML, JSON, and PHP as configuration formats in addition to XML.
 - Added configuration file auto-detection for phpmd.yml, phpmd.yaml, phpmd.json, phpmd.xml, and phpmd.php.
 - Added `exclude-pattern` support in YAML, JSON, and PHP configuration files (#909).
+- Added `format`, `cache-file`, `cache-strateg`, `baseline-file`, `bootstrap`, `cache`, `minimum-priority`, `maximum-priority`, `threads`, `paths`, and `suffixes` to the configuration files.
 - Added `#[SuppressWarnings]` PHP attribute as the preferred way to suppress warnings.
 - Added progress bar during analysis, use `--no-progress` option to hide it.
 - Added `--threads` option for parallel file parsing.
@@ -1013,4 +1014,3 @@ phpmd-0.1.0 (2009/12/20)
 ========================
 
 Initial release
-

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,8 @@ A ``phpmd.yml`` rule set file could look like this:
 
   name: My first PHPMD rule set
   description: My custom rule set that checks my code...
+  path:
+    - "src/"
   exclude-pattern:
     - "*/vendor/*"
   rules:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -52,7 +52,7 @@ Run `phpmd analyze --help` to see all available options.
 
 In addition to XML, PHPMD 3 supports rule set configuration in YAML, JSON, and PHP. YAML is the recommended format for new projects. See the [creating a custom rule set](https://phpmd.org/documentation/creating-a-ruleset.html) documentation for details.
 
-Exclude patterns can now also be configured directly in the rule set file using the `exclude-pattern` key, instead of relying on the `--exclude` CLI option.
+Common options can now be configured directly in the rule set file using the `exclude-pattern`, `format`, `cache-file`, `cache-strateg`, `baseline-file`, `bootstrap`, `cache`, `minimum-priority`, `maximum-priority`, `threads`, `paths`, and `suffixes` keys, instead of relying on the CLI option.
 
 ### Configuration file auto-detection
 

--- a/public/resources/web/xml/ruleset_xml_schema_1.0.0.xsd
+++ b/public/resources/web/xml/ruleset_xml_schema_1.0.0.xsd
@@ -9,8 +9,19 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element ref="description" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="format" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="cache-file" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="cache-strategy" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="baseline-file" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="bootstrap" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="cache" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="minimum-priority" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="maximum-priority" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="threads" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="paths" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element ref="exclude-pattern" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element ref="include-pattern" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="suffixes" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element ref="rule" minOccurs="1" maxOccurs="unbounded"/>
                 <xs:element ref="php-includepath" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>

--- a/public/rst/documentation/index.rst
+++ b/public/rst/documentation/index.rst
@@ -43,20 +43,22 @@ Command line options
 
   - ``--minimum-priority`` - The rule priority threshold; rules with lower
     priority than this will not be used.
+    Can also be configured via ``<minimum-priority>`` in the rule sets.
 
   - ``--maximum-priority`` - The rule priority threshold; rules with higher
     priority than this will not be used.
+    Can also be configured via ``<maximum-priority>`` in the rule sets.
 
   - ``--reportfile-text``, ``--reportfile-xml``, ``--reportfile-html``, etc. - Sends the report output
     to the specified file. Multiple report files in different formats can be written simultaneously.
 
   - ``--suffixes`` - Comma-separated string of valid source code filename
     extensions, e.g. php, phtml.
+    Can also be configured via ``<suffixes>`` in the rule sets.
 
   - ``--exclude`` - Comma-separated string of patterns that are used to ignore
     directories. Use asterisks to exclude by pattern. For example ``*src/foo/*.php`` or ``*src/foo/*``.
-    Exclude patterns can also be configured via ``<exclude-pattern>`` in XML rule sets,
-    or ``exclude-pattern`` in YAML, JSON, and PHP rule sets.
+    Can also be configured via ``<exclude-pattern>`` in the rule sets.
 
   - ``--strict`` - Also report those nodes with a ``#[SuppressWarnings]`` attribute.
 
@@ -69,12 +71,15 @@ Command line options
 
   - ``--cache`` - will enable the result cache. Will default to ``.phpmd.result-cache.php`` in the
     current working directory.
+    Can also be configured via ``<cache>`` in the rule sets.
 
   - ``--cache-file`` - in cooperation with ``--cache`` will override the default result cache file path of
     ``.phpmd.result-cache.php`` to the given file path.
+    Can also be configured via ``<cache-file>`` in the rule sets.
 
   - ``--cache-strategy`` - sets the caching strategy to determine if a file is still fresh. Either
     `content` to base it on the file contents, or `timestamp` to base it on the file modified timestamp.
+    Can also be configured via ``<cache-strategy>`` in the rule sets.
 
   - ``--generate-baseline`` - will generate a ``phpmd.baseline.xml`` for existing violations
     next to the ruleset definition file. The file paths of the violations will be relative to the current
@@ -86,6 +91,7 @@ Command line options
 
   -  ``--baseline-file`` - the filepath to a custom baseline xml file. If absent will
     default to ``phpmd.baseline.xml``
+    Can also be configured via ``<baseline-file>`` in the rule sets.
 
   - ``--color`` - enable color in output, for instance text renderer
     will show rule name in yellow and error description in red.
@@ -93,12 +99,14 @@ Command line options
   - ``--xdebug`` - will enable Xdebug for debugging PHP Mess Detector.
 
   - ``--bootstrap`` - an optional PHP script to load before running the analysis.
+    Can also be configured via ``<bootstrap>`` in the rule sets.
 
   - ``--input-file`` - a file containing a list of source paths to analyze (one per line).
 
   - ``--no-progress`` - do not show the progress bar, only the results.
 
   - ``--threads`` - the number of threads to use to parse the files.
+    Can also be configured via ``<threads>`` in the rule sets.
 
   - ``--coverage`` - Clover style CodeCoverage report, as produced by PHPUnit's --coverage-clover
     option.

--- a/src/RuleSetFactory.php
+++ b/src/RuleSetFactory.php
@@ -601,15 +601,201 @@ class RuleSetFactory
      *
      * http://pmd.sourceforge.net/pmd-5.0.4/howtomakearuleset.html#Excluding_files_from_a_ruleset
      *
-     * @param list<string> $fileName The filename of a rule-set definition.
+     * @param list<string> $fileNames The filename of a rule-set definition.
      * @return list<string>
      * @throws RuntimeException Thrown if file is not proper xml
      * @throws ParseException
      */
-    public function getExcludePatterns(array $fileName): array
+    public function getExcludePatterns(array $fileNames): array
     {
-        $excludes = [];
-        $files = array_map(trim(...), $fileName);
+        return $this->getArrayPropertyFromFile($fileNames, 'exclude-pattern');
+    }
+
+    /**
+     * Returns an array of paths
+     *
+     * @param list<string> $fileNames The filename of a rule-set definition.
+     * @return list<string>
+     * @throws RuntimeException Thrown if file is not proper xml
+     * @throws ParseException
+     */
+    public function getPaths(array $fileNames): array
+    {
+        return $this->getArrayPropertyFromFile($fileNames, 'paths');
+    }
+
+    /**
+     * Returns an array of suffixes
+     *
+     * @param list<string> $fileNames The filename of a rule-set definition.
+     * @return list<string>
+     * @throws RuntimeException Thrown if file is not proper xml
+     * @throws ParseException
+     */
+    public function getSuffixes(array $fileNames): array
+    {
+        return $this->getArrayPropertyFromFile($fileNames, 'suffixes');
+    }
+
+    /**
+     * @param list<string> $fileNames The filename of a rule-set definition.
+     * @throws RuntimeException Thrown if file is not proper xml
+     * @throws ParseException
+     */
+    public function getFormat(array $fileNames): ?string
+    {
+        $value = $this->getPropertyFromFile($fileNames, 'format');
+        if (!is_string($value) && $value !== null) {
+            throw new RuntimeException('Invalid format must be a string');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param list<string> $fileNames The filename of a rule-set definition.
+     * @throws RuntimeException Thrown if file is not proper xml
+     * @throws ParseException
+     */
+    public function getCacheFile(array $fileNames): ?string
+    {
+        $value = $this->getPropertyFromFile($fileNames, 'cache-file');
+        if (!is_string($value) && $value !== null) {
+            throw new RuntimeException('Invalid cache-file must be a string');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param list<string> $fileNames The filename of a rule-set definition.
+     * @throws RuntimeException Thrown if file is not proper xml
+     * @throws ParseException
+     */
+    public function getCacheStrategy(array $fileNames): ?string
+    {
+        $value = $this->getPropertyFromFile($fileNames, 'cache-strategy');
+        if (!is_string($value) && $value !== null) {
+            throw new RuntimeException('Invalid cache-strategy must be a string');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param list<string> $fileNames The filename of a rule-set definition.
+     * @throws RuntimeException Thrown if file is not proper xml
+     * @throws ParseException
+     */
+    public function getBaseLineFile(array $fileNames): ?string
+    {
+        $value = $this->getPropertyFromFile($fileNames, 'baseline-file');
+        if (!is_string($value) && $value !== null) {
+            throw new RuntimeException('Invalid baseline-file must be a string');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param list<string> $fileNames The filename of a rule-set definition.
+     * @throws RuntimeException Thrown if file is not proper xml
+     * @throws ParseException
+     */
+    public function getBoostrap(array $fileNames): ?string
+    {
+        $value = $this->getPropertyFromFile($fileNames, 'bootstrap');
+        if (!is_string($value) && $value !== null) {
+            throw new RuntimeException('Invalid bootstrap must be a string');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param list<string> $fileNames The filename of a rule-set definition.
+     * @throws RuntimeException Thrown if file is not proper xml
+     * @throws ParseException
+     */
+    public function getMinimumPriority(array $fileNames): ?int
+    {
+        $value = $this->getPropertyFromFile($fileNames, 'minimum-priority');
+        if ($value === null) {
+            return null;
+        }
+        if (!is_int($value) && !ctype_digit($value)) {
+            throw new RuntimeException('Invalid minimum-priority must be a integer');
+        }
+
+        return (int) $value;
+    }
+
+    /**
+     * @param list<string> $fileNames The filename of a rule-set definition.
+     * @throws RuntimeException Thrown if file is not proper xml
+     * @throws ParseException
+     */
+    public function getMaximumPriority(array $fileNames): ?int
+    {
+        $value = $this->getPropertyFromFile($fileNames, 'maximum-priority');
+        if ($value === null) {
+            return null;
+        }
+        if (!is_int($value) && !ctype_digit($value)) {
+            throw new RuntimeException('Invalid maximum-priority must be a integer');
+        }
+
+        return (int) $value;
+    }
+
+    /**
+     * @param list<string> $fileNames The filename of a rule-set definition.
+     * @throws RuntimeException Thrown if file is not proper xml
+     * @throws ParseException
+     */
+    public function getThreads(array $fileNames): ?int
+    {
+        $value = $this->getPropertyFromFile($fileNames, 'threads');
+        if ($value === null) {
+            return null;
+        }
+        if (!is_int($value) && !ctype_digit($value)) {
+            throw new RuntimeException('Invalid threads must be a integer');
+        }
+
+        return (int) $value;
+    }
+
+    /**
+     * @param list<string> $fileNames The filename of a rule-set definition.
+     * @throws RuntimeException Thrown if file is not proper xml
+     * @throws ParseException
+     */
+    public function getCache(array $fileNames): bool
+    {
+        $value = $this->getPropertyFromFile($fileNames, 'cache') ?? false;
+        if (is_string($value)) {
+            $value = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        }
+        if (!is_bool($value)) {
+            throw new RuntimeException('Invalid cache must be a boolean');
+        }
+
+        return $value;
+    }
+
+    /**
+     * Extract array property from a single ruleset file.
+     *
+     * @param list<string> $fileNames
+     * @return list<string>
+     * @throws RuntimeException
+     * @throws ParseException
+     */
+    private function getArrayPropertyFromFile(array $fileNames, string $property): array
+    {
+        $result = [];
+        $files = array_map(trim(...), $fileNames);
         $files = array_filter($files);
 
         foreach ($files as $ruleSetFileName) {
@@ -619,25 +805,64 @@ class RuleSetFactory
                 ? strtolower($match['format'])
                 : 'xml';
 
-            $excludes = [...$excludes, ...$this->getExcludePatternsFromFile($ruleSetFileName, $format)];
+            if ($format !== 'xml') {
+                $values = $this->getArrayPropertyFromArrayConfig($ruleSetFileName, $format, $property);
+                $result = [...$result, ...$values];
+
+                continue;
+            }
+
+            $values = $this->getArrayPropertyFromXmlConfig($ruleSetFileName, $property);
+            $result = [...$result, ...$values];
         }
 
-        return $excludes;
+        return $result;
     }
 
     /**
-     * Extract exclude patterns from a single ruleset file.
+     * Extract array property from an array-based config file (php, yml, yaml, json).
      *
      * @return list<string>
      * @throws RuntimeException
      * @throws ParseException
      */
-    private function getExcludePatternsFromFile(string $fileName, string $format): array
+    private function getArrayPropertyFromArrayConfig(string $fileName, string $format, string $property): array
     {
-        if ($format !== 'xml') {
-            return $this->getExcludePatternsFromArrayConfig($fileName, $format);
+        $config = match ($format) {
+            'php' => include $fileName,
+            'yml', 'yaml' => Yaml::parseFile($fileName),
+            'json' => json_decode(file_get_contents($fileName) ?: '', true),
+            default => throw new RuntimeException('Unsupported format: ' . $format),
+        };
+
+        if (!is_array($config)) {
+            throw new RuntimeException('Invalid config');
         }
 
+        $patterns = $config[$property] ?? [];
+        if (!is_array($patterns)) {
+            throw new RuntimeException("Invalid {$property} must be an array");
+        }
+
+        $values = [];
+        foreach ($patterns as $pattern) {
+            if (!is_string($pattern)) {
+                throw new RuntimeException("Invalid {$property} entry");
+            }
+            $values[] = $pattern;
+        }
+
+        return $values;
+    }
+
+    /**
+     * Extract array property from an xml-based config file.
+     *
+     * @return list<string>
+     * @throws RuntimeException
+     */
+    private function getArrayPropertyFromXmlConfig(string $fileName, string $property): array
+    {
         // Hide error messages
         $libxml = libxml_use_internal_errors(true);
         $fileContent = file_get_contents($fileName);
@@ -654,24 +879,56 @@ class RuleSetFactory
             throw new RuntimeException($error ? trim($error->message) : 'Unknown error');
         }
 
-        $excludes = [];
+        $values = [];
         foreach ($xml->children() as $node) {
-            if ($node->getName() === 'exclude-pattern') {
-                $excludes[] = '' . $node;
+            if ($node->getName() === $property) {
+                $values[] = '' . $node;
             }
         }
 
-        return $excludes;
+        return $values;
     }
 
     /**
-     * Extract exclude patterns from an array-based config file (php, yml, yaml, json).
-     *
-     * @return list<string>
+     * @param list<string> $fileNames
      * @throws RuntimeException
      * @throws ParseException
      */
-    private function getExcludePatternsFromArrayConfig(string $fileName, string $format): array
+    private function getPropertyFromFile(array $fileNames, string $property): mixed
+    {
+        $files = array_map(trim(...), $fileNames);
+        $files = array_filter($files);
+
+        foreach ($files as $ruleSetFileName) {
+            $ruleSetFileName = $this->createRuleSetFileName($ruleSetFileName);
+
+            $format = preg_match('/\.(?<format>php|json|ya?ml)(?:\.dist)?$/i', $ruleSetFileName, $match)
+                ? strtolower($match['format'])
+                : 'xml';
+
+            if ($format !== 'xml') {
+                $value = $this->getPropertyFromArrayConfig($ruleSetFileName, $format, $property);
+                if ($value !== null) {
+                    return $value;
+                }
+
+                continue;
+            }
+
+            $value = $this->getPropertyFromXmlConfig($ruleSetFileName, $property);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @throws RuntimeException
+     * @throws ParseException
+     */
+    private function getPropertyFromArrayConfig(string $fileName, string $format, string $property): mixed
     {
         $config = match ($format) {
             'php' => include $fileName,
@@ -684,20 +941,37 @@ class RuleSetFactory
             throw new RuntimeException('Invalid config');
         }
 
-        $patterns = $config['exclude-pattern'] ?? [];
-        if (!is_array($patterns)) {
-            throw new RuntimeException('Invalid exclude-pattern');
+        return $config[$property] ?? null;
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    private function getPropertyFromXmlConfig(string $fileName, string $property): ?string
+    {
+        // Hide error messages
+        $libxml = libxml_use_internal_errors(true);
+        $fileContent = file_get_contents($fileName);
+        if ($fileContent === false) {
+            throw new RuntimeException('Unable to load ' . $fileName);
         }
 
-        $excludes = [];
-        foreach ($patterns as $pattern) {
-            if (!is_string($pattern)) {
-                throw new RuntimeException('Invalid exclude-pattern entry');
+        $xml = simplexml_load_string($fileContent);
+        if (!$xml) {
+            // Reset error handling to previous setting
+            libxml_use_internal_errors($libxml);
+            $error = libxml_get_last_error();
+
+            throw new RuntimeException($error ? trim($error->message) : 'Unknown error');
+        }
+
+        foreach ($xml->children() as $node) {
+            if ($node->getName() === $property) {
+                return '' . $node;
             }
-            $excludes[] = $pattern;
         }
 
-        return $excludes;
+        return null;
     }
 
     /**

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -44,6 +44,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Yaml\Exception\ParseException;
 use TypeError;
 use ValueError;
 
@@ -101,20 +102,36 @@ final class Command extends SymfonyCommand
 
     /**
      * @throws InvalidArgumentException
+     * @throws RuntimeException
+     * @throws ParseException
      */
     protected function configure(): void
     {
         $ruleSetFactory = new RuleSetFactory();
         $availableRuleSets = $ruleSetFactory->listAvailableRuleSets();
         $renderers = $this->getListOfAvailableRenderers();
+        $defaultConfig = $this->getDefaultConfig();
 
+        /** @var list<string> */
+        $argv = $_SERVER['argv'];
+        $rules = [];
+        foreach ($argv as $arg) {
+            if (str_starts_with($arg, '--ruleset=')) {
+                $rules[] = substr($arg, 10);
+            }
+        }
+        $defaultConfig = $rules ?: $defaultConfig;
+
+        $paths = $defaultConfig ? $ruleSetFactory->getPaths($defaultConfig) : [];
         $this->addArgument(
             'paths',
             InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
-            'A php source code filename or directory, or "-" to scan stdin'
+            'A php source code filename or directory, or "-" to scan stdin',
+            $paths
         );
-        $defaultRenderer = 'text';
-        if (!in_array('text', $renderers, true)) {
+        $format = $defaultConfig ? $ruleSetFactory->getFormat($defaultConfig) : null;
+        $defaultRenderer = $format ?? 'text';
+        if (!in_array($defaultRenderer, $renderers, true)) {
             $defaultRenderer = reset($renderers);
         }
         $this->addOption(
@@ -130,29 +147,32 @@ final class Command extends SymfonyCommand
             null,
             InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
             'A ruleset filename or a comma-separated string of rulesetfilenames.',
-            $this->getDefaultConfig() ?? $availableRuleSets,
+            $defaultConfig ?? $availableRuleSets,
             $availableRuleSets
         );
+        $minimumPriority = $defaultConfig ? $ruleSetFactory->getMinimumPriority($defaultConfig) : null;
         $this->addOption(
             'minimum-priority',
             null,
             InputOption::VALUE_REQUIRED,
             'Rule priority threshold; rules with lower priority than this will not be used',
-            Rule::LOWEST_PRIORITY
+            $minimumPriority ?? Rule::LOWEST_PRIORITY
         );
+        $maximumPriority = $defaultConfig ? $ruleSetFactory->getMaximumPriority($defaultConfig) : null;
         $this->addOption(
             'maximum-priority',
             null,
             InputOption::VALUE_REQUIRED,
             'Rule priority threshold; rules with higher priority than this will not be used',
-            Rule::HIGHEST_PRIORITY
+            $maximumPriority ?? Rule::HIGHEST_PRIORITY
         );
+        $suffixes = $defaultConfig ? $ruleSetFactory->getSuffixes($defaultConfig) : [];
         $this->addOption(
             'suffixes',
             null,
             InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
             'Source code filename extensions',
-            ['php', 'php3', 'php4', 'php5', 'inc']
+            $suffixes ?: ['php', 'php3', 'php4', 'php5', 'inc']
         );
         $this->addOption(
             'exclude',
@@ -179,21 +199,28 @@ final class Command extends SymfonyCommand
             InputOption::VALUE_NONE,
             'Will exit with a zero code, even if any violations are found'
         );
-        $this->addOption('cache', null, InputOption::VALUE_NONE, 'Will enable the result cache.');
+        $cache = $defaultConfig ? $ruleSetFactory->getCache($defaultConfig) : false;
+        $this->addOption('cache', null, InputOption::VALUE_NEGATABLE, 'Will enable the result cache.', $cache);
+        $cacheFile = $defaultConfig ? $ruleSetFactory->getCacheFile($defaultConfig) : null;
         $this->addOption(
             'cache-file',
             null,
             InputOption::VALUE_REQUIRED,
             'Result cache file to use.',
-            '.phpmd.result-cache.php'
+            $cacheFile ?? '.phpmd.result-cache.php'
         );
+        $cacheStrategy = $defaultConfig ? $ruleSetFactory->getCacheStrategy($defaultConfig) : null;
+        $cacheStrategies = [ResultCacheStrategy::Content->value, ResultCacheStrategy::Timestamp->value];
+        if (!in_array($cacheStrategy, $cacheStrategies, true)) {
+            $cacheStrategy = reset($cacheStrategies);
+        }
         $this->addOption(
             'cache-strategy',
             null,
             InputOption::VALUE_REQUIRED,
             'Sets the caching strategy to determine if a file is still fresh. Either `content` to base it on the file contents, or `timestamp` to base it on the file modified timestamp',
-            ResultCacheStrategy::Content->value,
-            [ResultCacheStrategy::Content->value, ResultCacheStrategy::Timestamp->value]
+            $cacheStrategy,
+            $cacheStrategies
         );
         $this->addOption(
             'generate-baseline',
@@ -207,7 +234,14 @@ final class Command extends SymfonyCommand
             InputOption::VALUE_NONE,
             'Will remove any non-existing violations from the phpmd.baseline.xml'
         );
-        $this->addOption('baseline-file', null, InputOption::VALUE_REQUIRED, 'A custom location of the baseline file');
+        $baselineFile = $defaultConfig ? $ruleSetFactory->getBaseLineFile($defaultConfig) : null;
+        $this->addOption(
+            'baseline-file',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'A custom location of the baseline file',
+            $baselineFile
+        );
         $this->addOption(
             'extra-line-in-excerpt',
             null,
@@ -240,15 +274,24 @@ final class Command extends SymfonyCommand
         $this->addOption('reportfile-sarif', null, InputOption::VALUE_REQUIRED, 'Write report to a sarif file');
         $this->addOption('reportfile-text', null, InputOption::VALUE_REQUIRED, 'Write report to a text file');
         $this->addOption('reportfile-xml', null, InputOption::VALUE_REQUIRED, 'Write report to an xml file');
+        $bootstrap = $defaultConfig ? $ruleSetFactory->getBoostrap($defaultConfig) : null;
         $this->addOption(
             'bootstrap',
             null,
             InputOption::VALUE_REQUIRED,
-            'An optional script to load before running analysis'
+            'An optional script to load before running analysis',
+            $bootstrap
         );
         $this->addOption('input-file', null, InputOption::VALUE_REQUIRED, 'A file containing paths to analyze');
         $this->addOption('no-progress', null, InputOption::VALUE_NONE, 'Do not show progress bar, only results');
-        $this->addOption('threads', null, InputOption::VALUE_REQUIRED, 'Number of threads to use for parsing');
+        $threads = $defaultConfig ? $ruleSetFactory->getThreads($defaultConfig) : null;
+        $this->addOption(
+            'threads',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Number of threads to use for parsing',
+            $threads
+        );
     }
 
     /**


### PR DESCRIPTION
Type: feature
Resolves #1217
Breaking change: no

Allow for configuring most of the basic options in the configuration file, this allow most developers to simply run `vendor/bin/phpmd` once someone sets it up for there project.

Added options: `format`, `cache-file`, `cache-strateg`, `baseline-file`, `bootstrap`, `cache`, `minimum-priority`, `maximum-priority`, `threads`, `paths`, and `suffixes`.