### PR TITLE
Compare the occurrence a variable stands for, not its wrapper

### DIFF
--- a/.github/workflows/generate_phar.yml
+++ b/.github/workflows/generate_phar.yml
@@ -12,6 +12,8 @@ jobs:
   php-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
     env:
       COMPOSER_NO_INTERACTION: 1
 
@@ -82,10 +84,12 @@ jobs:
 
       - name: Release phpmd.phar
         if: github.event_name == 'release'
-        uses: skx/github-action-publish-binaries@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: |
-            phpmd.phar
-            phpmd.phar.asc
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          assets=(phpmd.phar)
+          if [ -f phpmd.phar.asc ]; then
+            assets+=(phpmd.phar.asc)
+          fi
+          gh release upload "$TAG_NAME" "${assets[@]}" --clobber

--- a/src/Utility/LastVariableWriting.php
+++ b/src/Utility/LastVariableWriting.php
@@ -58,7 +58,7 @@ final class LastVariableWriting
             }
 
             // Only check occurrences before, stop when found current node
-            if ($occurrence === $this->variable) {
+            if ($occurrence->getNode() === $this->variable->getNode()) {
                 break;
             }
 


### PR DESCRIPTION
Type: bugfix
Breaking change: no

LastVariableWriting walks a scope to find where a variable was last written before the occurrence it was asked about, and stopped once it reached that occurrence again. It compared the wrappers though, and the occurrences are wrapped while walking the scope whereas the variable asked about was wrapped by the caller, so the two were never the same object and the walk never stopped early.

Also includes https://github.com/phpmd/phpmd/pull/1338 to pass CI