### PR TITLE
Fix upgrade notes and harden the latest-v2 phar publishing

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -101,7 +101,7 @@ These changes only affect you if you have written custom rules or extended PHPMD
 - The `PHP_PMD_*` class aliases from PHPMD 1.x were already removed in 2.9. If you still use them, update to the `PHPMD\*` namespace.
 - `PHPMD\PHPMD::getIgnorePatterns()` and `setIgnorePatterns()` have been removed. Use `getExcludePatterns()` and `addExcludePatterns()` instead.
 - `PHPMD\RuleSetFactory::getIgnorePattern()` has been removed. Use `getExcludePatterns()` instead.
-- `PHPMD\Rule::getBooleanProperty()` has been renamed to `isBooleanProperty()`.
+- `PHPMD\Rule::getBooleanProperty()` has been renamed to `isTruthyProperty()`.
 - `PHPMD\RuleSetFactory::getCache()` has been renamed to `isCacheEnabled()`.
 - All PHPMD exceptions now use a dedicated exception hierarchy under `PHPMD\Exception\`.
 - Rule marker interfaces now include `EnumAware` and `TraitAware` in addition to the existing `ClassAware`, `FunctionAware`, `InterfaceAware`, and `MethodAware`.

--- a/public/config.php
+++ b/public/config.php
@@ -70,10 +70,12 @@ class PhpMdPharPublish extends PharPublish
         }
 
         $fileName = $fileName ?: 'phpmd.phar';
+        // The releases endpoint returns 30 items per page by default; request
+        // more so the last 2.x release stays visible once 3.x releases pile up.
         $versions = array_map(
             static fn ($release) => $release->tag_name,
             array_filter(
-                $this->json('releases'),
+                $this->json('releases?per_page=100'),
                 static fn ($release) => empty($release->draft)
                     && empty($release->prerelease)
                     && preg_match('/^2\./', $release->tag_name),
@@ -91,7 +93,7 @@ class PhpMdPharPublish extends PharPublish
         $filePath = $directory.'/'.$fileName;
         $this->download($filePath, 'releases/download/'.$latestV2.'/'.$fileName);
 
-        if (filesize($filePath) < $this->getPharMinimumSize()) {
+        if (!is_file($filePath) || filesize($filePath) < $this->getPharMinimumSize()) {
             @unlink($filePath);
             @rmdir($directory);
 


### PR DESCRIPTION
Some enhancements to #1323 

Correct the `UPGRADING.md` entry that pointed to a non-existent `isBooleanProperty()` method: `getBooleanProperty()` was renamed to `isTruthyProperty()`, as the `CHANGELOG` already says.

In the latest-v2 publisher, request up to 100 releases per page so the last 2.x release stays visible once more than 30 newer releases exist, and guard the file size check against a failed download.

Refs phpmd/phpmd#1055
