### PR TITLE
Accept legacy threshold property names as aliases

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,8 @@ Breaking changes:
 - Standardized rule threshold properties to `maximum` (#670). Rules now report
   only when the measured value exceeds (`>`) the configured `maximum`. Rules
   that check a lower bound (ShortVariable, ShortMethodName, ShortClassName)
-  keep the `minimum` property. Renamed properties:
+  keep the `minimum` property. Renamed properties (the old names remain
+  accepted as aliases):
   - CyclomaticComplexity: `reportLevel` -> `maximum`
   - NPathComplexity: `minimum` -> `maximum`
   - ExcessiveMethodLength: `minimum` -> `maximum`
@@ -23,6 +24,7 @@ Breaking changes:
   - TooManyPublicMethods: `maxmethods` -> `maximum`
   - NumberOfChildren: `minimum` -> `maximum`
   - DepthOfInheritance: `minimum` -> `maximum`
+
   Rules that previously reported when the value equaled the threshold
   (CyclomaticComplexity, NPathComplexity, ExcessiveMethodLength,
   ExcessiveClassLength, ExcessiveParameterList, ExcessivePublicCount,

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -97,7 +97,7 @@ A new exit code `3` has been added, which indicates that one or more files could
 
 Rules that check an upper bound now consistently use a property named `maximum`, and only report a violation when the measured value *exceeds* the configured value (`value > maximum`). Previously, several rules used `minimum`, `maxfields`, `maxmethods`, or `reportLevel` for what was semantically a maximum, and some reported already when the value *equaled* the threshold.
 
-If your custom rule set configures one of the following rules, rename the property:
+If your custom rule set configures one of the following rules, rename the property. The old names remain accepted as aliases, so an existing rule set keeps its configured thresholds, but the names in the right column are the documented ones going forward:
 
 | Rule                     | PHPMD 2       | PHPMD 3   |
 |--------------------------|---------------|-----------|
@@ -114,6 +114,8 @@ If your custom rule set configures one of the following rules, rename the proper
 | DepthOfInheritance       | `minimum`     | `maximum` |
 
 The comparison is now inclusive for all of these rules: the configured `maximum` is the highest still-accepted value, and only values above it are reported. Rules that previously reported when the value equaled the threshold (all of the above plus ExcessiveClassComplexity and CouplingBetweenObjects) accept one more unit than before. If you want to keep the exact same behavior as PHPMD 2 for a rule that used `value >= threshold`, configure `maximum` to the old value minus one.
+
+This also shifts the shipped defaults: on the default rule sets, values that sat exactly on a threshold (for example a class with a WMC of exactly 50 for ExcessiveClassComplexity, or a CBO of exactly 13 for CouplingBetweenObjects) are no longer reported. Baseline entries recorded for such violations will no longer match and can be removed from your baseline file.
 
 Rules that check a lower bound — ShortVariable, ShortMethodName, and ShortClassName — keep the `minimum` property (a name length *below* the configured minimum is reported).
 

--- a/rulesets/codesize.xml
+++ b/rulesets/codesize.xml
@@ -213,7 +213,7 @@ public class Foo {
 
     <rule name="TooManyFields"
           since="0.1"
-          message="The {0} {1} has {2} fields. Consider redesigning {1} to keep the number of fields under {3}."
+          message="The {0} {1} has {2} fields. Consider redesigning {1} to keep the number of fields at {3} or less."
           class="PHPMD\Rule\Design\TooManyFields"
           externalInfoUrl="https://phpmd.org/rules/codesize.html#toomanyfields">
         <description>
@@ -334,7 +334,7 @@ public class Foo extends Bar {
     <rule name="TooManyMethods"
           since="0.1"
           class="PHPMD\Rule\Design\TooManyMethods"
-          message="The {0} {1} has {2} non-getter- and setter-methods. Consider refactoring {1} to keep number of methods under {3}."
+          message="The {0} {1} has {2} non-getter- and setter-methods. Consider refactoring {1} to keep number of methods at {3} or less."
           externalInfoUrl="https://phpmd.org/rules/codesize.html#toomanymethods">
         <description>
             <![CDATA[
@@ -356,7 +356,7 @@ The default was changed from 10 to 25 in PHPMD 2.3.
     <rule name="TooManyPublicMethods"
           since="0.1"
           class="PHPMD\Rule\Design\TooManyPublicMethods"
-          message="The {0} {1} has {2} public methods. Consider refactoring {1} to keep number of public methods under {3}."
+          message="The {0} {1} has {2} public methods. Consider refactoring {1} to keep number of public methods at {3} or less."
           externalInfoUrl="https://phpmd.org/rules/codesize.html#toomanypublicmethods">
         <description>
             <![CDATA[

--- a/src/Rule/CyclomaticComplexity.php
+++ b/src/Rule/CyclomaticComplexity.php
@@ -20,6 +20,7 @@ namespace PHPMD\Rule;
 
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule checks a given method or function against the configured cyclomatic
@@ -27,15 +28,17 @@ use PHPMD\AbstractRule;
  */
 final class CyclomaticComplexity extends AbstractRule implements FunctionAware, MethodAware
 {
+    #[Threshold(['maximum', 'reportLevel'])]
+    public int $maximum;
+
     /**
      * This method checks the cyclomatic complexity for the given node against
      * a configured threshold.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
         $ccn = $node->getMetric('ccn2');
-        if ($ccn <= $threshold) {
+        if ($ccn <= $this->maximum) {
             return;
         }
 
@@ -45,7 +48,7 @@ final class CyclomaticComplexity extends AbstractRule implements FunctionAware, 
                 $node->getType(),
                 $node->getName(),
                 (string) $ccn,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/Design/DepthOfInheritance.php
+++ b/src/Rule/Design/DepthOfInheritance.php
@@ -21,28 +21,31 @@ namespace PHPMD\Rule\Design;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule will detect classes that are too deep in the inheritance tree.
  */
 final class DepthOfInheritance extends AbstractRule implements ClassAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the number of parents for the given class
      * node.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
         $dit = $node->getMetric('dit');
-        if ($dit > $threshold) {
+        if ($dit > $this->maximum) {
             $this->addViolation(
                 $node,
                 [
                     $node->getType(),
                     $node->getName(),
                     (string) $dit,
-                    (string) $threshold,
+                    (string) $this->maximum,
                 ]
             );
         }

--- a/src/Rule/Design/ExcessiveClassLength.php
+++ b/src/Rule/Design/ExcessiveClassLength.php
@@ -21,20 +21,22 @@ namespace PHPMD\Rule\Design;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule class will detect excessive long classes.
  */
 final class ExcessiveClassLength extends AbstractRule implements ClassAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the length of the given class node against a configured
      * threshold.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
-
         $loc = -1;
         if ($this->isTruthyProperty('ignore-whitespace')) {
             $loc = $node->getMetric('eloc');
@@ -43,10 +45,10 @@ final class ExcessiveClassLength extends AbstractRule implements ClassAware
             $loc = $node->getMetric('loc');
         }
 
-        if ($loc <= $threshold) {
+        if ($loc <= $this->maximum) {
             return;
         }
 
-        $this->addViolation($node, [$node->getName(), (string) $loc, (string) $threshold]);
+        $this->addViolation($node, [$node->getName(), (string) $loc, (string) $this->maximum]);
     }
 }

--- a/src/Rule/Design/ExcessiveMethodLength.php
+++ b/src/Rule/Design/ExcessiveMethodLength.php
@@ -22,6 +22,7 @@ use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule will detect to long methods, those methods are unreadable and in
@@ -29,14 +30,15 @@ use PHPMD\Rule\MethodAware;
  */
 final class ExcessiveMethodLength extends AbstractRule implements FunctionAware, MethodAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the lines of code length for the given function or
      * method node against a configured threshold.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
-
         $loc = -1;
         if ($this->isTruthyProperty('ignore-whitespace')) {
             $loc = $node->getMetric('eloc');
@@ -45,7 +47,7 @@ final class ExcessiveMethodLength extends AbstractRule implements FunctionAware,
             $loc = $node->getMetric('loc');
         }
 
-        if ($loc <= $threshold) {
+        if ($loc <= $this->maximum) {
             return;
         }
 
@@ -55,7 +57,7 @@ final class ExcessiveMethodLength extends AbstractRule implements FunctionAware,
                 $node->getType(),
                 $node->getName(),
                 (string) $loc,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/Design/ExcessiveParameterList.php
+++ b/src/Rule/Design/ExcessiveParameterList.php
@@ -24,12 +24,16 @@ use PHPMD\AbstractRule;
 use PHPMD\Node\AbstractCallableNode;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule class checks for excessive long function and method parameter lists.
  */
 final class ExcessiveParameterList extends AbstractRule implements FunctionAware, MethodAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the number of arguments for the given function or method
      * node against a configured threshold.
@@ -40,9 +44,8 @@ final class ExcessiveParameterList extends AbstractRule implements FunctionAware
             return;
         }
 
-        $threshold = $this->getIntProperty('maximum');
         $count = $node->getParameterCount();
-        if ($count <= $threshold) {
+        if ($count <= $this->maximum) {
             return;
         }
 
@@ -57,7 +60,7 @@ final class ExcessiveParameterList extends AbstractRule implements FunctionAware
                 $node->getType(),
                 $node->getName(),
                 (string) $count,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/Design/NPathComplexity.php
+++ b/src/Rule/Design/NPathComplexity.php
@@ -22,6 +22,7 @@ use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\FunctionAware;
 use PHPMD\Rule\MethodAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule will check the NPath-complexity of a method or function against the
@@ -29,15 +30,17 @@ use PHPMD\Rule\MethodAware;
  */
 final class NPathComplexity extends AbstractRule implements FunctionAware, MethodAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the acyclic complexity for the given node against a
      * configured threshold.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
         $npath = $node->getMetric('npath');
-        if ($npath <= $threshold) {
+        if ($npath <= $this->maximum) {
             return;
         }
 
@@ -47,7 +50,7 @@ final class NPathComplexity extends AbstractRule implements FunctionAware, Metho
                 $node->getType(),
                 $node->getName(),
                 (string) $npath,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/Design/NumberOfChildren.php
+++ b/src/Rule/Design/NumberOfChildren.php
@@ -21,12 +21,16 @@ namespace PHPMD\Rule\Design;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule will detect class that have to much direct child classes.
  */
 final class NumberOfChildren extends AbstractRule implements ClassAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the number of classes derived from the given class
      * node.
@@ -34,15 +38,14 @@ final class NumberOfChildren extends AbstractRule implements ClassAware
     public function apply(AbstractNode $node): void
     {
         $nocc = $node->getMetric('nocc');
-        $threshold = $this->getIntProperty('maximum');
-        if ($nocc > $threshold) {
+        if ($nocc > $this->maximum) {
             $this->addViolation(
                 $node,
                 [
                     $node->getType(),
                     $node->getName(),
                     (string) $nocc,
-                    (string) $threshold,
+                    (string) $this->maximum,
                 ]
             );
         }

--- a/src/Rule/Design/TooManyFields.php
+++ b/src/Rule/Design/TooManyFields.php
@@ -21,21 +21,24 @@ namespace PHPMD\Rule\Design;
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Rule\ClassAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule class will detect all classes with too much fields.
  */
 final class TooManyFields extends AbstractRule implements ClassAware
 {
+    #[Threshold(['maximum', 'maxfields'])]
+    public int $maximum;
+
     /**
      * This method checks the number of methods with in a given class and checks
      * this number against a configured threshold.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
         $vars = $node->getMetric('vars');
-        if ($vars <= $threshold) {
+        if ($vars <= $this->maximum) {
             return;
         }
         $this->addViolation(
@@ -44,7 +47,7 @@ final class TooManyFields extends AbstractRule implements ClassAware
                 $node->getType(),
                 $node->getName(),
                 (string) $vars,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/Design/TooManyMethods.php
+++ b/src/Rule/Design/TooManyMethods.php
@@ -22,12 +22,16 @@ use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ClassNode;
 use PHPMD\Rule\ClassAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule class will detect all classes with too many methods.
  */
 final class TooManyMethods extends AbstractRule implements ClassAware
 {
+    #[Threshold(['maximum', 'maxmethods'])]
+    public int $maximum;
+
     /** Regular expression that filters all methods that are ignored by this rule. */
     private string $ignoreRegexp;
 
@@ -43,12 +47,11 @@ final class TooManyMethods extends AbstractRule implements ClassAware
 
         $this->ignoreRegexp = $this->getStringProperty('ignorepattern');
 
-        $threshold = $this->getIntProperty('maximum');
-        if ($node->getMetric('nom') <= $threshold) {
+        if ($node->getMetric('nom') <= $this->maximum) {
             return;
         }
         $nom = $this->countMethods($node);
-        if ($nom <= $threshold) {
+        if ($nom <= $this->maximum) {
             return;
         }
         $this->addViolation(
@@ -57,7 +60,7 @@ final class TooManyMethods extends AbstractRule implements ClassAware
                 $node->getType(),
                 $node->getName(),
                 (string) $nom,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/Design/TooManyPublicMethods.php
+++ b/src/Rule/Design/TooManyPublicMethods.php
@@ -22,12 +22,16 @@ use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ClassNode;
 use PHPMD\Rule\ClassAware;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule class will detect all classes with too much public methods.
  */
 final class TooManyPublicMethods extends AbstractRule implements ClassAware
 {
+    #[Threshold(['maximum', 'maxmethods'])]
+    public int $maximum;
+
     /** Regular expression that filters all methods that are ignored by this rule. */
     private string $ignoreRegexp;
 
@@ -43,16 +47,15 @@ final class TooManyPublicMethods extends AbstractRule implements ClassAware
 
         $this->ignoreRegexp = $this->getStringProperty('ignorepattern');
 
-        $threshold = $this->getIntProperty('maximum');
         $publicMethodsCount = $node->getMetric('npm'); // NPM stands for Number of Public Methods
 
-        if ($publicMethodsCount !== null && $publicMethodsCount <= $threshold) {
+        if ($publicMethodsCount !== null && $publicMethodsCount <= $this->maximum) {
             return;
         }
 
         $nom = $this->countMethods($node);
 
-        if ($nom <= $threshold) {
+        if ($nom <= $this->maximum) {
             return;
         }
 
@@ -62,7 +65,7 @@ final class TooManyPublicMethods extends AbstractRule implements ClassAware
                 $node->getType(),
                 $node->getName(),
                 (string) $nom,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/src/Rule/ExcessivePublicCount.php
+++ b/src/Rule/ExcessivePublicCount.php
@@ -20,6 +20,7 @@ namespace PHPMD\Rule;
 
 use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
+use PHPMD\RuleProperty\Threshold;
 
 /**
  * This rule checks the number of public methods and fields in a given class.
@@ -27,15 +28,17 @@ use PHPMD\AbstractRule;
  */
 final class ExcessivePublicCount extends AbstractRule implements ClassAware, TraitAware
 {
+    #[Threshold(['maximum', 'minimum'])]
+    public int $maximum;
+
     /**
      * This method checks the number of public fields and methods in the given
      * class and checks that value against a configured threshold.
      */
     public function apply(AbstractNode $node): void
     {
-        $threshold = $this->getIntProperty('maximum');
         $cis = $node->getMetric('cis');
-        if ($cis <= $threshold) {
+        if ($cis <= $this->maximum) {
             return;
         }
         $this->addViolation(
@@ -44,7 +47,7 @@ final class ExcessivePublicCount extends AbstractRule implements ClassAware, Tra
                 $node->getType(),
                 $node->getName(),
                 (string) $cis,
-                (string) $threshold,
+                (string) $this->maximum,
             ]
         );
     }

--- a/tests/php/PHPMD/Rule/CyclomaticComplexityTest.php
+++ b/tests/php/PHPMD/Rule/CyclomaticComplexityTest.php
@@ -43,6 +43,21 @@ class CyclomaticComplexityTest extends AbstractTestCase
     }
 
     /**
+     * Tests that the legacy `reportLevel` property name is still accepted as
+     * an alias for `maximum`.
+     */
+    public function testRuleAcceptsLegacyReportLevelProperty(): void
+    {
+        $method = $this->getMethodMock('ccn2', 42);
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new CyclomaticComplexity();
+        $rule->setReport($report);
+        $rule->addProperty('reportLevel', '10');
+        $rule->apply($method);
+    }
+
+    /**
      * Test that the rule does not apply for a value that is equal with the
      * configured threshold.
      */

--- a/tests/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
+++ b/tests/php/PHPMD/Rule/Design/DepthOfInheritanceTest.php
@@ -50,4 +50,12 @@ class DepthOfInheritanceTest extends AbstractTestCase
         $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('dit', 43));
     }
+
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $rule = new DepthOfInheritance();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('minimum', '42');
+        $rule->apply($this->getClassMock('dit', 43));
+    }
 }

--- a/tests/php/PHPMD/Rule/Design/ExcessiveClassLengthTest.php
+++ b/tests/php/PHPMD/Rule/Design/ExcessiveClassLengthTest.php
@@ -44,6 +44,22 @@ class ExcessiveClassLengthTest extends AbstractTestCase
     }
 
     /**
+     * Tests that the legacy `minimum` property name is still accepted as an
+     * alias for `maximum`.
+     */
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $class = $this->getClassMock('loc', 42);
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new ExcessiveClassLength();
+        $rule->setReport($report);
+        $rule->addProperty('minimum', '41');
+        $rule->addProperty('ignore-whitespace', '0');
+        $rule->apply($class);
+    }
+
+    /**
      * Test that the rule does not apply for a value that is equal with the
      * configured threshold.
      */

--- a/tests/php/PHPMD/Rule/Design/ExcessiveMethodLengthTest.php
+++ b/tests/php/PHPMD/Rule/Design/ExcessiveMethodLengthTest.php
@@ -44,6 +44,22 @@ class ExcessiveMethodLengthTest extends AbstractTestCase
     }
 
     /**
+     * Tests that the legacy `minimum` property name is still accepted as an
+     * alias for `maximum`.
+     */
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $method = $this->getMethodMock('loc', 42);
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new ExcessiveMethodLength();
+        $rule->setReport($report);
+        $rule->addProperty('minimum', '41');
+        $rule->addProperty('ignore-whitespace', '0');
+        $rule->apply($method);
+    }
+
+    /**
      * Test that the rule does not apply for a value that is equal with the
      * configured threshold.
      */

--- a/tests/php/PHPMD/Rule/Design/ExcessiveParameterListTest.php
+++ b/tests/php/PHPMD/Rule/Design/ExcessiveParameterListTest.php
@@ -54,6 +54,14 @@ class ExcessiveParameterListTest extends AbstractTestCase
         $rule->apply($this->createMethod(42));
     }
 
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $rule = new ExcessiveParameterList();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('minimum', '3');
+        $rule->apply($this->createMethod(42));
+    }
+
     public function testApplyIgnoresFunctionsWithLessParametersThanMaximum(): void
     {
         $rule = new ExcessiveParameterList();

--- a/tests/php/PHPMD/Rule/Design/NPathComplexityTest.php
+++ b/tests/php/PHPMD/Rule/Design/NPathComplexityTest.php
@@ -43,6 +43,21 @@ class NPathComplexityTest extends AbstractTestCase
     }
 
     /**
+     * Tests that the legacy `minimum` property name is still accepted as an
+     * alias for `maximum`.
+     */
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $method = $this->getMethodMock('npath', 42);
+        $report = $this->getReportWithOneViolation();
+
+        $rule = new NPathComplexity();
+        $rule->setReport($report);
+        $rule->addProperty('minimum', '41');
+        $rule->apply($method);
+    }
+
+    /**
      * Test that the rule does not apply for a value that is equal with the
      * configured threshold.
      */

--- a/tests/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
+++ b/tests/php/PHPMD/Rule/Design/NumberOfChildrenTest.php
@@ -50,4 +50,12 @@ class NumberOfChildrenTest extends AbstractTestCase
         $rule->addProperty('maximum', '42');
         $rule->apply($this->getClassMock('nocc', 43));
     }
+
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $rule = new NumberOfChildren();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('minimum', '42');
+        $rule->apply($this->getClassMock('nocc', 43));
+    }
 }

--- a/tests/php/PHPMD/Rule/Design/TooManyFieldsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyFieldsTest.php
@@ -50,4 +50,12 @@ class TooManyFieldsTest extends AbstractTestCase
         $rule->addProperty('maximum', '23');
         $rule->apply($this->getClassMock('vars', 42));
     }
+
+    public function testRuleAcceptsLegacyMaxfieldsProperty(): void
+    {
+        $rule = new TooManyFields();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('maxfields', '23');
+        $rule->apply($this->getClassMock('vars', 42));
+    }
 }

--- a/tests/php/PHPMD/Rule/Design/TooManyMethodsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyMethodsTest.php
@@ -55,6 +55,15 @@ class TooManyMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));
     }
 
+    public function testRuleAcceptsLegacyMaxmethodsProperty(): void
+    {
+        $rule = new TooManyMethods();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('maxmethods', '23');
+        $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
+        $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));
+    }
+
     public function testRuleIgnoresGetterMethodsInTest(): void
     {
         $rule = new TooManyMethods();

--- a/tests/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
+++ b/tests/php/PHPMD/Rule/Design/TooManyPublicMethodsTest.php
@@ -59,6 +59,15 @@ class TooManyPublicMethodsTest extends AbstractTestCase
         $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));
     }
 
+    public function testRuleAcceptsLegacyMaxmethodsProperty(): void
+    {
+        $rule = new TooManyPublicMethods();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('maxmethods', '23');
+        $rule->addProperty('ignorepattern', '(^(set|get|inject))i');
+        $rule->apply($this->createClassMock(42, array_fill(0, 42, __FUNCTION__)));
+    }
+
     public function testRuleIgnoresGetterMethodsInTest(): void
     {
         $rule = new TooManyPublicMethods();

--- a/tests/php/PHPMD/Rule/ExcessivePublicCountTest.php
+++ b/tests/php/PHPMD/Rule/ExcessivePublicCountTest.php
@@ -35,6 +35,14 @@ class ExcessivePublicCountTest extends AbstractTestCase
         $rule->apply($this->getClassMock('cis', 23));
     }
 
+    public function testRuleAcceptsLegacyMinimumProperty(): void
+    {
+        $rule = new ExcessivePublicCount();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->addProperty('minimum', '23');
+        $rule->apply($this->getClassMock('cis', 42));
+    }
+
     public function testRuleDoesNotApplyToClassesWithSameNumberOfPublicMembersAsThreshold(): void
     {
         $rule = new ExcessivePublicCount();


### PR DESCRIPTION
Some enhancements to #1321 

Map the pre-3.0 property names (`reportLevel`, `minimum`, `maxfields`, `maxmethods`) to the new maximum property through the `Threshold` rule property attribute, so existing rule sets keep their configured thresholds instead of silently falling back to the defaults. Restores the dual-name handling `DepthOfInheritance` already had.

Also reword the `TooManyFields`, `TooManyMethods` and `TooManyPublicMethods` messages to the "at {3} or less" phrasing used by the other rules, document the shifted default thresholds and their effect on baseline files in UPGRADING.md, and cover every legacy alias with a test.

Refs phpmd/phpmd#670
