### PR TITLE
Only filter out first instance of worker command, support rule argument with spaces

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -115,9 +115,11 @@ final class Command extends SymfonyCommand
         /** @var list<string> */
         $argv = $_SERVER['argv'];
         $rules = [];
-        foreach ($argv as $arg) {
+        foreach ($argv as $index => $arg) {
             if (str_starts_with($arg, '--ruleset=')) {
                 $rules[] = substr($arg, 10);
+            } elseif ($arg === '--ruleset' && isset($argv[$index + 1])) {
+                $rules[] = $argv[$index + 1];
             }
         }
         $defaultConfig = $rules ?: $defaultConfig;

--- a/src/TextUI/PdependWorkerCommand.php
+++ b/src/TextUI/PdependWorkerCommand.php
@@ -58,10 +58,12 @@ final class PdependWorkerCommand extends SymfonyCommand
         // stdin. Strip it so pdepend sees only the arguments it understands.
         /** @var list<string> $argv */
         $argv = $_SERVER['argv'] ?? [];
-        $_SERVER['argv'] = array_values(array_filter(
-            $argv,
-            fn(string $arg): bool => $arg !== $this->getName(),
-        ));
+        $index = array_search($this->getName(), $argv, true);
+        if ($index !== false) {
+            unset($argv[$index]);
+        }
+
+        $_SERVER['argv'] = array_values($argv);
 
         return PdependCommand::main();
     }

--- a/tests/php/PHPMD/TextUI/CommandTest.php
+++ b/tests/php/PHPMD/TextUI/CommandTest.php
@@ -280,6 +280,34 @@ class CommandTest extends AbstractTestCase
         static::assertSame(Command::SUCCESS, $exitCode);
     }
 
+    /**
+     * @param list<string> $argv
+     */
+    #[DataProvider('dataProviderRulesetArgvSyntax')]
+    public function testConfigureReadsRulesetFromArgv(array $argv): void
+    {
+        $originalArgv = $_SERVER['argv'];
+        $_SERVER['argv'] = $argv;
+
+        try {
+            $ruleset = (new Command())->getDefinition()->getOption('ruleset');
+            static::assertSame(['design'], $ruleset->getDefault());
+        } finally {
+            $_SERVER['argv'] = $originalArgv;
+        }
+    }
+
+    /**
+     * @return list<list<list<string>>>
+     */
+    public static function dataProviderRulesetArgvSyntax(): array
+    {
+        return [
+            [['bin/phpmd', '--ruleset=design']],
+            [['bin/phpmd', '--ruleset', 'design']],
+        ];
+    }
+
     public function testMainPrintsVersionToStdout(): void
     {
         $changelog = file_get_contents(__DIR__ . '/../../../../CHANGELOG', false, null, 0, 1024) ?: '';


### PR DESCRIPTION
Type: bugfix
Breaking change: no

Based on feedback from https://github.com/phpmd/phpmd/pull/1316#pullrequestreview-4828571795 & https://github.com/phpmd/phpmd/pull/1315#pullrequestreview-4828593219