### PR TITLE
Get version from single source

### DIFF
--- a/src/PHPMD.php
+++ b/src/PHPMD.php
@@ -27,9 +27,6 @@ use PHPMD\Renderer\RendererInterface;
  */
 class PHPMD
 {
-    /** The current PHPMD version. */
-    final public const VERSION = '@package_version@';
-
     /**
      * This property will be set to <b>true</b> when an error
      * was found in the processed source code.

--- a/src/Renderer/GitHubCheckRunsRenderer.php
+++ b/src/Renderer/GitHubCheckRunsRenderer.php
@@ -20,8 +20,8 @@ namespace PHPMD\Renderer;
 
 use JsonException;
 use PHPMD\AbstractRenderer;
-use PHPMD\PHPMD;
 use PHPMD\Report;
+use PHPMD\TextUI\Command;
 
 /**
  * This class will render a report for GitHub Check Runs.
@@ -46,7 +46,7 @@ final class GitHubCheckRunsRenderer extends AbstractRenderer
     private function initReportData(Report $report): array
     {
         return [
-            'title' => sprintf('%s %s', 'phpmd', PHPMD::VERSION),
+            'title' => sprintf('%s %s', 'phpmd', Command::getVersion()),
             'summary' => $this->getReportSummary($report),
         ];
     }

--- a/src/Renderer/JSONRenderer.php
+++ b/src/Renderer/JSONRenderer.php
@@ -20,9 +20,9 @@ namespace PHPMD\Renderer;
 
 use JsonException;
 use PHPMD\AbstractRenderer;
-use PHPMD\PHPMD;
 use PHPMD\ProcessingError;
 use PHPMD\Report;
+use PHPMD\TextUI\Command;
 use PHPMD\Utility\Paths;
 
 /**
@@ -52,7 +52,7 @@ class JSONRenderer extends AbstractRenderer
     protected function initReportData(): array
     {
         return [
-            'version' => PHPMD::VERSION,
+            'version' => Command::getVersion(),
             'package' => 'phpmd',
             'timestamp' => date('c'),
         ];

--- a/src/Renderer/SARIFRenderer.php
+++ b/src/Renderer/SARIFRenderer.php
@@ -18,8 +18,8 @@
 
 namespace PHPMD\Renderer;
 
-use PHPMD\PHPMD;
 use PHPMD\Report;
+use PHPMD\TextUI\Command;
 
 /**
  * This class will render a SARIF (Static Analysis
@@ -44,7 +44,7 @@ final class SARIFRenderer extends JSONRenderer
                         'driver' => [
                             'name' => 'PHPMD',
                             'informationUri' => 'https://phpmd.org',
-                            'version' => PHPMD::VERSION,
+                            'version' => Command::getVersion(),
                             'rules' => [],
                         ],
                     ],

--- a/src/Renderer/XMLRenderer.php
+++ b/src/Renderer/XMLRenderer.php
@@ -19,8 +19,8 @@
 namespace PHPMD\Renderer;
 
 use PHPMD\AbstractRenderer;
-use PHPMD\PHPMD;
 use PHPMD\Report;
+use PHPMD\TextUI\Command;
 
 /**
  * This class will render a Java-PMD compatible xml-report.
@@ -50,7 +50,7 @@ class XMLRenderer extends AbstractRenderer
     public function renderReport(Report $report): void
     {
         $writer = $this->getWriter();
-        $writer->write('<pmd version="' . PHPMD::VERSION . '" ');
+        $writer->write('<pmd version="' . Command::getVersion() . '" ');
         $writer->write('tool="phpmd" ');
         $writer->write('timestamp="' . date('c') . '">');
         $writer->write(PHP_EOL);

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -480,7 +480,7 @@ final class Command extends SymfonyCommand
         $build = __DIR__ . '/../../CHANGELOG';
 
         $version = '@package_version@';
-        if (file_exists($build)) {
+        if (preg_match('/\d+\.\d+\.\d+/', $version) !== 1 && file_exists($build)) {
             $changelog = file_get_contents($build, false, null, 0, 1024) ?: '';
             $version = preg_match('/phpmd-([\S]+)/', $changelog, $match) ? $match[1] : $version;
         }

--- a/tests/php/PHPMD/Renderer/GitHubCheckRunsRendererTest.php
+++ b/tests/php/PHPMD/Renderer/GitHubCheckRunsRendererTest.php
@@ -20,8 +20,8 @@ namespace PHPMD\Renderer;
 
 use ArrayIterator;
 use PHPMD\AbstractTestCase;
-use PHPMD\PHPMD;
 use PHPMD\Stubs\RuleStub;
+use PHPMD\TextUI\Command;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -83,7 +83,7 @@ class GitHubCheckRunsRendererTest extends AbstractTestCase
         /** @var array{title: string, summary: string, annotations: list<array{path: string, violations: list<array{start_line: int, end_line: int, annotation_level: string, message: string, title: string, raw_details: array<string, mixed>}>}>} $data */
         $data = json_decode($output, true);
 
-        static::assertSame(sprintf('phpmd %s', PHPMD::VERSION), $data['title']);
+        static::assertSame(sprintf('phpmd %s', Command::getVersion()), $data['title']);
         static::assertCount(2, $data['annotations']);
 
         $firstAnnotation = $data['annotations'][0];


### PR DESCRIPTION
Type: refactoring
Issue: Resolves #1285
Breaking change: yes

This removes the const `VERSION`, instead version is always gotten from `Command::getVersion()` which now detects if the version was baked and if not gets it live from the changelog (which is also where the baked version comes from)