### PR TITLE
Add ShortOpenTag rule: detect PHP short open tags (fixes #771)

### DIFF
--- a/public/rst/rules/cleancode.rst
+++ b/public/rst/rules/cleancode.rst
@@ -171,6 +171,17 @@ Example: ::
           }
       }
 
+ShortOpenTag
+============
+
+Since: PHPMD 3.0.0
+
+Avoid using short open tags '<?'; use '<?php' instead. Short tags require the "short_open_tag" ini setting to be enabled to work reliably, which is not guaranteed across environments and is disabled by default in most modern setups.
+
+Example: ::
+
+  <? echo "Hello"; ?>
+
 UndefinedVariable
 =================
 

--- a/rulesets/cleancode.xml
+++ b/rulesets/cleancode.xml
@@ -236,6 +236,27 @@ function make() {
         </example>
     </rule>
 
+    <rule name="ShortOpenTag"
+          message="Avoid using short open tags '&lt;?'; use '&lt;?php' instead (line '{0}')."
+          class="PHPMD\Rule\CleanCode\ShortOpenTag"
+          externalInfoUrl="https://phpmd.org/rules/cleancode.html#shortopentag">
+        <description>
+            <![CDATA[
+The short open tag '<?' requires the "short_open_tag" ini setting to be
+enabled to work reliably, which is not guaranteed across environments and is
+disabled by default in most modern setups. Use the full '<?php' open tag
+instead, or the always-available '<?=' short echo tag when only echoing a
+single expression.
+            ]]>
+        </description>
+        <priority>2</priority>
+        <example>
+            <![CDATA[
+<? echo "Hello"; ?>
+            ]]>
+        </example>
+    </rule>
+
     <rule name="UndefinedVariable"
           since="2.8.0"
           message="Avoid using undefined variables such as '{0}' which will lead to PHP notices."

--- a/src/Rule/CleanCode/ShortOpenTag.php
+++ b/src/Rule/CleanCode/ShortOpenTag.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Rule\CleanCode;
+
+use PHPMD\AbstractNode;
+use PHPMD\AbstractRule;
+use PHPMD\Rule\ClassAware;
+use PHPMD\Rule\EnumAware;
+use PHPMD\Rule\FunctionAware;
+use PHPMD\Rule\InterfaceAware;
+use PHPMD\Rule\TraitAware;
+
+/**
+ * Short Open Tag Rule
+ *
+ * This rule detects usage of the short PHP open tag '<?' instead of '<?php'.
+ *
+ * @link https://www.php.net/manual/en/ini.core.php#ini.short-open-tag
+ */
+final class ShortOpenTag extends AbstractRule implements ClassAware, EnumAware, FunctionAware, InterfaceAware, TraitAware
+{
+    /**
+     * Files that have already been scanned, so each file is only reported once
+     * no matter how many class/trait/enum/function/interface nodes it contains.
+     *
+     * @var array<string, bool>
+     */
+    private array $processedFiles = [];
+
+    public function apply(AbstractNode $node): void
+    {
+        $fileName = $node->getFileName();
+        if ($fileName === null) {
+            return;
+        }
+
+        if (isset($this->processedFiles[$fileName])) {
+            return;
+        }
+
+        $this->processedFiles[$fileName] = true;
+
+        foreach ($this->findShortOpenTagLines($fileName) as $line) {
+            $this->addViolation($node, [(string) $line]);
+        }
+    }
+
+    /**
+     * Finds every line where a bare '<?' short open tag is used.
+     *
+     * '<?php' and '<?=' are always tokenized correctly by token_get_all()
+     * regardless of the "short_open_tag" ini setting, but a bare '<?' is only
+     * recognized as T_OPEN_TAG when "short_open_tag" is enabled. When it is
+     * disabled (the common default), the "<?" ends up merged into the
+     * surrounding T_INLINE_HTML token instead, so that case is also scanned
+     * for explicitly to keep detection independent of the local ini value.
+     *
+     * @return int[]
+     */
+    private function findShortOpenTagLines(string $fileName): array
+    {
+        $source = file_get_contents($fileName);
+        if ($source === false) {
+            return [];
+        }
+
+        return $this->scanTokens(token_get_all($source));
+    }
+
+    /**
+     * Walks a token_get_all() result and returns every line where a bare
+     * '<?' short open tag is used. Split out from findShortOpenTagLines() so
+     * it can be exercised directly with hand-built token arrays, since real
+     * tokenization of a bare '<?' is gated by the "short_open_tag" ini
+     * setting and can't be forced at runtime.
+     *
+     * @param array<int, array{0: int, 1: string, 2: int}|string> $tokens
+     * @return int[]
+     */
+    private function scanTokens(array $tokens): array
+    {
+        $lines = [];
+
+        foreach ($tokens as $index => $token) {
+            if (!is_array($token)) {
+                continue;
+            }
+
+            [$type, $image, $line] = $token;
+
+            if ($type === T_INLINE_HTML) {
+                foreach ($this->findShortOpenTagLinesInHtml($image, $line) as $htmlLine) {
+                    $lines[] = $htmlLine;
+                }
+
+                continue;
+            }
+
+            if ($type === T_OPEN_TAG && stripos($image, '<?php') !== 0 && !$this->isXmlProlog($tokens, $index)) {
+                $lines[] = $line;
+            }
+        }
+
+        $lines = array_unique($lines);
+        sort($lines);
+
+        return $lines;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function findShortOpenTagLinesInHtml(string $html, int $startLine): array
+    {
+        $lines = [];
+        if (!preg_match_all('/<\?(?!=|xml\b)/i', $html, $matches, PREG_OFFSET_CAPTURE)) {
+            return $lines;
+        }
+
+        foreach ($matches[0] as $match) {
+            $offset = $match[1];
+            $lines[] = $startLine + substr_count($html, "\n", 0, $offset);
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Checks whether a short open tag is immediately followed by "xml", i.e.
+     * it is an XML declaration such as '<?xml version="1.0"?>' rather than a
+     * short open tag mistake.
+     *
+     * @param array<int, array{0: int, 1: string, 2: int}|string> $tokens
+     */
+    private function isXmlProlog(array $tokens, int $openTagIndex): bool
+    {
+        for ($i = $openTagIndex + 1, $count = count($tokens); $i < $count; ++$i) {
+            $token = $tokens[$i];
+            if (!is_array($token)) {
+                return false;
+            }
+
+            if ($token[0] === T_WHITESPACE) {
+                continue;
+            }
+
+            return $token[0] === T_STRING && strcasecmp($token[1], 'xml') === 0;
+        }
+
+        return false;
+    }
+}

--- a/tests/php/PHPMD/Rule/CleanCode/ShortOpenTagTest.php
+++ b/tests/php/PHPMD/Rule/CleanCode/ShortOpenTagTest.php
@@ -1,0 +1,253 @@
+<?php
+
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+namespace PHPMD\Rule\CleanCode;
+
+use PDepend\Source\AST\ASTClass;
+use PHPMD\AbstractTestCase;
+use PHPMD\Node\ClassNode;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionMethod;
+use RuntimeException;
+
+/**
+ * Short Open Tag Test
+ *
+ * @coversDefaultClass \PHPMD\Rule\CleanCode\ShortOpenTag
+ */
+class ShortOpenTagTest extends AbstractTestCase
+{
+    /**
+     * Tests that the rule applies to a short open tag preceding a function.
+     *
+     * @covers ::apply
+     */
+    public function testAppliesToShortOpenTagInFunction(): void
+    {
+        $rule = new ShortOpenTag();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getFunction());
+    }
+
+    /**
+     * Tests that the rule applies once per short open tag found in a file
+     * that declares a class, deduplicating repeated visits to the same file.
+     *
+     * @covers ::apply
+     */
+    public function testAppliesToShortOpenTagInClass(): void
+    {
+        $rule = new ShortOpenTag();
+        $rule->setReport($this->getReportMock(2));
+        $rule->apply($this->getClass());
+    }
+
+    /**
+     * Tests that the rule does not apply to files only using the full '<?php' tag.
+     *
+     * @covers ::apply
+     */
+    public function testDoesNotApplyToFullOpenTag(): void
+    {
+        $rule = new ShortOpenTag();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getFunction());
+    }
+
+    /**
+     * Tests that the rule does not apply to a '<?' that only appears as text
+     * inside a string literal, not as an actual open tag.
+     *
+     * @covers ::apply
+     */
+    public function testDoesNotApplyToShortTagInsideString(): void
+    {
+        $rule = new ShortOpenTag();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getFunction());
+    }
+
+    /**
+     * Tests that the rule does not apply to the always-available '<?=' short echo tag.
+     *
+     * @covers ::apply
+     */
+    public function testDoesNotApplyToShortEchoTag(): void
+    {
+        $rule = new ShortOpenTag();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getFunction());
+    }
+
+    /**
+     * Tests that the rule does not apply to a leading '<?xml ...?>' declaration.
+     *
+     * @covers ::apply
+     */
+    public function testDoesNotApplyToXmlDeclaration(): void
+    {
+        $rule = new ShortOpenTag();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getFunction());
+    }
+
+    /**
+     * Tests that a real short open tag is still flagged even when the file
+     * also contains an '<?xml ...?>' declaration.
+     *
+     * @covers ::apply
+     */
+    public function testAppliesToShortOpenTagAfterXmlDeclaration(): void
+    {
+        $rule = new ShortOpenTag();
+        $rule->setReport($this->getReportWithOneViolation());
+        $rule->apply($this->getFunction());
+    }
+
+    /**
+     * Tests that the rule does not apply to a leading '<?XML ...?>' declaration.
+     *
+     * @covers ::apply
+     */
+    public function testDoesNotApplyToUppercaseXmlDeclaration(): void
+    {
+        $rule = new ShortOpenTag();
+        $rule->setReport($this->getReportWithNoViolation());
+        $rule->apply($this->getFunction());
+    }
+
+    /**
+     * Tests that visiting several nodes backed by the same file (e.g. several
+     * classes declared in one file) only scans and reports that file once.
+     *
+     * @covers ::apply
+     */
+    public function testAppliesOnlyOncePerFileAcrossMultipleNodes(): void
+    {
+        $fileName = static::createResourceUriForTest('testAppliesToShortOpenTagInFunction.php');
+
+        $rule = new ShortOpenTag();
+        $rule->setReport($this->getReportWithOneViolation());
+
+        $rule->apply($this->getNodeMockWithFileName($fileName));
+        $rule->apply($this->getNodeMockWithFileName($fileName));
+    }
+
+    /**
+     * @return ClassNode&MockObject
+     */
+    private function getNodeMockWithFileName(string $fileName): ClassNode
+    {
+        $node = $this->getMockBuilder(ClassNode::class)
+            ->setConstructorArgs([new ASTClass('FooBar')])
+            ->getMock();
+        $node->method('getFileName')->willReturn($fileName);
+
+        return $node;
+    }
+
+    /**
+     * Tests that a bare '<?' tokenized as T_OPEN_TAG (what real PHP produces
+     * when "short_open_tag" is enabled, which can't be forced at runtime) is
+     * flagged, using a hand-built token array to exercise that branch
+     * regardless of the local ini value.
+     *
+     * @covers ::scanTokens
+     */
+    public function testScanTokensFlagsShortOpenTagToken(): void
+    {
+        $lines = $this->invokeScanTokens([
+            [T_INLINE_HTML, '<html>', 1],
+            [T_OPEN_TAG, '<?', 10],
+            [T_ECHO, 'echo', 10],
+            [T_WHITESPACE, ' ', 10],
+            [T_CONSTANT_ENCAPSED_STRING, "'foo'", 10],
+            ';',
+        ]);
+
+        static::assertSame([10], $lines);
+    }
+
+    /**
+     * Tests that an XML declaration tokenized as T_OPEN_TAG followed by a
+     * separate T_STRING('xml') token (real PHP's shape when "short_open_tag"
+     * is enabled) is not flagged.
+     *
+     * @covers ::scanTokens
+     */
+    public function testScanTokensIgnoresXmlDeclarationToken(): void
+    {
+        $lines = $this->invokeScanTokens([
+            [T_OPEN_TAG, '<?', 1],
+            [T_STRING, 'xml', 1],
+            [T_WHITESPACE, ' ', 1],
+            [T_STRING, 'version', 1],
+            [T_CONSTANT_ENCAPSED_STRING, '"1.0"', 1],
+            [T_CLOSE_TAG, '?>', 1],
+        ]);
+
+        static::assertSame([], $lines);
+    }
+
+    /**
+     * Tests that the XML declaration exclusion is case-insensitive when
+     * matched via the T_OPEN_TAG + T_STRING token shape.
+     *
+     * @covers ::scanTokens
+     */
+    public function testScanTokensIgnoresUppercaseXmlDeclarationToken(): void
+    {
+        $lines = $this->invokeScanTokens([
+            [T_OPEN_TAG, '<?', 1],
+            [T_STRING, 'XML', 1],
+            [T_WHITESPACE, ' ', 1],
+            [T_STRING, 'version', 1],
+            [T_CONSTANT_ENCAPSED_STRING, '"1.0"', 1],
+            [T_CLOSE_TAG, '?>', 1],
+        ]);
+
+        static::assertSame([], $lines);
+    }
+
+    /**
+     * @param array<int, array{0: int, 1: string, 2: int}|string> $tokens
+     * @return int[]
+     */
+    private function invokeScanTokens(array $tokens): array
+    {
+        $rule = new ShortOpenTag();
+        $method = new ReflectionMethod(ShortOpenTag::class, 'scanTokens');
+        $method->setAccessible(true);
+
+        $lines = $method->invoke($rule, $tokens);
+        if (!is_array($lines)) {
+            throw new RuntimeException('ShortOpenTag::scanTokens() did not return an array.');
+        }
+
+        $result = [];
+        foreach ($lines as $line) {
+            if (!is_int($line)) {
+                throw new RuntimeException('ShortOpenTag::scanTokens() did not return an array of integers.');
+            }
+
+            $result[] = $line;
+        }
+
+        return $result;
+    }
+}

--- a/tests/resources/files/Rule/CleanCode/ShortOpenTag/testAppliesToShortOpenTagAfterXmlDeclaration.php
+++ b/tests/resources/files/Rule/CleanCode/ShortOpenTag/testAppliesToShortOpenTagAfterXmlDeclaration.php
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<html>
+<? echo "still a mistake"; ?>
+</html>
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+/**
+ * testAppliesToShortOpenTagAfterXmlDeclaration
+ *
+ * @return int
+ */
+function testAppliesToShortOpenTagAfterXmlDeclaration()
+{
+    return 1;
+}

--- a/tests/resources/files/Rule/CleanCode/ShortOpenTag/testAppliesToShortOpenTagInClass.php
+++ b/tests/resources/files/Rule/CleanCode/ShortOpenTag/testAppliesToShortOpenTagInClass.php
@@ -1,0 +1,38 @@
+<html>
+<? echo "old style"; ?>
+</html>
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+/**
+ * Class testAppliesToShortOpenTagInClass
+ */
+class testAppliesToShortOpenTagInClass
+{
+    /**
+     * bar
+     *
+     * @return int
+     */
+    public function bar()
+    {
+        return 1;
+    }
+}
+
+?>
+<? echo "trailing"; ?>

--- a/tests/resources/files/Rule/CleanCode/ShortOpenTag/testAppliesToShortOpenTagInFunction.php
+++ b/tests/resources/files/Rule/CleanCode/ShortOpenTag/testAppliesToShortOpenTagInFunction.php
@@ -1,0 +1,29 @@
+<html>
+<? echo "old style"; ?>
+</html>
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+/**
+ * testAppliesToShortOpenTagInFunction
+ *
+ * @return int
+ */
+function testAppliesToShortOpenTagInFunction()
+{
+    return 1;
+}

--- a/tests/resources/files/Rule/CleanCode/ShortOpenTag/testDoesNotApplyToFullOpenTag.php
+++ b/tests/resources/files/Rule/CleanCode/ShortOpenTag/testDoesNotApplyToFullOpenTag.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+/**
+ * testDoesNotApplyToFullOpenTag
+ *
+ * @return int
+ */
+function testDoesNotApplyToFullOpenTag()
+{
+    return 1;
+}

--- a/tests/resources/files/Rule/CleanCode/ShortOpenTag/testDoesNotApplyToShortEchoTag.php
+++ b/tests/resources/files/Rule/CleanCode/ShortOpenTag/testDoesNotApplyToShortEchoTag.php
@@ -1,0 +1,29 @@
+<html>
+<?= "echo shorthand is always available" ?>
+</html>
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+/**
+ * testDoesNotApplyToShortEchoTag
+ *
+ * @return int
+ */
+function testDoesNotApplyToShortEchoTag()
+{
+    return 1;
+}

--- a/tests/resources/files/Rule/CleanCode/ShortOpenTag/testDoesNotApplyToShortTagInsideString.php
+++ b/tests/resources/files/Rule/CleanCode/ShortOpenTag/testDoesNotApplyToShortTagInsideString.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+/**
+ * testDoesNotApplyToShortTagInsideString
+ *
+ * @return void
+ */
+function testDoesNotApplyToShortTagInsideString()
+{
+    echo "<?";
+}

--- a/tests/resources/files/Rule/CleanCode/ShortOpenTag/testDoesNotApplyToUppercaseXmlDeclaration.php
+++ b/tests/resources/files/Rule/CleanCode/ShortOpenTag/testDoesNotApplyToUppercaseXmlDeclaration.php
@@ -1,0 +1,29 @@
+<?XML version="1.0"?>
+<html>
+</html>
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+/**
+ * testDoesNotApplyToUppercaseXmlDeclaration
+ *
+ * @return int
+ */
+function testDoesNotApplyToUppercaseXmlDeclaration()
+{
+    return 1;
+}

--- a/tests/resources/files/Rule/CleanCode/ShortOpenTag/testDoesNotApplyToXmlDeclaration.php
+++ b/tests/resources/files/Rule/CleanCode/ShortOpenTag/testDoesNotApplyToXmlDeclaration.php
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<html>
+</html>
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+/**
+ * testDoesNotApplyToXmlDeclaration
+ *
+ * @return int
+ */
+function testDoesNotApplyToXmlDeclaration()
+{
+    return 1;
+}


### PR DESCRIPTION
Type: feature
Issue: Resolves #771
Breaking change: no

Adds a new CleanCode rule, `ShortOpenTag`, that flags PHP files using
the short open tag `<?` instead of `<?php`.

## Why this took until now
The issue was blocked on PDepend normalizing `<?` into `<?php` before
tokenizing, so PHPMD couldn't observe the distinction. That was fixed
upstream in pdepend/pdepend#490 (merged 2021); this repo's
`pdepend/pdepend: ^2.16.1` requirement already includes it. In
practice the new rule doesn't consume PDepend's tokenizer at all, it
reads the file and tokenizes it directly with `token_get_all()`, so
it isn't actually dependent on that PR, just aligned with the same
`<?`/`<?php`/`<?=` distinction it introduced.

## Detection approach
Only a bare `<?` is flagged; `<?=` is always available regardless of
`short_open_tag` and out of scope. Detecting the bare form correctly
turned out to be ini-sensitive: `<? ...` only tokenizes as
`T_OPEN_TAG` when `short_open_tag` is enabled (the increasingly
uncommon case), when it's disabled, the same text survives as literal
`T_INLINE_HTML`. The rule checks both token shapes so results don't
depend on the environment PHPMD happens to run in. A leading
`<?xml ...?>` declaration is excluded on both paths (common,
deliberate pattern with no simple fix), matched case-insensitively.

## Adding a New Rule checklist
- Added to `src/main/resources/rulesets/cleancode.xml`
- Implemented in `src/main/php/PHPMD/Rule/CleanCode/ShortOpenTag.php`
- Documented in `src/site/rst/rules/cleancode.rst`
- Covered in `src/test/php/PHPMD/Rule/CleanCode/ShortOpenTagTest.php`:
  applies/does not apply cases, xml-prolog exclusion (both ini paths,
  uppercase variant), short tag inside a string literal, dedup across
  multiple declarations in one file

Happy to adjust to whatever version this actually ships in.