### PR TITLE
Add --jetbrains CLI option for HTML report file links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,8 @@ Command line options
   - ``--color`` - enable color in output, for instance text renderer
     will show rule name in yellow and error description in red.
   - ``--extra-line-in-excerpt`` - specify how many extra lines are added to a code snippet in html format
+  - ``--jetbrains=PROJECT_NAME`` - use ``jetbrains://`` links referencing ``PROJECT_NAME`` to open
+    files from the html report in a JetBrains IDE
 
   - ``--threads`` - the number of threads to use to parse the files.
 

--- a/rulesets/controversial.xml
+++ b/rulesets/controversial.xml
@@ -14,7 +14,7 @@ This ruleset contains a collection of controversial rules.
           since="0.2"
           message = "{0} accesses the super-global variable {1}."
           class="PHPMD\Rule\Controversial\Superglobals"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#superglobals">
         <description>
             <![CDATA[
 Accessing a super-global variable directly is considered a bad practice.
@@ -38,7 +38,7 @@ class Foo {
           since="0.2"
           message = "The class {0} is not named in CamelCase."
           class="PHPMD\Rule\Controversial\CamelCaseClassName"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#camelcaseclassname">
         <description>
             <![CDATA[
 It is considered best practice to use the CamelCase notation to name classes.
@@ -62,7 +62,7 @@ class class_name {
           since="2.16"
           message = "The name {0} in namespace {1} is not named in CamelCase."
           class="PHPMD\Rule\Controversial\CamelCaseNamespace"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#camelcasenamespace">
         <description>
             <![CDATA[
 A rule to use CamelCase notation to name namespaces.
@@ -91,7 +91,7 @@ class class_name {
           since="0.2"
           message = "The property {0} is not named in camelCase."
           class="PHPMD\Rule\Controversial\CamelCasePropertyName"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#camelcasepropertyname">
         <description>
             <![CDATA[
 It is considered best practice to use the camelCase notation to name attributes.
@@ -122,7 +122,7 @@ class ClassName {
           since="0.2"
           message = "The method {0} is not named in camelCase."
           class="PHPMD\Rule\Controversial\CamelCaseMethodName"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#camelcasemethodname">
         <description>
             <![CDATA[
 It is considered best practice to use the camelCase notation to name methods.
@@ -154,7 +154,7 @@ class ClassName {
           since="0.2"
           message = "The parameter {0} is not named in camelCase."
           class="PHPMD\Rule\Controversial\CamelCaseParameterName"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#camelcaseparametername">
         <description>
             <![CDATA[
 It is considered best practice to use the camelCase notation to name parameters.
@@ -183,7 +183,7 @@ class ClassName {
           since="0.2"
           message = "The variable {0} is not named in camelCase."
           class="PHPMD\Rule\Controversial\CamelCaseVariableName"
-          externalInfoUrl="#">
+          externalInfoUrl="https://phpmd.org/rules/naming.html#camelcasevariablename">
         <description>
             <![CDATA[
 It is considered best practice to use the camelCase notation to name variables.

--- a/src/Renderer/HTMLRenderer.php
+++ b/src/Renderer/HTMLRenderer.php
@@ -294,6 +294,8 @@ final class HTMLRenderer extends AbstractRenderer
     public function __construct(
         /** Specify how many extra lines are added to a code snippet By default 2 */
         private int $extraLineInExcerpt,
+        /** If set, file links use the jetbrains:// protocol referencing this project name */
+        private ?string $jetbrains = null,
     ) {
     }
 
@@ -381,7 +383,11 @@ final class HTMLRenderer extends AbstractRenderer
 
             $descHtml = self::colorize(htmlentities($violation->getDescription()));
             $filePath = $violation->getFileName();
-            $fileHtml = "<a href='file://$filePath' target='_blank'>"
+            $fileHref = $this->jetbrains
+                ? 'jetbrains://phpstorm/navigate/reference?project=' . $this->jetbrains
+                    . "&path=$filePath:{$violation->getBeginLine()}"
+                : "file://$filePath";
+            $fileHtml = "<a href='$fileHref' target='_blank'>"
                 . self::highlightFile((string) $filePath) . '</a>';
 
             // Create an external link to rule's help, if there's any provided.

--- a/src/Renderer/RendererFactory.php
+++ b/src/Renderer/RendererFactory.php
@@ -22,7 +22,7 @@ final class RendererFactory
     /**
      * @throws InvalidArgumentException
      */
-    public function getRenderer(string $format): RendererInterface
+    public function getRenderer(string $format, ?string $jetbrains = null): RendererInterface
     {
         return match ($format) {
             'ansi' => new AnsiRenderer(),
@@ -30,7 +30,7 @@ final class RendererFactory
             'github' => new GitHubRenderer(),
             'githubcheckruns' => new GitHubCheckRunsRenderer(),
             'gitlab' => new GitLabRenderer(),
-            'html' => new HTMLRenderer(2),
+            'html' => new HTMLRenderer(2, $jetbrains),
             'json' => new JSONRenderer(),
             'sarif' => new SARIFRenderer(),
             'text' => new TextRenderer(),

--- a/src/TextUI/CommandConfigurator.php
+++ b/src/TextUI/CommandConfigurator.php
@@ -302,6 +302,12 @@ final class CommandConfigurator
             2
         );
         $command->addOption(
+            'jetbrains',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Use jetbrains:// links referencing PROJECT_NAME to open files from the html report in a JetBrains IDE'
+        );
+        $command->addOption(
             'coverage',
             null,
             InputOption::VALUE_REQUIRED,

--- a/src/TextUI/CommandLineOptions.php
+++ b/src/TextUI/CommandLineOptions.php
@@ -137,6 +137,9 @@ class CommandLineOptions
     /** Specify how many extra lines are added to a code snippet */
     private int $extraLineInExcerpt;
 
+    /** If set, file links in the html report use the jetbrains:// protocol and reference this project name. */
+    private ?string $jetbrains = null;
+
     /** number of cores to use for parsing */
     private ?int $threads = null;
 
@@ -180,6 +183,7 @@ class CommandLineOptions
             }
         }
         $this->extraLineInExcerpt = (int) $this->readInt($input, 'extra-line-in-excerpt');
+        $this->jetbrains = $this->readString($input, 'jetbrains');
 
         /** @var list<string> */
         $rulesets = $input->getOption('ruleset');
@@ -378,6 +382,15 @@ class CommandLineOptions
     }
 
     /**
+     * If set, file links in the html report use the jetbrains:// protocol
+     * and reference this project name.
+     */
+    public function jetbrains(): ?string
+    {
+        return $this->jetbrains;
+    }
+
+    /**
      * Creates a report renderer instance based on the user's command line
      * argument.
      *
@@ -405,7 +418,7 @@ class CommandLineOptions
     {
         $reportFormat = $reportFormat ?: $this->reportFormat ?: '';
 
-        return (new RendererFactory())->getRenderer($reportFormat);
+        return (new RendererFactory())->getRenderer($reportFormat, $this->jetbrains);
     }
 
     /**

--- a/tests/php/PHPMD/Renderer/HTMLRendererTest.php
+++ b/tests/php/PHPMD/Renderer/HTMLRendererTest.php
@@ -58,4 +58,49 @@ class HTMLRendererTest extends AbstractTestCase
             $writer->fetch()
         );
     }
+
+    public function testRendererUsesFileLinkByDefault(): void
+    {
+        $writer = new BufferedOutput();
+
+        $violations = [$this->getRuleViolationMock('/bar.php', 1)];
+
+        $report = $this->getReportWithNoViolation();
+        $report->expects(static::once())
+            ->method('getRuleViolations')
+            ->willReturn(new ArrayIterator($violations));
+
+        $renderer = new HTMLRenderer(2);
+        $renderer->setWriter($writer);
+
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        static::assertStringContainsString("href='file:///bar.php'", $writer->fetch());
+    }
+
+    public function testRendererUsesJetbrainsLinkWhenEnabled(): void
+    {
+        $writer = new BufferedOutput();
+
+        $violations = [$this->getRuleViolationMock('/bar.php', 1)];
+
+        $report = $this->getReportWithNoViolation();
+        $report->expects(static::once())
+            ->method('getRuleViolations')
+            ->willReturn(new ArrayIterator($violations));
+
+        $renderer = new HTMLRenderer(2, 'my-project');
+        $renderer->setWriter($writer);
+
+        $renderer->start();
+        $renderer->renderReport($report);
+        $renderer->end();
+
+        static::assertStringContainsString(
+            "href='jetbrains://phpstorm/navigate/reference?project=my-project&path=/bar.php:1'",
+            $writer->fetch()
+        );
+    }
 }

--- a/tests/php/PHPMD/TextUI/CommandLineOptionsTest.php
+++ b/tests/php/PHPMD/TextUI/CommandLineOptionsTest.php
@@ -582,4 +582,30 @@ class CommandLineOptionsTest extends AbstractTestCase
         $opts = new CommandLineOptions($args);
         static::assertSame(5, $opts->extraLineInExcerpt());
     }
+
+    public function testJetbrainsDefaultsToNull(): void
+    {
+        $args = $this->createInput(['paths' => [__FILE__], '--format' => 'text', '--ruleset' => ['codesize']]);
+        $opts = new CommandLineOptions($args);
+        static::assertNull($opts->jetbrains());
+    }
+
+    public function testCliOptionJetbrains(): void
+    {
+        $args = $this->createInput([
+            'paths' => [__FILE__],
+            '--format' => 'html',
+            '--ruleset' => ['codesize'],
+            '--jetbrains' => 'my-project',
+        ]);
+        $opts = new CommandLineOptions($args);
+        static::assertSame('my-project', $opts->jetbrains());
+
+        $renderer = $opts->createRenderer(new NullOutput());
+
+        $jetbrainsExtractor = new ReflectionProperty(HTMLRenderer::class, 'jetbrains');
+        $jetbrainsExtractor->setAccessible(true);
+
+        static::assertSame('my-project', $jetbrainsExtractor->getValue($renderer));
+    }
 }


### PR DESCRIPTION
## Summary
- Add a `--jetbrains=PROJECT_NAME` CLI option so the HTML renderer's file links use
  `jetbrains://phpstorm/navigate/reference?project=PROJECT_NAME&path=...` instead of a
  hardcoded project name; when not set, links fall back to a plain `file://` URL
- Add real `externalInfoUrl` values (previously `#`) for the naming rules in
  `controversial.xml`, pointing to the corresponding phpmd.org docs pages

Retargeted from #1331, which was opened against `master`. Rebased onto `3.x` (renderer/CLI
options code has diverged significantly there, e.g. `HTMLRenderer` and `CommandLineOptions`
use different construction patterns), and adjusted the wiring accordingly.

## Test plan
- Added `HTMLRendererTest` cases covering default `file://` links and `jetbrains://` links.
- Added `CommandLineOptionsTest` cases covering `--jetbrains` option parsing and renderer wiring.
- `vendor/bin/phpunit` passes (890 tests, 2586 assertions), `phpstan analyse` and `phpcs` clean on changed files.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>