### PR TITLE
Standardized rule threshold properties to maximum

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,8 @@ Breaking changes:
 - Standardized rule threshold properties to `maximum` (#670). Rules now report
   only when the measured value exceeds (`>`) the configured `maximum`. Rules
   that check a lower bound (ShortVariable, ShortMethodName, ShortClassName)
-  keep the `minimum` property. Renamed properties:
+  keep the `minimum` property. Renamed properties (the old names remain
+  accepted as aliases):
   - CyclomaticComplexity: `reportLevel` -> `maximum`
   - NPathComplexity: `minimum` -> `maximum`
   - ExcessiveMethodLength: `minimum` -> `maximum`
@@ -23,6 +24,7 @@ Breaking changes:
   - TooManyPublicMethods: `maxmethods` -> `maximum`
   - NumberOfChildren: `minimum` -> `maximum`
   - DepthOfInheritance: `minimum` -> `maximum`
+
   Rules that previously reported when the value equaled the threshold
   (CyclomaticComplexity, NPathComplexity, ExcessiveMethodLength,
   ExcessiveClassLength, ExcessiveParameterList, ExcessivePublicCount,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,27 @@ Breaking changes:
 - Changed minimum PHP version from 5.3.9 to 8.1.
 - Changed CLI from positional arguments to Symfony Console with named options.
   The command signature is now `phpmd analyze [options] [--] [<paths>...]`.
+- Standardized rule threshold properties to `maximum` (#670). Rules now report
+  only when the measured value exceeds (`>`) the configured `maximum`. Rules
+  that check a lower bound (ShortVariable, ShortMethodName, ShortClassName)
+  keep the `minimum` property. Renamed properties:
+  - CyclomaticComplexity: `reportLevel` -> `maximum`
+  - NPathComplexity: `minimum` -> `maximum`
+  - ExcessiveMethodLength: `minimum` -> `maximum`
+  - ExcessiveClassLength: `minimum` -> `maximum`
+  - ExcessiveParameterList: `minimum` -> `maximum`
+  - ExcessivePublicCount: `minimum` -> `maximum`
+  - TooManyFields: `maxfields` -> `maximum`
+  - TooManyMethods: `maxmethods` -> `maximum`
+  - TooManyPublicMethods: `maxmethods` -> `maximum`
+  - NumberOfChildren: `minimum` -> `maximum`
+  - DepthOfInheritance: `minimum` -> `maximum`
+  Rules that previously reported when the value equaled the threshold
+  (CyclomaticComplexity, NPathComplexity, ExcessiveMethodLength,
+  ExcessiveClassLength, ExcessiveParameterList, ExcessivePublicCount,
+  NumberOfChildren, DepthOfInheritance, ExcessiveClassComplexity,
+  CouplingBetweenObjects) now only report when the value is greater than
+  the threshold, so the configured `maximum` is the highest accepted value.
 - Removed `--ignore` option, use `--exclude` instead.
 - Removed `--extensions` option, use `--suffixes` instead.
 - Removed `--reportfile` option, use `--reportfile-text`, `--reportfile-xml`, etc.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,27 @@ Breaking changes:
 - Changed minimum PHP version from 5.3.9 to 8.1.
 - Changed CLI from positional arguments to Symfony Console with named options.
   The command signature is now `phpmd analyze [options] [--] [<paths>...]`.
+- Standardized rule threshold properties to `maximum` (#670). Rules now report
+  only when the measured value exceeds (`>`) the configured `maximum`. Rules
+  that check a lower bound (ShortVariable, ShortMethodName, ShortClassName)
+  keep the `minimum` property. Renamed properties:
+  - CyclomaticComplexity: `reportLevel` -> `maximum`
+  - NPathComplexity: `minimum` -> `maximum`
+  - ExcessiveMethodLength: `minimum` -> `maximum`
+  - ExcessiveClassLength: `minimum` -> `maximum`
+  - ExcessiveParameterList: `minimum` -> `maximum`
+  - ExcessivePublicCount: `minimum` -> `maximum`
+  - TooManyFields: `maxfields` -> `maximum`
+  - TooManyMethods: `maxmethods` -> `maximum`
+  - TooManyPublicMethods: `maxmethods` -> `maximum`
+  - NumberOfChildren: `minimum` -> `maximum`
+  - DepthOfInheritance: `minimum` -> `maximum`
+  Rules that previously reported when the value equaled the threshold
+  (CyclomaticComplexity, NPathComplexity, ExcessiveMethodLength,
+  ExcessiveClassLength, ExcessiveParameterList, ExcessivePublicCount,
+  NumberOfChildren, DepthOfInheritance, ExcessiveClassComplexity,
+  CouplingBetweenObjects) now only report when the value is greater than
+  the threshold, so the configured `maximum` is the highest accepted value.
 - Removed `--ignore` option, use `--exclude` instead.
 - Removed `--reportfile` option, use `--reportfile-text`, `--reportfile-xml`, etc.
 - Removed `--minimumpriority` and `--maximumpriority` aliases, use `--minimum-priority` and `--maximum-priority`.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -98,7 +98,7 @@ A new exit code `3` has been added, which indicates that one or more files could
 
 Rules that check an upper bound now consistently use a property named `maximum`, and only report a violation when the measured value *exceeds* the configured value (`value > maximum`). Previously, several rules used `minimum`, `maxfields`, `maxmethods`, or `reportLevel` for what was semantically a maximum, and some reported already when the value *equaled* the threshold.
 
-If your custom rule set configures one of the following rules, rename the property:
+If your custom rule set configures one of the following rules, rename the property. The old names remain accepted as aliases, so an existing rule set keeps its configured thresholds, but the names in the right column are the documented ones going forward:
 
 | Rule                     | PHPMD 2       | PHPMD 3   |
 |--------------------------|---------------|-----------|
@@ -115,6 +115,8 @@ If your custom rule set configures one of the following rules, rename the proper
 | DepthOfInheritance       | `minimum`     | `maximum` |
 
 The comparison is now inclusive for all of these rules: the configured `maximum` is the highest still-accepted value, and only values above it are reported. Rules that previously reported when the value equaled the threshold (all of the above plus ExcessiveClassComplexity and CouplingBetweenObjects) accept one more unit than before. If you want to keep the exact same behavior as PHPMD 2 for a rule that used `value >= threshold`, configure `maximum` to the old value minus one.
+
+This also shifts the shipped defaults: on the default rule sets, values that sat exactly on a threshold (for example a class with a WMC of exactly 50 for ExcessiveClassComplexity, or a CBO of exactly 13 for CouplingBetweenObjects) are no longer reported. Baseline entries recorded for such violations will no longer match and can be removed from your baseline file.
 
 Rules that check a lower bound — ShortVariable, ShortMethodName, and ShortClassName — keep the `minimum` property (a name length *below* the configured minimum is reported).
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -93,6 +93,30 @@ However, PHP attributes are recommended going forward, as they are type-safe and
 
 A new exit code `3` has been added, which indicates that one or more files could not be processed because of an error. Previously this would have been exit code `1`.
 
+### Standardized rule threshold properties
+
+Rules that check an upper bound now consistently use a property named `maximum`, and only report a violation when the measured value *exceeds* the configured value (`value > maximum`). Previously, several rules used `minimum`, `maxfields`, `maxmethods`, or `reportLevel` for what was semantically a maximum, and some reported already when the value *equaled* the threshold.
+
+If your custom rule set configures one of the following rules, rename the property:
+
+| Rule                     | PHPMD 2       | PHPMD 3   |
+|--------------------------|---------------|-----------|
+| CyclomaticComplexity     | `reportLevel` | `maximum` |
+| NPathComplexity          | `minimum`     | `maximum` |
+| ExcessiveMethodLength    | `minimum`     | `maximum` |
+| ExcessiveClassLength     | `minimum`     | `maximum` |
+| ExcessiveParameterList   | `minimum`     | `maximum` |
+| ExcessivePublicCount     | `minimum`     | `maximum` |
+| TooManyFields            | `maxfields`   | `maximum` |
+| TooManyMethods           | `maxmethods`  | `maximum` |
+| TooManyPublicMethods     | `maxmethods`  | `maximum` |
+| NumberOfChildren         | `minimum`     | `maximum` |
+| DepthOfInheritance       | `minimum`     | `maximum` |
+
+The comparison is now inclusive for all of these rules: the configured `maximum` is the highest still-accepted value, and only values above it are reported. Rules that previously reported when the value equaled the threshold (all of the above plus ExcessiveClassComplexity and CouplingBetweenObjects) accept one more unit than before. If you want to keep the exact same behavior as PHPMD 2 for a rule that used `value >= threshold`, configure `maximum` to the old value minus one.
+
+Rules that check a lower bound — ShortVariable, ShortMethodName, and ShortClassName — keep the `minimum` property (a name length *below* the configured minimum is reported).
+
 ### Internal API changes
 
 These changes only affect you if you have written custom rules or extended PHPMD classes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -94,6 +94,30 @@ However, PHP attributes are recommended going forward, as they are type-safe and
 
 A new exit code `3` has been added, which indicates that one or more files could not be processed because of an error. Previously this would have been exit code `1`.
 
+### Standardized rule threshold properties
+
+Rules that check an upper bound now consistently use a property named `maximum`, and only report a violation when the measured value *exceeds* the configured value (`value > maximum`). Previously, several rules used `minimum`, `maxfields`, `maxmethods`, or `reportLevel` for what was semantically a maximum, and some reported already when the value *equaled* the threshold.
+
+If your custom rule set configures one of the following rules, rename the property:
+
+| Rule                     | PHPMD 2       | PHPMD 3   |
+|--------------------------|---------------|-----------|
+| CyclomaticComplexity     | `reportLevel` | `maximum` |
+| NPathComplexity          | `minimum`     | `maximum` |
+| ExcessiveMethodLength    | `minimum`     | `maximum` |
+| ExcessiveClassLength     | `minimum`     | `maximum` |
+| ExcessiveParameterList   | `minimum`     | `maximum` |
+| ExcessivePublicCount     | `minimum`     | `maximum` |
+| TooManyFields            | `maxfields`   | `maximum` |
+| TooManyMethods           | `maxmethods`  | `maximum` |
+| TooManyPublicMethods     | `maxmethods`  | `maximum` |
+| NumberOfChildren         | `minimum`     | `maximum` |
+| DepthOfInheritance       | `minimum`     | `maximum` |
+
+The comparison is now inclusive for all of these rules: the configured `maximum` is the highest still-accepted value, and only values above it are reported. Rules that previously reported when the value equaled the threshold (all of the above plus ExcessiveClassComplexity and CouplingBetweenObjects) accept one more unit than before. If you want to keep the exact same behavior as PHPMD 2 for a rule that used `value >= threshold`, configure `maximum` to the old value minus one.
+
+Rules that check a lower bound — ShortVariable, ShortMethodName, and ShortClassName — keep the `minimum` property (a name length *below* the configured minimum is reported).
+
 ### Internal API changes
 
 These changes only affect you if you have written custom rules or extended PHPMD classes.

--- a/public/rst/documentation/creating-a-ruleset.rst
+++ b/public/rst/documentation/creating-a-ruleset.rst
@@ -88,7 +88,7 @@ __ /rules/codesize.html#cyclomaticcomplexity
     - ref: rulesets/codesize.xml/CyclomaticComplexity
       priority: 1
       properties:
-        reportLevel: 5
+        maximum: 5
 
 PHPMD handles all custom settings additively. This means that PHPMD keeps
 the original configuration for every setting that isn't customized in a
@@ -113,7 +113,7 @@ __ /rules/naming.html
     - ref: rulesets/codesize.xml/CyclomaticComplexity
       priority: 1
       properties:
-        reportLevel: 5
+        maximum: 5
     # Import naming rules, but exclude some
     - ref: rulesets/naming.xml
       exclude:
@@ -141,7 +141,7 @@ __ /rules/cleancode.html
     - ref: rulesets/codesize.xml/CyclomaticComplexity
       priority: 1
       properties:
-        reportLevel: 5
+        maximum: 5
     - ref: rulesets/naming.xml
       exclude:
         - ShortVariable
@@ -224,7 +224,7 @@ Adding rules, customizing properties, and excluding rules:
       <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
           <priority>1</priority>
           <properties>
-              <property name="reportLevel" value="5" />
+              <property name="maximum" value="5" />
           </properties>
       </rule>
 
@@ -271,13 +271,13 @@ This avoids having to exclude and re-include each rule individually.
     # Customize properties on individual rules without excluding them first
     - name: ExcessiveParameterList
       properties:
-        minimum: 15
+        maximum: 15
     - name: TooManyFields
       properties:
-        maxfields: 35
+        maximum: 35
     - name: TooManyMethods
       properties:
-        maxmethods: 35
+        maximum: 35
 
 In XML, the equivalent uses ``<rule name="...">`` elements with only a
 ``<properties>`` child — no ``ref`` attribute:
@@ -302,19 +302,19 @@ In XML, the equivalent uses ``<rule name="...">`` elements with only a
       <!-- Customize properties on individual rules without excluding them first -->
       <rule name="ExcessiveParameterList">
           <properties>
-              <property name="minimum" value="15" />
+              <property name="maximum" value="15" />
           </properties>
       </rule>
 
       <rule name="TooManyFields">
           <properties>
-              <property name="maxfields" value="35" />
+              <property name="maximum" value="35" />
           </properties>
       </rule>
 
       <rule name="TooManyMethods">
           <properties>
-              <property name="maxmethods" value="35" />
+              <property name="maximum" value="35" />
           </properties>
       </rule>
   </ruleset>
@@ -341,7 +341,7 @@ JSON example (``phpmd.json``):
           {
               "ref": "rulesets/codesize.xml/CyclomaticComplexity",
               "priority": 1,
-              "properties": {"reportLevel": 5}
+              "properties": {"maximum": 5}
           },
           {
               "ref": "rulesets/naming.xml",
@@ -378,7 +378,7 @@ PHP example (``phpmd.php``):
           [
               'ref' => 'rulesets/codesize.xml/CyclomaticComplexity',
               'priority' => 1,
-              'properties' => ['reportLevel' => 5],
+              'properties' => ['maximum' => 5],
           ],
           [
               'ref' => 'rulesets/naming.xml',

--- a/public/rst/rules/codesize.rst
+++ b/public/rst/rules/codesize.rst
@@ -56,7 +56,7 @@ This rule has the following properties:
 +-----------------------------------+---------------+-------------------------------------------------------------------+
 | Name                              | Default Value |  Description                                                      |
 +===================================+===============+===================================================================+
-| reportLevel                       | 10            | The Cyclomatic Complexity reporting threshold                     |
+| maximum                           | 10            | The Cyclomatic Complexity reporting threshold                     |
 +-----------------------------------+---------------+-------------------------------------------------------------------+
 | showClassesComplexity             | true          | Indicate if class average violation should be added to the report |
 +-----------------------------------+---------------+-------------------------------------------------------------------+
@@ -100,7 +100,7 @@ This rule has the following properties:
 +-----------------------------------+---------------+-------------------------------+
 | Name                              | Default Value | Description                   |
 +===================================+===============+===============================+
-| minimum                           | 200           | The npath reporting threshold |
+| maximum                           | 200           | The npath reporting threshold |
 +-----------------------------------+---------------+-------------------------------+
 
 ExcessiveMethodLength
@@ -125,7 +125,7 @@ This rule has the following properties:
 +-----------------------------------+---------------+-----------------------------------------+
 | Name                              | Default Value | Description                             |
 +===================================+===============+=========================================+
-| minimum                           | 100           | The method size reporting threshold     |
+| maximum                           | 100           | The method size reporting threshold     |
 +-----------------------------------+---------------+-----------------------------------------+
 | ignore-whitespace                 | false         | Count whitespace in reporting threshold |
 +-----------------------------------+---------------+-----------------------------------------+
@@ -150,7 +150,7 @@ This rule has the following properties:
 +-----------------------------------+---------------+-----------------------------------------+
 | Name                              | Default Value | Description                             |
 +===================================+===============+=========================================+
-| minimum                           | 1000          | The class size reporting threshold      |
+| maximum                           | 1000          | The class size reporting threshold      |
 +-----------------------------------+---------------+-----------------------------------------+
 | ignore-whitespace                 | false         | Count whitespace in reporting threshold |
 +-----------------------------------+---------------+-----------------------------------------+
@@ -176,7 +176,7 @@ This rule has the following properties:
 +-----------------------------------+---------------+-----------------------------------------+
 | Name                              | Default Value | Description                             |
 +===================================+===============+=========================================+
-| minimum                           | 10            | The parameter count reporting threshold |
+| maximum                           | 10            | The parameter count reporting threshold |
 +-----------------------------------+---------------+-----------------------------------------+
 
 ExcessivePublicCount
@@ -205,7 +205,7 @@ This rule has the following properties:
 +-----------------------------------+---------------+-----------------------------------------+
 | Name                              | Default Value | Description                             |
 +===================================+===============+=========================================+
-| minimum                           | 45            | The public item reporting threshold     |
+| maximum                           | 45            | The public item reporting threshold     |
 +-----------------------------------+---------------+-----------------------------------------+
 
 TooManyFields
@@ -229,7 +229,7 @@ This rule has the following properties:
 +-----------------------------------+---------------+-----------------------------------------+
 | Name                              | Default Value | Description                             |
 +===================================+===============+=========================================+
-| maxfields                         | 15            | The field count reporting threshold     |
+| maximum                           | 15            | The field count reporting threshold     |
 +-----------------------------------+---------------+-----------------------------------------+
 
 TooManyMethods
@@ -244,7 +244,7 @@ This rule has the following properties:
 +-----------------------------------+---------------+--------------------------------------+
 | Name                              | Default Value | Description                          |
 +===================================+===============+======================================+
-| maxmethods                        | 25            | The method count reporting threshold |
+| maximum                           | 25            | The method count reporting threshold |
 +-----------------------------------+---------------+--------------------------------------+
 | ignorepattern                     | (^(set|get))i | Ignore methods matching this regex   |
 +-----------------------------------+---------------+--------------------------------------+
@@ -261,7 +261,7 @@ This rule has the following properties:
 +-----------------------------------+---------------+-----------------------------------------+
 | Name                              | Default Value | Description                             |
 +===================================+===============+=========================================+
-| maxmethods                        | 10            | The method count reporting threshold    |
+| maximum                           | 10            | The method count reporting threshold    |
 +-----------------------------------+---------------+-----------------------------------------+
 | ignorepattern                     | (^(set|get))i | Ignore methods matching this regex      |
 +-----------------------------------+---------------+-----------------------------------------+

--- a/public/rst/rules/design.rst
+++ b/public/rst/rules/design.rst
@@ -78,7 +78,7 @@ This rule has the following properties:
 +-----------------------------------+---------------+---------------------------------------------+
 | Name                              | Default Value | Description                                 |
 +===================================+===============+=============================================+
-| minimum                           | 15            | Maximum number of acceptable child classes. |
+| maximum                           | 15            | Maximum number of acceptable child classes. |
 +-----------------------------------+---------------+---------------------------------------------+
 
 DepthOfInheritance
@@ -93,7 +93,7 @@ This rule has the following properties:
 +-----------------------------------+---------------+----------------------------------------------+
 | Name                              | Default Value | Description                                  |
 +===================================+===============+==============================================+
-| minimum                           | 6             | Maximum number of acceptable parent classes. |
+| maximum                           | 6             | Maximum number of acceptable parent classes. |
 +-----------------------------------+---------------+----------------------------------------------+
 
 CouplingBetweenObjects

--- a/rulesets/codesize.xml
+++ b/rulesets/codesize.xml
@@ -213,7 +213,7 @@ public class Foo {
 
     <rule name="TooManyFields"
           since="0.1"
-          message="The {0} {1} has {2} fields. Consider redesigning {1} to keep the number of fields under {3}."
+          message="The {0} {1} has {2} fields. Consider redesigning {1} to keep the number of fields at {3} or less."
           class="PHPMD\Rule\Design\TooManyFields"
           externalInfoUrl="https://phpmd.org/rules/codesize.html#toomanyfields">
         <description>
@@ -334,7 +334,7 @@ public class Foo extends Bar {
     <rule name="TooManyMethods"
           since="0.1"
           class="PHPMD\Rule\Design\TooManyMethods"
-          message="The {0} {1} has {2} non-getter- and setter-methods. Consider refactoring {1} to keep number of methods under {3}."
+          message="The {0} {1} has {2} non-getter- and setter-methods. Consider refactoring {1} to keep number of methods at {3} or less."
           externalInfoUrl="https://phpmd.org/rules/codesize.html#toomanymethods">
         <description>
             <![CDATA[
@@ -356,7 +356,7 @@ The default was changed from 10 to 25 in PHPMD 2.3.
     <rule name="TooManyPublicMethods"
           since="0.1"
           class="PHPMD\Rule\Design\TooManyPublicMethods"
-          message="The {0} {1} has {2} public methods. Consider refactoring {1} to keep number of public methods under {3}."
+          message="The {0} {1} has {2} public methods. Consider refactoring {1} to keep number of public methods at {3} or less."
           externalInfoUrl="https://phpmd.org/rules/codesize.html#toomanypublicmethods">
         <description>
             <![CDATA[

--- a/rulesets/codesize.xml
+++ b/rulesets/codesize.xml
@@ -25,7 +25,7 @@ method entry. The decision points are 'if', 'while', 'for', and 'case labels'. G
         </description>
         <priority>3</priority>
         <properties>
-            <property name="reportLevel" description="The Cyclomatic Complexity reporting threshold"  value="10"/>
+            <property name="maximum" description="The Cyclomatic Complexity reporting threshold" value="10"/>
             <property name="showClassesComplexity"
                       description="Indicate if class average violation should be added to the report"
                       value="true"/>
@@ -87,7 +87,7 @@ A threshold of 200 is generally considered the point where measures should be ta
         </description>
         <priority>3</priority>
         <properties>
-            <property name="minimum" description="The npath reporting threshold" value="200"/>
+            <property name="maximum" description="The npath reporting threshold" value="200"/>
         </properties>
         <example>
             <![CDATA[
@@ -111,7 +111,7 @@ too much. Try to reduce the method size by creating helper methods and removing 
         </description>
         <priority>3</priority>
         <properties>
-            <property name="minimum" description="The method size reporting threshold" value="100"/>
+            <property name="maximum" description="The method size reporting threshold" value="100"/>
             <property name="ignore-whitespace" description="Count whitespace in reporting threshold" value="false"/>
         </properties>
         <example>
@@ -139,7 +139,7 @@ manageable.
         </description>
         <priority>3</priority>
         <properties>
-            <property name="minimum" description="The class size reporting threshold"  value="1000"/>
+            <property name="maximum" description="The class size reporting threshold" value="1000"/>
             <property name="ignore-whitespace" description="Count whitespace in reporting threshold" value="false"/>
         </properties>
         <example>
@@ -155,7 +155,7 @@ class Foo {
 
     <rule name="ExcessiveParameterList"
           since="0.1"
-          message="The {0} {1} has {2} parameters. Consider reducing the number of parameters to less than {3}."
+          message="The {0} {1} has {2} parameters. Consider reducing the number of parameters to {3} or less."
           class="PHPMD\Rule\Design\ExcessiveParameterList"
           externalInfoUrl="https://phpmd.org/rules/codesize.html#excessiveparameterlist">
         <description>
@@ -164,7 +164,7 @@ wrap the numerous parameters.  Basically, try to group the parameters together.
         </description>
         <priority>3</priority>
         <properties>
-            <property name="minimum" description="The parameter count reporting threshold" value="10"/>
+            <property name="maximum" description="The parameter count reporting threshold" value="10"/>
             <property name="exceptions" description="Comma-separated list of method/function names to ignore" value=""/>
         </properties>
         <example>
@@ -182,7 +182,7 @@ class Foo {
 
     <rule name="ExcessivePublicCount"
           since="0.1"
-          message="The {0} {1} has {2} public methods and attributes. Consider reducing the number of public items to less than {3}."
+          message="The {0} {1} has {2} public methods and attributes. Consider reducing the number of public items to {3} or less."
           class="PHPMD\Rule\ExcessivePublicCount"
           externalInfoUrl="https://phpmd.org/rules/codesize.html#excessivepubliccount">
         <description>
@@ -192,7 +192,7 @@ thoroughly test it.
         </description>
         <priority>3</priority>
         <properties>
-            <property name="minimum" description="The public item reporting threshold" value="45"/>
+            <property name="maximum" description="The public item reporting threshold" value="45"/>
         </properties>
         <example>
             <![CDATA[
@@ -224,7 +224,7 @@ field.
         </description>
         <priority>3</priority>
         <properties>
-            <property name="maxfields" description="The field count reporting threshold " value="15"/>
+            <property name="maximum" description="The field count reporting threshold" value="15"/>
         </properties>
         <example>
             <![CDATA[
@@ -348,7 +348,7 @@ The default was changed from 10 to 25 in PHPMD 2.3.
         </description>
         <priority>3</priority>
         <properties>
-            <property name="maxmethods" description="The method count reporting threshold" value="25"/>
+            <property name="maximum" description="The method count reporting threshold" value="25"/>
             <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get|is|has|with|test))i"/>
         </properties>
     </rule>
@@ -368,7 +368,7 @@ By default it ignores methods starting with 'get', 'set', 'is', 'has', 'with', o
         </description>
         <priority>3</priority>
         <properties>
-            <property name="maxmethods" description="The method count reporting threshold" value="10"/>
+            <property name="maximum" description="The method count reporting threshold" value="10"/>
             <property name="ignorepattern" description="Ignore methods matching this regex" value="(^(set|get|is|has|with|test))i"/>
         </properties>
     </rule>

--- a/rulesets/design.xml
+++ b/rulesets/design.xml
@@ -105,7 +105,7 @@ class Foo {
 
     <rule name="NumberOfChildren"
           since="0.2"
-          message = "The {0} {1} has {2} children. Consider to rebalance this class hierarchy to keep number of children under {3}."
+          message = "The {0} {1} has {2} children. Consider to rebalance this class hierarchy to keep number of children at {3} or less."
           class="PHPMD\Rule\Design\NumberOfChildren"
           externalInfoUrl="https://phpmd.org/rules/design.html#numberofchildren">
         <description>
@@ -116,14 +116,14 @@ class hierarchy. You should consider to refactor this class hierarchy.
         </description>
         <priority>2</priority>
         <properties>
-            <property name="minimum" value="15" description="Maximum number of acceptable child classes." />
+            <property name="maximum" value="15" description="Maximum number of acceptable child classes." />
         </properties>
         <example />
     </rule>
 
     <rule name="DepthOfInheritance"
           since="0.2"
-          message = "The {0} {1} has {2} parents. Consider to reduce the depth of this class hierarchy to under {3}."
+          message = "The {0} {1} has {2} parents. Consider to reduce the depth of this class hierarchy to {3} or less."
           class="PHPMD\Rule\Design\DepthOfInheritance"
           externalInfoUrl="https://phpmd.org/rules/design.html#depthofinheritance">
         <description>
@@ -134,14 +134,14 @@ hierarchy. You should consider to refactor this class hierarchy.
         </description>
         <priority>2</priority>
         <properties>
-            <property name="minimum" value="6" description="Maximum number of acceptable parent classes." />
+            <property name="maximum" value="6" description="Maximum number of acceptable parent classes." />
         </properties>
         <example />
     </rule>
 
     <rule name="CouplingBetweenObjects"
           since="1.1.0"
-          message="The class {0} has a coupling between objects value of {1}. Consider to reduce the number of dependencies under {2}."
+          message="The class {0} has a coupling between objects value of {1}. Consider to reduce the number of dependencies to {2} or less."
           class="PHPMD\Rule\Design\CouplingBetweenObjects"
           externalInfoUrl="https://phpmd.org/rules/design.html#couplingbetweenobjects">
         <description>

--- a/src/Rule/CyclomaticComplexity.php
+++ b/src/Rule/CyclomaticComplexity.php
@@ -33,9 +33,9 @@ final class CyclomaticComplexity extends AbstractRule implements FunctionAware, 
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('reportLevel');
+        $threshold = $this->getIntProperty('maximum');
         $ccn = $node->getMetric('ccn2');
-        if ($ccn < $threshold) {
+        if ($ccn <= $threshold) {
             return;
         }
 

--- a/src/Rule/CyclomaticComplexity.php
+++ b/src/Rule/CyclomaticComplexity.php
@@ -20,6 +20,7 @@ namespace PHPMD\Rule;
 
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule checks a given method or function against the configured cyclomatic
@@ -27,15 +28,17 @@ use PHPMD\AbstractRule;
  */
 final class CyclomaticComplexity extends AbstractRule implements FunctionAware, MethodAware
 {
+    #[Threshold(['maximum', 'reportLevel'])]
+    public int $maximum;
+
     /**
      * This method checks the cyclomatic complexity for the given node against
      * a configured threshold.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
         $ccn = $node->getMetric('ccn2');
-        if ($ccn <= $threshold) {
+        if ($ccn <= $this->maximum) {
             return;
         }
 
@@ -45,7 +48,7 @@ final class CyclomaticComplexity extends AbstractRule implements FunctionAware, 
                 $node->getType(),
                 $node->getName(),
                 (string) $ccn,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/Design/CouplingBetweenObjects.php
+++ b/src/Rule/Design/CouplingBetweenObjects.php
@@ -37,7 +37,7 @@ final class CouplingBetweenObjects extends AbstractRule implements ClassAware
     {
         $cbo = $node->getMetric('cbo');
         $threshold = $this->getIntProperty('maximum');
-        if ($cbo >= $threshold) {
+        if ($cbo > $threshold) {
             $this->addViolation($node, [$node->getName(), (string) $cbo, (string) $threshold]);
         }
     }

--- a/src/Rule/Design/DepthOfInheritance.php
+++ b/src/Rule/Design/DepthOfInheritance.php
@@ -18,7 +18,6 @@
 
 namespace PHPMD\Rule\Design;
 
-use OutOfBoundsException;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
@@ -34,19 +33,9 @@ final class DepthOfInheritance extends AbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node): void
     {
-        try {
-            $threshold = $this->getIntProperty('maximum');
-            $comparison = 1;
-        } catch (OutOfBoundsException) {
-            $threshold = $this->getIntProperty('minimum');
-            $comparison = 2;
-        }
-
+        $threshold = $this->getIntProperty('maximum');
         $dit = $node->getMetric('dit');
-        if (
-            ($comparison === 1 && $dit > $threshold) ||
-            ($comparison === 2 && $dit >= $threshold)
-        ) {
+        if ($dit > $threshold) {
             $this->addViolation(
                 $node,
                 [

--- a/src/Rule/Design/DepthOfInheritance.php
+++ b/src/Rule/Design/DepthOfInheritance.php
@@ -21,28 +21,31 @@ namespace PHPMD\Rule\Design;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule will detect classes that are too deep in the inheritance tree.
  */
 final class DepthOfInheritance extends AbstractRule implements ClassAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the number of parents for the given class
      * node.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
         $dit = $node->getMetric('dit');
-        if ($dit > $threshold) {
+        if ($dit > $this->maximum) {
             $this->addViolation(
                 $node,
                 [
                     $node->getType(),
                     $node->getName(),
                     (string) $dit,
-                    (string) $threshold,
+                    (string) $this->maximum,
                 ]
             );
         }

--- a/src/Rule/Design/ExcessiveClassComplexity.php
+++ b/src/Rule/Design/ExcessiveClassComplexity.php
@@ -39,7 +39,7 @@ final class ExcessiveClassComplexity extends AbstractRule implements ClassAware
         $threshold = $this->getIntProperty('maximum');
         $actual = $node->getMetric('wmc');
 
-        if ($actual >= $threshold) {
+        if ($actual > $threshold) {
             $this->addViolation($node, [$node->getName(), (string) $actual, (string) $threshold]);
         }
     }

--- a/src/Rule/Design/ExcessiveClassLength.php
+++ b/src/Rule/Design/ExcessiveClassLength.php
@@ -21,20 +21,22 @@ namespace PHPMD\Rule\Design;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule class will detect excessive long classes.
  */
 final class ExcessiveClassLength extends AbstractRule implements ClassAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the length of the given class node against a configured
      * threshold.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
-
         $loc = -1;
         if ($this->isTruthyProperty('ignore-whitespace')) {
             $loc = $node->getMetric('eloc');
@@ -43,10 +45,10 @@ final class ExcessiveClassLength extends AbstractRule implements ClassAware
             $loc = $node->getMetric('loc');
         }
 
-        if ($loc <= $threshold) {
+        if ($loc <= $this->maximum) {
             return;
         }
 
-        $this->addViolation($node, [$node->getName(), (string) $loc, (string) $threshold]);
+        $this->addViolation($node, [$node->getName(), (string) $loc, (string) $this->maximum]);
     }
 }

--- a/src/Rule/Design/ExcessiveClassLength.php
+++ b/src/Rule/Design/ExcessiveClassLength.php
@@ -33,7 +33,7 @@ final class ExcessiveClassLength extends AbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('minimum');
+        $threshold = $this->getIntProperty('maximum');
 
         $loc = -1;
         if ($this->isTruthyProperty('ignore-whitespace')) {
@@ -43,7 +43,7 @@ final class ExcessiveClassLength extends AbstractRule implements ClassAware
             $loc = $node->getMetric('loc');
         }
 
-        if ($loc < $threshold) {
+        if ($loc <= $threshold) {
             return;
         }
 

--- a/src/Rule/Design/ExcessiveMethodLength.php
+++ b/src/Rule/Design/ExcessiveMethodLength.php
@@ -35,7 +35,7 @@ final class ExcessiveMethodLength extends AbstractRule implements FunctionAware,
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('minimum');
+        $threshold = $this->getIntProperty('maximum');
 
         $loc = -1;
         if ($this->isTruthyProperty('ignore-whitespace')) {
@@ -45,7 +45,7 @@ final class ExcessiveMethodLength extends AbstractRule implements FunctionAware,
             $loc = $node->getMetric('loc');
         }
 
-        if ($loc < $threshold) {
+        if ($loc <= $threshold) {
             return;
         }
 

--- a/src/Rule/Design/ExcessiveMethodLength.php
+++ b/src/Rule/Design/ExcessiveMethodLength.php
@@ -22,6 +22,7 @@ use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule will detect to long methods, those methods are unreadable and in
@@ -29,14 +30,15 @@ use PHPMD\Rule\MethodAware;
  */
 final class ExcessiveMethodLength extends AbstractRule implements FunctionAware, MethodAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the lines of code length for the given function or
      * method node against a configured threshold.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
-
         $loc = -1;
         if ($this->isTruthyProperty('ignore-whitespace')) {
             $loc = $node->getMetric('eloc');
@@ -45,7 +47,7 @@ final class ExcessiveMethodLength extends AbstractRule implements FunctionAware,
             $loc = $node->getMetric('loc');
         }
 
-        if ($loc <= $threshold) {
+        if ($loc <= $this->maximum) {
             return;
         }
 
@@ -55,7 +57,7 @@ final class ExcessiveMethodLength extends AbstractRule implements FunctionAware,
                 $node->getType(),
                 $node->getName(),
                 (string) $loc,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/Design/ExcessiveParameterList.php
+++ b/src/Rule/Design/ExcessiveParameterList.php
@@ -40,9 +40,9 @@ final class ExcessiveParameterList extends AbstractRule implements FunctionAware
             return;
         }
 
-        $threshold = $this->getIntProperty('minimum');
+        $threshold = $this->getIntProperty('maximum');
         $count = $node->getParameterCount();
-        if ($count < $threshold) {
+        if ($count <= $threshold) {
             return;
         }
 

--- a/src/Rule/Design/ExcessiveParameterList.php
+++ b/src/Rule/Design/ExcessiveParameterList.php
@@ -24,12 +24,16 @@ use PHPMD\AbstractRule;
 use PHPMD\Node\AbstractCallableNode;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule class checks for excessive long function and method parameter lists.
  */
 final class ExcessiveParameterList extends AbstractRule implements FunctionAware, MethodAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the number of arguments for the given function or method
      * node against a configured threshold.
@@ -40,9 +44,8 @@ final class ExcessiveParameterList extends AbstractRule implements FunctionAware
             return;
         }
 
-        $threshold = $this->getIntProperty('maximum');
         $count = $node->getParameterCount();
-        if ($count <= $threshold) {
+        if ($count <= $this->maximum) {
             return;
         }
 
@@ -57,7 +60,7 @@ final class ExcessiveParameterList extends AbstractRule implements FunctionAware
                 $node->getType(),
                 $node->getName(),
                 (string) $count,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/Design/NPathComplexity.php
+++ b/src/Rule/Design/NPathComplexity.php
@@ -35,9 +35,9 @@ final class NPathComplexity extends AbstractRule implements FunctionAware, Metho
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('minimum');
+        $threshold = $this->getIntProperty('maximum');
         $npath = $node->getMetric('npath');
-        if ($npath < $threshold) {
+        if ($npath <= $threshold) {
             return;
         }
 

--- a/src/Rule/Design/NPathComplexity.php
+++ b/src/Rule/Design/NPathComplexity.php
@@ -22,6 +22,7 @@ use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule will check the NPath-complexity of a method or function against the
@@ -29,15 +30,17 @@ use PHPMD\Rule\MethodAware;
  */
 final class NPathComplexity extends AbstractRule implements FunctionAware, MethodAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the acyclic complexity for the given node against a
      * configured threshold.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
         $npath = $node->getMetric('npath');
-        if ($npath <= $threshold) {
+        if ($npath <= $this->maximum) {
             return;
         }
 
@@ -47,7 +50,7 @@ final class NPathComplexity extends AbstractRule implements FunctionAware, Metho
                 $node->getType(),
                 $node->getName(),
                 (string) $npath,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/Design/NumberOfChildren.php
+++ b/src/Rule/Design/NumberOfChildren.php
@@ -21,12 +21,16 @@ namespace PHPMD\Rule\Design;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule will detect class that have to much direct child classes.
  */
 final class NumberOfChildren extends AbstractRule implements ClassAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the number of classes derived from the given class
      * node.
@@ -34,15 +38,14 @@ final class NumberOfChildren extends AbstractRule implements ClassAware
     public function apply(AbstractNode $node): void
     {
         $nocc = $node->getMetric('nocc');
-        $threshold = $this->getIntProperty('maximum');
-        if ($nocc > $threshold) {
+        if ($nocc > $this->maximum) {
             $this->addViolation(
                 $node,
                 [
                     $node->getType(),
                     $node->getName(),
                     (string) $nocc,
-                    (string) $threshold,
+                    (string) $this->maximum,
                 ]
             );
         }

--- a/src/Rule/Design/NumberOfChildren.php
+++ b/src/Rule/Design/NumberOfChildren.php
@@ -34,8 +34,8 @@ final class NumberOfChildren extends AbstractRule implements ClassAware
     public function apply(AbstractNode $node): void
     {
         $nocc = $node->getMetric('nocc');
-        $threshold = $this->getIntProperty('minimum');
-        if ($nocc >= $threshold) {
+        $threshold = $this->getIntProperty('maximum');
+        if ($nocc > $threshold) {
             $this->addViolation(
                 $node,
                 [

--- a/src/Rule/Design/TooManyFields.php
+++ b/src/Rule/Design/TooManyFields.php
@@ -21,21 +21,24 @@ namespace PHPMD\Rule\Design;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule class will detect all classes with too much fields.
  */
 final class TooManyFields extends AbstractRule implements ClassAware
 {
+    #[Threshold(['maximum', 'maxfields'])]
+    public int $maximum;
+
     /**
      * This method checks the number of methods with in a given class and checks
      * this number against a configured threshold.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
         $vars = $node->getMetric('vars');
-        if ($vars <= $threshold) {
+        if ($vars <= $this->maximum) {
             return;
         }
         $this->addViolation(
@@ -44,7 +47,7 @@ final class TooManyFields extends AbstractRule implements ClassAware
                 $node->getType(),
                 $node->getName(),
                 (string) $vars,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/Design/TooManyFields.php
+++ b/src/Rule/Design/TooManyFields.php
@@ -33,7 +33,7 @@ final class TooManyFields extends AbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maxfields');
+        $threshold = $this->getIntProperty('maximum');
         $vars = $node->getMetric('vars');
         if ($vars <= $threshold) {
             return;

--- a/src/Rule/Design/TooManyMethods.php
+++ b/src/Rule/Design/TooManyMethods.php
@@ -22,12 +22,16 @@ use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ClassNode;
 use PHPMD\Rule\ClassAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule class will detect all classes with too many methods.
  */
 final class TooManyMethods extends AbstractRule implements ClassAware
 {
+    #[Threshold(['maximum', 'maxmethods'])]
+    public int $maximum;
+
     /** Regular expression that filters all methods that are ignored by this rule. */
     private string $ignoreRegexp;
 
@@ -43,12 +47,11 @@ final class TooManyMethods extends AbstractRule implements ClassAware
 
         $this->ignoreRegexp = $this->getStringProperty('ignorepattern');
 
-        $threshold = $this->getIntProperty('maximum');
-        if ($node->getMetric('nom') <= $threshold) {
+        if ($node->getMetric('nom') <= $this->maximum) {
             return;
         }
         $nom = $this->countMethods($node);
-        if ($nom <= $threshold) {
+        if ($nom <= $this->maximum) {
             return;
         }
         $this->addViolation(
@@ -57,7 +60,7 @@ final class TooManyMethods extends AbstractRule implements ClassAware
                 $node->getType(),
                 $node->getName(),
                 (string) $nom,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/Design/TooManyMethods.php
+++ b/src/Rule/Design/TooManyMethods.php
@@ -43,7 +43,7 @@ final class TooManyMethods extends AbstractRule implements ClassAware
 
         $this->ignoreRegexp = $this->getStringProperty('ignorepattern');
 
-        $threshold = $this->getIntProperty('maxmethods');
+        $threshold = $this->getIntProperty('maximum');
         if ($node->getMetric('nom') <= $threshold) {
             return;
         }

--- a/src/Rule/Design/TooManyPublicMethods.php
+++ b/src/Rule/Design/TooManyPublicMethods.php
@@ -43,7 +43,7 @@ final class TooManyPublicMethods extends AbstractRule implements ClassAware
 
         $this->ignoreRegexp = $this->getStringProperty('ignorepattern');
 
-        $threshold = $this->getIntProperty('maxmethods');
+        $threshold = $this->getIntProperty('maximum');
         $publicMethodsCount = $node->getMetric('npm'); // NPM stands for Number of Public Methods
 
         if ($publicMethodsCount !== null && $publicMethodsCount <= $threshold) {

--- a/src/Rule/Design/TooManyPublicMethods.php
+++ b/src/Rule/Design/TooManyPublicMethods.php
@@ -22,12 +22,16 @@ use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ClassNode;
 use PHPMD\Rule\ClassAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule class will detect all classes with too much public methods.
  */
 final class TooManyPublicMethods extends AbstractRule implements ClassAware
 {
+    #[Threshold(['maximum', 'maxmethods'])]
+    public int $maximum;
+
     /** Regular expression that filters all methods that are ignored by this rule. */
     private string $ignoreRegexp;
 
@@ -43,16 +47,15 @@ final class TooManyPublicMethods extends AbstractRule implements ClassAware
 
         $this->ignoreRegexp = $this->getStringProperty('ignorepattern');
 
-        $threshold = $this->getIntProperty('maximum');
         $publicMethodsCount = $node->getMetric('npm'); // NPM stands for Number of Public Methods
 
-        if ($publicMethodsCount !== null && $publicMethodsCount <= $threshold) {
+        if ($publicMethodsCount !== null && $publicMethodsCount <= $this->maximum) {
             return;
         }
 
         $nom = $this->countMethods($node);
 
-        if ($nom <= $threshold) {
+        if ($nom <= $this->maximum) {
             return;
         }
 
@@ -62,7 +65,7 @@ final class TooManyPublicMethods extends AbstractRule implements ClassAware
                 $node->getType(),
                 $node->getName(),
                 (string) $nom,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/ExcessivePublicCount.php
+++ b/src/Rule/ExcessivePublicCount.php
@@ -20,6 +20,7 @@ namespace PHPMD\Rule;
 
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule checks the number of public methods and fields in a given class.
@@ -27,15 +28,17 @@ use PHPMD\AbstractRule;
  */
 final class ExcessivePublicCount extends AbstractRule implements ClassAware, TraitAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the number of public fields and methods in the given
      * class and checks that value against a configured threshold.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
         $cis = $node->getMetric('cis');
-        if ($cis <= $threshold) {
+        if ($cis <= $this->maximum) {
             return;
         }
         $this->addViolation(
@@ -44,7 +47,7 @@ final class ExcessivePublicCount extends AbstractRule implements ClassAware, Tra
                 $node->getType(),
                 $node->getName(),
                 (string) $cis,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/ExcessivePublicCount.php
+++ b/src/Rule/ExcessivePublicCount.php
@@ -33,9 +33,9 @@ final class ExcessivePublicCount extends AbstractRule implements ClassAware, Tra
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('minimum');
+        $threshold = $this->getIntProperty('maximum');
         $cis = $node->getMetric('cis');
-        if ($cis < $threshold) {
+        if ($cis <= $threshold) {
             return;
         }
         $this->addViolation(

--- a/tests/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
+++ b/tests/php/PHPMD/Integration/CouplingBetweenObjectsIntegrationTest.php
@@ -50,7 +50,7 @@ class CouplingBetweenObjectsIntegrationTest extends AbstractTestCase
         static::assertNotFalse($content);
         static::assertStringContainsString(
             'has a coupling between objects value of 14. ' .
-            'Consider to reduce the number of dependencies under 13.',
+            'Consider to reduce the number of dependencies to 13 or less.',
             $content
         );
     }

--- a/tests/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest.php
+++ b/tests/php/PHPMD/Regression/ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest.php
@@ -29,7 +29,7 @@ class ExcessivePublicCountRuleNeverExecutedTicket015RegressionTest extends Abstr
     public function testRuleSetInvokesRuleForClassInstance(): void
     {
         $rule = new ExcessivePublicCount();
-        $rule->addProperty('minimum', '3');
+        $rule->addProperty('maximum', '3');
 
         $class = $this->getClass();
         $class->setMetrics(['cis' => 4]);

--- a/tests/php/PHPMD/Rule/CyclomaticComplexityTest.php
+++ b/tests/php/PHPMD/Rule/CyclomaticComplexityTest.php
@@ -43,6 +43,21 @@ class CyclomaticComplexityTest extends AbstractTestCase
     }
 
     /**
+     * Tests that the legacy `reportLevel` property name is still accepted as
+     * an alias for `maximum`.
+     */
+    public function testRuleAcceptsLegacyReportLevelProperty(): void
+    {
+        $method = $this->getMethodMock('ccn2', 42);
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new CyclomaticComplexity();
+        $rule->setReport($report);
+        $rule->addProperty('reportLevel', '10');
+        $rule->apply($method);
+    }
+
+    /**
      * Test that the rule does not apply for a value that is equal with the
      * configured threshold.
      */

--- a/tests/php/PHPMD/Rule/CyclomaticComplexityTest.php
+++ b/tests/php/PHPMD/Rule/CyclomaticComplexityTest.php
@@ -38,22 +38,22 @@ class CyclomaticComplexityTest extends AbstractTestCase
 
         $rule = new CyclomaticComplexity();
         $rule->setReport($report);
-        $rule->addProperty('reportLevel', '10');
+        $rule->addProperty('maximum', '10');
         $rule->apply($method);
     }
 
     /**
-     * Test that the rule applies for a value that is equal with the configured
-     * threshold.
+     * Test that the rule does not apply for a value that is equal with the
+     * configured threshold.
      */
-    public function testRuleAppliesForValueEqualToThreshold(): void
+    public function testRuleDoesNotApplyForValueEqualToThreshold(): void
     {
         $method = $this->getMethodMock('ccn2', 42);
-        $report = $this->getReportWithOneViolation();
+        $report = $this->getReportWithNoViolation();
 
         $rule = new CyclomaticComplexity();
         $rule->setReport($report);
-        $rule->addProperty('reportLevel', '42');
+        $rule->addProperty('maximum', '42');
         $rule->apply($method);
     }
 
@@ -68,7 +68,7 @@ class CyclomaticComplexityTest extends AbstractTestCase
 
         $rule = new CyclomaticComplexity();
         $rule->setReport($report);
-        $rule->addProperty('reportLevel', '23');
+        $rule->addProperty('maximum', '23');
         $rule->apply($method);
     }
 }

--- a/tests/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
+++ b/tests/php/PHPMD/Rule/Design/CouplingBetweenObjectsTest.php
@@ -37,10 +37,10 @@ class CouplingBetweenObjectsTest extends AbstractTestCase
         $rule->apply($this->getClassMock('cbo', 41));
     }
 
-    public function testRuleAppliesToClassWithCboEqualToThreshold(): void
+    public function testRuleNotAppliesToClassWithCboEqualToThreshold(): void
     {
         $rule = new CouplingBetweenObjects();
-        $rule->setReport($this->getReportWithOneViolation());
+        $rule->setReport($this->getReportWithNoViolation());
         $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('cbo', 42));
     }

--- a/tests/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
+++ b/tests/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
@@ -50,4 +50,12 @@ class DepthOfInheritanceTest extends AbstractTestCase
         $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('dit', 43));
     }
+
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $rule = new DepthOfInheritance();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('minimum', '42');
+        $rule->apply($this->getClassMock('dit', 43));
+    }
 }

--- a/tests/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
+++ b/tests/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
@@ -31,15 +31,15 @@ class DepthOfInheritanceTest extends AbstractTestCase
     {
         $rule = new DepthOfInheritance();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('minimum', '42');
+        $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('dit', 41));
     }
 
-    public function testRuleAppliesToClassWithNumberOfParentIdenticalToThreshold(): void
+    public function testRuleNotAppliesToClassWithNumberOfParentIdenticalToThreshold(): void
     {
         $rule = new DepthOfInheritance();
-        $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('minimum', '42');
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('dit', 42));
     }
 
@@ -47,7 +47,7 @@ class DepthOfInheritanceTest extends AbstractTestCase
     {
         $rule = new DepthOfInheritance();
         $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('minimum', '42');
+        $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('dit', 43));
     }
 }

--- a/tests/php/PHPMD/Rule/Design/ExcessiveClassComplexityTest.php
+++ b/tests/php/PHPMD/Rule/Design/ExcessiveClassComplexityTest.php
@@ -40,10 +40,10 @@ class ExcessiveClassComplexityTest extends AbstractTestCase
         $rule->apply($class);
     }
 
-    public function testRuleAppliesForValueEqualToThreshold(): void
+    public function testRuleNotAppliesForValueEqualToThreshold(): void
     {
         $class = $this->getClassMock('wmc', 42);
-        $report = $this->getReportWithOneViolation();
+        $report = $this->getReportWithNoViolation();
 
         $rule = new ExcessiveClassComplexity();
         $rule->setReport($report);

--- a/tests/php/PHPMD/Rule/Design/ExcessiveClassLengthTest.php
+++ b/tests/php/PHPMD/Rule/Design/ExcessiveClassLengthTest.php
@@ -38,23 +38,23 @@ class ExcessiveClassLengthTest extends AbstractTestCase
 
         $rule = new ExcessiveClassLength();
         $rule->setReport($report);
-        $rule->addProperty('minimum', '41');
+        $rule->addProperty('maximum', '41');
         $rule->addProperty('ignore-whitespace', '0');
         $rule->apply($class);
     }
 
     /**
-     * Test that the rule applies for a value that is equal with the configured
-     * threshold.
+     * Test that the rule does not apply for a value that is equal with the
+     * configured threshold.
      */
-    public function testRuleAppliesForValueEqualToThreshold(): void
+    public function testRuleDoesNotApplyForValueEqualToThreshold(): void
     {
         $class = $this->getClassMock('loc', 42);
-        $report = $this->getReportWithOneViolation();
+        $report = $this->getReportWithNoViolation();
 
         $rule = new ExcessiveClassLength();
         $rule->setReport($report);
-        $rule->addProperty('minimum', '42');
+        $rule->addProperty('maximum', '42');
         $rule->addProperty('ignore-whitespace', '0');
         $rule->apply($class);
     }
@@ -70,7 +70,7 @@ class ExcessiveClassLengthTest extends AbstractTestCase
 
         $rule = new ExcessiveClassLength();
         $rule->setReport($report);
-        $rule->addProperty('minimum', '23');
+        $rule->addProperty('maximum', '23');
         $rule->addProperty('ignore-whitespace', '0');
         $rule->apply($class);
     }
@@ -85,7 +85,7 @@ class ExcessiveClassLengthTest extends AbstractTestCase
 
         $rule = new ExcessiveClassLength();
         $rule->setReport($report);
-        $rule->addProperty('minimum', '23');
+        $rule->addProperty('maximum', '23');
         $rule->addProperty('ignore-whitespace', '1');
         $rule->apply($class);
     }

--- a/tests/php/PHPMD/Rule/Design/ExcessiveClassLengthTest.php
+++ b/tests/php/PHPMD/Rule/Design/ExcessiveClassLengthTest.php
@@ -44,6 +44,22 @@ class ExcessiveClassLengthTest extends AbstractTestCase
     }
 
     /**
+     * Tests that the legacy `minimum` property name is still accepted as an
+     * alias for `maximum`.
+     */
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $class = $this->getClassMock('loc', 42);
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new ExcessiveClassLength();
+        $rule->setReport($report);
+        $rule->addProperty('minimum', '41');
+        $rule->addProperty('ignore-whitespace', '0');
+        $rule->apply($class);
+    }
+
+    /**
      * Test that the rule does not apply for a value that is equal with the
      * configured threshold.
      */

--- a/tests/php/PHPMD/Rule/Design/ExcessiveMethodLengthTest.php
+++ b/tests/php/PHPMD/Rule/Design/ExcessiveMethodLengthTest.php
@@ -44,6 +44,22 @@ class ExcessiveMethodLengthTest extends AbstractTestCase
     }
 
     /**
+     * Tests that the legacy `minimum` property name is still accepted as an
+     * alias for `maximum`.
+     */
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $method = $this->getMethodMock('loc', 42);
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new ExcessiveMethodLength();
+        $rule->setReport($report);
+        $rule->addProperty('minimum', '41');
+        $rule->addProperty('ignore-whitespace', '0');
+        $rule->apply($method);
+    }
+
+    /**
      * Test that the rule does not apply for a value that is equal with the
      * configured threshold.
      */

--- a/tests/php/PHPMD/Rule/Design/ExcessiveMethodLengthTest.php
+++ b/tests/php/PHPMD/Rule/Design/ExcessiveMethodLengthTest.php
@@ -38,23 +38,23 @@ class ExcessiveMethodLengthTest extends AbstractTestCase
 
         $rule = new ExcessiveMethodLength();
         $rule->setReport($report);
-        $rule->addProperty('minimum', '41');
+        $rule->addProperty('maximum', '41');
         $rule->addProperty('ignore-whitespace', '0');
         $rule->apply($method);
     }
 
     /**
-     * Test that the rule applies for a value that is equal with the configured
-     * threshold.
+     * Test that the rule does not apply for a value that is equal with the
+     * configured threshold.
      */
-    public function testRuleAppliesForValueEqualToThreshold(): void
+    public function testRuleDoesNotApplyForValueEqualToThreshold(): void
     {
         $method = $this->getMethodMock('loc', 42);
-        $report = $this->getReportWithOneViolation();
+        $report = $this->getReportWithNoViolation();
 
         $rule = new ExcessiveMethodLength();
         $rule->setReport($report);
-        $rule->addProperty('minimum', '42');
+        $rule->addProperty('maximum', '42');
         $rule->addProperty('ignore-whitespace', '0');
         $rule->apply($method);
     }
@@ -70,7 +70,7 @@ class ExcessiveMethodLengthTest extends AbstractTestCase
 
         $rule = new ExcessiveMethodLength();
         $rule->setReport($report);
-        $rule->addProperty('minimum', '23');
+        $rule->addProperty('maximum', '23');
         $rule->addProperty('ignore-whitespace', '0');
         $rule->apply($method);
     }
@@ -85,7 +85,7 @@ class ExcessiveMethodLengthTest extends AbstractTestCase
 
         $rule = new ExcessiveMethodLength();
         $rule->setReport($report);
-        $rule->addProperty('minimum', '23');
+        $rule->addProperty('maximum', '23');
         $rule->addProperty('ignore-whitespace', '1');
         $rule->apply($class);
     }

--- a/tests/php/PHPMD/Rule/Design/ExcessiveParameterListTest.php
+++ b/tests/php/PHPMD/Rule/Design/ExcessiveParameterListTest.php
@@ -30,51 +30,51 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[CoversClass(ExcessiveParameterList::class)]
 class ExcessiveParameterListTest extends AbstractTestCase
 {
-    public function testApplyIgnoresMethodsWithLessParametersThanMinimum(): void
+    public function testApplyIgnoresMethodsWithLessParametersThanMaximum(): void
     {
         $rule = new ExcessiveParameterList();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('minimum', '4');
+        $rule->addProperty('maximum', '4');
         $rule->apply($this->createMethod(3));
     }
 
-    public function testApplyReportsMethodsWithIdenticalParametersAndMinimum(): void
+    public function testApplyIgnoresMethodsWithIdenticalParametersAndMaximum(): void
     {
         $rule = new ExcessiveParameterList();
-        $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('minimum', '3');
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->addProperty('maximum', '3');
         $rule->apply($this->createMethod(3));
     }
 
-    public function testApplyReportsMethodsWithMoreParametersThanMinimum(): void
+    public function testApplyReportsMethodsWithMoreParametersThanMaximum(): void
     {
         $rule = new ExcessiveParameterList();
         $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('minimum', '3');
+        $rule->addProperty('maximum', '3');
         $rule->apply($this->createMethod(42));
     }
 
-    public function testApplyIgnoresFunctionsWithLessParametersThanMinimum(): void
+    public function testApplyIgnoresFunctionsWithLessParametersThanMaximum(): void
     {
         $rule = new ExcessiveParameterList();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('minimum', '4');
+        $rule->addProperty('maximum', '4');
         $rule->apply($this->createFunction(3));
     }
 
-    public function testApplyReportsFunctionsWithIdenticalParametersAndMinimum(): void
+    public function testApplyIgnoresFunctionsWithIdenticalParametersAndMaximum(): void
     {
         $rule = new ExcessiveParameterList();
-        $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('minimum', '3');
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->addProperty('maximum', '3');
         $rule->apply($this->createFunction(3));
     }
 
-    public function testApplyReportsFunctionsWithMoreParametersThanMinimum(): void
+    public function testApplyReportsFunctionsWithMoreParametersThanMaximum(): void
     {
         $rule = new ExcessiveParameterList();
         $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('minimum', '3');
+        $rule->addProperty('maximum', '3');
         $rule->apply($this->createFunction(42));
     }
 
@@ -89,7 +89,7 @@ class ExcessiveParameterListTest extends AbstractTestCase
 
         $rule = new ExcessiveParameterList();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('minimum', '3');
+        $rule->addProperty('maximum', '2');
         $rule->addProperty('exceptions', 'fooBar');
         $rule->apply($method);
     }
@@ -105,7 +105,7 @@ class ExcessiveParameterListTest extends AbstractTestCase
 
         $rule = new ExcessiveParameterList();
         $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('minimum', '3');
+        $rule->addProperty('maximum', '2');
         $rule->addProperty('exceptions', 'otherMethod');
         $rule->apply($method);
     }
@@ -121,7 +121,7 @@ class ExcessiveParameterListTest extends AbstractTestCase
 
         $rule = new ExcessiveParameterList();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('minimum', '3');
+        $rule->addProperty('maximum', '2');
         $rule->addProperty('exceptions', 'fooBar');
         $rule->apply($function);
     }
@@ -133,7 +133,7 @@ class ExcessiveParameterListTest extends AbstractTestCase
     {
         $rule = new ExcessiveParameterList();
         $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('minimum', '3');
+        $rule->addProperty('maximum', '2');
         $rule->apply($this->createMethod(3));
     }
 

--- a/tests/php/PHPMD/Rule/Design/ExcessiveParameterListTest.php
+++ b/tests/php/PHPMD/Rule/Design/ExcessiveParameterListTest.php
@@ -54,6 +54,14 @@ class ExcessiveParameterListTest extends AbstractTestCase
         $rule->apply($this->createMethod(42));
     }
 
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $rule = new ExcessiveParameterList();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('minimum', '3');
+        $rule->apply($this->createMethod(42));
+    }
+
     public function testApplyIgnoresFunctionsWithLessParametersThanMaximum(): void
     {
         $rule = new ExcessiveParameterList();

--- a/tests/php/PHPMD/Rule/Design/NPathComplexityTest.php
+++ b/tests/php/PHPMD/Rule/Design/NPathComplexityTest.php
@@ -38,22 +38,22 @@ class NPathComplexityTest extends AbstractTestCase
 
         $rule = new NPathComplexity();
         $rule->setReport($report);
-        $rule->addProperty('minimum', '41');
+        $rule->addProperty('maximum', '41');
         $rule->apply($method);
     }
 
     /**
-     * Test that the rule applies for a value that is equal with the configured
-     * threshold.
+     * Test that the rule does not apply for a value that is equal with the
+     * configured threshold.
      */
-    public function testRuleAppliesForValueEqualToThreshold(): void
+    public function testRuleDoesNotApplyForValueEqualToThreshold(): void
     {
         $method = $this->getMethodMock('npath', 42);
-        $report = $this->getReportWithOneViolation();
+        $report = $this->getReportWithNoViolation();
 
         $rule = new NPathComplexity();
         $rule->setReport($report);
-        $rule->addProperty('minimum', '42');
+        $rule->addProperty('maximum', '42');
         $rule->apply($method);
     }
 
@@ -68,7 +68,7 @@ class NPathComplexityTest extends AbstractTestCase
 
         $rule = new NPathComplexity();
         $rule->setReport($report);
-        $rule->addProperty('minimum', '23');
+        $rule->addProperty('maximum', '23');
         $rule->apply($method);
     }
 }

--- a/tests/php/PHPMD/Rule/Design/NPathComplexityTest.php
+++ b/tests/php/PHPMD/Rule/Design/NPathComplexityTest.php
@@ -43,6 +43,21 @@ class NPathComplexityTest extends AbstractTestCase
     }
 
     /**
+     * Tests that the legacy `minimum` property name is still accepted as an
+     * alias for `maximum`.
+     */
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $method = $this->getMethodMock('npath', 42);
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new NPathComplexity();
+        $rule->setReport($report);
+        $rule->addProperty('minimum', '41');
+        $rule->apply($method);
+    }
+
+    /**
      * Test that the rule does not apply for a value that is equal with the
      * configured threshold.
      */

--- a/tests/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
+++ b/tests/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
@@ -50,4 +50,12 @@ class NumberOfChildrenTest extends AbstractTestCase
         $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('nocc', 43));
     }
+
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $rule = new NumberOfChildren();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('minimum', '42');
+        $rule->apply($this->getClassMock('nocc', 43));
+    }
 }

--- a/tests/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
+++ b/tests/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
@@ -31,15 +31,15 @@ class NumberOfChildrenTest extends AbstractTestCase
     {
         $rule = new NumberOfChildren();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('minimum', '42');
+        $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('nocc', 41));
     }
 
-    public function testRuleAppliesToClassWithChildrenIdenticalToThreshold(): void
+    public function testRuleNotAppliesToClassWithChildrenIdenticalToThreshold(): void
     {
         $rule = new NumberOfChildren();
-        $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('minimum', '42');
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('nocc', 42));
     }
 
@@ -47,7 +47,7 @@ class NumberOfChildrenTest extends AbstractTestCase
     {
         $rule = new NumberOfChildren();
         $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('minimum', '42');
+        $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('nocc', 43));
     }
 }

--- a/tests/php/PHPMD/Rule/Design/TooManyFieldsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyFieldsTest.php
@@ -50,4 +50,12 @@ class TooManyFieldsTest extends AbstractTestCase
         $rule->addProperty('maximum', '23');
         $rule->apply($this->getClassMock('vars', 42));
     }
+
+    public function testRuleAcceptsLegacyMaxfieldsProperty(): void
+    {
+        $rule = new TooManyFields();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('maxfields', '23');
+        $rule->apply($this->getClassMock('vars', 42));
+    }
 }

--- a/tests/php/PHPMD/Rule/Design/TooManyFieldsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyFieldsTest.php
@@ -31,7 +31,7 @@ class TooManyFieldsTest extends AbstractTestCase
     {
         $rule = new TooManyFields();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxfields', '42');
+        $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('vars', 23));
     }
 
@@ -39,7 +39,7 @@ class TooManyFieldsTest extends AbstractTestCase
     {
         $rule = new TooManyFields();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxfields', '42');
+        $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('vars', 42));
     }
 
@@ -47,7 +47,7 @@ class TooManyFieldsTest extends AbstractTestCase
     {
         $rule = new TooManyFields();
         $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('maxfields', '23');
+        $rule->addProperty('maximum', '23');
         $rule->apply($this->getClassMock('vars', 42));
     }
 }

--- a/tests/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -55,6 +55,15 @@ class TooManyMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));
     }
 
+    public function testRuleAcceptsLegacyMaxmethodsProperty(): void
+    {
+        $rule = new TooManyMethods();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('maxmethods', '23');
+        $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
+        $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));
+    }
+
     public function testRuleIgnoresGetterMethodsInTest(): void
     {
         $rule = new TooManyMethods();

--- a/tests/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -32,7 +32,7 @@ class TooManyMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '42');
+        $rule->addProperty('maximum', '42');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(23));
     }
@@ -41,7 +41,7 @@ class TooManyMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '42');
+        $rule->addProperty('maximum', '42');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(42));
     }
@@ -50,7 +50,7 @@ class TooManyMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('maxmethods', '23');
+        $rule->addProperty('maximum', '23');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));
     }
@@ -59,7 +59,7 @@ class TooManyMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('maximum', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'getClass']));
     }
@@ -68,7 +68,7 @@ class TooManyMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('maximum', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'setClass']));
     }
@@ -77,7 +77,7 @@ class TooManyMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('maximum', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'injectClass']));
     }
@@ -86,7 +86,7 @@ class TooManyMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '2');
+        $rule->addProperty('maximum', '2');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(3, ['invoke', 'getClass', 'setClass']));
     }
@@ -95,7 +95,7 @@ class TooManyMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('maximum', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'hasClass']));
     }
@@ -104,7 +104,7 @@ class TooManyMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('maximum', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'isClass']));
     }
@@ -113,7 +113,7 @@ class TooManyMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('maximum', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'withClass']));
     }

--- a/tests/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -36,7 +36,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '42');
+        $rule->addProperty('maximum', '42');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(23));
     }
@@ -45,7 +45,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '42');
+        $rule->addProperty('maximum', '42');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(42));
     }
@@ -54,7 +54,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('maxmethods', '23');
+        $rule->addProperty('maximum', '23');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));
     }
@@ -63,7 +63,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('maximum', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'getClass']));
     }
@@ -72,7 +72,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('maximum', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'setClass']));
     }
@@ -81,7 +81,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('maximum', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'injectClass']));
     }
@@ -90,7 +90,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '2');
+        $rule->addProperty('maximum', '2');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(3, ['foo', 'bar'], ['baz', 'bah']));
     }
@@ -99,7 +99,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '2');
+        $rule->addProperty('maximum', '2');
         $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'getClass', 'setClass']));
     }
@@ -108,7 +108,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('maximum', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'hasClass']));
     }
@@ -117,7 +117,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('maximum', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'isClass']));
     }
@@ -126,7 +126,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('maximum', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|is|has|with))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'withClass']));
     }
@@ -135,7 +135,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
     {
         $rule = new TooManyPublicMethods();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('maxmethods', '1');
+        $rule->addProperty('maximum', '1');
         $rule->addProperty('ignorepattern', '(^(set|get|is|has|with|test))i');
         $rule->apply($this->createClassMock(2, ['invoke', 'testMyFeature']));
     }
@@ -146,7 +146,7 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule = new TooManyPublicMethods();
         $report = new Report();
         $rule->setReport($report);
-        $rule->addProperty('maxmethods', '5');
+        $rule->addProperty('maximum', '5');
         $rule->addProperty('ignorepattern', '');
         $rule->apply($class);
         $violations = $report->getRuleViolations();

--- a/tests/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -59,6 +59,15 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));
     }
 
+    public function testRuleAcceptsLegacyMaxmethodsProperty(): void
+    {
+        $rule = new TooManyPublicMethods();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('maxmethods', '23');
+        $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
+        $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));
+    }
+
     public function testRuleIgnoresGetterMethodsInTest(): void
     {
         $rule = new TooManyPublicMethods();

--- a/tests/php/PHPMD/Rule/ExcessivePublicCountTest.php
+++ b/tests/php/PHPMD/Rule/ExcessivePublicCountTest.php
@@ -35,6 +35,14 @@ class ExcessivePublicCountTest extends AbstractTestCase
         $rule->apply($this->getClassMock('cis', 23));
     }
 
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $rule = new ExcessivePublicCount();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('minimum', '23');
+        $rule->apply($this->getClassMock('cis', 42));
+    }
+
     public function testRuleDoesNotApplyToClassesWithSameNumberOfPublicMembersAsThreshold(): void
     {
         $rule = new ExcessivePublicCount();

--- a/tests/php/PHPMD/Rule/ExcessivePublicCountTest.php
+++ b/tests/php/PHPMD/Rule/ExcessivePublicCountTest.php
@@ -31,15 +31,15 @@ class ExcessivePublicCountTest extends AbstractTestCase
     {
         $rule = new ExcessivePublicCount();
         $rule->setReport($this->getReportWithNoViolation());
-        $rule->addProperty('minimum', '42');
+        $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('cis', 23));
     }
 
-    public function testRuleAppliesToClassesWithSameNumberOfPublicMembersAsThreshold(): void
+    public function testRuleDoesNotApplyToClassesWithSameNumberOfPublicMembersAsThreshold(): void
     {
         $rule = new ExcessivePublicCount();
-        $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('minimum', '42');
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('cis', 42));
     }
 
@@ -47,7 +47,7 @@ class ExcessivePublicCountTest extends AbstractTestCase
     {
         $rule = new ExcessivePublicCount();
         $rule->setReport($this->getReportWithOneViolation());
-        $rule->addProperty('minimum', '23');
+        $rule->addProperty('maximum', '23');
         $rule->apply($this->getClassMock('cis', 42));
     }
 }

--- a/tests/resources/files/rulesets/exclude-pattern.xml
+++ b/tests/resources/files/rulesets/exclude-pattern.xml
@@ -10,7 +10,7 @@
     <rule ref="rulesets/codesize.xml/CyclomaticComplexity" />
     <rule ref="rulesets/codesize.xml/NPathComplexity">
         <properties>
-            <property name="minimum" value="50" />
+            <property name="maximum" value="50" />
         </properties>
     </rule>
 

--- a/tests/resources/files/rulesets/pmd-refset1.xml
+++ b/tests/resources/files/rulesets/pmd-refset1.xml
@@ -10,7 +10,7 @@
     <rule ref="rulesets/codesize.xml/CyclomaticComplexity" />
     <rule ref="rulesets/codesize.xml/NPathComplexity">
         <properties>
-            <property name="minimum" value="50" />
+            <property name="maximum" value="50" />
         </properties>
     </rule>
 </ruleset>


### PR DESCRIPTION
Type: refactoring
Issue: Resolves #670
Breaking change: yes

Standardized rule threshold properties to `maximum`. Rules now report
  only when the measured value exceeds (`>`) the configured `maximum`. Rules
  that check a lower bound (ShortVariable, ShortMethodName, ShortClassName)
  keep the `minimum` property. Renamed properties:
  - CyclomaticComplexity: `reportLevel` -> `maximum`
  - NPathComplexity: `minimum` -> `maximum`
  - ExcessiveMethodLength: `minimum` -> `maximum`
  - ExcessiveClassLength: `minimum` -> `maximum`
  - ExcessiveParameterList: `minimum` -> `maximum`
  - ExcessivePublicCount: `minimum` -> `maximum`
  - TooManyFields: `maxfields` -> `maximum`
  - TooManyMethods: `maxmethods` -> `maximum`
  - TooManyPublicMethods: `maxmethods` -> `maximum`
  - NumberOfChildren: `minimum` -> `maximum`
  - DepthOfInheritance: `minimum` -> `maximum`
  
  Rules that previously reported when the value equaled the threshold
  (CyclomaticComplexity, NPathComplexity, ExcessiveMethodLength,
  ExcessiveClassLength, ExcessiveParameterList, ExcessivePublicCount,
  NumberOfChildren, DepthOfInheritance, ExcessiveClassComplexity,
  CouplingBetweenObjects) now only report when the value is greater than
  the threshold, so the configured `maximum` is the highest accepted value.