### PR TITLE
Fix false positive unused variable when bound by reference

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,6 +53,7 @@ Fixed:
 
 - Fixed false positive in `UnusedLocalVariable` for variables used with coalescing assignment.
 - Fixed #814: Correctly attribute argument to variadic parameter.
+- Fixed #927: False positive in `UnusedLocalVariable` when a variable bound by reference is written to.
 - Fixed #1016: Crash when isPassedByReference checks a parent that does not exist.
 - Fixed #1236: PHP 8.4 deprecation for ReflectionMethod::__construct() with 1 argument.
 - Fixed: `--strict` did not reveal `LongVariable` suppressions on fields/variables/parameters, nor `UnusedPrivateMethod` suppressions on private methods.

--- a/src/Rule/UnusedLocalVariable.php
+++ b/src/Rule/UnusedLocalVariable.php
@@ -38,6 +38,7 @@ use PHPMD\AbstractNode;
 use PHPMD\Attribute\SuppressWarnings;
 use PHPMD\Node\AbstractCallableNode;
 use PHPMD\Rule\Design\CouplingBetweenObjects;
+use PHPMD\Rule\Design\ExcessiveClassComplexity;
 use PHPMD\Utility\ExceptionsList;
 
 /**
@@ -45,6 +46,7 @@ use PHPMD\Utility\ExceptionsList;
  * that are not used by any code in the analyzed source artifact.
  */
 #[SuppressWarnings(CouplingBetweenObjects::class)]
+#[SuppressWarnings(ExcessiveClassComplexity::class)]
 final class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware, MethodAware
 {
     /**
@@ -116,6 +118,8 @@ final class UnusedLocalVariable extends AbstractLocalVariable implements Functio
             return false;
         }
 
+        $boundByReference = false;
+
         foreach ($nodes as $node) {
             $parent = $node->getParent();
 
@@ -130,9 +134,36 @@ final class UnusedLocalVariable extends AbstractLocalVariable implements Functio
             if (in_array($node->getNode(), array_slice($parent->getChildren(), 1), true)) {
                 return true;
             }
+
+            if ($this->isReferenceAssignment($parent)) {
+                $boundByReference = true;
+
+                continue;
+            }
+
+            // Assigning to a variable that was bound by reference writes to
+            // the referenced value, so the assignment itself is a usage.
+            if ($boundByReference) {
+                return true;
+            }
         }
 
         return false;
+    }
+
+    /**
+     * Checks if the given assignment binds the target variable by reference,
+     * like <b>$variable = &$other</b>.
+     *
+     * @param AbstractNode<AbstractASTNode> $assignment
+     */
+    private function isReferenceAssignment(AbstractNode $assignment): bool
+    {
+        $value = $assignment->getChildren()[1] ?? null;
+        $children = $value instanceof ASTExpression ? $value->getChildren() : [];
+
+        return ($children[0] ?? null) instanceof ASTExpression
+            && $children[0]->getImage() === '&';
     }
 
     /**

--- a/tests/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToUsedReference.php
+++ b/tests/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToUsedReference.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+class testRuleDoesNotApplyToUsedReference
+{
+    public function testRuleDoesNotApplyToUsedReference() {
+        $a = 1;
+        $b = &$a;
+        $b = 2;
+        print($a);
+    }
+}

--- a/tests/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToUsedReference.php
+++ b/tests/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToUsedReference.php
@@ -14,9 +14,11 @@
  * @license https://opensource.org/licenses/bsd-license.php BSD License
  * @link http://phpmd.org/
  */
+
 class testRuleDoesNotApplyToUsedReference
 {
-    public function testRuleDoesNotApplyToUsedReference() {
+    public function testRuleDoesNotApplyToUsedReference()
+    {
         $a = 1;
         $b = &$a;
         $b = 2;


### PR DESCRIPTION
Type: bugfix
Issue: Resolves #927
Breaking change: no
