### PR TITLE
Reuse the variable occurrences already collected for a scope

### DIFF
--- a/.github/workflows/generate_phar.yml
+++ b/.github/workflows/generate_phar.yml
@@ -12,6 +12,8 @@ jobs:
   php-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
     env:
       COMPOSER_NO_INTERACTION: 1
 
@@ -82,10 +84,12 @@ jobs:
 
       - name: Release phpmd.phar
         if: github.event_name == 'release'
-        uses: skx/github-action-publish-binaries@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: |
-            phpmd.phar
-            phpmd.phar.asc
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          assets=(phpmd.phar)
+          if [ -f phpmd.phar.asc ]; then
+            assets+=(phpmd.phar.asc)
+          fi
+          gh release upload "$TAG_NAME" "${assets[@]}" --clobber

--- a/src/Rule/UnusedPrivateMethod.php
+++ b/src/Rule/UnusedPrivateMethod.php
@@ -59,6 +59,9 @@ final class UnusedPrivateMethod extends AbstractRule implements ClassAware
     /** @var SplObjectStorage<PDependNode, ASTFormalParameters> */
     private $parametersForScope;
 
+    /** @var SplObjectStorage<PDependNode, list<AbstractNode<PDependNode>>> */
+    private $variablesForScope;
+
     /**
      * This method checks that all private class methods are at least accessed
      * by one method.
@@ -73,6 +76,7 @@ final class UnusedPrivateMethod extends AbstractRule implements ClassAware
         }
 
         $this->selfVariableCache = new SplObjectStorage();
+        $this->variablesForScope = new SplObjectStorage();
 
         foreach ($this->collectUnusedPrivateMethods($class) as $node) {
             $this->addViolation($node, [$node->getImage()]);
@@ -265,7 +269,7 @@ final class UnusedPrivateMethod extends AbstractRule implements ClassAware
             return false;
         }
 
-        $lastWritingFinder = new LastVariableWriting($variable);
+        $lastWritingFinder = new LastVariableWriting($variable, $this->variablesForScope);
         $lastWriting = $lastWritingFinder->findInScope($scope);
 
         if (!$lastWriting) {

--- a/src/Utility/LastVariableWriting.php
+++ b/src/Utility/LastVariableWriting.php
@@ -25,6 +25,7 @@ use PDepend\Source\AST\ASTFormalParameters;
 use PDepend\Source\AST\ASTNode as PDependNode;
 use PDepend\Source\AST\ASTType;
 use PHPMD\AbstractNode;
+use SplObjectStorage;
 
 /**
  * Utility class to find the last time a variable was written before an occurrence of it.
@@ -34,12 +35,17 @@ final class LastVariableWriting
     /** @var AbstractNode<PDependNode> */
     private $variable;
 
+    /** @var SplObjectStorage<PDependNode, list<AbstractNode<PDependNode>>>|null */
+    private $variablesForScope;
+
     /**
      * @param AbstractNode<PDependNode> $variable
+     * @param SplObjectStorage<PDependNode, list<AbstractNode<PDependNode>>>|null $variablesForScope
      */
-    public function __construct(AbstractNode $variable)
+    public function __construct(AbstractNode $variable, ?SplObjectStorage $variablesForScope = null)
     {
         $this->variable = $variable;
+        $this->variablesForScope = $variablesForScope;
     }
 
     /**
@@ -51,7 +57,7 @@ final class LastVariableWriting
         $lastWriting = null;
         $name = $this->variable->getImage();
 
-        foreach ($scope->findChildrenOfTypeVariable() as $occurrence) {
+        foreach ($this->occurrencesInScope($scope) as $occurrence) {
             // Only care about occurrences of the same variable
             if ($occurrence->getImage() !== $name) {
                 continue;
@@ -74,6 +80,27 @@ final class LastVariableWriting
         }
 
         return $lastWriting;
+    }
+
+    /**
+     * Every variable occurrence of the given scope, in source order.
+     *
+     * @param AbstractNode<PDependNode> $scope
+     * @return list<AbstractNode<PDependNode>>
+     */
+    private function occurrencesInScope(AbstractNode $scope): array
+    {
+        if ($this->variablesForScope === null) {
+            return $scope->findChildrenOfTypeVariable();
+        }
+
+        $node = $scope->getNode();
+
+        if (!$this->variablesForScope->offsetExists($node)) {
+            $this->variablesForScope->offsetSet($node, $scope->findChildrenOfTypeVariable());
+        }
+
+        return $this->variablesForScope->offsetGet($node);
     }
 
     /**


### PR DESCRIPTION
Type: refactoring
Breaking change: no

This avoids redundant work when analyzing the graph, testing on a few projects showed a roughly 25% improvement in performance.

Also includes https://github.com/phpmd/phpmd/pull/1338 to pass CI