### PR TITLE
Move reference assignment detection to AbstractLocalVariable

### DIFF
--- a/src/Rule/AbstractLocalVariable.php
+++ b/src/Rule/AbstractLocalVariable.php
@@ -19,8 +19,10 @@
 namespace PHPMD\Rule;
 
 use OutOfBoundsException;
+use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTArrayIndexExpression;
+use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTNode as PDependNode;
@@ -274,6 +276,21 @@ abstract class AbstractLocalVariable extends AbstractRule
         }
 
         return isset($parameters[$argumentPosition]) && $parameters[$argumentPosition]->isPassedByReference();
+    }
+
+    /**
+     * Checks if the given assignment binds the target variable by reference,
+     * like <b>$variable = &$other</b>.
+     *
+     * @param AbstractNode<AbstractASTNode> $assignment
+     */
+    protected function isReferenceAssignment(AbstractNode $assignment): bool
+    {
+        $value = $assignment->getChildren()[1] ?? null;
+        $children = $value instanceof ASTExpression ? $value->getChildren() : [];
+
+        return ($children[0] ?? null) instanceof ASTExpression
+            && $children[0]->getImage() === '&';
     }
 
     /**

--- a/src/Rule/UnusedLocalVariable.php
+++ b/src/Rule/UnusedLocalVariable.php
@@ -38,7 +38,6 @@ use PHPMD\AbstractNode;
 use PHPMD\Attribute\SuppressWarnings;
 use PHPMD\Node\AbstractCallableNode;
 use PHPMD\Rule\Design\CouplingBetweenObjects;
-use PHPMD\Rule\Design\ExcessiveClassComplexity;
 use PHPMD\Utility\ExceptionsList;
 
 /**
@@ -46,7 +45,6 @@ use PHPMD\Utility\ExceptionsList;
  * that are not used by any code in the analyzed source artifact.
  */
 #[SuppressWarnings(CouplingBetweenObjects::class)]
-#[SuppressWarnings(ExcessiveClassComplexity::class)]
 final class UnusedLocalVariable extends AbstractLocalVariable implements FunctionAware, MethodAware
 {
     /**
@@ -149,21 +147,6 @@ final class UnusedLocalVariable extends AbstractLocalVariable implements Functio
         }
 
         return false;
-    }
-
-    /**
-     * Checks if the given assignment binds the target variable by reference,
-     * like <b>$variable = &$other</b>.
-     *
-     * @param AbstractNode<AbstractASTNode> $assignment
-     */
-    private function isReferenceAssignment(AbstractNode $assignment): bool
-    {
-        $value = $assignment->getChildren()[1] ?? null;
-        $children = $value instanceof ASTExpression ? $value->getChildren() : [];
-
-        return ($children[0] ?? null) instanceof ASTExpression
-            && $children[0]->getImage() === '&';
     }
 
     /**

--- a/tests/resources/files/Rule/UnusedLocalVariable/testRuleAppliesToUnusedReference.php
+++ b/tests/resources/files/Rule/UnusedLocalVariable/testRuleAppliesToUnusedReference.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleAppliesToUnusedReference
+{
+    public function testRuleAppliesToUnusedReference()
+    {
+        $a = 1;
+        $b = &$a;
+        print($a);
+    }
+}

--- a/tests/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToUsedReferenceInChainedAssignment.php
+++ b/tests/resources/files/Rule/UnusedLocalVariable/testRuleDoesNotApplyToUsedReferenceInChainedAssignment.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testRuleDoesNotApplyToUsedReferenceInChainedAssignment
+{
+    public function testRuleDoesNotApplyToUsedReferenceInChainedAssignment()
+    {
+        $a = 1;
+        $c = $b = &$a;
+        $b = 2;
+        print($a . $c);
+    }
+}


### PR DESCRIPTION
Some enhancements to #1325 

Moving `isReferenceAssignment()` to the shared base class keeps the complexity of `UnusedLocalVariable` below the `ExcessiveClassComplexity` threshold, so the class no longer needs to suppress the project's own rule. Verified with the self-analysis run.

Add two fixtures around the reference binding behavior: an unused reference (bound but never written) is still reported, and a reference bound through a chained assignment is recognized as used.

Refs phpmd/phpmd#927
