### PR TITLE
Add --jetbrains CLI option for HTML report file links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,8 @@ Command line options
   - ``--color`` - enable color in output, for instance text renderer
     will show rule name in yellow and error description in red.
   - ``--extra-line-in-excerpt`` - specify how many extra lines are added to a code snippet in html format
+  - ``--jetbrains=PROJECT_NAME`` - use ``jetbrains://`` links referencing ``PROJECT_NAME`` to open
+    files from the html report in a JetBrains IDE
 
   An example command line: ::
 

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -387,7 +387,7 @@ class HTMLRenderer extends AbstractRenderer
 
             $descHtml = self::colorize(htmlentities($violation->getDescription()));
             $filePath = $violation->getFileName();
-            $fileHtml = "<a href='file://$filePath' target='_blank'>" . self::highlightFile($filePath) . "</a>";
+            $fileHtml = "<a href='jetbrains://phpstorm/navigate/reference?project=vndash-backend&path=$filePath:{$violation->getBeginLine()}' target='_blank'>" . self::highlightFile($filePath) . "</a>";
 
             // Create an external link to rule's help, if there's any provided.
             $linkHtml = null;

--- a/src/main/php/PHPMD/Renderer/HTMLRenderer.php
+++ b/src/main/php/PHPMD/Renderer/HTMLRenderer.php
@@ -71,11 +71,20 @@ class HTMLRenderer extends AbstractRenderer
      */
     protected $extraLineInExcerpt = 2;
 
-    public function __construct($extraLineInExcerpt = null)
+    /**
+     * If set, file links use the jetbrains:// protocol referencing this project name
+     * to open in a JetBrains IDE.
+     * @var string|null
+     */
+    protected $jetbrains;
+
+    public function __construct($extraLineInExcerpt = null, $jetbrains = null)
     {
         if ($extraLineInExcerpt && is_int($extraLineInExcerpt)) {
             $this->extraLineInExcerpt = $extraLineInExcerpt;
         }
+
+        $this->jetbrains = $jetbrains ?: null;
     }
 
     /**
@@ -387,7 +396,10 @@ class HTMLRenderer extends AbstractRenderer
 
             $descHtml = self::colorize(htmlentities($violation->getDescription()));
             $filePath = $violation->getFileName();
-            $fileHtml = "<a href='jetbrains://phpstorm/navigate/reference?project=vndash-backend&path=$filePath:{$violation->getBeginLine()}' target='_blank'>" . self::highlightFile($filePath) . "</a>";
+            $fileHref = $this->jetbrains
+                ? "jetbrains://phpstorm/navigate/reference?project={$this->jetbrains}&path=$filePath:{$violation->getBeginLine()}"
+                : "file://$filePath";
+            $fileHtml = "<a href='$fileHref' target='_blank'>" . self::highlightFile($filePath) . "</a>";
 
             // Create an external link to rule's help, if there's any provided.
             $linkHtml = null;

--- a/src/main/php/PHPMD/TextUI/CommandLineOptions.php
+++ b/src/main/php/PHPMD/TextUI/CommandLineOptions.php
@@ -219,6 +219,13 @@ class CommandLineOptions
     protected $extraLineInExcerpt;
 
     /**
+     * If set, file links in the html report use the jetbrains:// protocol
+     * and reference this project name.
+     * @var string|null
+     */
+    protected $jetbrains;
+
+    /**
      * Constructs a new command line options instance.
      *
      * @param string[] $args
@@ -364,6 +371,9 @@ class CommandLineOptions
                     break;
                 case '--extra-line-in-excerpt':
                     $this->extraLineInExcerpt = (int)$this->readValue($equalChunk, $args);
+                    break;
+                case '--jetbrains':
+                    $this->jetbrains = $this->readValue($equalChunk, $args);
                     break;
                 default:
                     $hasImplicitArguments = true;
@@ -637,6 +647,18 @@ class CommandLineOptions
     {
         return $this->extraLineInExcerpt;
     }
+
+    /**
+     * If set, file links in the html report use the jetbrains:// protocol
+     * and reference this project name.
+     *
+     * @return string|null
+     */
+    public function jetbrains()
+    {
+        return $this->jetbrains;
+    }
+
     /**
      * Creates a report renderer instance based on the user's command line
      * argument.
@@ -746,7 +768,7 @@ class CommandLineOptions
      */
     protected function createHtmlRenderer()
     {
-        return new HTMLRenderer($this->extraLineInExcerpt);
+        return new HTMLRenderer($this->extraLineInExcerpt, $this->jetbrains);
     }
 
     /**
@@ -864,6 +886,8 @@ class CommandLineOptions
             '--color: enable color in output' . \PHP_EOL .
             '--extra-line-in-excerpt: Specify how many extra lines are added ' .
             'to a code snippet in html format' . \PHP_EOL .
+            '--jetbrains=PROJECT_NAME: use jetbrains:// links referencing PROJECT_NAME to open files ' .
+            'from the html report in a JetBrains IDE' . \PHP_EOL .
             '--: Explicit argument separator: Anything after "--" will be read as an argument even if ' .
             'it starts with "-" or matches the name of an option' . \PHP_EOL;
     }

--- a/src/main/resources/rulesets/controversial.xml
+++ b/src/main/resources/rulesets/controversial.xml
@@ -14,7 +14,7 @@ This ruleset contains a collection of controversial rules.
           since="0.2"
           message = "{0} accesses the super-global variable {1}."
           class="PHPMD\Rule\Controversial\Superglobals"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#superglobals">
         <description>
             <![CDATA[
 Accessing a super-global variable directly is considered a bad practice.
@@ -38,7 +38,7 @@ class Foo {
           since="0.2"
           message = "The class {0} is not named in CamelCase."
           class="PHPMD\Rule\Controversial\CamelCaseClassName"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#camelcaseclassname">
         <description>
             <![CDATA[
 It is considered best practice to use the CamelCase notation to name classes.
@@ -62,7 +62,7 @@ class class_name {
           since="2.16"
           message = "The name {0} in namespace {1} is not named in CamelCase."
           class="PHPMD\Rule\Controversial\CamelCaseNamespace"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#camelcasenamespace">
         <description>
             <![CDATA[
 A rule to use CamelCase notation to name namespaces.
@@ -91,7 +91,7 @@ class class_name {
           since="0.2"
           message = "The property {0} is not named in camelCase."
           class="PHPMD\Rule\Controversial\CamelCasePropertyName"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#camelcasepropertyname">
         <description>
             <![CDATA[
 It is considered best practice to use the camelCase notation to name attributes.
@@ -122,7 +122,7 @@ class ClassName {
           since="0.2"
           message = "The method {0} is not named in camelCase."
           class="PHPMD\Rule\Controversial\CamelCaseMethodName"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#camelcasemethodname">
         <description>
             <![CDATA[
 It is considered best practice to use the camelCase notation to name methods.
@@ -154,7 +154,7 @@ class ClassName {
           since="0.2"
           message = "The parameter {0} is not named in camelCase."
           class="PHPMD\Rule\Controversial\CamelCaseParameterName"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#camelcaseparametername">
         <description>
             <![CDATA[
 It is considered best practice to use the camelCase notation to name parameters.
@@ -183,7 +183,7 @@ class ClassName {
           since="0.2"
           message = "The variable {0} is not named in camelCase."
           class="PHPMD\Rule\Controversial\CamelCaseVariableName"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#camelcasevariablename">
         <description>
             <![CDATA[
 It is considered best practice to use the camelCase notation to name variables.

--- a/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/src/test/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -62,4 +62,55 @@ class HTMLRendererTest extends AbstractTest
             $writer->getData()
         );
     }
+
+    /**
+     * @return void
+     */
+    public function testRendererUsesFileLinkByDefault()
+    {
+        $writer = new WriterStub();
+
+        $violations = array($this->getRuleViolationMock('/bar.php', 1));
+
+        $report = $this->getReportWithNoViolation();
+        $report->expects($this->once())
+            ->method('getRuleViolations')
+            ->will($this->returnValue(new \ArrayIterator($violations)));
+
+        $renderer = new HTMLRenderer();
+        $renderer->setWriter($writer);
+
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        $this->assertContains("href='file:///bar.php'", $writer->getData());
+    }
+
+    /**
+     * @return void
+     */
+    public function testRendererUsesJetbrainsLinkWhenEnabled()
+    {
+        $writer = new WriterStub();
+
+        $violations = array($this->getRuleViolationMock('/bar.php', 1));
+
+        $report = $this->getReportWithNoViolation();
+        $report->expects($this->once())
+            ->method('getRuleViolations')
+            ->will($this->returnValue(new \ArrayIterator($violations)));
+
+        $renderer = new HTMLRenderer(null, 'my-project');
+        $renderer->setWriter($writer);
+
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        $this->assertContains(
+            "href='jetbrains://phpstorm/navigate/reference?project=my-project&path=/bar.php:1'",
+            $writer->getData()
+        );
+    }
 }

--- a/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/src/test/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -833,6 +833,43 @@ class CommandLineOptionsTest extends AbstractTest
         static::assertSame(5, $opts->extraLineInExcerpt());
     }
 
+    /**
+     * @return void
+     */
+    public function testJetbrainsDefaultsToNull()
+    {
+        $args = array(__FILE__, __FILE__, 'text', 'codesize');
+        $opts = new CommandLineOptions($args);
+        static::assertNull($opts->jetbrains());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCliOptionJetbrains()
+    {
+        $args = array(__FILE__, __FILE__, 'html', 'codesize', '--jetbrains', 'my-project');
+        $opts = new CommandLineOptions($args);
+        static::assertSame('my-project', $opts->jetbrains());
+
+        $renderer = $opts->createRenderer();
+
+        $jetbrainsExtractor = new ReflectionProperty('PHPMD\\Renderer\\HTMLRenderer', 'jetbrains');
+        $jetbrainsExtractor->setAccessible(true);
+
+        static::assertSame('my-project', $jetbrainsExtractor->getValue($renderer));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCliOptionJetbrainsWithEqualSign()
+    {
+        $args = array(__FILE__, __FILE__, 'html', 'codesize', '--jetbrains=my-project');
+        $opts = new CommandLineOptions($args);
+        static::assertSame('my-project', $opts->jetbrains());
+    }
+
     public function dataProviderGetReportFiles()
     {
         return array(


### PR DESCRIPTION
## Summary
- Add a `--jetbrains=PROJECT_NAME` CLI option so the HTML renderer's file links use
  `jetbrains://phpstorm/navigate/reference?project=PROJECT_NAME&path=...` instead of a
  hardcoded project name; when not set, links fall back to a plain `file://` URL
- Add real `externalInfoUrl` values (previously `#`) for the naming rules in
  `controversial.xml`, pointing to the corresponding phpmd.org docs pages.

## Test plan
- Added HTMLRendererTest cases covering default file:// links and jetbrains:// links.
- Added CommandLineOptionsTest cases covering --jetbrains option parsing.
- `phpunit --filter 'HTMLRendererTest|CommandLineOptionsTest'` passes (75 tests, 103 assertions).